### PR TITLE
Add head injection API for SEO meta and Open Graph tags

### DIFF
--- a/examples/website/e2e_head_injection_test.go
+++ b/examples/website/e2e_head_injection_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/chromedp/chromedp"
+)
+
+// ---------------------------------------------------------------------------
+// E2E tests for the head injection API (issue #5).
+//
+// These tests verify that ALL three tiers of head injection actually
+// render in a real browser — not just in unit-test string checks.
+//
+// Tier 1: WithHeadHTML escape hatch (tested via website integration)
+// Tier 2: Typed helpers — favicon, theme-color, description, OG, Twitter,
+//         canonical URL, preconnect
+// Tier 3: SEOScreen per-page override — About page implements HeadHTML()
+// ---------------------------------------------------------------------------
+
+// collectHeadHTML navigates to url and returns document.head.innerHTML.
+func collectHeadHTML(t *testing.T, ctx context.Context, url string) string {
+	t.Helper()
+	var headHTML string
+	err := chromedp.Run(ctx,
+		chromedp.Navigate(url),
+		pageReady(),
+		chromedp.Evaluate(`document.head.innerHTML`, &headHTML),
+	)
+	if err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+	return headHTML
+}
+
+// TestE2E_HeadInjection_AllGlobalTagsPresent verifies that every typed
+// helper option configured on the website host produces real DOM elements.
+// This is the E2E proof that the full typed helper tier works end-to-end.
+func TestE2E_HeadInjection_AllGlobalTagsPresent(t *testing.T) {
+	base := startE2EServer(t)
+	ctx := newE2EBrowserCtx(t)
+	headHTML := collectHeadHTML(t, ctx, base+"/")
+
+	// Every typed helper configured in main.go must appear in the DOM
+	checks := []struct {
+		label string
+		want  string
+	}{
+		// WithFavicon
+		{"favicon", `<link rel="icon" href="/static/favicon.ico">`},
+		// WithDescription
+		{"description", `<meta name="description" content="GoFastr demo website — SSR framework with islands, signals, and themes">`},
+		// WithThemeColor
+		{"theme-color", `<meta name="theme-color" content="#f7f5ee">`},
+		// WithOpenGraph (3 fields set)
+		{"og:title", `<meta property="og:title" content="GoFastr">`},
+		{"og:url", `<meta property="og:url" content="https://gofastr.dev">`},
+		{"og:type", `<meta property="og:type" content="website">`},
+		// WithTwitterCard (2 fields set)
+		{"twitter:card", `<meta name="twitter:card" content="summary_large_image">`},
+		{"twitter:title", `<meta name="twitter:title" content="GoFastr">`},
+		// WithCanonicalURL
+		{"canonical", `<link rel="canonical" href="https://gofastr.dev">`},
+		// WithPreconnect (2 origins)
+		{"preconnect fonts.googleapis.com", `<link rel="preconnect" href="https://fonts.googleapis.com">`},
+		{"preconnect fonts.gstatic.com", `<link rel="preconnect" href="https://fonts.gstatic.com">`},
+	}
+
+	for _, tc := range checks {
+		tc := tc
+		t.Run(tc.label, func(t *testing.T) {
+			if !strings.Contains(headHTML, tc.want) {
+				t.Errorf("head missing %s tag:\n  want: %s\n  head:\n%s", tc.label, tc.want, headHTML)
+			}
+		})
+	}
+}
+
+// TestE2E_HeadInjection_SEOScreenPerScreen verifies the per-page SEOScreen
+// override. The About screen implements HeadHTML() which should inject
+// page-specific og:title and og:description ALONGSIDE the global tags.
+func TestE2E_HeadInjection_SEOScreenPerScreen(t *testing.T) {
+	base := startE2EServer(t)
+	ctx := newE2EBrowserCtx(t)
+	headHTML := collectHeadHTML(t, ctx, base+"/about")
+
+	// Global tags still present on the about page
+	assertContains(t, headHTML, `<link rel="icon" href="/static/favicon.ico">`)
+	assertContains(t, headHTML, `<meta name="theme-color" content="#f7f5ee">`)
+	assertContains(t, headHTML, `<link rel="canonical" href="https://gofastr.dev">`)
+
+	// Per-screen SEOScreen tags from AboutScreen.HeadHTML()
+	assertContains(t, headHTML, `<meta property="og:title" content="About GoFastr">`)
+	assertContains(t, headHTML, `<meta property="og:description" content="Learn about the GoFastr framework, its layered design, and current status.">`)
+
+	// Both global og:title ("GoFastr") and per-screen og:title ("About GoFastr")
+	// should be present — they coexist
+	ogTitleCount := strings.Count(headHTML, `<meta property="og:title"`)
+	if ogTitleCount != 2 {
+		t.Errorf("expected 2 og:title meta tags (1 global + 1 per-screen), got %d", ogTitleCount)
+	}
+}
+
+// TestE2E_HeadInjection_NoSEOScreenOnOtherPages verifies that pages
+// without SEOScreen only get the global tags — no per-screen leakage.
+func TestE2E_HeadInjection_NoSEOScreenOnOtherPages(t *testing.T) {
+	base := startE2EServer(t)
+	ctx := newE2EBrowserCtx(t)
+
+	// Home page doesn't implement SEOScreen
+	headHTML := collectHeadHTML(t, ctx, base+"/")
+
+	// Global tags present
+	assertContains(t, headHTML, `<link rel="icon" href="/static/favicon.ico">`)
+	assertContains(t, headHTML, `<meta name="theme-color" content="#f7f5ee">`)
+
+	// The About page's per-screen tags should NOT be on the home page
+	assertNotContains(t, headHTML, `<meta property="og:title" content="About GoFastr">`)
+	assertNotContains(t, headHTML, `Learn about the GoFastr framework`)
+
+	// Only the global og:title
+	ogTitleCount := strings.Count(headHTML, `<meta property="og:title"`)
+	if ogTitleCount != 1 {
+		t.Errorf("expected 1 og:title (global only) on home page, got %d", ogTitleCount)
+	}
+}
+
+// TestE2E_HeadInjection_MultiplePagesAllGetGlobalTags verifies that
+// several different pages all receive the global head tags — proving
+// the injection isn't accidentally scoped to a single route.
+func TestE2E_HeadInjection_MultiplePagesAllGetGlobalTags(t *testing.T) {
+	base := startE2EServer(t)
+	ctx := newE2EBrowserCtx(t)
+
+	for _, path := range []string{"/", "/about", "/components/accordion", "/components/tabs"} {
+		path := path
+		t.Run(path, func(t *testing.T) {
+			headHTML := collectHeadHTML(t, ctx, base+path)
+			assertContains(t, headHTML, `<link rel="icon" href="/static/favicon.ico">`)
+			assertContains(t, headHTML, `<meta name="theme-color" content="#f7f5ee">`)
+			assertContains(t, headHTML, `<link rel="canonical" href="https://gofastr.dev">`)
+		})
+	}
+}
+
+// TestE2E_HeadInjection_TitleTag verifies that the <title> element
+// renders correctly in the browser's document.title — proving the
+// SSR title generation works end-to-end through the full rendering
+// pipeline (app.RenderPage → injectChrome → browser).
+func TestE2E_HeadInjection_TitleTag(t *testing.T) {
+	base := startE2EServer(t)
+	ctx := newE2EBrowserCtx(t)
+
+	var title string
+	err := chromedp.Run(ctx,
+		chromedp.Navigate(base+"/"),
+		pageReady(),
+		chromedp.Evaluate(`document.title`, &title),
+	)
+	if err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+	if !strings.Contains(title, "Home") || !strings.Contains(title, "GoFastr") {
+		t.Errorf("home page title should contain 'Home' and 'GoFastr', got %q", title)
+	}
+
+	// Verify the about page title too
+	var aboutTitle string
+	err = chromedp.Run(ctx,
+		chromedp.Navigate(base+"/about"),
+		pageReady(),
+		chromedp.Evaluate(`document.title`, &aboutTitle),
+	)
+	if err != nil {
+		t.Fatalf("chromedp about: %v", err)
+	}
+	if !strings.Contains(aboutTitle, "About") {
+		t.Errorf("about page title should contain 'About', got %q", aboutTitle)
+	}
+}
+
+func assertContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("expected to find %q in output", needle)
+	}
+}
+
+func assertNotContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if strings.Contains(haystack, needle) {
+		t.Errorf("expected NOT to find %q in output, but it was present", needle)
+	}
+}

--- a/examples/website/main.go
+++ b/examples/website/main.go
@@ -88,7 +88,23 @@ func setupServer() (*framework.App, *uihost.UIHost) {
 	site.Register("/about", &AboutScreen{}, nil)
 
 	cssStr := createStyleSheet(*site.Theme)
-	hostOpts := []uihost.Option{uihost.WithCustomCSS(cssStr)}
+	hostOpts := []uihost.Option{
+		uihost.WithCustomCSS(cssStr),
+		uihost.WithFavicon("/static/favicon.ico"),
+		uihost.WithDescription("GoFastr demo website — SSR framework with islands, signals, and themes"),
+		uihost.WithThemeColor("#f7f5ee"),
+		uihost.WithOpenGraph(uihost.OG{
+			Title: "GoFastr",
+			URL:   "https://gofastr.dev",
+			Type:  "website",
+		}),
+		uihost.WithTwitterCard(uihost.TwitterCard{
+			Card:  "summary_large_image",
+			Title: "GoFastr",
+		}),
+		uihost.WithCanonicalURL("https://gofastr.dev"),
+		uihost.WithPreconnect("https://fonts.googleapis.com", "https://fonts.gstatic.com"),
+	}
 	if devMode() {
 		hostOpts = append(hostOpts, uihost.WithExtraScripts("/__livereload.js"))
 	}

--- a/examples/website/screen_about.go
+++ b/examples/website/screen_about.go
@@ -5,16 +5,26 @@ import (
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core/render"
 	"github.com/DonaldMurillo/gofastr/framework/ui"
+	"github.com/DonaldMurillo/gofastr/framework/uihost" // SEOScreen interface
 )
 
 // AboutScreen — composed from framework/ui semantic components, so
 // every visible element on this page is also a real test case for
 // PageHeader / Section / Callout.
+// Also implements uihost.SEOScreen for E2E head injection testing.
 type AboutScreen struct{}
+
+// Compile-time assertion that AboutScreen implements SEOScreen.
+var _ uihost.SEOScreen = (*AboutScreen)(nil)
 
 func (s *AboutScreen) ScreenTitle() string        { return "About" }
 func (s *AboutScreen) ScreenDescription() string  { return "Project status, scope, and trade-offs." }
 func (s *AboutScreen) ScreenType() app.ScreenType { return app.ScreenPage }
+
+// HeadHTML provides per-screen SEO tags for the about page.
+func (s *AboutScreen) HeadHTML() string {
+	return `<meta property="og:title" content="About GoFastr"><meta property="og:description" content="Learn about the GoFastr framework, its layered design, and current status.">`
+}
 
 func (s *AboutScreen) Render() render.HTML {
 	return render.Tag("div", map[string]string{"class": "doc-body"},

--- a/framework/uihost/head_test.go
+++ b/framework/uihost/head_test.go
@@ -1,0 +1,360 @@
+package uihost
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+// ---------------------------------------------------------------------------
+// Head injection test components
+// ---------------------------------------------------------------------------
+
+// seoTestComp is a component that also implements SEOScreen.
+type seoTestComp struct {
+	headHTML string
+}
+
+func (c *seoTestComp) Render() render.HTML {
+	return render.Text("SEO page")
+}
+
+func (c *seoTestComp) HeadHTML() string {
+	return c.headHTML
+}
+
+// ---------------------------------------------------------------------------
+// A. WithHeadHTML escape hatch
+// ---------------------------------------------------------------------------
+
+func TestWithHeadHTML(t *testing.T) {
+	application := app.NewApp("HeadTest")
+	application.SetDefaultLayout(app.NewLayout("main"))
+	application.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+
+	host := New(application,
+		WithHeadHTML(`<link rel="icon" href="/static/favicon.ico"><meta name="theme-color" content="#f7f5ee">`),
+	)
+
+	rec := httptest.NewRecorder()
+	host.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	page := rec.Body.String()
+
+	assertContains(t, page, `<link rel="icon" href="/static/favicon.ico">`)
+	assertContains(t, page, `<meta name="theme-color" content="#f7f5ee">`)
+
+	// Head content must be inside <head>, not <body>
+	headClose := strings.Index(page, "</head>")
+	bodyOpen := strings.Index(page, "<body")
+	iconAt := strings.Index(page, `<link rel="icon"`)
+	if iconAt >= headClose || iconAt >= bodyOpen {
+		t.Errorf("head HTML must appear before </head> and <body>; iconAt=%d headClose=%d bodyOpen=%d",
+			iconAt, headClose, bodyOpen)
+	}
+}
+
+func TestWithHeadHTMLNotInjectedByDefault(t *testing.T) {
+	ds := newTestUIHost()
+	rec := httptest.NewRecorder()
+	ds.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	page := rec.Body.String()
+
+	assertNotContains(t, page, `<link rel="icon"`)
+	assertNotContains(t, page, `theme-color`)
+}
+
+// ---------------------------------------------------------------------------
+// B. Typed convenience methods
+// ---------------------------------------------------------------------------
+
+func TestWithFavicon(t *testing.T) {
+	application := app.NewApp("FaviconTest")
+	application.SetDefaultLayout(app.NewLayout("main"))
+	application.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+
+	host := New(application, WithFavicon("/static/favicon.ico"))
+
+	rec := httptest.NewRecorder()
+	host.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	page := rec.Body.String()
+
+	assertContains(t, page, `<link rel="icon" href="/static/favicon.ico">`)
+}
+
+func TestWithThemeColor(t *testing.T) {
+	application := app.NewApp("ThemeColorTest")
+	application.SetDefaultLayout(app.NewLayout("main"))
+	application.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+
+	host := New(application, WithThemeColor("#f7f5ee"))
+
+	rec := httptest.NewRecorder()
+	host.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	page := rec.Body.String()
+
+	assertContains(t, page, `<meta name="theme-color" content="#f7f5ee">`)
+}
+
+func TestWithDescription(t *testing.T) {
+	application := app.NewApp("DescTest")
+	application.SetDefaultLayout(app.NewLayout("main"))
+	application.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+
+	host := New(application, WithDescription("A test site for head injection"))
+
+	rec := httptest.NewRecorder()
+	host.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	page := rec.Body.String()
+
+	assertContains(t, page, `<meta name="description" content="A test site for head injection">`)
+}
+
+func TestWithOpenGraph(t *testing.T) {
+	application := app.NewApp("OGTest")
+	application.SetDefaultLayout(app.NewLayout("main"))
+	application.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+
+	host := New(application, WithOpenGraph(OG{
+		Title:       "My Site",
+		Description: "Best site ever",
+		Image:       "https://example.com/og.png",
+		URL:         "https://example.com",
+		Type:        "website",
+	}))
+
+	rec := httptest.NewRecorder()
+	host.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	page := rec.Body.String()
+
+	assertContains(t, page, `<meta property="og:title" content="My Site">`)
+	assertContains(t, page, `<meta property="og:description" content="Best site ever">`)
+	assertContains(t, page, `<meta property="og:image" content="https://example.com/og.png">`)
+	assertContains(t, page, `<meta property="og:url" content="https://example.com">`)
+	assertContains(t, page, `<meta property="og:type" content="website">`)
+}
+
+func TestWithTwitterCard(t *testing.T) {
+	application := app.NewApp("TwitterTest")
+	application.SetDefaultLayout(app.NewLayout("main"))
+	application.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+
+	host := New(application, WithTwitterCard(TwitterCard{
+		Card:        "summary_large_image",
+		Title:       "My Site",
+		Description: "Best site",
+		Image:       "https://example.com/card.png",
+	}))
+
+	rec := httptest.NewRecorder()
+	host.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	page := rec.Body.String()
+
+	assertContains(t, page, `<meta name="twitter:card" content="summary_large_image">`)
+	assertContains(t, page, `<meta name="twitter:title" content="My Site">`)
+	assertContains(t, page, `<meta name="twitter:description" content="Best site">`)
+	assertContains(t, page, `<meta name="twitter:image" content="https://example.com/card.png">`)
+}
+
+func TestWithCanonicalURL(t *testing.T) {
+	application := app.NewApp("CanonicalTest")
+	application.SetDefaultLayout(app.NewLayout("main"))
+	application.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+
+	host := New(application, WithCanonicalURL("https://example.com/page"))
+
+	rec := httptest.NewRecorder()
+	host.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	page := rec.Body.String()
+
+	assertContains(t, page, `<link rel="canonical" href="https://example.com/page">`)
+}
+
+func TestWithPreconnect(t *testing.T) {
+	application := app.NewApp("PreconnectTest")
+	application.SetDefaultLayout(app.NewLayout("main"))
+	application.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+
+	host := New(application, WithPreconnect("https://fonts.googleapis.com", "https://fonts.gstatic.com"))
+
+	rec := httptest.NewRecorder()
+	host.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	page := rec.Body.String()
+
+	assertContains(t, page, `<link rel="preconnect" href="https://fonts.googleapis.com">`)
+	assertContains(t, page, `<link rel="preconnect" href="https://fonts.gstatic.com">`)
+}
+
+// ---------------------------------------------------------------------------
+// C. Per-screen SEOScreen interface
+// ---------------------------------------------------------------------------
+
+func TestSEOScreenOverride(t *testing.T) {
+	application := app.NewApp("SEOTest")
+	application.SetDefaultLayout(app.NewLayout("main"))
+
+	seoComp := &seoTestComp{
+		headHTML: `<meta name="description" content="Per-screen SEO"><meta property="og:title" content="Custom OG Title">`,
+	}
+	application.RegisterScreen(app.NewScreen("/about", seoComp).WithTitle("About"), nil)
+
+	host := New(application)
+
+	rec := httptest.NewRecorder()
+	host.ServeHTTP(rec, httptest.NewRequest("GET", "/about", nil))
+	page := rec.Body.String()
+
+	assertContains(t, page, `<meta name="description" content="Per-screen SEO">`)
+	assertContains(t, page, `<meta property="og:title" content="Custom OG Title">`)
+}
+
+func TestSEOScreenPlusGlobalHead(t *testing.T) {
+	// Both global (WithHeadHTML) and per-screen head should appear
+	application := app.NewApp("CombinedTest")
+	application.SetDefaultLayout(app.NewLayout("main"))
+
+	seoComp := &seoTestComp{
+		headHTML: `<meta property="og:title" content="Screen OG">`,
+	}
+	application.RegisterScreen(app.NewScreen("/about", seoComp).WithTitle("About"), nil)
+	application.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+
+	host := New(application,
+		WithFavicon("/favicon.ico"),
+	)
+
+	// About page: global favicon + per-screen OG
+	rec := httptest.NewRecorder()
+	host.ServeHTTP(rec, httptest.NewRequest("GET", "/about", nil))
+	page := rec.Body.String()
+
+	assertContains(t, page, `<link rel="icon" href="/favicon.ico">`)     // global
+	assertContains(t, page, `<meta property="og:title" content="Screen OG">`) // per-screen
+
+	// Home page: global favicon, NO per-screen OG
+	rec2 := httptest.NewRecorder()
+	host.ServeHTTP(rec2, httptest.NewRequest("GET", "/", nil))
+	page2 := rec2.Body.String()
+
+	assertContains(t, page2, `<link rel="icon" href="/favicon.ico">`)
+	assertNotContains(t, page2, `Screen OG`)
+}
+
+func TestSEOScreenNoOverride(t *testing.T) {
+	// Screen that doesn't implement SEOScreen should work fine
+	application := app.NewApp("NoSEOTest")
+	application.SetDefaultLayout(app.NewLayout("main"))
+	application.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+
+	host := New(application, WithFavicon("/favicon.ico"))
+
+	rec := httptest.NewRecorder()
+	host.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	page := rec.Body.String()
+
+	assertContains(t, page, `<link rel="icon" href="/favicon.ico">`)
+	// No crash, no extra head content
+	assertNotContains(t, page, `og:title`)
+}
+
+// ---------------------------------------------------------------------------
+// D. All typed helpers combined
+// ---------------------------------------------------------------------------
+
+func TestAllTypedHelpersCombined(t *testing.T) {
+	application := app.NewApp("AllHelpers")
+	application.SetDefaultLayout(app.NewLayout("main"))
+	application.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+
+	host := New(application,
+		WithFavicon("/favicon.ico"),
+		WithThemeColor("#0f0"),
+		WithDescription("All helpers test"),
+		WithOpenGraph(OG{Title: "OG Title", URL: "https://example.com"}),
+		WithTwitterCard(TwitterCard{Card: "summary", Title: "Twitter Title"}),
+		WithCanonicalURL("https://example.com/"),
+		WithPreconnect("https://cdn.example.com"),
+	)
+
+	rec := httptest.NewRecorder()
+	host.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	page := rec.Body.String()
+
+	// All tags should be present in <head>
+	for _, want := range []string{
+		`<link rel="icon" href="/favicon.ico">`,
+		`<meta name="theme-color" content="#0f0">`,
+		`<meta name="description" content="All helpers test">`,
+		`<meta property="og:title" content="OG Title">`,
+		`<meta name="twitter:card" content="summary">`,
+		`<link rel="canonical" href="https://example.com/">`,
+		`<link rel="preconnect" href="https://cdn.example.com">`,
+	} {
+		assertContains(t, page, want)
+	}
+
+	// Everything before </head>
+	headClose := strings.Index(page, "</head>")
+	for _, want := range []string{
+		`<link rel="icon"`,
+		`<meta name="theme-color"`,
+		`<meta property="og:title"`,
+		`<link rel="canonical"`,
+	} {
+		at := strings.Index(page, want)
+		if at >= headClose {
+			t.Errorf("%q found after </head> (at=%d, headClose=%d)", want, at, headClose)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// E. HTML escaping / injection safety
+// ---------------------------------------------------------------------------
+
+func TestTypedHelpersEscapeAttrs(t *testing.T) {
+	// Ensure typed helpers escape user-provided values
+	application := app.NewApp("EscapeTest")
+	application.SetDefaultLayout(app.NewLayout("main"))
+	application.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+
+	host := New(application, WithDescription(`<script>alert("xss")</script>`))
+
+	rec := httptest.NewRecorder()
+	host.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	page := rec.Body.String()
+
+	// The raw <script> tag must NOT appear in output — it must be escaped
+	assertNotContains(t, page, `<script>alert("xss")</script>`)
+	// The escaped form should be in the content attribute
+	assertContains(t, page, `&lt;script&gt;`)
+}
+
+// ---------------------------------------------------------------------------
+// F. Static export (RenderStaticPage) includes head tags
+// ---------------------------------------------------------------------------
+
+func TestRenderStaticPageIncludesHeadTags(t *testing.T) {
+	application := app.NewApp("StaticHeadTest")
+	application.SetDefaultLayout(app.NewLayout("main"))
+	application.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+
+	host := New(application,
+		WithFavicon("/favicon.ico"),
+		WithDescription("Static export head tags"),
+	)
+
+	ctx := context.Background()
+	page, err := host.RenderStaticPage(ctx, "/")
+	if err != nil {
+		t.Fatalf("RenderStaticPage: %v", err)
+	}
+
+	assertContains(t, page, `<link rel="icon" href="/favicon.ico">`)
+	assertContains(t, page, `<meta name="description" content="Static export head tags">`)
+	// No SSE meta in static output
+	assertNotContains(t, page, `data-sse`)
+}

--- a/framework/uihost/uihost.go
+++ b/framework/uihost/uihost.go
@@ -9,9 +9,9 @@ import (
 	cryptorand "crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
-	stdhtml "html"
 	"encoding/json"
 	"fmt"
+	stdhtml "html"
 	"io/fs"
 	"net/http"
 	"os"
@@ -31,6 +31,26 @@ import (
 	"github.com/DonaldMurillo/gofastr/core/router"
 )
 
+// OG holds Open Graph meta tag values for social sharing.
+// Zero-value fields are omitted from output.
+type OG struct {
+	Title       string
+	Description string
+	Image       string
+	URL         string
+	Type        string
+}
+
+// TwitterCard holds Twitter Card meta tag values.
+// Zero-value fields are omitted from output.
+type TwitterCard struct {
+	Card        string // e.g. "summary", "summary_large_image"
+	Title       string
+	Description string
+	Image       string
+	Site        string // @username
+}
+
 // UIHost mounts a core-ui application onto a router. It serves rendered
 // pages with runtime.js, compiled action JS, SSE streaming for islands,
 // sessions, and signal-driven live updates. The framework.App is
@@ -48,6 +68,8 @@ type UIHost struct {
 	staticFS       fs.FS                                // embedded filesystem for static files
 	routeGraph     *style.RouteGraph                    // route graph for progressive CSS loading
 	signals        map[string]SignalAny                 // signalID → signal for live updates
+	headHTML       string                               // raw HTML to inject into <head> (escape hatch)
+	headTags       []string                             // typed head tags built from convenience options
 
 	// standalone is a private router lazily mounted on first ServeHTTP call,
 	// so the host can satisfy http.Handler when it is used outside a
@@ -67,6 +89,19 @@ type SignalAny interface {
 	GetAsInterface() interface{}
 	UpdateAsInterface(v interface{})
 	Subscribe() <-chan struct{}
+}
+
+// SEOScreen is an optional interface that screens can implement to
+// inject per-screen HTML into <head>. This enables per-page SEO:
+// Open Graph tags, description meta, structured data, etc. The
+// returned HTML is injected alongside any global head tags from
+// WithHeadHTML / WithFavicon / etc.
+//
+// WARNING: the returned HTML is injected verbatim. Implementers must
+// escape any dynamic content (e.g. html.EscapeString for user-supplied
+// titles or descriptions) to prevent XSS.
+type SEOScreen interface {
+	HeadHTML() string
 }
 
 // routeInfoJSON is the JSON shape sent to the browser as __gofastr_routes.
@@ -101,6 +136,100 @@ func WithExtraScripts(urls ...string) Option {
 func WithRouteGraph(rg *style.RouteGraph) Option {
 	return func(ds *UIHost) {
 		ds.routeGraph = rg
+	}
+}
+
+// WithHeadHTML injects raw HTML into every page's <head>. This is the
+// escape hatch for arbitrary head content. The HTML is injected verbatim
+// — callers must ensure it is CSP-compatible (no inline <script> or
+// <style> tags). For safe, auto-escaped alternatives, see WithFavicon,
+// WithThemeColor, WithDescription, WithOpenGraph, WithTwitterCard,
+// WithCanonicalURL, and WithPreconnect.
+func WithHeadHTML(html string) Option {
+	return func(ds *UIHost) {
+		ds.headHTML = html
+	}
+}
+
+// WithFavicon adds a <link rel="icon"> tag to <head>.
+func WithFavicon(href string) Option {
+	return func(ds *UIHost) {
+		ds.headTags = append(ds.headTags, fmt.Sprintf(`<link rel="icon" href="%s">`, stdhtml.EscapeString(href)))
+	}
+}
+
+// WithThemeColor adds a <meta name="theme-color"> tag to <head>.
+func WithThemeColor(color string) Option {
+	return func(ds *UIHost) {
+		ds.headTags = append(ds.headTags, fmt.Sprintf(`<meta name="theme-color" content="%s">`, stdhtml.EscapeString(color)))
+	}
+}
+
+// WithDescription adds a <meta name="description"> tag to <head>.
+func WithDescription(desc string) Option {
+	return func(ds *UIHost) {
+		ds.headTags = append(ds.headTags, fmt.Sprintf(`<meta name="description" content="%s">`, stdhtml.EscapeString(desc)))
+	}
+}
+
+// WithOpenGraph adds Open Graph <meta property="og:..."> tags to <head>.
+// Zero-value fields are omitted.
+func WithOpenGraph(og OG) Option {
+	return func(ds *UIHost) {
+		if og.Title != "" {
+			ds.headTags = append(ds.headTags, fmt.Sprintf(`<meta property="og:title" content="%s">`, stdhtml.EscapeString(og.Title)))
+		}
+		if og.Description != "" {
+			ds.headTags = append(ds.headTags, fmt.Sprintf(`<meta property="og:description" content="%s">`, stdhtml.EscapeString(og.Description)))
+		}
+		if og.Image != "" {
+			ds.headTags = append(ds.headTags, fmt.Sprintf(`<meta property="og:image" content="%s">`, stdhtml.EscapeString(og.Image)))
+		}
+		if og.URL != "" {
+			ds.headTags = append(ds.headTags, fmt.Sprintf(`<meta property="og:url" content="%s">`, stdhtml.EscapeString(og.URL)))
+		}
+		if og.Type != "" {
+			ds.headTags = append(ds.headTags, fmt.Sprintf(`<meta property="og:type" content="%s">`, stdhtml.EscapeString(og.Type)))
+		}
+	}
+}
+
+// WithTwitterCard adds Twitter Card <meta name="twitter:..."> tags to <head>.
+// Zero-value fields are omitted.
+func WithTwitterCard(tc TwitterCard) Option {
+	return func(ds *UIHost) {
+		if tc.Card != "" {
+			ds.headTags = append(ds.headTags, fmt.Sprintf(`<meta name="twitter:card" content="%s">`, stdhtml.EscapeString(tc.Card)))
+		}
+		if tc.Title != "" {
+			ds.headTags = append(ds.headTags, fmt.Sprintf(`<meta name="twitter:title" content="%s">`, stdhtml.EscapeString(tc.Title)))
+		}
+		if tc.Description != "" {
+			ds.headTags = append(ds.headTags, fmt.Sprintf(`<meta name="twitter:description" content="%s">`, stdhtml.EscapeString(tc.Description)))
+		}
+		if tc.Image != "" {
+			ds.headTags = append(ds.headTags, fmt.Sprintf(`<meta name="twitter:image" content="%s">`, stdhtml.EscapeString(tc.Image)))
+		}
+		if tc.Site != "" {
+			ds.headTags = append(ds.headTags, fmt.Sprintf(`<meta name="twitter:site" content="%s">`, stdhtml.EscapeString(tc.Site)))
+		}
+	}
+}
+
+// WithCanonicalURL adds a <link rel="canonical"> tag to <head>.
+func WithCanonicalURL(url string) Option {
+	return func(ds *UIHost) {
+		ds.headTags = append(ds.headTags, fmt.Sprintf(`<link rel="canonical" href="%s">`, stdhtml.EscapeString(url)))
+	}
+}
+
+// WithPreconnect adds <link rel="preconnect"> tags for the given origins.
+// Use for early DNS/TCP/TLS connections to external resources (fonts, CDNs).
+func WithPreconnect(origins ...string) Option {
+	return func(ds *UIHost) {
+		for _, o := range origins {
+			ds.headTags = append(ds.headTags, fmt.Sprintf(`<link rel="preconnect" href="%s">`, stdhtml.EscapeString(o)))
+		}
 	}
 }
 
@@ -507,30 +636,40 @@ func (ds *UIHost) handlePage(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	page := ds.injectChrome(string(html), sessionID)
+	page := ds.injectChrome(string(html), path, sessionID)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprint(w, page)
 }
 
 // injectChrome adds links and scripts pointing at the host's served
-// endpoints. Everything stays as external resources — no inline <style>
-// or inline <script> — so the default strict Content-Security-Policy
-// (default-src 'self') works without 'unsafe-inline'.
-//
-// When sessionID is non-empty, an SSE meta tag pointing at this session
-// is injected too. SSG output passes "" for sessionID — the client will
-// lazily create a session on first interaction if it ever needs one.
-func (ds *UIHost) injectChrome(page, sessionID string) string {
-	return ds.injectChromeMode(page, sessionID, true)
+// endpoints. pagePath is the route path used for SEOScreen resolution.
+func (ds *UIHost) injectChrome(page, pagePath, sessionID string) string {
+	return ds.injectChromeMode(page, pagePath, sessionID, true)
+}
+
+// screenHeadHTML returns per-screen head content from the SEOScreen
+// interface. pagePath is the route path used to resolve the screen.
+func (ds *UIHost) screenHeadHTML(pagePath string) string {
+	if ds.App == nil || pagePath == "" {
+		return ""
+	}
+	screen, _, ok := ds.App.Router.Resolve(pagePath)
+	if !ok {
+		return ""
+	}
+	if seo, ok := screen.Component.(SEOScreen); ok {
+		return seo.HeadHTML()
+	}
+	return ""
 }
 
 // injectChromeMode is the underlying chrome injector. bundle=false
 // suppresses the comp-bundle.css endpoint and emits one <link> per
 // component instead — used by static export, since static hosts
 // don't typically serve query-parameterized files. Live HTTP mode
-// always passes bundle=true.
-func (ds *UIHost) injectChromeMode(page, sessionID string, bundle bool) string {
+// always passes bundle=true. pagePath is used for SEOScreen resolution.
+func (ds *UIHost) injectChromeMode(page, pagePath, sessionID string, bundle bool) string {
 	// <head>
 	if sessionID != "" {
 		sseMeta := fmt.Sprintf(`<meta name="gofastr-sse" content="/__gofastr/sse?session=%s">`, sessionID)
@@ -544,6 +683,23 @@ func (ds *UIHost) injectChromeMode(page, sessionID string, bundle bool) string {
 		page = strings.Replace(page,
 			"</head>",
 			`<link rel="stylesheet" href="/__gofastr/app.css">`+"\n</head>", 1)
+	}
+
+	// Head injection: global typed tags + raw HTML + per-screen SEOScreen.
+	// Order: typed helpers → WithHeadHTML → SEOScreen. Typed helpers are
+	// set at New() time; SEOScreen is per-request.
+	var headParts []string
+	for _, tag := range ds.headTags {
+		headParts = append(headParts, tag)
+	}
+	if ds.headHTML != "" {
+		headParts = append(headParts, ds.headHTML)
+	}
+	if screenHead := ds.screenHeadHTML(pagePath); screenHead != "" {
+		headParts = append(headParts, screenHead)
+	}
+	if len(headParts) > 0 {
+		page = strings.Replace(page, "</head>", strings.Join(headParts, "\n")+"\n</head>", 1)
 	}
 	// Route graph + component catalog ship as inline JSON in
 	// <script type="application/json"> blocks — the browser treats
@@ -957,7 +1113,7 @@ func (ds *UIHost) RenderStaticPage(ctx context.Context, path string) (string, er
 	// bundle=false: static hosts don't serve query-paramed files, so
 	// emit one <link rel=stylesheet> per registered component instead
 	// of the comp-bundle.css?names= form.
-	return ds.injectChromeMode(string(html), "", false), nil
+	return ds.injectChromeMode(string(html), path, "", false), nil
 }
 
 // actionsToJS converts an ActionRegistry to browser-runnable JavaScript


### PR DESCRIPTION
Closes #5

## Summary

- **Escape hatch**: `WithHeadHTML(string)` — raw HTML into `<head>`, documented as CSP-bypassing
- **Typed helpers**: `WithFavicon`, `WithThemeColor`, `WithDescription`, `WithOpenGraph`, `WithTwitterCard`, `WithCanonicalURL`, `WithPreconnect` — all auto-escape values via `html.EscapeString`
- **Per-screen SEOScreen**: optional interface with `HeadHTML() string` for page-specific SEO override
- Head injection works in both live HTTP mode and `RenderStaticPage` (static export)

## Changes

| File | Description |
|------|-------------|
| `framework/uihost/uihost.go` | +170 lines: OG/TwitterCard types, 8 option constructors, SEOScreen interface, head injection in `injectChromeMode`, security docs |
| `framework/uihost/head_test.go` | +360 lines: 15 tests covering all three tiers |

## Quality

- **TDD**: 15 tests written and verified RED before implementation
- **Adversarial reviews**: 3 subagent reviews (correctness, security/perf, architecture) — all approved
- **Review feedback addressed**: import ordering, CSP warnings on raw HTML paths, RenderStaticPage test, test rename
- **All existing tests pass** — no regressions

## Test Plan

- [x] All 15 new head injection tests pass
- [x] Typed helpers properly escape via `html.EscapeString`
- [x] `WithHeadHTML` injects raw HTML with CSP warning docs
- [x] SEOScreen per-page content merges with global head options
- [x] Non-SEOScreen screens render without errors
- [x] `RenderStaticPage` includes head tags
- [x] Full suite (`go test ./core-ui/... ./framework/... ./cmd/...`) green