### PR TITLE
fix: 3 easy wins from issue #2 (migration, skip-link, heading slug)

### DIFF
--- a/cmd/gofastr/init.go
+++ b/cmd/gofastr/init.go
@@ -121,7 +121,7 @@ func main() {
 	fwApp.Mount(uihost.New(site))
 
 	// Run migrations
-	migrator := migrate.New(db, migrate.WithTableName("_migrations"))
+	migrator := migrate.New(db, migrate.WithTableName("_migrations"), migrate.WithDialect(migrate.DialectSQLite))
 	entities.RegisterMigrations(migrator)
 	if err := migrator.Up(context.Background()); err != nil {
 		log.Printf("Migration warning: %%v", err)

--- a/core-ui/html/html_test.go
+++ b/core-ui/html/html_test.go
@@ -197,6 +197,25 @@ func TestHeading(t *testing.T) {
 		}
 	})
 
+	t.Run("slug strips HTML entities from escaped text", func(t *testing.T) {
+		// render.Text escapes apostrophe to &#39; — slug must unescape
+		// before slugifying so we get "hi-im-donald" not "hi-i-39-m-donald".
+		h := Heading(HeadingConfig{Level: 2}, render.Text("Hi, I'm Donald"))
+		if strings.Contains(string(h), "-39-") {
+			t.Errorf("slug should not contain -39- from HTML entity escaping, got %q", h)
+		}
+		if !strings.Contains(string(h), `id="heading-hi-i-m-donald"`) {
+			t.Errorf("expected id heading-hi-i-m-donald, got %q", h)
+		}
+	})
+
+	t.Run("slug handles ampersands and quotes", func(t *testing.T) {
+		h := Heading(HeadingConfig{Level: 2}, render.Text("Tom & Jerry \"the best\""))
+		if !strings.Contains(string(h), `id="heading-tom-jerry-the-best"`) {
+			t.Errorf("expected id heading-tom-jerry-the-best, got %q", h)
+		}
+	})
+
 	t.Run("preserves explicit id", func(t *testing.T) {
 		h := Heading(HeadingConfig{Level: 1, ID: "custom-id"}, render.Text("Title"))
 		assertContains(t, h, `id="custom-id"`)

--- a/core-ui/html/text.go
+++ b/core-ui/html/text.go
@@ -2,6 +2,7 @@ package html
 
 import (
 	"fmt"
+	"html"
 	"regexp"
 	"strings"
 
@@ -47,7 +48,11 @@ type TimeConfig struct {
 var nonAlphaNum = regexp.MustCompile(`[^a-zA-Z0-9]+`)
 
 // slugify converts a string to a URL-friendly slug for use as an HTML id.
+// It first unescapes HTML entities (e.g. &#39; → ') so that escaped
+// apostrophes and other characters don't leak numeric entity codes
+// into the slug.
 func slugify(s string) string {
+	s = html.UnescapeString(s)
 	s = strings.ToLower(strings.TrimSpace(s))
 	s = nonAlphaNum.ReplaceAllString(s, "-")
 	s = strings.Trim(s, "-")

--- a/framework/uihost/uihost.go
+++ b/framework/uihost/uihost.go
@@ -175,6 +175,35 @@ const frameworkBuiltinCSS = `
   white-space: nowrap;
   border: 0;
 }
+/* Skip-link: visually hidden until focused, then revealed as a
+   visible overlay so keyboard users can jump to #main-content.
+   Apps can override via their own .skip-link / .skip-link:focus
+   rules. */
+.skip-link {
+  position: absolute !important;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+.skip-link:focus {
+  position: fixed !important;
+  top: 8px; left: 8px;
+  width: auto; height: auto;
+  padding: 8px 16px;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+  z-index: 9999;
+  background: #18181B;
+  color: #FAFAFA;
+  border-radius: 4px;
+  font: 0.9rem system-ui, -apple-system, sans-serif;
+  text-decoration: none;
+}
 /* SPA-nav failure toast — shown when loadPage can't fetch the new
    page (offline, server error). Positioned bottom-right; auto-hides
    after 4s via the runtime. Strict-CSP-clean (no inline styles). */

--- a/framework/uihost/uihost_test.go
+++ b/framework/uihost/uihost_test.go
@@ -417,6 +417,14 @@ func TestUIHostAppCSSShipsFrameworkBuiltinCSS(t *testing.T) {
 		t.Errorf("app.css must ship .fui-visually-hidden helper — without it the polite live region for SPA-nav and the skip link become visible on screen; got:\n%s",
 			truncate(body, 600))
 	}
+	if !strings.Contains(body, ".skip-link") {
+		t.Errorf("app.css must ship .skip-link default styles — without it the skip-to-content link is visible on every page; got:\n%s",
+			truncate(body, 600))
+	}
+	if !strings.Contains(body, ".skip-link:focus") {
+		t.Errorf("app.css must ship .skip-link:focus styles — without them the skip link cannot be revealed to keyboard users; got:\n%s",
+			truncate(body, 600))
+	}
 }
 
 func TestUIHostCustomCSS(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes 3 high-impact, low-effort items from #2 (does not close it — remaining items tracked separately).

### 1. Scaffold migration dialect (#7)
The scaffolded `main.go` called `migrate.New(db)` without `WithDialect`, but always uses SQLite. This caused `NOW()` (the Postgres default) in the CREATE TABLE DDL → syntax error on every boot:
```
Migration warning: creating migrations table: near "(": syntax error
```
**Fix:** Added `migrate.WithDialect(migrate.DialectSQLite)` to the scaffold template.

### 2. Skip-link default CSS (#15.4)
The framework emits `<a class="skip-link" href="#main-content">` on every page but had no CSS to hide it. It rendered as a visible blue link.
**Fix:** Added `.skip-link` (visually hidden) and `.skip-link:focus` (revealed as overlay) to `frameworkBuiltinCSS`.

### 3. Heading ID apostrophe encoding (#15.7)
`render.Text("I'm Donald")` escapes `'` to `&#39;`. The heading auto-id generator slugified the escaped HTML, producing `hi-i-39-m-donald`.
**Fix:** Added `html.UnescapeString()` at the start of `slugify()`.

## Files changed
| File | Change |
|------|--------|
| `cmd/gofastr/init.go` | Added `WithDialect(DialectSQLite)` in scaffold |
| `core-ui/html/text.go` | Added `html.UnescapeString` in `slugify()` |
| `core-ui/html/html_test.go` | Added 2 test cases for entity escaping |
| `framework/uihost/uihost.go` | Added 29 lines default `.skip-link` CSS |
| `framework/uihost/uihost_test.go` | Added 2 assertions for skip-link CSS |

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (1 pre-existing failure in `examples/core-ui-demo` unrelated)
- [x] New tests: heading slug with apostrophes, ampersands, quotes
- [x] New tests: skip-link CSS presence in app.css
- [x] 3 independent adversarial code reviews completed — all pass

Refs #2
