### PR TITLE
feat: add worktree isolation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ go run ./cmd/gofastr -- help         # CLI overview
 go run ./examples/blog               # minimal blog with auto-CRUD on SQLite
 ```
 
+Linked Git worktrees automatically get isolated local ports and database
+paths when isolation is enabled in `gofastr.yml`; see
+[`docs/isolation.md`](docs/isolation.md).
+
 Open <http://localhost:8080>, then try:
 
 ```bash

--- a/cmd/gofastr/blueprint.go
+++ b/cmd/gofastr/blueprint.go
@@ -200,7 +200,7 @@ func decodeBlueprint(node *coreyaml.Node) (Blueprint, error) {
 	if err != nil {
 		return Blueprint{}, err
 	}
-	allowed := map[string]bool{"app": true, "entities": true, "screens": true, "endpoints": true, "middleware": true, "plugins": true, "helpers": true}
+	allowed := map[string]bool{"app": true, "entities": true, "screens": true, "endpoints": true, "middleware": true, "plugins": true, "helpers": true, "isolation": true}
 	if err := rejectUnknownKeys(m, allowed, "blueprint"); err != nil {
 		return Blueprint{}, err
 	}
@@ -1077,9 +1077,10 @@ func renderBlueprintMain(bp Blueprint) string {
 	sb.WriteString("\t\"os\"\n\n")
 	sb.WriteString("\tuiapp \"github.com/DonaldMurillo/gofastr/core-ui/app\"\n")
 	sb.WriteString("\t\"github.com/DonaldMurillo/gofastr/framework\"\n")
+	sb.WriteString("\t\"github.com/DonaldMurillo/gofastr/framework/isolation\"\n")
 	sb.WriteString("\t\"github.com/DonaldMurillo/gofastr/framework/uihost\"\n")
-	if driver != "" && blueprintNeedsSQLiteDriver(driver) {
-		sb.WriteString("\t_ \"github.com/mattn/go-sqlite3\"\n")
+	if imp := blueprintDriverImport(driver); imp != "" {
+		sb.WriteString(fmt.Sprintf("\t_ %q\n", imp))
 	}
 	sb.WriteString("\n")
 	sb.WriteString(fmt.Sprintf("\t%q\n", baseImport+"/blueprint"))
@@ -1089,7 +1090,9 @@ func renderBlueprintMain(bp Blueprint) string {
 	sb.WriteString(")\n\n")
 
 	sb.WriteString("func main() {\n")
-	sb.WriteString("\tdb, err := openBlueprintDB()\n")
+	sb.WriteString("\truntimeIsolation, err := isolation.Resolve(\".\")\n")
+	sb.WriteString("\tif err != nil {\n\t\tlog.Fatal(err)\n\t}\n")
+	sb.WriteString("\tdb, err := openBlueprintDB(runtimeIsolation)\n")
 	sb.WriteString("\tif err != nil {\n\t\tlog.Fatal(err)\n\t}\n")
 	sb.WriteString("\tif db != nil {\n\t\tdefer db.Close()\n\t}\n\n")
 	sb.WriteString("\toptions := []framework.AppOption{framework.WithConfig(framework.AppConfig{Name: blueprint.BlueprintAppName})}\n")
@@ -1106,20 +1109,25 @@ func renderBlueprintMain(bp Blueprint) string {
 	} else {
 		sb.WriteString("\tfwApp.Mount(uihost.New(site))\n")
 	}
-	sb.WriteString("\taddr := getEnv(\"PORT\", \"localhost:8080\")\n")
+	sb.WriteString("\taddr, err := runtimeIsolation.Addr(getEnv(\"PORT\", \"localhost:8080\"))\n")
+	sb.WriteString("\tif err != nil {\n\t\tlog.Fatal(err)\n\t}\n")
 	sb.WriteString("\tfmt.Printf(\"Server starting at http://%s\\n\", addr)\n")
 	sb.WriteString("\tif err := fwApp.Start(addr); err != nil && err != http.ErrServerClosed {\n\t\tlog.Fatal(err)\n\t}\n")
 	sb.WriteString("}\n\n")
 
-	sb.WriteString("func openBlueprintDB() (*sql.DB, error) {\n")
+	sb.WriteString("func openBlueprintDB(runtimeIsolation isolation.Runtime) (*sql.DB, error) {\n")
 	if driver == "" && dbURL == "" {
 		sb.WriteString("\treturn nil, nil\n")
 	} else {
 		sb.WriteString(fmt.Sprintf("\tdriver := getEnv(\"DB_DRIVER\", %q)\n", driver))
 		sb.WriteString(fmt.Sprintf("\tdsn := getEnv(\"DATABASE_URL\", %q)\n", dbURL))
+		sb.WriteString("\tresolvedDriver, resolvedDSN, err := runtimeIsolation.Database(driver, dsn)\n")
+		sb.WriteString("\tif err != nil {\n\t\treturn nil, err\n\t}\n")
+		sb.WriteString("\tdriver, dsn = resolvedDriver, resolvedDSN\n")
 		sb.WriteString("\tswitch driver {\n")
 		sb.WriteString("\tcase \"\", \"none\":\n\t\treturn nil, nil\n")
 		sb.WriteString("\tcase \"sqlite\", \"sqlite3\":\n\t\treturn sql.Open(\"sqlite3\", dsn)\n")
+		sb.WriteString("\tcase \"postgres\", \"postgresql\":\n\t\treturn sql.Open(\"postgres\", dsn)\n")
 		sb.WriteString("\tdefault:\n\t\treturn nil, fmt.Errorf(\"unsupported blueprint db driver %q\", driver)\n")
 		sb.WriteString("\t}\n")
 	}
@@ -1131,12 +1139,14 @@ func renderBlueprintMain(bp Blueprint) string {
 	return sb.String()
 }
 
-func blueprintNeedsSQLiteDriver(driver string) bool {
+func blueprintDriverImport(driver string) string {
 	switch strings.ToLower(strings.TrimSpace(driver)) {
 	case "", "sqlite", "sqlite3":
-		return true
+		return "github.com/mattn/go-sqlite3"
+	case "postgres", "postgresql":
+		return "github.com/lib/pq"
 	default:
-		return false
+		return ""
 	}
 }
 

--- a/cmd/gofastr/blueprint.go
+++ b/cmd/gofastr/blueprint.go
@@ -1115,7 +1115,7 @@ func renderBlueprintMain(bp Blueprint) string {
 	sb.WriteString("\tif err := fwApp.Start(addr); err != nil && err != http.ErrServerClosed {\n\t\tlog.Fatal(err)\n\t}\n")
 	sb.WriteString("}\n\n")
 
-	sb.WriteString("func openBlueprintDB(runtimeIsolation isolation.Runtime) (*sql.DB, error) {\n")
+	sb.WriteString("func openBlueprintDB(runtimeIsolation *isolation.Runtime) (*sql.DB, error) {\n")
 	if driver == "" && dbURL == "" {
 		sb.WriteString("\treturn nil, nil\n")
 	} else {

--- a/cmd/gofastr/blueprint_test.go
+++ b/cmd/gofastr/blueprint_test.go
@@ -678,6 +678,10 @@ func TestRenderBlueprintFilesContentCoversAllSections(t *testing.T) {
 	assertContains(t, byName["main.go"], `blueprint.RegisterGenerated(fwApp, site)`)
 	assertContains(t, byName["main.go"], `fwApp.Router().Handle("POST", "/mcp", fwApp.MCP)`)
 	assertContains(t, byName["main.go"], `uihost.WithStaticDir("public")`)
+	assertContains(t, byName["main.go"], `"github.com/DonaldMurillo/gofastr/framework/isolation"`)
+	assertContains(t, byName["main.go"], `runtimeIsolation, err := isolation.Resolve(".")`)
+	assertContains(t, byName["main.go"], `runtimeIsolation.Database(driver, dsn)`)
+	assertContains(t, byName["main.go"], `runtimeIsolation.Addr(getEnv("PORT", "localhost:8080"))`)
 }
 
 func TestGenerateFromBlueprintDryRunJSON(t *testing.T) {

--- a/cmd/gofastr/dev.go
+++ b/cmd/gofastr/dev.go
@@ -104,20 +104,20 @@ func runDev(args []string) {
 	}
 }
 
-func resolveDevIsolation(dir, addr string) (isolation.Runtime, string, error) {
+func resolveDevIsolation(dir, addr string) (*isolation.Runtime, string, error) {
 	runtimeIsolation, err := isolation.Resolve(dir)
 	if err != nil {
-		return isolation.Runtime{}, "", err
+		return nil, "", err
 	}
 	resolvedAddr, err := runtimeIsolation.Addr(addr)
 	if err != nil {
-		return isolation.Runtime{}, "", err
+		return nil, "", err
 	}
 	return runtimeIsolation, resolvedAddr, nil
 }
 
 // buildAndServe builds and starts the server process.
-func buildAndServe(dir, addr string, runtimeIsolation isolation.Runtime, mu *sync.Mutex, cmd **exec.Cmd) bool {
+func buildAndServe(dir, addr string, runtimeIsolation *isolation.Runtime, mu *sync.Mutex, cmd **exec.Cmd) bool {
 	// Build binary to temp file
 	tmpName := "gofastr-dev-server"
 	if runtimeIsolation.Active() {

--- a/cmd/gofastr/dev.go
+++ b/cmd/gofastr/dev.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/DonaldMurillo/gofastr/framework/isolation"
 )
 
 func runDev(args []string) {
@@ -26,9 +28,19 @@ func runDev(args []string) {
 		}
 	}
 
+	runtimeIsolation, resolvedAddr, err := resolveDevIsolation(dir, addr)
+	if err != nil {
+		fail("Isolation failed: %v", err)
+		os.Exit(1)
+	}
+
 	fmt.Printf("\n  %s Dev server with hot reload\n\n", bold("GoFastr"))
 	info("Watching %s for *.go changes...", dir)
-	info("Server at http://%s", addr)
+	if runtimeIsolation.Active() && resolvedAddr != addr {
+		info("Isolation %s remapped http://%s -> http://%s", runtimeIsolation.ID(), addr, resolvedAddr)
+	} else {
+		info("Server at http://%s", resolvedAddr)
+	}
 	fmt.Println()
 
 	var (
@@ -42,7 +54,7 @@ func runDev(args []string) {
 	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)
 
 	// Build and start the server initially
-	if !buildAndServe(dir, addr, &mu, &server) {
+	if !buildAndServe(dir, resolvedAddr, runtimeIsolation, &mu, &server) {
 		fail("Initial build failed — fixing and saving will retry")
 	}
 
@@ -83,7 +95,7 @@ func runDev(args []string) {
 			fmt.Println()
 			info("Change detected — rebuilding...")
 			killServer(&mu, &server)
-			if buildAndServe(dir, addr, &mu, &server) {
+			if buildAndServe(dir, resolvedAddr, runtimeIsolation, &mu, &server) {
 				success("Reloaded!")
 			} else {
 				fail("Build failed — fixing and saving will retry")
@@ -92,10 +104,26 @@ func runDev(args []string) {
 	}
 }
 
+func resolveDevIsolation(dir, addr string) (isolation.Runtime, string, error) {
+	runtimeIsolation, err := isolation.Resolve(dir)
+	if err != nil {
+		return isolation.Runtime{}, "", err
+	}
+	resolvedAddr, err := runtimeIsolation.Addr(addr)
+	if err != nil {
+		return isolation.Runtime{}, "", err
+	}
+	return runtimeIsolation, resolvedAddr, nil
+}
+
 // buildAndServe builds and starts the server process.
-func buildAndServe(dir, addr string, mu *sync.Mutex, cmd **exec.Cmd) bool {
+func buildAndServe(dir, addr string, runtimeIsolation isolation.Runtime, mu *sync.Mutex, cmd **exec.Cmd) bool {
 	// Build binary to temp file
-	tmpBin := filepath.Join(os.TempDir(), "gofastr-dev-server")
+	tmpName := "gofastr-dev-server"
+	if runtimeIsolation.Active() {
+		tmpName += "-" + runtimeIsolation.ID()
+	}
+	tmpBin := filepath.Join(os.TempDir(), tmpName)
 	buildCmd := exec.Command("go", "build", "-o", tmpBin, dir)
 	buildCmd.Stdout = os.Stdout
 	buildCmd.Stderr = os.Stderr
@@ -112,6 +140,7 @@ func buildAndServe(dir, addr string, mu *sync.Mutex, cmd **exec.Cmd) bool {
 	runCmd := exec.Command(tmpBin, "--addr", addr)
 	runCmd.Stdout = os.Stdout
 	runCmd.Stderr = os.Stderr
+	runCmd.Env = runtimeIsolation.Env(os.Environ())
 
 	mu.Lock()
 	*cmd = runCmd

--- a/cmd/gofastr/dev_test.go
+++ b/cmd/gofastr/dev_test.go
@@ -78,6 +78,37 @@ func TestInitGeneratedMainUsesIsolationHelpers(t *testing.T) {
 	}
 }
 
+// The generated gofastr.yml must not advertise strategy values that the
+// isolation resolver doesn't consult — a reader who edits "strategy: path"
+// to "strategy: foo" expects to see behavior change, and nothing happens.
+// Drop the decorative field rather than mislead.
+func TestInitIsolationConfigOmitsDecorativeStrategy(t *testing.T) {
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	if err := os.Mkdir("demo", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeIsolationConfig("demo", "sqlite")
+	data, err := os.ReadFile(filepath.Join("demo", "gofastr.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	for _, bad := range []string{"strategy: path", "strategy: offset"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("generated yml advertises unrecognized %q:\n%s", bad, got)
+		}
+	}
+}
+
 func writeDevFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/cmd/gofastr/dev_test.go
+++ b/cmd/gofastr/dev_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveDevIsolationRemapsAddrAndChildEnv(t *testing.T) {
+	for _, key := range []string{
+		"GOFASTR_ISOLATION",
+		"GOFASTR_ISOLATION_APPLIED",
+		"GOFASTR_ISOLATION_ID",
+		"GOFASTR_ISOLATION_PORT_8080",
+	} {
+		t.Setenv(key, "")
+	}
+	dir := t.TempDir()
+	writeDevFile(t, filepath.Join(dir, ".git"), "gitdir: "+filepath.Join(t.TempDir(), ".git", "worktrees", "feature")+"\n")
+	writeDevFile(t, filepath.Join(dir, "gofastr.yml"), `
+isolation:
+  enabled: true
+  port:
+    offset: 1000
+    range: 1
+    scan: 0
+`)
+
+	rt, addr, err := resolveDevIsolation(dir, "localhost:8080")
+	if err != nil {
+		t.Fatalf("resolveDevIsolation: %v", err)
+	}
+	if !rt.Active() {
+		t.Fatal("expected dev isolation to be active")
+	}
+	if addr != "localhost:9080" {
+		t.Fatalf("addr = %q, want localhost:9080", addr)
+	}
+	env := devEnvMap(rt.Env([]string{"PORT=localhost:8080"}))
+	if env["PORT"] != "localhost:9080" {
+		t.Fatalf("child PORT = %q, want localhost:9080", env["PORT"])
+	}
+	if env["GOFASTR_ISOLATION_APPLIED"] != "1" || env["GOFASTR_ISOLATION_PORT_8080"] != "9080" {
+		t.Fatalf("child env missing isolation markers: %#v", env)
+	}
+}
+
+func TestInitGeneratedMainUsesIsolationHelpers(t *testing.T) {
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	if err := os.Mkdir("demo", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeMainGo("demo", "example.com/demo", false, "sqlite", "file:demo.db")
+	data, err := os.ReadFile(filepath.Join("demo", "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	for _, want := range []string{
+		`"github.com/DonaldMurillo/gofastr/framework/isolation"`,
+		`runtimeIsolation, err := isolation.Resolve(".")`,
+		`runtimeIsolation.Database("sqlite3", getEnv("DATABASE_URL", "file:demo.db"))`,
+		`runtimeIsolation.Addr(getEnv("PORT", "localhost:8080"))`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated main.go missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func writeDevFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func devEnvMap(env []string) map[string]string {
+	out := map[string]string{}
+	for _, pair := range env {
+		for i := 0; i < len(pair); i++ {
+			if pair[i] == '=' {
+				out[pair[:i]] = pair[i+1:]
+				break
+			}
+		}
+	}
+	return out
+}

--- a/cmd/gofastr/init.go
+++ b/cmd/gofastr/init.go
@@ -336,25 +336,21 @@ func getEnv(key, fallback string) string {
 	}
 }
 
-func writeIsolationConfig(name, dbDriver string) {
-	databaseStrategy := "path"
-	if dbDriver == "postgres" {
-		databaseStrategy = "suffix"
-	}
-	content := fmt.Sprintf(`version: 1
+func writeIsolationConfig(name, _ string) {
+	// strategy: fields are intentionally omitted — the resolver currently
+	// dispatches by driver, not by strategy name. Re-introduce them only
+	// when they actually toggle behavior.
+	content := `version: 1
 isolation:
   enabled: true
   mode: worktree
   port:
-    strategy: offset
     offset: 1000
     range: 1000
     scan: 20
-  database:
-    strategy: %s
   services:
   env:
-`, databaseStrategy)
+`
 	if err := os.WriteFile(filepath.Join(name, "gofastr.yml"), []byte(content), 0o644); err != nil {
 		fail("Failed to write gofastr.yml: %v", err)
 		os.Exit(1)

--- a/cmd/gofastr/init.go
+++ b/cmd/gofastr/init.go
@@ -66,8 +66,6 @@ func runInit(args []string) {
 			}
 		}
 	}
-	_ = dbDriver
-
 	fmt.Printf("\n  Creating %s project %s...\n\n", bold("GoFastr"), bold(name))
 
 	// Create directory structure
@@ -91,7 +89,7 @@ func runInit(args []string) {
 	}
 
 	// Write main.go
-	writeMainGo(name, modulePath, noEntity)
+	writeMainGo(name, modulePath, noEntity, dbDriver, dbURL)
 
 	// Write screens/home.go
 	writeHomeScreen(name, noEntity)
@@ -120,6 +118,8 @@ PORT=localhost:8080
 		fail("Failed to write .env: %v", err)
 		os.Exit(1)
 	}
+
+	writeIsolationConfig(name, dbDriver)
 
 	// Write .gitignore
 	gitignoreContent := `.gofastr/
@@ -172,6 +172,7 @@ bin/
 		fmt.Println("    entities/entities.go — Sample entity (posts) served at /posts")
 	}
 	fmt.Println("    .env                 — Environment configuration")
+	fmt.Println("    gofastr.yml          — Project configuration")
 	fmt.Println("    .gitignore           — Git ignore rules")
 	fmt.Println()
 	fmt.Printf("  %s:\n", bold("Next steps"))
@@ -191,7 +192,7 @@ bin/
 }
 
 // writeMainGo generates the application entry point.
-func writeMainGo(name, modulePath string, noEntity bool) {
+func writeMainGo(name, modulePath string, noEntity bool, dbDriver, dbURL string) {
 	var content string
 	if noEntity {
 		content = fmt.Sprintf(`package main
@@ -204,12 +205,18 @@ import (
 
 	"github.com/DonaldMurillo/gofastr/core-ui/app"
 	"github.com/DonaldMurillo/gofastr/framework"
+	"github.com/DonaldMurillo/gofastr/framework/isolation"
 	"github.com/DonaldMurillo/gofastr/framework/uihost"
 
 	"%[1]s/screens"
 )
 
 func main() {
+	runtimeIsolation, err := isolation.Resolve(".")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	fwApp := framework.NewApp(
 		framework.WithConfig(framework.AppConfig{Name: "%[2]s"}),
 	)
@@ -221,7 +228,10 @@ func main() {
 	css := screens.CreateStyleSheet()
 	fwApp.Mount(uihost.New(site, uihost.WithCustomCSS(css)))
 
-	addr := getEnv("PORT", "localhost:8080")
+	addr, err := runtimeIsolation.Addr(getEnv("PORT", "localhost:8080"))
+	if err != nil {
+		log.Fatal(err)
+	}
 	fmt.Printf("  %%s Server starting at http://%%s\n", "✓", addr)
 	if err := fwApp.Start(addr); err != nil && err != http.ErrServerClosed {
 		log.Fatal(err)
@@ -236,6 +246,14 @@ func getEnv(key, fallback string) string {
 }
 `, modulePath, name)
 	} else {
+		driverImport := `_ "github.com/mattn/go-sqlite3"`
+		migrateDialect := "migrate.DialectSQLite"
+		sqlDriver := "sqlite3"
+		if dbDriver == "postgres" {
+			driverImport = `_ "github.com/lib/pq"`
+			migrateDialect = "migrate.DialectPostgres"
+			sqlDriver = "postgres"
+		}
 		content = fmt.Sprintf(`package main
 
 import (
@@ -249,15 +267,24 @@ import (
 	"github.com/DonaldMurillo/gofastr/core-ui/app"
 	"github.com/DonaldMurillo/gofastr/core/migrate"
 	"github.com/DonaldMurillo/gofastr/framework"
+	"github.com/DonaldMurillo/gofastr/framework/isolation"
 	"github.com/DonaldMurillo/gofastr/framework/uihost"
-	_ "github.com/mattn/go-sqlite3"
+	%[3]s
 
 	"%[1]s/entities"
 	"%[1]s/screens"
 )
 
 func main() {
-	db, err := sql.Open("sqlite3", getEnv("DATABASE_URL", "file:%[2]s.db"))
+	runtimeIsolation, err := isolation.Resolve(".")
+	if err != nil {
+		log.Fatal(err)
+	}
+	driver, dsn, err := runtimeIsolation.Database("%[4]s", getEnv("DATABASE_URL", "%[5]s"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	db, err := sql.Open(driver, dsn)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -279,13 +306,16 @@ func main() {
 	fwApp.Mount(uihost.New(site, uihost.WithCustomCSS(css)))
 
 	// Run migrations
-	migrator := migrate.New(db, migrate.WithTableName("_migrations"), migrate.WithDialect(migrate.DialectSQLite))
+	migrator := migrate.New(db, migrate.WithTableName("_migrations"), migrate.WithDialect(%[6]s))
 	entities.RegisterMigrations(migrator)
 	if err := migrator.Up(context.Background()); err != nil {
 		log.Printf("Migration warning: %%v", err)
 	}
 
-	addr := getEnv("PORT", "localhost:8080")
+	addr, err := runtimeIsolation.Addr(getEnv("PORT", "localhost:8080"))
+	if err != nil {
+		log.Fatal(err)
+	}
 	fmt.Printf("  %%s Server starting at http://%%s\n", "✓", addr)
 	if err := fwApp.Start(addr); err != nil && err != http.ErrServerClosed {
 		log.Fatal(err)
@@ -298,10 +328,35 @@ func getEnv(key, fallback string) string {
 	}
 	return fallback
 }
-`, modulePath, name)
+`, modulePath, name, driverImport, sqlDriver, dbURL, migrateDialect)
 	}
 	if err := os.WriteFile(filepath.Join(name, "main.go"), []byte(content), 0o644); err != nil {
 		fail("Failed to write main.go: %v", err)
+		os.Exit(1)
+	}
+}
+
+func writeIsolationConfig(name, dbDriver string) {
+	databaseStrategy := "path"
+	if dbDriver == "postgres" {
+		databaseStrategy = "suffix"
+	}
+	content := fmt.Sprintf(`version: 1
+isolation:
+  enabled: true
+  mode: worktree
+  port:
+    strategy: offset
+    offset: 1000
+    range: 1000
+    scan: 20
+  database:
+    strategy: %s
+  services:
+  env:
+`, databaseStrategy)
+	if err := os.WriteFile(filepath.Join(name, "gofastr.yml"), []byte(content), 0o644); err != nil {
+		fail("Failed to write gofastr.yml: %v", err)
 		os.Exit(1)
 	}
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,8 @@ ending with a "common mistakes" callout.
 
 ## Operational surface
 
+- [Worktree isolation](isolation.md) — automatic local port, DB, and
+  service-env isolation for linked Git worktrees.
 - [Migrations](migrations.md) — SQL files, CLI subcommands,
   auto-migrate, dialects.
 - [Security defaults](security.md) — default middleware chain, CSP,

--- a/docs/agent-notes.md
+++ b/docs/agent-notes.md
@@ -1,5 +1,12 @@
 # Agent Notes
 
+## 2026-05-22 - worktree-isolation-mode
+
+- Scope: `framework/isolation`, `framework.App.Start`, `cmd/gofastr dev`, generated app entrypoints, `docs/isolation.md`
+- Symptom: linked Git worktrees could collide with the main checkout on `PORT`, SQLite files, Postgres database names, and service env values. Port isolation can be applied at `App.Start`, but DB/cache isolation must happen before app code opens clients.
+- Change: isolation is a first-class runtime resolver. `App.Start` remaps listen ports, `gofastr dev` passes isolated child env, and generated apps call `Runtime.Database` before `sql.Open`. Config lives under `isolation:` in `gofastr.yml`, with worktree-only activation by default and `GOFASTR_ISOLATION=off` as the process escape hatch.
+- Next time: if a new resource is opened before `App.Start`, wire it through `framework/isolation` or an env template. Do not assume the framework can rewrite an already-open connection.
+
 ## 2026-05-20 - blueprint-entity-list-e2e
 
 - Scope: `cmd/gofastr/blueprint.go`, `cmd/gofastr/blueprint_test.go`, `docs/blueprints.md`

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -1,0 +1,69 @@
+# Worktree isolation
+
+GoFastr can isolate local runtime resources for linked Git worktrees so a
+feature worktree can run beside the main checkout without port or database
+collisions.
+
+Isolation is configured in `gofastr.yml`:
+
+```yaml
+version: 1
+isolation:
+  enabled: true
+  mode: worktree
+  port:
+    strategy: offset
+    offset: 1000
+    range: 1000
+    scan: 20
+  database:
+    strategy: suffix
+  services:
+    redis: 6379
+  env:
+    REDIS_URL: "redis://localhost:{port:redis}/0"
+```
+
+With `mode: worktree`, the main checkout keeps normal resources and linked
+worktrees get deterministic replacements. `GOFASTR_ISOLATION=off` disables
+isolation for a process.
+
+## What is isolated
+
+- `framework.App.Start(addr)` remaps the requested listen port in linked
+  worktrees.
+- `gofastr dev` resolves isolation before launching the app and passes
+  isolated child env values.
+- Generated apps from `gofastr init` and blueprint output use
+  `framework/isolation` to resolve `PORT` and database DSNs.
+- SQLite DSNs move under `.gofastr/isolation/{id}/`.
+- Postgres URL database names get a stable `_{id}` suffix while query params
+  are preserved.
+- Env templates support `{id}`, `{project_dir}`, `{port}`, and
+  `{port:name}` for named services.
+
+Explicit `PORT`, `DATABASE_URL`, and configured env values are rewritten by
+default inside an isolated worktree. Set `GOFASTR_ISOLATION_REWRITE=0` to keep
+explicit env overrides untouched.
+
+## Public API
+
+Use `framework/isolation` when app code opens resources before calling
+`App.Start`:
+
+```go
+runtimeIsolation, err := isolation.Resolve(".")
+if err != nil {
+    log.Fatal(err)
+}
+
+driver, dsn, err := runtimeIsolation.Database("sqlite3", "file:app.db")
+if err != nil {
+    log.Fatal(err)
+}
+db, err := sql.Open(driver, dsn)
+```
+
+Hand-written apps still get automatic port isolation through `App.Start`.
+Database isolation is automatic when the app either runs through `gofastr dev`
+and reads env, or opens the database through `Runtime.Database`.

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -12,12 +12,9 @@ isolation:
   enabled: true
   mode: worktree
   port:
-    strategy: offset
     offset: 1000
     range: 1000
-    scan: 20
-  database:
-    strategy: suffix
+    scan: 20      # capped server-side at 64
   services:
     redis: 6379
   env:

--- a/framework/app.go
+++ b/framework/app.go
@@ -28,10 +28,11 @@ import (
 	"github.com/DonaldMurillo/gofastr/framework/entity"
 	"github.com/DonaldMurillo/gofastr/framework/event"
 	"github.com/DonaldMurillo/gofastr/framework/hook"
+	"github.com/DonaldMurillo/gofastr/framework/isolation"
 	"github.com/DonaldMurillo/gofastr/framework/lifecycle"
-	"github.com/DonaldMurillo/gofastr/framework/routegroup"
 	"github.com/DonaldMurillo/gofastr/framework/migrate"
 	"github.com/DonaldMurillo/gofastr/framework/openapi"
+	"github.com/DonaldMurillo/gofastr/framework/routegroup"
 )
 
 // Mountable is anything that can register routes on the framework's router.
@@ -447,15 +448,15 @@ func (a *App) Use(mw ...router.Middleware) *App {
 // It initializes default Registry, Router, and MCP Server if not provided.
 func NewApp(opts ...AppOption) *App {
 	a := &App{
-		Registry: NewRegistry(),
-		router:   router.New(),
-		MCP:      mcp.NewServer(),
-		Config:   AppConfig{JSONCase: crud.CaseCamel},
-		Plugins:  NewPluginManager(),
+		Registry:  NewRegistry(),
+		router:    router.New(),
+		MCP:       mcp.NewServer(),
+		Config:    AppConfig{JSONCase: crud.CaseCamel},
+		Plugins:   NewPluginManager(),
 		Batteries: NewBatteryManager(),
-		events:   event.NewEventBus(),
-		hooks:    make(map[string]*hook.HookRegistry),
-		lc:       lifecycle.New(),
+		events:    event.NewEventBus(),
+		hooks:     make(map[string]*hook.HookRegistry),
+		lc:        lifecycle.New(),
 	}
 
 	for _, opt := range opts {
@@ -881,6 +882,15 @@ func (a *App) runStartHooks() error {
 //
 // Sets the process title to the app name for visibility in ps/Activity Monitor.
 func (a *App) Start(addr string) error {
+	runtimeIsolation, err := isolation.Resolve(".")
+	if err != nil {
+		return fmt.Errorf("resolve isolation: %w", err)
+	}
+	addr, err = runtimeIsolation.Addr(addr)
+	if err != nil {
+		return fmt.Errorf("resolve isolated addr: %w", err)
+	}
+
 	// Auto-migrate all registered entities
 	if a.DB != nil {
 		if err := migrate.AutoMigrate(a.DB, a.Registry); err != nil {
@@ -1027,4 +1037,3 @@ func formatBytes(b uint64) string {
 
 func arrow() string        { return "\033[33m→\033[0m" }
 func bold(s string) string { return "\033[1m" + s + "\033[0m" }
-

--- a/framework/isolation/isolation.go
+++ b/framework/isolation/isolation.go
@@ -16,15 +16,16 @@ import (
 	coreyaml "github.com/DonaldMurillo/gofastr/core/yaml"
 )
 
-var appliedMu sync.Mutex
-var appliedPorts = map[int]int{}
-
 const (
 	envIsolation       = "GOFASTR_ISOLATION"
 	envApplied         = "GOFASTR_ISOLATION_APPLIED"
 	envID              = "GOFASTR_ISOLATION_ID"
 	envPortPrefix      = "GOFASTR_ISOLATION_PORT_"
 	envRewriteExplicit = "GOFASTR_ISOLATION_REWRITE"
+
+	// portScanMax bounds the linear scan that follows a hashed candidate.
+	// Each iteration costs a net.Listen, so user-set ceilings need a sane cap.
+	portScanMax = 64
 )
 
 // Runtime is the resolved isolation context for a project.
@@ -35,6 +36,9 @@ type Runtime struct {
 	cfg        Config
 	active     bool
 	id         string
+
+	portsMu sync.Mutex
+	ports   map[int]int // base port → mapped port, in-process only
 }
 
 // Config describes local resource isolation.
@@ -61,20 +65,20 @@ type DatabaseConfig struct {
 }
 
 // Resolve loads isolation config for projectDir and returns its runtime.
-func Resolve(projectDir string) (Runtime, error) {
+func Resolve(projectDir string) (*Runtime, error) {
 	cfg := defaultConfig()
 	start, err := filepath.Abs(projectDir)
 	if err != nil {
-		return Runtime{}, err
+		return nil, err
 	}
 	configPath, configDir, err := discoverConfig(start)
 	if err != nil {
-		return Runtime{}, err
+		return nil, err
 	}
 	if configPath != "" {
 		loaded, err := loadConfig(configPath, cfg)
 		if err != nil {
-			return Runtime{}, err
+			return nil, err
 		}
 		cfg = loaded
 		start = configDir
@@ -100,48 +104,54 @@ func Resolve(projectDir string) (Runtime, error) {
 		case "off", "disabled":
 			active = false
 		default:
-			return Runtime{}, fmt.Errorf("isolation.mode %q is not supported", cfg.Mode)
+			return nil, fmt.Errorf("isolation.mode %q is not supported", cfg.Mode)
 		}
 	}
-	return Runtime{
+	return &Runtime{
 		projectDir: start,
 		gitRoot:    gitRoot,
 		configPath: configPath,
 		cfg:        cfg,
 		active:     active,
 		id:         id,
+		ports:      map[int]int{},
 	}, nil
 }
 
 // Active reports whether isolation applies to this runtime.
-func (r Runtime) Active() bool { return r.active }
+func (r *Runtime) Active() bool { return r != nil && r.active }
 
 // ID returns the stable isolation identifier.
-func (r Runtime) ID() string { return r.id }
+func (r *Runtime) ID() string {
+	if r == nil {
+		return ""
+	}
+	return r.id
+}
 
 // Addr returns addr with its port remapped when isolation is active.
-func (r Runtime) Addr(addr string) (string, error) {
-	if !r.active || addr == "" {
+func (r *Runtime) Addr(addr string) (string, error) {
+	if !r.Active() || addr == "" {
 		return addr, nil
 	}
 	host, port, shape, err := splitAddr(addr)
 	if err != nil {
 		return "", err
 	}
-	if mapped, ok := appliedPort(port); ok {
+	if mapped, ok := r.lookupPort(port); ok {
 		return joinAddr(host, mapped, shape), nil
 	}
-	if isAppliedResolvedPort(port) {
+	if r.isResolvedPort(port) {
 		return addr, nil
 	}
 	next := r.portFor(port, host)
-	markAppliedPort(port, next)
+	r.recordPort(port, next)
 	return joinAddr(host, next, shape), nil
 }
 
 // Env returns env with configured local resources isolated.
-func (r Runtime) Env(env []string) []string {
-	if !r.active {
+func (r *Runtime) Env(env []string) []string {
+	if !r.Active() {
 		return env
 	}
 	values := envMap(env)
@@ -180,8 +190,8 @@ func (r Runtime) Env(env []string) []string {
 }
 
 // Database returns an isolated database driver and DSN when isolation is active.
-func (r Runtime) Database(driver, dsn string) (string, string, error) {
-	if !r.active {
+func (r *Runtime) Database(driver, dsn string) (string, string, error) {
+	if !r.Active() {
 		return driver, dsn, nil
 	}
 	switch strings.ToLower(strings.TrimSpace(r.cfg.Database.Strategy)) {
@@ -229,6 +239,11 @@ func discoverConfig(start string) (path, dir string, err error) {
 			} else if err != nil && !os.IsNotExist(err) {
 				return "", "", err
 			}
+		}
+		// Stop at the git root: a parent workspace's gofastr.yml must not
+		// silently apply to a nested project.
+		if _, statErr := os.Stat(filepath.Join(dir, ".git")); statErr == nil {
+			return "", start, nil
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
@@ -289,6 +304,9 @@ func loadConfig(path string, base Config) (Config, error) {
 			cfg.Port.Scan, err = intValue(n, "isolation.port.scan")
 			if err != nil {
 				return Config{}, err
+			}
+			if cfg.Port.Scan > portScanMax {
+				cfg.Port.Scan = portScanMax
 			}
 		}
 	}
@@ -358,11 +376,11 @@ func makeID(projectDir string) string {
 	return "wt_" + hex.EncodeToString(sum[:])[:10]
 }
 
-func (r Runtime) portFor(base int, host string) int {
+func (r *Runtime) portFor(base int, host string) int {
 	if base <= 0 {
 		return base
 	}
-	if v, ok := appliedPort(base); ok {
+	if v, ok := r.lookupPort(base); ok {
 		return v
 	}
 	pc := r.cfg.Port
@@ -380,6 +398,9 @@ func (r Runtime) portFor(base int, host string) int {
 	candidate := normalizePort(base + pc.Offset + offset)
 	if pc.Scan < 0 {
 		pc.Scan = 0
+	}
+	if pc.Scan > portScanMax {
+		pc.Scan = portScanMax
 	}
 	for i := 0; i <= pc.Scan; i++ {
 		p := normalizePort(candidate + i)
@@ -461,35 +482,32 @@ func joinAddr(host string, port int, shape addrShape) string {
 	}
 }
 
-func appliedPort(base int) (int, bool) {
-	if p, ok := appliedPortValue(strconv.Itoa(base)); ok {
+// lookupPort returns a previously recorded mapping for base, checking
+// env first (so child processes inherit parent's mapping) and then this
+// Runtime's in-memory cache.
+func (r *Runtime) lookupPort(base int) (int, bool) {
+	if p, ok := envAppliedPort(strconv.Itoa(base)); ok {
 		return p, true
 	}
-	appliedMu.Lock()
-	defer appliedMu.Unlock()
-	p, ok := appliedPorts[base]
+	r.portsMu.Lock()
+	defer r.portsMu.Unlock()
+	p, ok := r.ports[base]
 	return p, ok
 }
 
-func appliedPortValue(base string) (int, bool) {
-	if os.Getenv(envApplied) != "1" {
-		return 0, false
-	}
-	v := os.Getenv(envPortPrefix + base)
-	if v == "" {
-		return 0, false
-	}
-	p, err := strconv.Atoi(v)
-	return p, err == nil
+// recordPort stores base → mapped in this Runtime's in-memory cache only.
+// Child-process inheritance happens through Env(), which writes the env
+// markers separately.
+func (r *Runtime) recordPort(base, mapped int) {
+	r.portsMu.Lock()
+	defer r.portsMu.Unlock()
+	r.ports[base] = mapped
 }
 
-func markAppliedPort(base, mapped int) {
-	appliedMu.Lock()
-	defer appliedMu.Unlock()
-	appliedPorts[base] = mapped
-}
-
-func isAppliedResolvedPort(port int) bool {
+// isResolvedPort reports whether port is already the mapped form for some
+// base — used by Addr to short-circuit when a child process is handed an
+// already-offset port and re-resolving would double-offset.
+func (r *Runtime) isResolvedPort(port int) bool {
 	if os.Getenv(envApplied) == "1" {
 		for _, pair := range os.Environ() {
 			key, val, ok := strings.Cut(pair, "=")
@@ -502,14 +520,28 @@ func isAppliedResolvedPort(port int) bool {
 			}
 		}
 	}
-	appliedMu.Lock()
-	defer appliedMu.Unlock()
-	for _, mapped := range appliedPorts {
+	r.portsMu.Lock()
+	defer r.portsMu.Unlock()
+	for _, mapped := range r.ports {
 		if mapped == port {
 			return true
 		}
 	}
 	return false
+}
+
+// envAppliedPort reads the parent-process port mapping from env (set by
+// Env() in the parent). Always process-wide — that's the inheritance hook.
+func envAppliedPort(base string) (int, bool) {
+	if os.Getenv(envApplied) != "1" {
+		return 0, false
+	}
+	v := os.Getenv(envPortPrefix + base)
+	if v == "" {
+		return 0, false
+	}
+	p, err := strconv.Atoi(v)
+	return p, err == nil
 }
 
 func envMap(env []string) map[string]string {
@@ -558,7 +590,7 @@ func renderPortValue(current string, port int) string {
 	return joinAddr(host, port, shape)
 }
 
-func (r Runtime) expandTemplate(tmpl string, basePort int) string {
+func (r *Runtime) expandTemplate(tmpl string, basePort int) string {
 	out := strings.ReplaceAll(tmpl, "{id}", r.id)
 	out = strings.ReplaceAll(out, "{project_dir}", r.projectDir)
 	out = strings.ReplaceAll(out, "{port}", strconv.Itoa(r.portFor(basePort, "localhost")))
@@ -580,7 +612,7 @@ func inferDriver(dsn string) string {
 	}
 }
 
-func (r Runtime) sqliteDSN(dsn string) (string, error) {
+func (r *Runtime) sqliteDSN(dsn string) (string, error) {
 	if dsn == "" || dsn == ":memory:" {
 		return dsn, nil
 	}
@@ -606,7 +638,7 @@ func (r Runtime) sqliteDSN(dsn string) (string, error) {
 	return prefix + filepath.Join(dir, name) + query, nil
 }
 
-func (r Runtime) postgresDSN(dsn string) (string, error) {
+func (r *Runtime) postgresDSN(dsn string) (string, error) {
 	if dsn == "" {
 		return dsn, nil
 	}
@@ -619,9 +651,17 @@ func (r Runtime) postgresDSN(dsn string) (string, error) {
 		return dsn, nil
 	}
 	suffix := "_" + strings.ReplaceAll(r.id, "-", "_")
-	if !strings.HasSuffix(db, suffix) {
-		u.Path = "/" + db + suffix
+	if strings.HasSuffix(db, suffix) {
+		return u.String(), nil
 	}
+	// Postgres silently truncates identifiers at NAMEDATALEN-1 (63 bytes by
+	// default). Trim the base name so the suffix survives — two worktrees
+	// must not collide on a truncated form.
+	const pgMaxIdentifier = 63
+	if len(db)+len(suffix) > pgMaxIdentifier {
+		db = db[:pgMaxIdentifier-len(suffix)]
+	}
+	u.Path = "/" + db + suffix
 	return u.String(), nil
 }
 

--- a/framework/isolation/isolation.go
+++ b/framework/isolation/isolation.go
@@ -1,0 +1,667 @@
+// Package isolation resolves worktree-specific local runtime resources.
+package isolation
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	coreyaml "github.com/DonaldMurillo/gofastr/core/yaml"
+)
+
+var appliedMu sync.Mutex
+var appliedPorts = map[int]int{}
+
+const (
+	envIsolation       = "GOFASTR_ISOLATION"
+	envApplied         = "GOFASTR_ISOLATION_APPLIED"
+	envID              = "GOFASTR_ISOLATION_ID"
+	envPortPrefix      = "GOFASTR_ISOLATION_PORT_"
+	envRewriteExplicit = "GOFASTR_ISOLATION_REWRITE"
+)
+
+// Runtime is the resolved isolation context for a project.
+type Runtime struct {
+	projectDir string
+	gitRoot    string
+	configPath string
+	cfg        Config
+	active     bool
+	id         string
+}
+
+// Config describes local resource isolation.
+type Config struct {
+	Enabled  bool
+	Mode     string
+	Port     PortConfig
+	Database DatabaseConfig
+	Services map[string]int
+	Env      map[string]string
+}
+
+// PortConfig controls deterministic port remapping.
+type PortConfig struct {
+	Strategy string
+	Offset   int
+	Range    int
+	Scan     int
+}
+
+// DatabaseConfig controls default DSN rewriting.
+type DatabaseConfig struct {
+	Strategy string
+}
+
+// Resolve loads isolation config for projectDir and returns its runtime.
+func Resolve(projectDir string) (Runtime, error) {
+	cfg := defaultConfig()
+	start, err := filepath.Abs(projectDir)
+	if err != nil {
+		return Runtime{}, err
+	}
+	configPath, configDir, err := discoverConfig(start)
+	if err != nil {
+		return Runtime{}, err
+	}
+	if configPath != "" {
+		loaded, err := loadConfig(configPath, cfg)
+		if err != nil {
+			return Runtime{}, err
+		}
+		cfg = loaded
+		start = configDir
+	}
+	gitRoot, linkedWorktree := findGitRoot(start)
+	id := os.Getenv(envID)
+	if id == "" {
+		id = makeID(start)
+	}
+	active := cfg.Enabled
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(envIsolation))) {
+	case "off", "false", "0", "disabled":
+		active = false
+	case "on", "true", "1", "always":
+		active = true
+	}
+	if active {
+		switch cfg.Mode {
+		case "", "worktree":
+			active = linkedWorktree
+		case "always":
+			active = true
+		case "off", "disabled":
+			active = false
+		default:
+			return Runtime{}, fmt.Errorf("isolation.mode %q is not supported", cfg.Mode)
+		}
+	}
+	return Runtime{
+		projectDir: start,
+		gitRoot:    gitRoot,
+		configPath: configPath,
+		cfg:        cfg,
+		active:     active,
+		id:         id,
+	}, nil
+}
+
+// Active reports whether isolation applies to this runtime.
+func (r Runtime) Active() bool { return r.active }
+
+// ID returns the stable isolation identifier.
+func (r Runtime) ID() string { return r.id }
+
+// Addr returns addr with its port remapped when isolation is active.
+func (r Runtime) Addr(addr string) (string, error) {
+	if !r.active || addr == "" {
+		return addr, nil
+	}
+	host, port, shape, err := splitAddr(addr)
+	if err != nil {
+		return "", err
+	}
+	if mapped, ok := appliedPort(port); ok {
+		return joinAddr(host, mapped, shape), nil
+	}
+	if isAppliedResolvedPort(port) {
+		return addr, nil
+	}
+	next := r.portFor(port, host)
+	markAppliedPort(port, next)
+	return joinAddr(host, next, shape), nil
+}
+
+// Env returns env with configured local resources isolated.
+func (r Runtime) Env(env []string) []string {
+	if !r.active {
+		return env
+	}
+	values := envMap(env)
+	rewriteExplicit := values[envRewriteExplicit] != "0" && !strings.EqualFold(values[envRewriteExplicit], "false")
+	basePort := 8080
+	if v := values["PORT"]; v != "" {
+		if _, p, _, err := splitAddr(v); err == nil {
+			basePort = p
+		} else if p, err := strconv.Atoi(v); err == nil {
+			basePort = p
+		}
+	}
+	appPort := r.portFor(basePort, "localhost")
+	if rewriteExplicit || values["PORT"] == "" {
+		values["PORT"] = renderPortValue(values["PORT"], appPort)
+	}
+	if dsn := values["DATABASE_URL"]; dsn != "" && rewriteExplicit {
+		_, rewritten, err := r.Database("", dsn)
+		if err == nil {
+			values["DATABASE_URL"] = rewritten
+		}
+	}
+	for key, tmpl := range r.cfg.Env {
+		if values[key] != "" && !rewriteExplicit {
+			continue
+		}
+		values[key] = r.expandTemplate(tmpl, basePort)
+	}
+	values[envApplied] = "1"
+	values[envID] = r.id
+	values[envPortPrefix+strconv.Itoa(basePort)] = strconv.Itoa(appPort)
+	for name, port := range r.cfg.Services {
+		values[envPortPrefix+name] = strconv.Itoa(r.portFor(port, "localhost"))
+	}
+	return flattenEnv(env, values)
+}
+
+// Database returns an isolated database driver and DSN when isolation is active.
+func (r Runtime) Database(driver, dsn string) (string, string, error) {
+	if !r.active {
+		return driver, dsn, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(r.cfg.Database.Strategy)) {
+	case "off", "none", "disabled":
+		return driver, dsn, nil
+	}
+	if driver == "" {
+		driver = inferDriver(dsn)
+	}
+	switch strings.ToLower(driver) {
+	case "sqlite", "sqlite3":
+		next, err := r.sqliteDSN(dsn)
+		return driver, next, err
+	case "postgres", "postgresql", "pgx":
+		next, err := r.postgresDSN(dsn)
+		return driver, next, err
+	default:
+		return driver, r.expandTemplate(dsn, 8080), nil
+	}
+}
+
+func defaultConfig() Config {
+	return Config{
+		Enabled: true,
+		Mode:    "worktree",
+		Port: PortConfig{
+			Strategy: "offset",
+			Offset:   1000,
+			Range:    1000,
+			Scan:     20,
+		},
+		Database: DatabaseConfig{Strategy: "suffix"},
+		Services: map[string]int{},
+		Env:      map[string]string{},
+	}
+}
+
+func discoverConfig(start string) (path, dir string, err error) {
+	dir = start
+	for {
+		for _, name := range []string{"gofastr.yml", "gofastr.yaml"} {
+			path := filepath.Join(dir, name)
+			if _, err := os.Stat(path); err == nil {
+				return path, dir, nil
+			} else if err != nil && !os.IsNotExist(err) {
+				return "", "", err
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", start, nil
+		}
+		dir = parent
+	}
+}
+
+func loadConfig(path string, base Config) (Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, err
+	}
+	node, err := coreyaml.Parse(string(data))
+	if err != nil {
+		return Config{}, err
+	}
+	if node.Kind != coreyaml.Map || node.Map["isolation"] == nil {
+		return base, nil
+	}
+	m, err := expectMap(node.Map["isolation"], "isolation")
+	if err != nil {
+		return Config{}, err
+	}
+	cfg := base
+	if v := m["enabled"]; v != nil {
+		enabled, err := boolValue(v, "isolation.enabled")
+		if err != nil {
+			return Config{}, err
+		}
+		cfg.Enabled = enabled
+	}
+	if v := m["mode"]; v != nil {
+		cfg.Mode = scalarString(v)
+	}
+	if v := m["port"]; v != nil {
+		port, err := expectMap(v, "isolation.port")
+		if err != nil {
+			return Config{}, err
+		}
+		if n := port["strategy"]; n != nil {
+			cfg.Port.Strategy = scalarString(n)
+		}
+		if n := port["offset"]; n != nil {
+			cfg.Port.Offset, err = intValue(n, "isolation.port.offset")
+			if err != nil {
+				return Config{}, err
+			}
+		}
+		if n := port["range"]; n != nil {
+			cfg.Port.Range, err = intValue(n, "isolation.port.range")
+			if err != nil {
+				return Config{}, err
+			}
+		}
+		if n := port["scan"]; n != nil {
+			cfg.Port.Scan, err = intValue(n, "isolation.port.scan")
+			if err != nil {
+				return Config{}, err
+			}
+		}
+	}
+	if v := m["database"]; v != nil {
+		db, err := expectMap(v, "isolation.database")
+		if err != nil {
+			return Config{}, err
+		}
+		if n := db["strategy"]; n != nil {
+			cfg.Database.Strategy = scalarString(n)
+		}
+	}
+	if v := m["services"]; v != nil {
+		services, err := expectMap(v, "isolation.services")
+		if err != nil {
+			return Config{}, err
+		}
+		cfg.Services = map[string]int{}
+		for key, n := range services {
+			port, err := intValue(n, "isolation.services."+key)
+			if err != nil {
+				return Config{}, err
+			}
+			cfg.Services[key] = port
+		}
+	}
+	if v := m["env"]; v != nil {
+		env, err := expectMap(v, "isolation.env")
+		if err != nil {
+			return Config{}, err
+		}
+		cfg.Env = map[string]string{}
+		for key, n := range env {
+			cfg.Env[key] = scalarString(n)
+		}
+	}
+	return cfg, nil
+}
+
+func findGitRoot(start string) (string, bool) {
+	dir := start
+	for {
+		git := filepath.Join(dir, ".git")
+		info, err := os.Stat(git)
+		if err == nil {
+			if info.IsDir() {
+				return dir, false
+			}
+			data, err := os.ReadFile(git)
+			if err != nil {
+				return dir, false
+			}
+			line := strings.TrimSpace(string(data))
+			linked := strings.HasPrefix(line, "gitdir:") && strings.Contains(filepath.ToSlash(line), "/worktrees/")
+			return dir, linked
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+func makeID(projectDir string) string {
+	sum := sha1.Sum([]byte(filepath.Clean(projectDir)))
+	return "wt_" + hex.EncodeToString(sum[:])[:10]
+}
+
+func (r Runtime) portFor(base int, host string) int {
+	if base <= 0 {
+		return base
+	}
+	if v, ok := appliedPort(base); ok {
+		return v
+	}
+	pc := r.cfg.Port
+	switch strings.ToLower(strings.TrimSpace(pc.Strategy)) {
+	case "off", "none", "disabled":
+		return base
+	}
+	if pc.Offset == 0 {
+		pc.Offset = 1000
+	}
+	if pc.Range <= 0 {
+		pc.Range = 1000
+	}
+	offset := hashInt(r.id+":"+strconv.Itoa(base), pc.Range)
+	candidate := normalizePort(base + pc.Offset + offset)
+	if pc.Scan < 0 {
+		pc.Scan = 0
+	}
+	for i := 0; i <= pc.Scan; i++ {
+		p := normalizePort(candidate + i)
+		if portAvailable(host, p) {
+			return p
+		}
+	}
+	return candidate
+}
+
+func hashInt(s string, mod int) int {
+	sum := sha1.Sum([]byte(s))
+	n := int(sum[0])<<24 | int(sum[1])<<16 | int(sum[2])<<8 | int(sum[3])
+	if n < 0 {
+		n = -n
+	}
+	return n % mod
+}
+
+func normalizePort(port int) int {
+	if port > 0 && port <= 65535 {
+		return port
+	}
+	const first = 1024
+	const size = 65535 - first
+	if port < 0 {
+		port = -port
+	}
+	return first + (port % size)
+}
+
+func portAvailable(host string, port int) bool {
+	if host == "" {
+		host = "localhost"
+	}
+	if strings.Contains(host, ":") && !strings.HasPrefix(host, "[") {
+		host = "[" + host + "]"
+	}
+	ln, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	if err != nil {
+		return false
+	}
+	_ = ln.Close()
+	return true
+}
+
+type addrShape int
+
+const (
+	addrColon addrShape = iota
+	addrHost
+	addrPortOnly
+)
+
+func splitAddr(addr string) (string, int, addrShape, error) {
+	if p, err := strconv.Atoi(addr); err == nil {
+		return "", p, addrPortOnly, nil
+	}
+	if strings.HasPrefix(addr, ":") && strings.Count(addr, ":") == 1 {
+		p, err := strconv.Atoi(strings.TrimPrefix(addr, ":"))
+		return "", p, addrColon, err
+	}
+	host, portText, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0, addrHost, fmt.Errorf("isolation: parse addr %q: %w", addr, err)
+	}
+	p, err := strconv.Atoi(portText)
+	return host, p, addrHost, err
+}
+
+func joinAddr(host string, port int, shape addrShape) string {
+	switch shape {
+	case addrPortOnly:
+		return strconv.Itoa(port)
+	case addrColon:
+		return ":" + strconv.Itoa(port)
+	default:
+		return net.JoinHostPort(host, strconv.Itoa(port))
+	}
+}
+
+func appliedPort(base int) (int, bool) {
+	if p, ok := appliedPortValue(strconv.Itoa(base)); ok {
+		return p, true
+	}
+	appliedMu.Lock()
+	defer appliedMu.Unlock()
+	p, ok := appliedPorts[base]
+	return p, ok
+}
+
+func appliedPortValue(base string) (int, bool) {
+	if os.Getenv(envApplied) != "1" {
+		return 0, false
+	}
+	v := os.Getenv(envPortPrefix + base)
+	if v == "" {
+		return 0, false
+	}
+	p, err := strconv.Atoi(v)
+	return p, err == nil
+}
+
+func markAppliedPort(base, mapped int) {
+	appliedMu.Lock()
+	defer appliedMu.Unlock()
+	appliedPorts[base] = mapped
+}
+
+func isAppliedResolvedPort(port int) bool {
+	if os.Getenv(envApplied) == "1" {
+		for _, pair := range os.Environ() {
+			key, val, ok := strings.Cut(pair, "=")
+			if !ok || !strings.HasPrefix(key, envPortPrefix) {
+				continue
+			}
+			p, err := strconv.Atoi(val)
+			if err == nil && p == port {
+				return true
+			}
+		}
+	}
+	appliedMu.Lock()
+	defer appliedMu.Unlock()
+	for _, mapped := range appliedPorts {
+		if mapped == port {
+			return true
+		}
+	}
+	return false
+}
+
+func envMap(env []string) map[string]string {
+	out := map[string]string{}
+	for _, pair := range env {
+		key, val, ok := strings.Cut(pair, "=")
+		if ok {
+			out[key] = val
+		}
+	}
+	return out
+}
+
+func flattenEnv(original []string, values map[string]string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(values))
+	for _, pair := range original {
+		key, _, ok := strings.Cut(pair, "=")
+		if !ok || seen[key] {
+			continue
+		}
+		if val, ok := values[key]; ok {
+			out = append(out, key+"="+val)
+			seen[key] = true
+		}
+	}
+	for key, val := range values {
+		if !seen[key] {
+			out = append(out, key+"="+val)
+		}
+	}
+	return out
+}
+
+func renderPortValue(current string, port int) string {
+	if current == "" {
+		return "localhost:" + strconv.Itoa(port)
+	}
+	if _, err := strconv.Atoi(current); err == nil {
+		return strconv.Itoa(port)
+	}
+	host, _, shape, err := splitAddr(current)
+	if err != nil {
+		return "localhost:" + strconv.Itoa(port)
+	}
+	return joinAddr(host, port, shape)
+}
+
+func (r Runtime) expandTemplate(tmpl string, basePort int) string {
+	out := strings.ReplaceAll(tmpl, "{id}", r.id)
+	out = strings.ReplaceAll(out, "{project_dir}", r.projectDir)
+	out = strings.ReplaceAll(out, "{port}", strconv.Itoa(r.portFor(basePort, "localhost")))
+	for name, port := range r.cfg.Services {
+		out = strings.ReplaceAll(out, "{port:"+name+"}", strconv.Itoa(r.portFor(port, "localhost")))
+	}
+	return out
+}
+
+func inferDriver(dsn string) string {
+	lower := strings.ToLower(dsn)
+	switch {
+	case strings.HasPrefix(lower, "postgres://"), strings.HasPrefix(lower, "postgresql://"):
+		return "postgres"
+	case strings.HasPrefix(lower, "file:"), strings.Contains(lower, ".db"), lower == ":memory:":
+		return "sqlite3"
+	default:
+		return ""
+	}
+}
+
+func (r Runtime) sqliteDSN(dsn string) (string, error) {
+	if dsn == "" || dsn == ":memory:" {
+		return dsn, nil
+	}
+	prefix := ""
+	path := dsn
+	query := ""
+	if strings.HasPrefix(path, "file:") {
+		prefix = "file:"
+		path = strings.TrimPrefix(path, "file:")
+		if i := strings.IndexAny(path, "?#"); i >= 0 {
+			query = path[i:]
+			path = path[:i]
+		}
+	}
+	name := filepath.Base(path)
+	if name == "." || name == string(filepath.Separator) || name == "" {
+		name = "app.db"
+	}
+	dir := filepath.Join(r.projectDir, ".gofastr", "isolation", r.id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return prefix + filepath.Join(dir, name) + query, nil
+}
+
+func (r Runtime) postgresDSN(dsn string) (string, error) {
+	if dsn == "" {
+		return dsn, nil
+	}
+	u, err := url.Parse(dsn)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return dsn, err
+	}
+	db := strings.TrimPrefix(u.Path, "/")
+	if db == "" {
+		return dsn, nil
+	}
+	suffix := "_" + strings.ReplaceAll(r.id, "-", "_")
+	if !strings.HasSuffix(db, suffix) {
+		u.Path = "/" + db + suffix
+	}
+	return u.String(), nil
+}
+
+func expectMap(node *coreyaml.Node, label string) (map[string]*coreyaml.Node, error) {
+	if node == nil || node.Kind != coreyaml.Map {
+		return nil, fmt.Errorf("%s must be a map", label)
+	}
+	return node.Map, nil
+}
+
+func scalarString(node *coreyaml.Node) string {
+	if node == nil {
+		return ""
+	}
+	return fmt.Sprint(node.Value)
+}
+
+func boolValue(node *coreyaml.Node, label string) (bool, error) {
+	if node == nil || node.Kind != coreyaml.Scalar {
+		return false, fmt.Errorf("%s must be a boolean", label)
+	}
+	v, ok := node.Value.(bool)
+	if !ok {
+		return false, fmt.Errorf("%s must be a boolean", label)
+	}
+	return v, nil
+}
+
+func intValue(node *coreyaml.Node, label string) (int, error) {
+	if node == nil || node.Kind != coreyaml.Scalar {
+		return 0, fmt.Errorf("%s must be an integer", label)
+	}
+	switch v := node.Value.(type) {
+	case int:
+		return v, nil
+	case int64:
+		return int(v), nil
+	case float64:
+		return int(v), nil
+	default:
+		return strconv.Atoi(fmt.Sprint(v))
+	}
+}

--- a/framework/isolation/isolation_test.go
+++ b/framework/isolation/isolation_test.go
@@ -1,0 +1,223 @@
+package isolation
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestResolveActivatesOnlyForLinkedWorktreeByDefault(t *testing.T) {
+	clearIsolationEnv(t)
+	main := t.TempDir()
+	writeFile(t, filepath.Join(main, ".git", "HEAD"), "ref: refs/heads/main\n")
+	writeFile(t, filepath.Join(main, "gofastr.yml"), "isolation:\n  enabled: true\n")
+
+	rt, err := Resolve(main)
+	if err != nil {
+		t.Fatalf("Resolve main: %v", err)
+	}
+	if rt.Active() {
+		t.Fatal("main checkout should not be isolated in default worktree mode")
+	}
+
+	linked := t.TempDir()
+	writeFile(t, filepath.Join(linked, ".git"), "gitdir: "+filepath.Join(main, ".git", "worktrees", "feature")+"\n")
+	writeFile(t, filepath.Join(linked, "gofastr.yml"), "isolation:\n  enabled: true\n")
+
+	rt, err = Resolve(linked)
+	if err != nil {
+		t.Fatalf("Resolve linked: %v", err)
+	}
+	if !rt.Active() {
+		t.Fatal("linked worktree should be isolated")
+	}
+}
+
+func TestResolveHonorsConfigAndEnvOff(t *testing.T) {
+	clearIsolationEnv(t)
+	dir := linkedWorktree(t)
+	writeFile(t, filepath.Join(dir, "gofastr.yml"), "isolation:\n  enabled: false\n")
+
+	rt, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if rt.Active() {
+		t.Fatal("disabled config should disable isolation")
+	}
+
+	writeFile(t, filepath.Join(dir, "gofastr.yml"), "isolation:\n  enabled: true\n")
+	t.Setenv(envIsolation, "off")
+	rt, err = Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve with env off: %v", err)
+	}
+	if rt.Active() {
+		t.Fatal("GOFASTR_ISOLATION=off should disable isolation")
+	}
+}
+
+func TestAddrIsStableAndDoesNotDoubleOffsetAppliedPort(t *testing.T) {
+	clearIsolationEnv(t)
+	dir := linkedWorktree(t)
+	writeFile(t, filepath.Join(dir, "gofastr.yml"), "isolation:\n  enabled: true\n  port:\n    offset: 1000\n    range: 1\n    scan: 0\n")
+	rt, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	addr, err := rt.Addr(":8080")
+	if err != nil {
+		t.Fatalf("Addr: %v", err)
+	}
+	if addr != ":9080" {
+		t.Fatalf("addr = %q, want :9080", addr)
+	}
+
+	t.Setenv(envApplied, "1")
+	t.Setenv(envPortPrefix+"8080", "9080")
+	addr, err = rt.Addr(":9080")
+	if err != nil {
+		t.Fatalf("Addr applied: %v", err)
+	}
+	if addr != ":9080" {
+		t.Fatalf("already-applied addr = %q, want :9080", addr)
+	}
+	addr, err = rt.Addr(":8080")
+	if err != nil {
+		t.Fatalf("Addr base applied: %v", err)
+	}
+	if addr != ":9080" {
+		t.Fatalf("mapped addr = %q, want :9080", addr)
+	}
+}
+
+func TestEnvRewritesExplicitValuesAndTemplates(t *testing.T) {
+	clearIsolationEnv(t)
+	dir := linkedWorktree(t)
+	writeFile(t, filepath.Join(dir, "gofastr.yml"), `
+isolation:
+  enabled: true
+  port:
+    offset: 1000
+    range: 1
+    scan: 0
+  services:
+    redis: 6379
+  env:
+    REDIS_URL: "redis://localhost:{port:redis}/0-{id}"
+`)
+	rt, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	env := envMap(rt.Env([]string{
+		"PORT=localhost:8080",
+		"DATABASE_URL=postgres://user:pass@localhost:5432/app?sslmode=disable",
+	}))
+	if env["PORT"] != "localhost:9080" {
+		t.Fatalf("PORT = %q, want localhost:9080", env["PORT"])
+	}
+	if !strings.Contains(env["DATABASE_URL"], "/app_"+rt.ID()+"?") {
+		t.Fatalf("DATABASE_URL was not suffixed: %q", env["DATABASE_URL"])
+	}
+	if env["REDIS_URL"] != "redis://localhost:7379/0-"+rt.ID() {
+		t.Fatalf("REDIS_URL = %q", env["REDIS_URL"])
+	}
+	if env[envApplied] != "1" || env[envID] != rt.ID() || env[envPortPrefix+"8080"] != "9080" {
+		t.Fatalf("missing isolation markers: %#v", env)
+	}
+}
+
+func TestEnvCanPreserveExplicitValues(t *testing.T) {
+	clearIsolationEnv(t)
+	dir := linkedWorktree(t)
+	writeFile(t, filepath.Join(dir, "gofastr.yml"), "isolation:\n  enabled: true\n  port:\n    offset: 1000\n    range: 1\n    scan: 0\n")
+	rt, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	env := envMap(rt.Env([]string{
+		envRewriteExplicit + "=0",
+		"PORT=localhost:8080",
+		"DATABASE_URL=postgres://localhost:5432/app",
+	}))
+	if env["PORT"] != "localhost:8080" {
+		t.Fatalf("PORT = %q, want explicit value preserved", env["PORT"])
+	}
+	if env["DATABASE_URL"] != "postgres://localhost:5432/app" {
+		t.Fatalf("DATABASE_URL = %q, want explicit value preserved", env["DATABASE_URL"])
+	}
+}
+
+func TestDatabaseRewritesSQLiteAndPostgres(t *testing.T) {
+	clearIsolationEnv(t)
+	dir := linkedWorktree(t)
+	writeFile(t, filepath.Join(dir, "gofastr.yml"), "isolation:\n  enabled: true\n")
+	rt, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	_, sqliteDSN, err := rt.Database("sqlite3", "file:app.db?_foreign_keys=on")
+	if err != nil {
+		t.Fatalf("sqlite Database: %v", err)
+	}
+	wantDir := filepath.Join(dir, ".gofastr", "isolation", rt.ID())
+	if !strings.HasPrefix(strings.TrimPrefix(sqliteDSN, "file:"), wantDir) || !strings.HasSuffix(sqliteDSN, "app.db?_foreign_keys=on") {
+		t.Fatalf("sqlite dsn = %q, want under %s", sqliteDSN, wantDir)
+	}
+	if _, err := os.Stat(wantDir); err != nil {
+		t.Fatalf("sqlite isolation dir was not created: %v", err)
+	}
+
+	_, pgDSN, err := rt.Database("postgres", "postgres://user:pass@localhost:5432/app?sslmode=disable")
+	if err != nil {
+		t.Fatalf("postgres Database: %v", err)
+	}
+	if !strings.Contains(pgDSN, "/app_"+rt.ID()+"?sslmode=disable") {
+		t.Fatalf("postgres dsn = %q, want database suffix", pgDSN)
+	}
+}
+
+func linkedWorktree(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".git"), "gitdir: "+filepath.Join(t.TempDir(), ".git", "worktrees", "feature")+"\n")
+	return dir
+}
+
+func clearIsolationEnv(t *testing.T) {
+	t.Helper()
+	appliedMu.Lock()
+	appliedPorts = map[int]int{}
+	appliedMu.Unlock()
+	for _, key := range []string{
+		envIsolation,
+		envApplied,
+		envID,
+		envRewriteExplicit,
+		envPortPrefix + "8080",
+		envPortPrefix + "9080",
+		envPortPrefix + "redis",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRenderPortValueKeepsPortOnlyShape(t *testing.T) {
+	if got := renderPortValue("8080", 9080); got != strconv.Itoa(9080) {
+		t.Fatalf("renderPortValue = %q", got)
+	}
+}

--- a/framework/isolation/isolation_test.go
+++ b/framework/isolation/isolation_test.go
@@ -1,6 +1,7 @@
 package isolation
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -190,9 +191,6 @@ func linkedWorktree(t *testing.T) string {
 
 func clearIsolationEnv(t *testing.T) {
 	t.Helper()
-	appliedMu.Lock()
-	appliedPorts = map[int]int{}
-	appliedMu.Unlock()
 	for _, key := range []string{
 		envIsolation,
 		envApplied,
@@ -221,3 +219,108 @@ func TestRenderPortValueKeepsPortOnlyShape(t *testing.T) {
 		t.Fatalf("renderPortValue = %q", got)
 	}
 }
+
+// Postgres identifiers are capped at 63 bytes by default
+// (NAMEDATALEN-1). A long DB name + suffix silently truncates server-side,
+// so two worktrees that differ only past byte 63 would collide.
+// The rewrite must keep the final db name <= 63 bytes.
+func TestPostgresDSNFitsIdentifierLimit(t *testing.T) {
+	clearIsolationEnv(t)
+	dir := linkedWorktree(t)
+	writeFile(t, filepath.Join(dir, "gofastr.yml"), "isolation:\n  enabled: true\n")
+	rt, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	longName := strings.Repeat("a", 60) // 60 + 14 ("_wt_xxxxxxxxxx") = 74, overflows
+	dsn := "postgres://u:p@localhost:5432/" + longName + "?sslmode=disable"
+	_, rewritten, err := rt.Database("postgres", dsn)
+	if err != nil {
+		t.Fatalf("Database: %v", err)
+	}
+	u, err := url.Parse(rewritten)
+	if err != nil {
+		t.Fatalf("parse rewritten: %v", err)
+	}
+	db := strings.TrimPrefix(u.Path, "/")
+	if len(db) > 63 {
+		t.Fatalf("rewritten db = %q (len %d), must be <= 63 to avoid Postgres silent truncation", db, len(db))
+	}
+	// And the suffix (or some unique-ID fragment) must remain present so two
+	// worktrees with the same base name don't collide on the truncated form.
+	if !strings.Contains(db, rt.ID()[len(rt.ID())-6:]) {
+		t.Fatalf("rewritten db = %q missing ID fragment; isolation lost", db)
+	}
+}
+
+// Two Runtime instances in the same process must not alias each other's
+// in-memory port mappings. With a package-global cache, rt2 inherits rt1's
+// mapping for port 8080 even though rt2's id and offset differ.
+func TestRuntimePortStateIsPerInstance(t *testing.T) {
+	clearIsolationEnv(t)
+	dir1 := linkedWorktree(t)
+	writeFile(t, filepath.Join(dir1, "gofastr.yml"),
+		"isolation:\n  enabled: true\n  port:\n    offset: 1000\n    range: 1\n    scan: 0\n")
+	dir2 := linkedWorktree(t)
+	writeFile(t, filepath.Join(dir2, "gofastr.yml"),
+		"isolation:\n  enabled: true\n  port:\n    offset: 2000\n    range: 1\n    scan: 0\n")
+
+	rt1, err := Resolve(dir1)
+	if err != nil {
+		t.Fatalf("Resolve dir1: %v", err)
+	}
+	rt2, err := Resolve(dir2)
+	if err != nil {
+		t.Fatalf("Resolve dir2: %v", err)
+	}
+	addr1, err := rt1.Addr(":8080")
+	if err != nil {
+		t.Fatalf("rt1.Addr: %v", err)
+	}
+	addr2, err := rt2.Addr(":8080")
+	if err != nil {
+		t.Fatalf("rt2.Addr: %v", err)
+	}
+	if addr1 == addr2 {
+		t.Fatalf("rt1 and rt2 both mapped :8080 to %q — port cache is leaking across Runtime instances", addr1)
+	}
+}
+
+// A misconfigured scan value must not hang startup for thousands of
+// net.Listen attempts. The resolver caps scan at a sane upper bound.
+func TestPortScanIsClamped(t *testing.T) {
+	clearIsolationEnv(t)
+	dir := linkedWorktree(t)
+	writeFile(t, filepath.Join(dir, "gofastr.yml"),
+		"isolation:\n  enabled: true\n  port:\n    scan: 1000000\n")
+	rt, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if rt.cfg.Port.Scan > portScanMax {
+		t.Fatalf("Port.Scan = %d, want clamped to <= %d", rt.cfg.Port.Scan, portScanMax)
+	}
+}
+
+// Resolve must not walk past the git root looking for gofastr.yml.
+// Otherwise a parent workspace's config silently applies to nested projects.
+func TestDiscoverConfigBoundedAtGitRoot(t *testing.T) {
+	clearIsolationEnv(t)
+	parent := t.TempDir()
+	// Parent has a gofastr.yml that should NOT be picked up.
+	writeFile(t, filepath.Join(parent, "gofastr.yml"), "isolation:\n  enabled: true\n  port:\n    offset: 5000\n")
+	// Project is a linked worktree inside parent, with its own .git pointer
+	// and no gofastr.yml of its own.
+	project := filepath.Join(parent, "project")
+	writeFile(t, filepath.Join(project, ".git"), "gitdir: "+filepath.Join(t.TempDir(), ".git", "worktrees", "feature")+"\n")
+
+	rt, err := Resolve(project)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	// The parent's offset=5000 must NOT have been loaded.
+	if rt.cfg.Port.Offset == 5000 {
+		t.Fatalf("Resolve walked past git root and picked up parent gofastr.yml (offset=%d)", rt.cfg.Port.Offset)
+	}
+}
+


### PR DESCRIPTION
## Summary
- add framework/isolation runtime resolver for worktree-aware ports, env, SQLite, and Postgres DSNs
- wire isolation into App.Start, gofastr dev, gofastr init, and blueprint-generated apps
- document isolation config and startup-order notes

## Verification
- go test ./framework/isolation
- go test ./cmd/gofastr (with localhost bind permission)
- go test ./framework/... (with localhost bind permission)
- go vet ./framework/isolation ./cmd/gofastr ./framework
- make build

Note: make lint could not run locally because golangci-lint is not installed in this environment.