### PR TITLE
perf(runtime): minify embedded JS in prod + carve copy handler

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -483,11 +483,13 @@ benchstat dist/bench/<tier>-before.txt dist/bench/<tier>.txt
 
 ## 8. Runtime code-split
 
-**Status:** implemented — 31 split modules in `core-ui/runtime/src/`, `loadModule()` loader with hover prefetch via `data-fui-prefetch`, idle scheduling via `requestIdleCallback`.
+**Status:** implemented + minified — 32 split modules in `core-ui/runtime/src/`, `loadModule()` loader with hover prefetch via `data-fui-prefetch`, idle scheduling via `requestIdleCallback`. A token-aware JS minifier (`core-ui/runtime/minify`) runs at first read in production, env-gated via `GOFASTR_ENV` / `GOFASTR_DEV` (see [runtime-minification.md](framework/docs/content/runtime-minification.md)). The `~10 KB gz core` target is met: bundled `runtime.js` ships at ~10.4 KB gz post-minify (was 28 KB gz pre-minify, single bundle, everything).
 
 Goal: shrink the parser-blocking JS payload on a typical page from ~31 KB
 gz (one bundle, everything) to ~10 KB gz (core only) + lazy modules loaded
-on hover / idle / first-use.
+on hover / idle / first-use. **Met** via minification + targeted carves
+(`src/copy.js` extracted from the main bundle; remaining carves like
+`navigate.js` are forward-looking).
 
 ### Status quo
 

--- a/core-ui/ARCHITECTURE.md
+++ b/core-ui/ARCHITECTURE.md
@@ -58,6 +58,10 @@ The framework primitives live in:
 - `core-ui/island` — the runtime-side island manager (registration, SSE push, slot lookup)
 - `core-ui/signal` — reactive state values that trigger SSE pushes
 - `core-ui/runtime/runtime.js` — the client-side hydration runtime
+  (minified at first read in production; see
+  [`runtime-minification.md`](../framework/docs/content/runtime-minification.md))
+- `core-ui/runtime/minify` — token-aware Go JS minifier that
+  shrinks every embedded runtime source on first read
 
 ---
 

--- a/core-ui/runtime/budget_test.go
+++ b/core-ui/runtime/budget_test.go
@@ -30,11 +30,14 @@ func TestRuntimeModuleSizeBudgets(t *testing.T) {
 	// Current high-water marks. Treat each override as a TODO to
 	// shrink toward the ROADMAP goal above. Update DOWN when a module
 	// shrinks; never update up.
+	//
+	// Post-minify the bundled runtime meets the 12 KB gz goal on its
+	// own; widgets is the only module that still needs further carving
+	// to hit the per-module 3 KB goal (lightbox cleared it).
 	moduleOverrides := map[string]int{
-		"widgets":  7 * 1024,  // goal 3 KB. Bulk: focus-trap + modal stack + dismiss machinery.
-		"lightbox": 5 * 1024,  // goal 3 KB. Bulk: pinch-zoom + pan + keyboard nav.
+		"widgets": 5 * 1024, // goal 3 KB. Bulk: focus-trap + modal stack + dismiss machinery.
 	}
-	const coreOverride = 28 * 1024 // goal 12 KB. Bulk: the bundled runtime carries the full primitive set; per-module splits are an optional path that hasn't carved core yet.
+	const coreOverride = 12 * 1024 // ROADMAP goal met after minify (was 28 KB pre-minify).
 
 	core, err := RuntimeJS()
 	if err != nil {

--- a/core-ui/runtime/forms_dedup_test.go
+++ b/core-ui/runtime/forms_dedup_test.go
@@ -29,7 +29,9 @@ func TestFormDispatcher_SingleSourceOfTruth(t *testing.T) {
 	if !strings.Contains(runtimeJS, "data-fui-rpc") {
 		t.Error("runtime.js missing data-fui-rpc form-submit branch")
 	}
-	if !strings.Contains(runtimeJS, "redirect: 'follow'") {
+	// Minified spacing has no space after the colon.
+	if !strings.Contains(runtimeJS, "redirect:'follow'") &&
+		!strings.Contains(runtimeJS, "redirect: 'follow'") {
 		t.Error("runtime.js missing Location-follow path")
 	}
 

--- a/core-ui/runtime/minify/corpus_test.go
+++ b/core-ui/runtime/minify/corpus_test.go
@@ -1,0 +1,102 @@
+package minify
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMinifyRuntimeCorpus runs every embedded runtime source through
+// the minifier and asserts:
+//
+//   - output is non-empty
+//   - output is strictly smaller than input
+//   - the minifier is idempotent: Minify(Minify(x)) == Minify(x)
+//   - well-known anchor strings survive (sanity that we didn't truncate)
+//
+// We deliberately do NOT compare raw punct counts against the input —
+// comments and string literals contain `[`, `(`, `{` characters that
+// legitimately disappear during minification. Idempotency is the
+// stronger invariant: the minifier must reach a fixed point in one
+// pass.
+func TestMinifyRuntimeCorpus(t *testing.T) {
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("repoRoot: %v", err)
+	}
+
+	type file struct {
+		path    string
+		anchors []string
+	}
+	files := []file{
+		{
+			path: filepath.Join(root, "core-ui/runtime/runtime.js"),
+			anchors: []string{
+				// Identifiers and string literals — comments are stripped.
+				"data-fui-os",
+				"__gofastr",
+			},
+		},
+	}
+	srcDir := filepath.Join(root, "core-ui/runtime/src")
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		t.Fatalf("read src dir: %v", err)
+	}
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".js") {
+			continue
+		}
+		files = append(files, file{path: filepath.Join(srcDir, e.Name())})
+	}
+
+	for _, f := range files {
+		name := filepath.Base(f.path)
+		t.Run(name, func(t *testing.T) {
+			raw, err := os.ReadFile(f.path)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			src := string(raw)
+			out := Minify(src)
+			if out == "" {
+				t.Fatalf("%s: minifier returned empty", name)
+			}
+			if len(out) >= len(src) {
+				t.Errorf("%s: did not shrink (in=%d out=%d)", name, len(src), len(out))
+			}
+			if out2 := Minify(out); out2 != out {
+				t.Errorf("%s: not idempotent (len1=%d len2=%d)", name, len(out), len(out2))
+			}
+			for _, a := range f.anchors {
+				if !strings.Contains(out, a) {
+					t.Errorf("%s: anchor %q missing from minified output", name, a)
+				}
+			}
+		})
+	}
+}
+
+// repoRoot walks upward from the package dir to find the gofastr
+// repo root (the dir holding go.mod). The minify package lives at
+// core-ui/runtime/minify so the root is three levels up.
+func repoRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir := wd
+	for i := 0; i < 8; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", os.ErrNotExist
+}

--- a/core-ui/runtime/minify/minify.go
+++ b/core-ui/runtime/minify/minify.go
@@ -1,0 +1,518 @@
+// Package minify implements a token-aware JavaScript minifier used to
+// shrink the embedded runtime sources before they're served.
+//
+// Scope (tier-2):
+//
+//   - Strip line + block comments.
+//   - Collapse whitespace, preserving newlines only where ASI cares.
+//   - Distinguish regex literals from division.
+//   - Preserve string + template-literal payloads byte-for-byte.
+//   - Insert a single space when removing whitespace would fuse two
+//     adjacent tokens (`let a` → `leta`, `+ +` → `++`, `/ /` → `//`).
+//
+// Out of scope (would be tier-3): identifier renaming, dead-code
+// elimination, constant folding, anything that requires a parser.
+//
+// The output is intentionally still valid, readable-ish JavaScript —
+// it stays parseable by the browser without source maps and a developer
+// can still set breakpoints inside it.
+package minify
+
+import "strings"
+
+// Minify returns a shrunk-but-equivalent JavaScript source. The output
+// preserves the semantics of the input across every construct the
+// embedded runtime currently uses. Inputs that aren't valid JS produce
+// undefined-but-stable output (the minifier never panics).
+func Minify(src string) string {
+	if src == "" {
+		return ""
+	}
+	m := &minifier{src: src}
+	m.run()
+	return m.out.String()
+}
+
+type tokKind int
+
+const (
+	tkNone tokKind = iota
+	tkIdent
+	tkNumber
+	tkPunct
+	tkString
+	tkRegex
+)
+
+type minifier struct {
+	src string
+	pos int
+	out strings.Builder
+
+	hasEmitted    bool
+	lastKind      tokKind
+	lastByte      byte
+	lastIdent     string
+	lastWasIncDec bool
+
+	sawNewline bool
+	sawSpace   bool
+}
+
+// Tokens after which a `/` starts a regex literal rather than a
+// division operator. JavaScript's grammar is famously context-sensitive
+// here; this set covers every keyword that legitimately precedes a
+// regex.
+var regexKeywords = map[string]bool{
+	"return": true, "typeof": true, "instanceof": true, "in": true, "of": true,
+	"new": true, "delete": true, "void": true, "throw": true, "case": true,
+	"do": true, "else": true, "if": true, "while": true, "for": true,
+	"var": true, "let": true, "const": true, "yield": true, "await": true,
+	"switch": true,
+}
+
+// Keywords that trigger ASI when followed by a newline. The newline
+// MUST survive minification or the program semantics change.
+var asiKeywords = map[string]bool{
+	"return": true, "throw": true, "break": true, "continue": true, "yield": true,
+}
+
+func isIdentStart(c byte) bool {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_' || c == '$'
+}
+func isIdentCont(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9')
+}
+func isDigit(c byte) bool    { return c >= '0' && c <= '9' }
+func isHexDigit(c byte) bool { return isDigit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') }
+
+func (m *minifier) peek(off int) byte {
+	if m.pos+off >= len(m.src) || m.pos+off < 0 {
+		return 0
+	}
+	return m.src[m.pos+off]
+}
+
+func (m *minifier) run() {
+	for m.pos < len(m.src) {
+		m.step()
+	}
+}
+
+// step consumes the next thing in the input: whitespace, a comment,
+// or one token. Whitespace + comments are absorbed silently (only
+// their newline-ness is recorded); tokens are emitted via the
+// emit* helpers, which call emitSep first to decide on separator.
+func (m *minifier) step() {
+	c := m.src[m.pos]
+	switch {
+	case c == ' ' || c == '\t' || c == '\r':
+		m.sawSpace = true
+		m.pos++
+	case c == '\n':
+		m.sawNewline = true
+		m.sawSpace = true
+		m.pos++
+	case c == '/' && m.peek(1) == '/':
+		m.skipLineComment()
+	case c == '/' && m.peek(1) == '*':
+		m.skipBlockComment()
+	case c == '\'' || c == '"':
+		m.emitString(c)
+	case c == '`':
+		m.emitTemplate()
+	case c == '/' && m.prevAllowsRegex():
+		m.emitRegex()
+	case isIdentStart(c):
+		m.emitIdent()
+	case isDigit(c):
+		m.emitNumber()
+	case c == '.' && isDigit(m.peek(1)):
+		m.emitNumber()
+	default:
+		m.emitPunct()
+	}
+}
+
+func (m *minifier) skipLineComment() {
+	for m.pos < len(m.src) && m.src[m.pos] != '\n' {
+		m.pos++
+	}
+	m.sawSpace = true
+}
+
+func (m *minifier) skipBlockComment() {
+	m.pos += 2
+	for m.pos < len(m.src) {
+		if m.pos+1 < len(m.src) && m.src[m.pos] == '*' && m.src[m.pos+1] == '/' {
+			m.pos += 2
+			break
+		}
+		if m.src[m.pos] == '\n' {
+			m.sawNewline = true
+		}
+		m.pos++
+	}
+	m.sawSpace = true
+}
+
+// prevAllowsRegex returns true when a `/` at the current position
+// should be lexed as the start of a regex literal. See the comment on
+// regexKeywords for the keyword set; otherwise: after a punct other
+// than `)`/`]`, OR at the very start of input.
+func (m *minifier) prevAllowsRegex() bool {
+	if !m.hasEmitted {
+		return true
+	}
+	switch m.lastKind {
+	case tkIdent:
+		return regexKeywords[m.lastIdent]
+	case tkNumber, tkString, tkRegex:
+		return false
+	case tkPunct:
+		if m.lastByte == ')' || m.lastByte == ']' {
+			return false
+		}
+		if m.lastWasIncDec {
+			return false
+		}
+		return true
+	}
+	return true
+}
+
+// endsExpr reports whether the last emitted token completes an
+// expression — which makes a following newline ASI-relevant when the
+// next token starts with an ambiguous prefix character.
+func (m *minifier) endsExpr() bool {
+	if m.lastWasIncDec {
+		return true
+	}
+	switch m.lastKind {
+	case tkIdent:
+		return !asiKeywords[m.lastIdent]
+	case tkNumber, tkString, tkRegex:
+		return true
+	case tkPunct:
+		return m.lastByte == ')' || m.lastByte == ']'
+	}
+	return false
+}
+
+// isASIHazardPrefix lists the bytes that, when starting a new line,
+// can be interpreted as continuation of the previous expression
+// instead of the start of a new statement. Keeping the newline alive
+// preserves ASI.
+func isASIHazardPrefix(c byte) bool {
+	switch c {
+	case '(', '[', '+', '-', '/', '`':
+		return true
+	}
+	return false
+}
+
+// fusionRisk reports whether two adjacent bytes would form a different
+// token than the two original tokens did with whitespace between them.
+func fusionRisk(last, first byte) bool {
+	if isIdentCont(last) && isIdentCont(first) {
+		return true
+	}
+	if last == '+' && first == '+' {
+		return true
+	}
+	if last == '-' && first == '-' {
+		return true
+	}
+	if last == '/' && (first == '/' || first == '*') {
+		return true
+	}
+	return false
+}
+
+// emitSep writes whatever separator (if any) is needed between the
+// last-emitted token and the next chunk starting with firstByte.
+// Resets the whitespace-seen flags afterward.
+func (m *minifier) emitSep(firstByte byte) {
+	defer func() {
+		m.sawNewline = false
+		m.sawSpace = false
+	}()
+	if !m.hasEmitted {
+		return
+	}
+	if m.sawNewline {
+		if m.lastKind == tkIdent && asiKeywords[m.lastIdent] {
+			m.out.WriteByte('\n')
+			return
+		}
+		if m.endsExpr() && isASIHazardPrefix(firstByte) {
+			m.out.WriteByte('\n')
+			return
+		}
+	}
+	// Only insert a fusion-guard space when the original source had
+	// whitespace between these two tokens. Adjacent characters that
+	// were never separated cannot fuse into a different token by
+	// definition — and forcing a space there would break `i++` into
+	// `i+ +`, regex flags into `/x/ g`, and so on.
+	if fusionRisk(m.lastByte, firstByte) && m.sawSpace {
+		m.out.WriteByte(' ')
+	}
+}
+
+func (m *minifier) emitIdent() {
+	start := m.pos
+	for m.pos < len(m.src) && isIdentCont(m.src[m.pos]) {
+		m.pos++
+	}
+	ident := m.src[start:m.pos]
+	m.emitSep(ident[0])
+	m.out.WriteString(ident)
+	m.lastKind = tkIdent
+	m.lastByte = ident[len(ident)-1]
+	m.lastIdent = ident
+	m.lastWasIncDec = false
+	m.hasEmitted = true
+}
+
+func (m *minifier) emitNumber() {
+	start := m.pos
+	// Hex / octal / binary prefixes: 0x.. 0o.. 0b..
+	if m.src[m.pos] == '0' && m.pos+1 < len(m.src) {
+		n := m.src[m.pos+1]
+		if n == 'x' || n == 'X' || n == 'o' || n == 'O' || n == 'b' || n == 'B' {
+			m.pos += 2
+			for m.pos < len(m.src) && (isHexDigit(m.src[m.pos]) || m.src[m.pos] == '_') {
+				m.pos++
+			}
+			m.flushNumber(start)
+			return
+		}
+	}
+	// Decimal: digits, '.', exponent, BigInt 'n' suffix, '_' separators.
+	for m.pos < len(m.src) {
+		c := m.src[m.pos]
+		switch {
+		case isDigit(c), c == '.', c == '_':
+			m.pos++
+		case c == 'e' || c == 'E':
+			m.pos++
+			if m.pos < len(m.src) && (m.src[m.pos] == '+' || m.src[m.pos] == '-') {
+				m.pos++
+			}
+		case c == 'n':
+			m.pos++
+			m.flushNumber(start)
+			return
+		default:
+			m.flushNumber(start)
+			return
+		}
+	}
+	m.flushNumber(start)
+}
+
+func (m *minifier) flushNumber(start int) {
+	num := m.src[start:m.pos]
+	m.emitSep(num[0])
+	m.out.WriteString(num)
+	m.lastKind = tkNumber
+	m.lastByte = num[len(num)-1]
+	m.lastIdent = ""
+	m.lastWasIncDec = false
+	m.hasEmitted = true
+}
+
+func (m *minifier) emitString(quote byte) {
+	start := m.pos
+	m.pos++ // opening quote
+	for m.pos < len(m.src) {
+		c := m.src[m.pos]
+		if c == '\\' {
+			if m.pos+1 < len(m.src) {
+				m.pos += 2
+				continue
+			}
+			m.pos++
+			break
+		}
+		if c == quote {
+			m.pos++
+			break
+		}
+		m.pos++
+	}
+	str := m.src[start:m.pos]
+	m.emitSep(str[0])
+	m.out.WriteString(str)
+	m.lastKind = tkString
+	m.lastByte = quote
+	m.lastIdent = ""
+	m.lastWasIncDec = false
+	m.hasEmitted = true
+}
+
+// emitTemplate handles a backtick template literal. The literal text
+// is copied verbatim (whitespace is significant inside backticks), but
+// each `${...}` expression is recursively minified.
+func (m *minifier) emitTemplate() {
+	m.emitSep('`')
+	m.out.WriteByte('`')
+	m.pos++
+	for m.pos < len(m.src) {
+		c := m.src[m.pos]
+		if c == '\\' {
+			m.out.WriteByte(c)
+			if m.pos+1 < len(m.src) {
+				m.out.WriteByte(m.src[m.pos+1])
+				m.pos += 2
+			} else {
+				m.pos++
+			}
+			continue
+		}
+		if c == '`' {
+			m.out.WriteByte('`')
+			m.pos++
+			break
+		}
+		if c == '$' && m.peek(1) == '{' {
+			m.out.WriteString("${")
+			m.pos += 2
+			m.minifyTemplateExpr()
+			continue
+		}
+		m.out.WriteByte(c)
+		m.pos++
+	}
+	m.lastKind = tkString
+	m.lastByte = '`'
+	m.lastIdent = ""
+	m.lastWasIncDec = false
+	m.hasEmitted = true
+}
+
+// minifyTemplateExpr runs the standard token loop with a brace-depth
+// counter; exits (and emits the closing `}`) when depth returns to 0.
+// On entry we've just written `${`. On exit, m.pos points one past
+// the matching `}`.
+func (m *minifier) minifyTemplateExpr() {
+	saved := *m
+	// Reset emit state so the first token inside ${...} doesn't get a
+	// stale separator (we've just written `${`, which acts like an
+	// opener).
+	m.hasEmitted = true
+	m.lastKind = tkPunct
+	m.lastByte = '{'
+	m.lastIdent = ""
+	m.lastWasIncDec = false
+	m.sawNewline = false
+	m.sawSpace = false
+
+	depth := 1
+	for depth > 0 && m.pos < len(m.src) {
+		c := m.src[m.pos]
+		if c == '{' {
+			depth++
+			m.emitPunct()
+			continue
+		}
+		if c == '}' {
+			depth--
+			if depth == 0 {
+				m.pos++
+				m.out.WriteByte('}')
+				break
+			}
+			m.emitPunct()
+			continue
+		}
+		m.step()
+	}
+
+	// Restore the OUTSIDE state. From the template's POV, all that
+	// happened is we wrote one logical "expression block" between `${`
+	// and `}`. The next thing emitted will be more template text
+	// (verbatim) or the closing backtick — neither cares about prev-token
+	// classification, so restoring saved is the correct stance.
+	pos := m.pos
+	out := m.out
+	*m = saved
+	m.pos = pos
+	m.out = out
+}
+
+func (m *minifier) emitRegex() {
+	start := m.pos
+	m.pos++ // opening '/'
+	inClass := false
+	for m.pos < len(m.src) {
+		c := m.src[m.pos]
+		if c == '\\' {
+			if m.pos+1 < len(m.src) {
+				m.pos += 2
+				continue
+			}
+			m.pos++
+			break
+		}
+		if c == '\n' {
+			// A regex literal cannot contain a raw newline. We
+			// misclassified — fall back to emitting `/` as punct.
+			m.pos = start
+			m.emitPunctChar('/')
+			return
+		}
+		if c == '[' {
+			inClass = true
+			m.pos++
+			continue
+		}
+		if c == ']' && inClass {
+			inClass = false
+			m.pos++
+			continue
+		}
+		if c == '/' && !inClass {
+			m.pos++
+			break
+		}
+		m.pos++
+	}
+	// Flags.
+	for m.pos < len(m.src) && isIdentCont(m.src[m.pos]) {
+		m.pos++
+	}
+	tok := m.src[start:m.pos]
+	m.emitSep(tok[0])
+	m.out.WriteString(tok)
+	m.lastKind = tkRegex
+	m.lastByte = tok[len(tok)-1]
+	m.lastIdent = ""
+	m.lastWasIncDec = false
+	m.hasEmitted = true
+}
+
+// emitPunct emits exactly one byte of punctuation. Multi-char
+// operators in the source (`===`, `=>`, `**=`, …) come through as
+// consecutive single-byte emits with no whitespace between them, so
+// the output is byte-identical to the source for any compound op.
+func (m *minifier) emitPunct() {
+	c := m.src[m.pos]
+	m.emitPunctChar(c)
+	m.pos++
+}
+
+func (m *minifier) emitPunctChar(c byte) {
+	incDec := false
+	if (c == '+' || c == '-') && m.lastByte == c && m.lastKind == tkPunct && !m.sawSpace && !m.lastWasIncDec {
+		incDec = true
+	}
+	m.emitSep(c)
+	m.out.WriteByte(c)
+	m.lastKind = tkPunct
+	m.lastByte = c
+	m.lastIdent = ""
+	m.lastWasIncDec = incDec
+	m.hasEmitted = true
+}

--- a/core-ui/runtime/minify/minify_test.go
+++ b/core-ui/runtime/minify/minify_test.go
@@ -1,0 +1,141 @@
+package minify
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMinify(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		// --- comments ---
+		{"line comment", "a=1;// foo\nb=2;", "a=1;b=2;"},
+		{"block comment", "a=1;/* foo */b=2;", "a=1;b=2;"},
+		{"block comment with newline", "a=1;/* foo\nbar */b=2;", "a=1;b=2;"},
+		{"trailing line comment no newline", "a=1;// foo", "a=1;"},
+		{"comment between idents keeps space", "let/*x*/a=1;", "let a=1;"},
+		// Block comment carrying a newline still counts for ASI when
+		// it follows an ASI keyword.
+		{"asi keyword + comment newline", "return/* x\ny */a", "return\na"},
+
+		// --- whitespace collapse ---
+		{"spaces around operator", "a  +  b", "a+b"},
+		{"tabs around operator", "a\t+\tb", "a+b"},
+		{"newline around operator", "a +\n  b", "a+b"},
+		{"keep one space between idents", "let  a  =  1", "let a=1"},
+		{"keep space between keyword and ident", "return foo", "return foo"},
+
+		// --- string literals ---
+		{"single quotes preserved", "x='a  b';", "x='a  b';"},
+		{"double quotes preserved", "x=\"a  b\";", "x=\"a  b\";"},
+		{"escaped quote in string", `x='a\'b';`, `x='a\'b';`},
+		{"newline in string via escape", `x='a\nb';`, `x='a\nb';`},
+		{"comment-looking text inside string", "x='// not a comment';", "x='// not a comment';"},
+
+		// --- template literals ---
+		{"template basic", "x=`a  b`;", "x=`a  b`;"},
+		{"template with expr", "x=`a ${b+c} d`;", "x=`a ${b+c} d`;"},
+		{"template nested", "x=`a${`b${c}d`}e`;", "x=`a${`b${c}d`}e`;"},
+		{"template with whitespace in expr", "x=`a${ b  +  c }d`;", "x=`a${b+c}d`;"},
+
+		// --- regex vs division ---
+		{"regex after equals", "let r=/foo/g;", "let r=/foo/g;"},
+		{"regex after paren", "x(/foo/);", "x(/foo/);"},
+		{"regex after return", "return /foo/;", "return/foo/;"},
+		{"division between idents", "x = a / b;", "x=a/b;"},
+		{"regex with slash in class", "let r=/[/]/g;", "let r=/[/]/g;"},
+		{"regex with escaped slash", `let r=/\//g;`, `let r=/\//g;`},
+
+		// --- ASI hazards ---
+		{"return newline preserved", "function f(){return\n  a\n}", "function f(){return\na}"},
+		{"throw newline preserved", "throw\nnew Error()", "throw\nnew Error()"},
+		{"break newline preserved", "for(;;){break\n}", "for(;;){break\n}"},
+		{"continue newline preserved", "for(;;){continue\n}", "for(;;){continue\n}"},
+
+		// --- identifier fusion guard ---
+		{"keyword ident", "let a=1", "let a=1"},
+		{"two keywords", "const await=1", "const await=1"},
+		{"number ident", "if(1 in x){}", "if(1 in x){}"},
+
+		// --- increment/decrement vs unary plus/minus ---
+		// `i++` is one token; the second `+` must NOT be separated.
+		{"postfix increment", "for(i=0;i<n;i++){}", "for(i=0;i<n;i++){}"},
+		{"postfix decrement", "i--", "i--"},
+		{"prefix increment", "++i", "++i"},
+		// `a + +b` with whitespace stays separated.
+		{"binary plus unary plus", "a + +b", "a+ +b"},
+		// `a+++b` lexes as `a++ + b` (maximal munch) — keep verbatim.
+		{"triple plus maximal munch", "a+++b", "a+++b"},
+
+		// --- regex with literal control bytes in character class ---
+		// runtime.js has `/^[\s\x00-\x1f]+/` for URL-scheme scrubbing;
+		// the NUL byte must not derail lexing.
+		{"regex with NUL and control range", "x.replace(/^[\\s\x00-\x1f]+/,'')", "x.replace(/^[\\s\x00-\x1f]+/,'')"},
+
+		// --- empty / edge ---
+		{"empty", "", ""},
+		{"only comment", "// just a comment", ""},
+		{"only block comment", "/* x */", ""},
+		{"only whitespace", "   \n  \t  ", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Minify(c.in)
+			if got != c.want {
+				t.Errorf("\n  in:   %q\n  got:  %q\n  want: %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestMinifyShrinks asserts the minifier never grows input. Cheap
+// regression guard against any policy bug that emits more than it
+// consumes.
+func TestMinifyShrinks(t *testing.T) {
+	samples := []string{
+		"// header\nfunction foo(a, b) {\n  return a + b;\n}\n",
+		"const x = {\n  a: 1,\n  b: 2,\n  c: [1, 2, 3],\n};\n",
+		"if (x === y) {\n  doThing();\n} else {\n  other();\n}\n",
+	}
+	for i, s := range samples {
+		out := Minify(s)
+		if len(out) > len(s) {
+			t.Errorf("sample %d grew: in=%d out=%d\nin:  %s\nout: %s", i, len(s), len(out), s, out)
+		}
+	}
+}
+
+// TestMinifyPreservesStringContent — string + template literal payload
+// must round-trip byte-for-byte. The only thing the minifier touches
+// inside ${...} is whitespace.
+func TestMinifyPreservesStringContent(t *testing.T) {
+	cases := []string{
+		`"hello world"`,
+		`'  spaces  matter  '`,
+		"`raw template ${x} stuff`",
+		`"// not a comment"`,
+		`'/* not a block */'`,
+	}
+	for _, c := range cases {
+		out := Minify("x=" + c + ";")
+		if !strings.Contains(out, c) {
+			t.Errorf("literal not preserved\n  in:  x=%s;\n  out: %s", c, out)
+		}
+	}
+}
+
+// TestMinifyBracesBalanced — sanity: minifier must not eat structural
+// punctuation. Loose check (raw count) but catches catastrophic bugs.
+func TestMinifyBracesBalanced(t *testing.T) {
+	src := `function f(a, b) {
+  if (a > b) { return [a, b, {x: 1, y: 2}]; }
+  return /foo/.test(a);
+}`
+	out := Minify(src)
+	for _, ch := range []string{"{", "}", "(", ")", "[", "]"} {
+		if strings.Count(src, ch) != strings.Count(out, ch) {
+			t.Errorf("punct %q count drift: src=%d out=%d\nout: %s", ch, strings.Count(src, ch), strings.Count(out, ch), out)
+		}
+	}
+}

--- a/core-ui/runtime/minify/security_test.go
+++ b/core-ui/runtime/minify/security_test.go
@@ -1,0 +1,110 @@
+package minify
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMinify_PreservesURLSchemeGuardRegex pins the most security-relevant
+// regex in the runtime — the URL-scheme guard that strips leading
+// whitespace and control bytes before checking startsWith("javascript:"),
+// "vbscript:", "data:" etc. The character class contains LITERAL NUL and
+// other control bytes (0x00–0x1F) inside the brackets; a minifier that
+// silently stripped or escaped those would let `\x00javascript:` slip
+// past the guard.
+func TestMinify_PreservesURLSchemeGuardRegex(t *testing.T) {
+	// Embedded literal control bytes — these go straight into the regex
+	// character class in runtime.js. The minifier must preserve them.
+	src := "x.replace(/^[\\s\x00-\x1f]+/, '').toLowerCase()"
+	out := Minify(src)
+	for _, b := range []byte{0x00, 0x1f} {
+		if !strings.ContainsRune(out, rune(b)) {
+			t.Errorf("SECURITY: [scheme-guard] minified output missing control byte 0x%02x: %q", b, out)
+		}
+	}
+	if !strings.Contains(out, "/^[\\s\x00-\x1f]+/") {
+		t.Errorf("SECURITY: [scheme-guard] minified regex body altered: %q", out)
+	}
+}
+
+// TestMinify_PreservesSchemeStringLiterals locks in that the scheme
+// names compared via startsWith survive intact. A minifier that
+// case-folded, trimmed, or otherwise touched string literal payloads
+// would silently break the guard ("Javascript:" passes a case-folded
+// "javascript:" check; etc).
+func TestMinify_PreservesSchemeStringLiterals(t *testing.T) {
+	src := `
+		if (v.startsWith('javascript:')) return true;
+		if (v.startsWith('vbscript:')) return true;
+		if (v.startsWith('data:')) return true;
+	`
+	out := Minify(src)
+	for _, want := range []string{"'javascript:'", "'vbscript:'", "'data:'"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("SECURITY: [scheme-guard] string literal %s missing from minified output: %q", want, out)
+		}
+	}
+}
+
+// TestMinify_DoesNotIntroduceScriptCloser asserts the minifier never
+// emits a literal </script> sequence that wasn't already present in
+// the input. The bundled runtime is served as an external <script
+// src=…> so this is defense-in-depth — but a host that ever inlines
+// the bundle would be one buggy minifier transform away from an HTML
+// parser premature-close.
+func TestMinify_DoesNotIntroduceScriptCloser(t *testing.T) {
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("repoRoot: %v", err)
+	}
+	paths := []string{filepath.Join(root, "core-ui/runtime/runtime.js")}
+	srcDir := filepath.Join(root, "core-ui/runtime/src")
+	entries, _ := os.ReadDir(srcDir)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".js" {
+			paths = append(paths, filepath.Join(srcDir, e.Name()))
+		}
+	}
+	for _, p := range paths {
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		// `</script>` substring count must not increase. We compare
+		// case-insensitively because HTML parsers also do.
+		srcCount := strings.Count(strings.ToLower(string(raw)), "</script>")
+		out := Minify(string(raw))
+		outCount := strings.Count(strings.ToLower(out), "</script>")
+		if outCount > srcCount {
+			t.Errorf("SECURITY: [script-closer] %s introduced </script> sequence (in=%d out=%d)", filepath.Base(p), srcCount, outCount)
+		}
+	}
+}
+
+// TestMinify_PreservesIsUnsafeSignalUrlIdentifier ensures the runtime's
+// scheme-guard function name survives untouched. The identifier is
+// referenced from string-bound signal hydration; renaming it would
+// silently disable the guard at every call site.
+func TestMinify_PreservesIsUnsafeSignalUrlIdentifier(t *testing.T) {
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("repoRoot: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "core-ui/runtime/runtime.js"))
+	if err != nil {
+		t.Fatalf("read runtime.js: %v", err)
+	}
+	out := Minify(string(raw))
+	for _, want := range []string{
+		"_isUnsafeSignalUrl",
+		"'javascript:'",
+		"'vbscript:'",
+		"'data:'",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("SECURITY: [scheme-guard] minified runtime.js missing %q — the URL-scheme guard may be broken", want)
+		}
+	}
+}

--- a/core-ui/runtime/minify/sizes_test.go
+++ b/core-ui/runtime/minify/sizes_test.go
@@ -1,0 +1,76 @@
+package minify
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReportSizes prints raw + gz sizes for the runtime corpus before
+// and after minification. Not an assertion — it exists so a `go test
+// -run TestReportSizes -v` invocation surfaces the actual shrink we're
+// shipping. Useful when tightening budget_test.go overrides.
+func TestReportSizes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("size report skipped in short mode")
+	}
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("repoRoot: %v", err)
+	}
+	paths := []string{filepath.Join(root, "core-ui/runtime/runtime.js")}
+	srcDir := filepath.Join(root, "core-ui/runtime/src")
+	entries, _ := os.ReadDir(srcDir)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".js" {
+			paths = append(paths, filepath.Join(srcDir, e.Name()))
+		}
+	}
+
+	var totalRaw, totalMinRaw, totalGz, totalMinGz int
+	t.Logf("%-30s  %8s -> %8s  (%5s)   %8s -> %8s  (%5s)",
+		"file", "raw", "min", "Δ", "gz", "min-gz", "Δ")
+	for _, p := range paths {
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		min := Minify(string(raw))
+		rgz := gz(raw)
+		mgz := gz([]byte(min))
+		totalRaw += len(raw)
+		totalMinRaw += len(min)
+		totalGz += rgz
+		totalMinGz += mgz
+		t.Logf("%-30s  %8d -> %8d  (%4.1f%%)   %8d -> %8d  (%4.1f%%)",
+			filepath.Base(p),
+			len(raw), len(min), pct(len(raw), len(min)),
+			rgz, mgz, pct(rgz, mgz))
+	}
+	t.Logf("%-30s  %8d -> %8d  (%4.1f%%)   %8d -> %8d  (%4.1f%%)",
+		"TOTAL",
+		totalRaw, totalMinRaw, pct(totalRaw, totalMinRaw),
+		totalGz, totalMinGz, pct(totalGz, totalMinGz))
+	if totalMinRaw >= totalRaw {
+		t.Errorf("corpus did not shrink in aggregate")
+	}
+	_ = fmt.Sprintf // keep fmt referenced if logging changes
+}
+
+func pct(before, after int) float64 {
+	if before == 0 {
+		return 0
+	}
+	return 100 * float64(before-after) / float64(before)
+}
+
+func gz(b []byte) int {
+	var buf bytes.Buffer
+	w, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	_, _ = w.Write(b)
+	_ = w.Close()
+	return buf.Len()
+}

--- a/core-ui/runtime/preload.go
+++ b/core-ui/runtime/preload.go
@@ -19,6 +19,7 @@ type demandLoadMarker struct {
 // the bottom of core-ui/runtime/runtime.js (search for "DEMAND-LOAD
 // SCANNERS"). The drift test enforces both sides stay aligned.
 var demandLoadMarkers = []demandLoadMarker{
+	{"data-fui-copy-text-from", "copy"},
 	{"data-fui-fileupload", "fileupload"},
 	{"data-fui-popover-anchor", "popover"},
 	{"data-fui-menu", "menu"},

--- a/core-ui/runtime/runtime.go
+++ b/core-ui/runtime/runtime.go
@@ -21,8 +21,13 @@ package runtime
 import (
 	"embed"
 	"io/fs"
+	"os"
 	"sort"
+	"strconv"
 	"strings"
+	"sync"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/runtime/minify"
 )
 
 //go:embed runtime.js
@@ -34,14 +39,96 @@ var colorSchemeFS embed.FS
 //go:embed src/*.js
 var modulesFS embed.FS
 
-// RuntimeJS returns the bundled runtime — the single-file IIFE every
-// page ships by default.
-func RuntimeJS() (string, error) {
-	data, err := fs.ReadFile(bundleFS, "runtime.js")
-	if err != nil {
-		return "", err
+// nominify reports whether minification should be skipped on this
+// process. The default is "production wins":
+//
+//   - GOFASTR_ENV set to "production"/"prod"/"live"/"staging" → minify.
+//   - GOFASTR_DEV truthy (and GOFASTR_ENV not a non-dev env) → keep raw
+//     so browser devtools show readable stack traces.
+//   - Neither set → minify (the right default for any app that just
+//     `go run`s its binary in production with no env hints).
+//   - RUNTIME_NOMINIFY truthy → force raw (manual override; trumps the
+//     env detection so a dev can debug a production-config app).
+//   - RUNTIME_MINIFY truthy → force minify (manual override; useful when
+//     reproducing a prod issue from a dev workstation).
+//
+// Evaluated once at startup; flipping the env mid-process has no effect
+// because Module/RuntimeJS results are cached behind sync.Once.
+var nominifyOnce sync.Once
+var nominifyVal bool
+
+func nominify() bool {
+	nominifyOnce.Do(func() {
+		// Explicit manual overrides win.
+		if envBool("RUNTIME_NOMINIFY") {
+			nominifyVal = true
+			return
+		}
+		if envBool("RUNTIME_MINIFY") {
+			nominifyVal = false
+			return
+		}
+		// Production-shaped env → minify.
+		if isNonDevEnv(os.Getenv("GOFASTR_ENV")) {
+			nominifyVal = false
+			return
+		}
+		// Explicit dev-mode → skip minify.
+		if envBool("GOFASTR_DEV") {
+			nominifyVal = true
+			return
+		}
+		// Nothing set → minify by default.
+		nominifyVal = false
+	})
+	return nominifyVal
+}
+
+func envBool(key string) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return false
 	}
-	return string(data), nil
+	b, err := strconv.ParseBool(v)
+	return err == nil && b
+}
+
+func isNonDevEnv(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "production", "prod", "live", "staging":
+		return true
+	}
+	return false
+}
+
+// Cached minified payloads. Computed lazily on first read so the
+// minify pass runs at most once per source per process; subsequent
+// reads (and there are many — every page render) are pure map lookups.
+var (
+	bundleOnce  sync.Once
+	bundleData  string
+	bundleErr   error
+	modulesOnce sync.Once
+	modulesData map[string]string
+)
+
+// RuntimeJS returns the bundled runtime — the single-file IIFE every
+// page ships by default. Minified on first call (or returned verbatim
+// when RUNTIME_NOMINIFY=1).
+func RuntimeJS() (string, error) {
+	bundleOnce.Do(func() {
+		raw, err := fs.ReadFile(bundleFS, "runtime.js")
+		if err != nil {
+			bundleErr = err
+			return
+		}
+		if nominify() {
+			bundleData = string(raw)
+			return
+		}
+		bundleData = minify.Minify(string(raw))
+	})
+	return bundleData, bundleErr
 }
 
 // MustRuntimeJS returns the bundled runtime or panics.
@@ -83,16 +170,40 @@ func ColorSchemeJS() (string, error) {
 // Module returns the source of a single split runtime module by name
 // (e.g. "fileupload"). Used by the HTTP server to serve
 // /__gofastr/runtime/<name>.js. Returns "", false when the module is
-// not embedded.
+// not embedded. Minified on first read (cached).
 func Module(name string) (string, bool) {
 	if !validModuleName(name) {
 		return "", false
 	}
-	data, err := fs.ReadFile(modulesFS, "src/"+name+".js")
+	modulesOnce.Do(loadModules)
+	src, ok := modulesData[name]
+	return src, ok
+}
+
+func loadModules() {
+	entries, err := fs.ReadDir(modulesFS, "src")
 	if err != nil {
-		return "", false
+		modulesData = map[string]string{}
+		return
 	}
-	return string(data), true
+	skip := nominify()
+	modulesData = make(map[string]string, len(entries))
+	for _, e := range entries {
+		n := e.Name()
+		if !strings.HasSuffix(n, ".js") {
+			continue
+		}
+		raw, err := fs.ReadFile(modulesFS, "src/"+n)
+		if err != nil {
+			continue
+		}
+		name := strings.TrimSuffix(n, ".js")
+		if skip {
+			modulesData[name] = string(raw)
+		} else {
+			modulesData[name] = minify.Minify(string(raw))
+		}
+	}
 }
 
 // ModuleSize returns the byte size of a single embedded module, or 0
@@ -109,17 +220,10 @@ func ModuleSize(name string) int {
 // ModuleNames returns the sorted list of split modules currently
 // embedded. Each name maps 1:1 to a /__gofastr/runtime/<name>.js URL.
 func ModuleNames() []string {
-	entries, err := fs.ReadDir(modulesFS, "src")
-	if err != nil {
-		return nil
-	}
-	out := make([]string, 0, len(entries))
-	for _, e := range entries {
-		n := e.Name()
-		if !strings.HasSuffix(n, ".js") {
-			continue
-		}
-		out = append(out, strings.TrimSuffix(n, ".js"))
+	modulesOnce.Do(loadModules)
+	out := make([]string, 0, len(modulesData))
+	for name := range modulesData {
+		out = append(out, name)
 	}
 	sort.Strings(out)
 	return out

--- a/core-ui/runtime/runtime.js
+++ b/core-ui/runtime/runtime.js
@@ -1651,75 +1651,12 @@
   // DOM, triggers a load. Scanners run after DOMContentLoaded + after
   // every SPA-nav swap (`gofastr:navigate`) + when the MutationObserver
   // sees newly inserted DOM.
-  // -----------------------------------------------------------------------
-  // Global copy-to-clipboard handler.
-  //
-  // Any element with `data-fui-copy-text-from='<selector>'` copies the
-  // matching element's textContent on click — works inside or outside a
-  // widget context. Feedback channels:
-  //
-  //   - Adds `.fui-copied` to the button for 1.2s (CSS swaps inner
-  //     `.ui-copy-btn__label` ↔ `.ui-copy-btn__copied` spans).
-  //   - If the button has a sibling/ancestor `[data-fui-copy-status]`,
-  //     writes the configured text into it (polite aria-live region).
-  //   - If `data-fui-copy-toast` is set, dispatches a toast via
-  //     `window.__gofastr.toast({...})` so callers can opt into
-  //     "Copied!" notifications without per-button JS.
-  // -----------------------------------------------------------------------
-  document.addEventListener('click', (e) => {
-    const btn = e.target && e.target.closest && e.target.closest('[data-fui-copy-text-from]');
-    if (!btn) return;
-    const sel = btn.getAttribute('data-fui-copy-text-from');
-    if (!sel) return;
-    const target = document.querySelector(sel);
-    if (!target) return;
-    e.preventDefault();
-    const text = (target.innerText || target.textContent || '').trim();
-    const flash = () => {
-      btn.classList.add('fui-copied');
-      setTimeout(() => btn.classList.remove('fui-copied'), 1200);
-    };
-    const announce = () => {
-      const root = btn.parentElement || btn;
-      const status = root.querySelector('[data-fui-copy-status]')
-        || btn.querySelector('[data-fui-copy-status]');
-      if (!status) return;
-      const msg = btn.getAttribute('data-fui-copy-announce') || 'Copied';
-      status.textContent = '';
-      setTimeout(() => { status.textContent = msg; }, 30);
-    };
-    const fireToast = () => {
-      const raw = btn.getAttribute('data-fui-copy-toast');
-      if (!raw) return;
-      try {
-        const cfg = JSON.parse(raw);
-        if (window.__gofastr && window.__gofastr.toast) {
-          window.__gofastr.toast(cfg);
-        } else if (window.__gofastr && window.__gofastr.loadModule) {
-          // Toast stack might not be loaded yet — load on demand.
-          window.__gofastr.loadModule('toasts').then(() => {
-            if (window.__gofastr.toast) window.__gofastr.toast(cfg);
-          }).catch(() => {});
-        }
-      } catch (_) { /* malformed JSON: ignore */ }
-    };
-    const success = () => { flash(); announce(); fireToast(); };
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(text).then(success, success);
-    } else {
-      try {
-        const ta = document.createElement('textarea');
-        ta.value = text;
-        document.body.appendChild(ta);
-        ta.select();
-        document.execCommand('copy');
-        ta.remove();
-        success();
-      } catch (_) { /* deliberately silent — copy is best-effort */ }
-    }
-  });
-
   const _moduleMarkers = [
+    // Copy-to-clipboard delegated handler. Loaded when any
+    // [data-fui-copy-text-from] button is on the page (or arrives via
+    // SPA-nav). The src/copy.js module installs a single document-level
+    // listener that handles every button.
+    { name: 'copy',       selector: '[data-fui-copy-text-from]' },
     { name: 'fileupload', selector: '[data-fui-fileupload]' },
     { name: 'popover',    selector: '[data-fui-popover-anchor]' },
     { name: 'menu',       selector: '[data-fui-menu]' },

--- a/core-ui/runtime/runtime_test.go
+++ b/core-ui/runtime/runtime_test.go
@@ -5,6 +5,45 @@ import (
 	"testing"
 )
 
+// TestNominifyEnvGating pins the env contract: prod wins by default,
+// dev opts out, manual overrides trump env detection. Subtests can't
+// share the sync.Once cache — exercise the underlying decision via the
+// helpers directly.
+func TestNominifyEnvGating(t *testing.T) {
+	t.Setenv("RUNTIME_NOMINIFY", "")
+	t.Setenv("RUNTIME_MINIFY", "")
+	t.Setenv("GOFASTR_ENV", "")
+	t.Setenv("GOFASTR_DEV", "")
+
+	// envBool / isNonDevEnv behaviour.
+	if envBool("RUNTIME_NOMINIFY") {
+		t.Error("envBool with empty value should be false")
+	}
+	t.Setenv("X_TEST_BOOL", "1")
+	if !envBool("X_TEST_BOOL") {
+		t.Error(`envBool("1") should be true`)
+	}
+	t.Setenv("X_TEST_BOOL", "true")
+	if !envBool("X_TEST_BOOL") {
+		t.Error(`envBool("true") should be true`)
+	}
+	t.Setenv("X_TEST_BOOL", "false")
+	if envBool("X_TEST_BOOL") {
+		t.Error(`envBool("false") should be false`)
+	}
+
+	for _, e := range []string{"production", "prod", "live", "staging", "PRODUCTION"} {
+		if !isNonDevEnv(e) {
+			t.Errorf("isNonDevEnv(%q) should be true", e)
+		}
+	}
+	for _, e := range []string{"", "dev", "development", "test", "local"} {
+		if isNonDevEnv(e) {
+			t.Errorf("isNonDevEnv(%q) should be false", e)
+		}
+	}
+}
+
 func TestRuntimeJS(t *testing.T) {
 	js, err := RuntimeJS()
 	if err != nil {
@@ -13,7 +52,10 @@ func TestRuntimeJS(t *testing.T) {
 	if len(js) == 0 {
 		t.Fatal("runtime JS is empty")
 	}
-	// Check essential features are present
+	// Check essential features are present. Anchors must be either
+	// identifiers/string-literals (preserved verbatim by the minifier)
+	// or use whitespace patterns the minifier produces — bare `foo:bar`
+	// (no space after `:`) rather than `foo: bar`.
 	checks := []string{
 		"__gofastr",
 		"register",
@@ -22,8 +64,6 @@ func TestRuntimeJS(t *testing.T) {
 		"data-action-${eventType}",
 		"data-component",
 		"MutationObserver",
-		"EventSource",
-		"data-island",
 		"hydrate",
 		"collectParams",
 		"screenCache",            // screen caching for back-navigation
@@ -36,12 +76,10 @@ func TestRuntimeJS(t *testing.T) {
 		"data-fui-style",         // <link> dedup key
 		"scheduleIdleLoads",      // LoadPrewarm idle queue
 		"data-fui-comp",          // marker attr the scanner reads
-		"data-fui-copy-status",   // SR-announce sibling for copy-text-from
-		"data-fui-copy-announce", // copy success message override
-		"data-fui-copy-toast",    // toast emit on copy success
+		"data-fui-copy-text-from",// marker triggers copy module load
 		"data-fui-os",            // OS detection on <html> for ShortcutHint
 		"data-fui-spa",           // opt-IN form-intercept for non-JSON forms
-		"redirect: 'follow'",     // form-intercept follows server Location headers
+		"redirect:'follow'",      // form-intercept follows server Location headers (minified spacing)
 		"application/x-www-form-urlencoded", // SPA-opt-in body encoding
 	}
 	for _, check := range checks {
@@ -108,7 +146,12 @@ func TestRuntimeJSSyntax(t *testing.T) {
 		}
 		trimmed = strings.TrimSpace(trimmed[idx+1:])
 	}
-	if !strings.HasPrefix(trimmed, "(() =>") && !strings.HasPrefix(trimmed, "(function") {
+	// Accept both minified (`(()=>`) and unminified (`(() =>`) IIFE
+	// preludes. The RUNTIME_NOMINIFY=1 dev path keeps the original
+	// spacing.
+	if !strings.HasPrefix(trimmed, "(()=>") &&
+		!strings.HasPrefix(trimmed, "(() =>") &&
+		!strings.HasPrefix(trimmed, "(function") {
 		t.Errorf("runtime should be an IIFE, got: %s", truncate(trimmed, 50))
 	}
 	// Should end with closing
@@ -172,7 +215,6 @@ func TestRuntimeModule_Widgets(t *testing.T) {
 		"data-fui-rpc",
 		"data-fui-autogrow",
 		"data-fui-persist-storage",
-		"data-fui-copy-text-from",
 		"data-fui-charcount-source",
 		"data-fui-clear-on-esc",
 		"data-fui-submit-on-enter",
@@ -185,6 +227,9 @@ func TestRuntimeModule_Widgets(t *testing.T) {
 		"__fuiModalEsc",   // installed once at module load
 		"__fuiModalTab",
 		"loadedModules",
+		// `data-fui-copy-text-from` was previously checked here but
+		// only lives in a comment now (the delegated handler moved
+		// to core); the minifier correctly strips it.
 	} {
 		if !strings.Contains(src, want) {
 			t.Errorf("widgets module missing %q", want)
@@ -196,6 +241,29 @@ func TestRuntimeModule_Widgets(t *testing.T) {
 	// per-widget primitives split into a forms module.
 	if size := ModuleSize("widgets"); size > 32000 {
 		t.Errorf("widgets module is %d bytes — budget is 32000", size)
+	}
+}
+
+func TestRuntimeModule_Copy(t *testing.T) {
+	src, ok := Module("copy")
+	if !ok {
+		t.Fatal("copy module not embedded")
+	}
+	for _, want := range []string{
+		"data-fui-copy-text-from", // marker
+		"data-fui-copy-status",    // SR-announce sibling
+		"data-fui-copy-announce",  // override text
+		"data-fui-copy-toast",     // toast-on-copy opt-in
+		"fui-copied",              // visual feedback class
+		"navigator.clipboard",     // primary path
+		"loadedModules",           // self-registers as loaded
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("copy module missing %q", want)
+		}
+	}
+	if size := ModuleSize("copy"); size > 1800 {
+		t.Errorf("copy module is %d bytes — budget is 1800", size)
 	}
 }
 

--- a/core-ui/runtime/src/copy.js
+++ b/core-ui/runtime/src/copy.js
@@ -1,0 +1,83 @@
+// Copy-to-clipboard runtime module.
+//
+// Loaded on-demand when a [data-fui-copy-text-from] marker is on the
+// page (or arrives via SPA-nav). The handler delegates from document,
+// so a single listener covers every copy button on the page.
+//
+// Triggers:
+//   data-fui-copy-text-from="<selector>"   the element whose text to copy
+//
+// Feedback channels:
+//   - Adds `.fui-copied` to the button for 1.2s (CSS swaps the inner
+//     `.ui-copy-btn__label` ↔ `.ui-copy-btn__copied` spans).
+//   - If the button has a sibling/ancestor [data-fui-copy-status],
+//     writes the configured text into it (polite aria-live region).
+//     data-fui-copy-announce overrides the default "Copied" string.
+//   - If data-fui-copy-toast is set (JSON config), dispatches a toast
+//     via window.__gofastr.toast({...}). Loads the toasts module on
+//     demand if it isn't already present.
+//
+// No server round-trip — clipboard write is client-only.
+
+(function () {
+  'use strict';
+
+  document.addEventListener('click', function (e) {
+    const btn = e.target && e.target.closest && e.target.closest('[data-fui-copy-text-from]');
+    if (!btn) return;
+    const sel = btn.getAttribute('data-fui-copy-text-from');
+    if (!sel) return;
+    const target = document.querySelector(sel);
+    if (!target) return;
+    e.preventDefault();
+    const text = (target.innerText || target.textContent || '').trim();
+
+    const flash = () => {
+      btn.classList.add('fui-copied');
+      setTimeout(() => btn.classList.remove('fui-copied'), 1200);
+    };
+    const announce = () => {
+      const root = btn.parentElement || btn;
+      const status = root.querySelector('[data-fui-copy-status]')
+        || btn.querySelector('[data-fui-copy-status]');
+      if (!status) return;
+      const msg = btn.getAttribute('data-fui-copy-announce') || 'Copied';
+      status.textContent = '';
+      setTimeout(() => { status.textContent = msg; }, 30);
+    };
+    const fireToast = () => {
+      const raw = btn.getAttribute('data-fui-copy-toast');
+      if (!raw) return;
+      try {
+        const cfg = JSON.parse(raw);
+        if (window.__gofastr && window.__gofastr.toast) {
+          window.__gofastr.toast(cfg);
+        } else if (window.__gofastr && window.__gofastr.loadModule) {
+          // Toast stack might not be loaded yet — load on demand.
+          window.__gofastr.loadModule('toasts').then(() => {
+            if (window.__gofastr.toast) window.__gofastr.toast(cfg);
+          }).catch(() => {});
+        }
+      } catch (_) { /* malformed JSON: ignore */ }
+    };
+    const success = () => { flash(); announce(); fireToast(); };
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(success, success);
+    } else {
+      try {
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        ta.remove();
+        success();
+      } catch (_) { /* deliberately silent — copy is best-effort */ }
+    }
+  });
+
+  // Self-register as loaded so the marker scanner skips re-fetching.
+  window.__gofastr = window.__gofastr || {};
+  (window.__gofastr.loadedModules ||= {}).copy = true;
+})();

--- a/framework/docs/content/README.md
+++ b/framework/docs/content/README.md
@@ -53,6 +53,8 @@ ending with a "common mistakes" callout.
 - [Plugins](plugins.md) — `Plugin` + optional capability interfaces.
 - [Dev-mode livereload](dev-livereload.md) — auto-wired SSE refresh
   under `gofastr dev`; env kill switches for prod.
+- [Runtime JS minification](runtime-minification.md) — embedded
+  `runtime.js` minifier, env gating, prod-wins defaults.
 
 ## Operational surface
 

--- a/framework/docs/content/agent-notes.md
+++ b/framework/docs/content/agent-notes.md
@@ -1,5 +1,25 @@
 # Agent Notes
 
+## 2026-05-26 - runtime JS minifier + copy module carve
+
+- **Scope:** new `core-ui/runtime/minify` package (token-aware JS minifier, pure Go, zero deps), `core-ui/runtime/runtime.go` wires it into `RuntimeJS()` + `Module()` via `sync.Once`, new `core-ui/runtime/src/copy.js` (carved out of `runtime.js`), `core-ui/runtime/preload.go` adds copy marker, `framework/docs/content/runtime-minification.md`, ROADMAP §8 status update.
+
+- **Minifier is env-gated, prod-wins.** Default polarity: minify unless `GOFASTR_DEV=1` (and `GOFASTR_ENV` is not a non-dev env). `RUNTIME_NOMINIFY=1` / `RUNTIME_MINIFY=1` are manual overrides that trump the env detection. An end-user who just `go build`s their app and runs in production with no env vars gets the minified runtime automatically. Dev workflow (`gofastr dev` → `GOFASTR_DEV=1`) keeps raw output so browser stack traces stay readable.
+
+- **Tier-2 scope, intentionally narrow.** Strip comments + whitespace, distinguish regex from division (via prev-token class), preserve string + template-literal payloads byte-for-byte (including `${…}` interpolation re-tokenized), preserve ASI hazards (`return\nfoo`), keep `++`/`--` un-split, handle control bytes in regex char classes (runtime.js has `/^[\s\x00-\x1f]+/`). No identifier renaming, no DCE — output stays parseable + debuggable without source maps.
+
+- **The `i++` bug.** First implementation inserted a fusion-guard space whenever two `+` would be adjacent. That broke `i++` into `i+ +`, which Acorn rejected as a parse error. Fix: only emit the fusion-guard space when the original source had whitespace between the two tokens (`m.sawSpace`). Adjacent chars in the source can't fuse into a different token by definition. Same logic applies to `--`, `//`, `/*`.
+
+- **Copy carve is the pattern.** `[data-fui-copy-text-from]` global click delegator moved from runtime.js → `src/copy.js`. Lazy-loaded via the existing `_moduleMarkers` scanner. Pages without copy buttons no longer parse the clipboard logic. Net runtime.js shrink was small (~340B raw) but architecturally it validates the carve-on-demand pattern for future growth.
+
+- **Sizes after.** Bundled `runtime.js`: 92 KB raw / 28 KB gz → 38 KB raw / **10.4 KB gz** (beats the ROADMAP §8 12 KB gz target). Total embedded JS corpus: 262 KB raw / 88 KB gz → 132 KB raw / 44 KB gz. `budget_test.go` overrides tightened accordingly.
+
+- **Stale-anchor cleanup.** Several tests grepped for substrings (`EventSource`, `data-island`, `redirect: 'follow'`, `(() =>`) that either lived only in comments (the minifier correctly strips them) or used pre-minify spacing. Replaced with code-only anchors or relaxed to accept both spacings.
+
+- **Tests:** new `core-ui/runtime/minify` package suite (table-driven unit + corpus idempotency + size report); `TestNominifyEnvGating` pins the env contract; `TestRuntimeModule_Copy` covers the new module. Full website chromedp e2e (285 tests) green against the minified runtime. Per-module budget for `copy`: 1.8 KB raw.
+
+- **Next time:** when carving more code out of `runtime.js`, check `core-ui/runtime/preload.go`'s `demandLoadMarkers` table — the marker must be added there too or pages won't get the `<link rel="modulepreload">` tag. Drift test (`TestDemandLoadMarkersMatchRuntimeJS`) enforces alignment.
+
 ## 2026-05-24 - core/dotenv + auto-load in NewApp
 
 - **Scope:** new `core/dotenv` package (parser, expander, loader), `framework.NewApp` auto-load wiring, `cmd/gofastr` migrate-command swap, `framework/docs/content/dotenv.md`.

--- a/framework/docs/content/runtime-minification.md
+++ b/framework/docs/content/runtime-minification.md
@@ -1,0 +1,83 @@
+# Runtime JS minification
+
+GoFastr embeds its client-side runtime (`runtime.js` and the
+on-demand modules under `core-ui/runtime/src/*.js`) directly into the
+host-app binary via `//go:embed`. By default, every deployed binary
+ships the **minified** form of those scripts — typically 50% smaller
+raw and 50% smaller gzipped than the embedded source.
+
+The minifier is a token-aware JavaScript pass implemented in
+`core-ui/runtime/minify` (pure Go, zero deps). Tier-2 scope:
+strip comments, collapse whitespace, distinguish regex literals from
+division, preserve string + template-literal payloads byte-for-byte,
+preserve ASI hazards (`return\nfoo`), and keep `++`/`--` together
+without identifier-fusion damage. Identifier renaming and dead-code
+elimination are out of scope — the output stays parseable JavaScript
+a developer can still read in browser devtools, just compactly.
+
+## When it runs
+
+The minifier is invoked once per source on first read (`sync.Once`),
+so the cost is paid at most once per process. Subsequent reads — and
+every page render hits the runtime — are pure map lookups.
+
+Whether the minifier runs at all is gated by env vars:
+
+| Env state                                              | Result   |
+|--------------------------------------------------------|----------|
+| `GOFASTR_ENV` ∈ {`production`, `prod`, `live`, `staging`} | minify   |
+| `GOFASTR_DEV=1` (and `GOFASTR_ENV` not a non-dev env)  | raw      |
+| neither set                                            | minify   |
+| `RUNTIME_NOMINIFY=1`                                   | raw      |
+| `RUNTIME_MINIFY=1`                                     | minify   |
+
+`RUNTIME_NOMINIFY` and `RUNTIME_MINIFY` are manual overrides that
+trump the env detection — useful for reproducing a prod-only issue
+from a dev workstation, or for debugging an end-user app that
+otherwise auto-detects as production.
+
+The defaults follow a **"production wins"** rule: an end-user who
+simply `go build`s their app and runs the binary in production —
+without setting any env vars — gets the minified runtime
+automatically. Dev mode opts OUT via `GOFASTR_DEV=1`, the same env
+flag that already enables [livereload](dev-livereload.md).
+
+## What's served
+
+Two HTTP routes are affected:
+
+- `GET /__gofastr/runtime.js` — the bundled core runtime
+- `GET /__gofastr/runtime/<name>.js` — each on-demand module
+  (`copy`, `toasts`, `widgets`, `popover`, etc.)
+
+Both return whichever form (raw or minified) the gating contract
+selected at process startup. The minified output is still a valid
+ES2020+ IIFE — no source maps are emitted, but the code remains
+human-readable enough to set breakpoints in.
+
+## Sizes
+
+After minification (typical end-user deploy):
+
+- `runtime.js`: ~38 KB raw / ~10 KB gz (was 92 KB raw / 28 KB gz)
+- All embedded modules combined: ~131 KB raw / ~44 KB gz (was 262 KB
+  / 88 KB gz)
+
+Reverse proxies (nginx, CloudFront, etc.) typically apply
+`Content-Encoding: gzip` or `br` on top, so the bytes actually on the
+wire are smaller still. GoFastr itself does not set
+`Content-Encoding` headers — that stays in the operator's control.
+
+## Verifying behaviour in your app
+
+A quick sanity check after deploying:
+
+```bash
+curl -s https://your-app.example.com/__gofastr/runtime.js | head -c 80
+```
+
+- Minified: starts with `(()=>{'use strict';try{const ua=…`
+- Raw:      starts with `// GoFastr Core-UI Runtime v0.4 — ES2020+…`
+
+If you expected one and got the other, check `GOFASTR_ENV` /
+`GOFASTR_DEV` / `RUNTIME_NOMINIFY` on the running process.

--- a/framework/uihost/uihost_test.go
+++ b/framework/uihost/uihost_test.go
@@ -164,7 +164,10 @@ func TestUIHostServesRuntimeJS(t *testing.T) {
 	}
 	body := w.Body.String()
 	assertContains(t, body, "__gofastr")
-	assertContains(t, body, "EventSource")
+	// `EventSource` lived in a runtime.js comment until SSE was
+	// extracted to its own module — the minifier correctly strips
+	// comments. Anchor on something that's actually in the code now.
+	assertContains(t, body, "screenCache")
 	ct := w.Header().Get("Content-Type")
 	if !strings.Contains(ct, "javascript") {
 		t.Errorf("expected javascript content type, got %q", ct)


### PR DESCRIPTION
## Summary

Shrinks the framework's embedded client-side JavaScript payload by ~50% raw and ~50% gzipped, and validates the on-demand carve pattern with one small extraction. Two commits:

1. **`feat(core-ui/runtime/minify)`** — new pure-Go, zero-dep token-aware JS minifier (tier-2 scope: comments, whitespace, regex-vs-division, ASI, template literals, no identifier renaming).
2. **`perf(core-ui/runtime)`** — wires the minifier into `RuntimeJS()` / `Module()` (env-gated, prod-wins) and carves the `[data-fui-copy-text-from]` clipboard delegator into `src/copy.js` (loaded on-demand).

## Sizes

| | Before | After | Δ |
|---|---:|---:|---:|
| `runtime.js` raw | 92 KB | 38 KB | **-58%** |
| `runtime.js` gz | 28 KB | **10.4 KB** | **-63%** |
| All embedded JS raw | 262 KB | 132 KB | -50% |
| All embedded JS gz | 88 KB | 44 KB | -50% |

`runtime.js` now beats the [ROADMAP §8](https://github.com/DonaldMurillo/gofastr/blob/main/ROADMAP.md#8-runtime-code-split) 12 KB gz core target.

## Env-gating contract (prod-wins)

| Env state | Result |
|---|---|
| `GOFASTR_ENV` ∈ {`production`, `prod`, `live`, `staging`} | minify |
| `GOFASTR_DEV=1` (and `GOFASTR_ENV` not non-dev) | raw (readable stack traces in devtools) |
| neither set | **minify** |
| `RUNTIME_NOMINIFY=1` | raw (manual override) |
| `RUNTIME_MINIFY=1` | minify (manual override) |

End-user who just `go build`s their app gets the minified bundle automatically in prod. Dev mode (`gofastr dev` → `GOFASTR_DEV=1`) keeps raw output.

## Notable subtleties

- Token-aware lexer distinguishes regex literals from division via prev-token class — handles `/^[\s\x00-\x1f]+/`-style regex with literal NUL bytes that runtime.js actually uses for URL-scheme scrubbing.
- Fusion-guard space is conditional on `m.sawSpace`: adjacent chars in the source can't fuse into a different token by definition, so `i++` stays `i++` (an earlier version split it into `i+ +` and broke Acorn parsing).
- Template literals preserve their text payload byte-for-byte; only the `${…}` expression body gets re-tokenized.
- Stale-anchor cleanup: a handful of tests grepped substrings that only existed in source comments (`EventSource`, `data-island`, `data-fui-copy-text-from` in widgets.js) or used pre-minify spacing (`redirect: 'follow'`). The minifier correctly strips comments and tightens spacing — tests now anchor on code-only substrings or accept both spacings.

## Docs

- **New**: [`framework/docs/content/runtime-minification.md`](framework/docs/content/runtime-minification.md) — env gating contract, prod-wins behavior, how to verify.
- **Updated**: `ROADMAP.md` §8 (target met), `core-ui/ARCHITECTURE.md` (minify package mention), `framework/docs/content/agent-notes.md` (changelog entry), `framework/docs/content/README.md` (index).

## Test plan

- [x] `go test ./core-ui/runtime/minify/` — unit tests (regex-vs-div, ASI, template literals, `++`/`--`, control bytes) + corpus idempotency test
- [x] `go test ./core-ui/runtime/...` — including `TestNominifyEnvGating`, `TestRuntimeModule_Copy`, budget test with tightened limits
- [x] `go test ./framework/uihost/ ./framework/docs/`
- [x] `node --check` + `acorn` parse the minified output cleanly
- [x] **Full website chromedp e2e: 285/285 PASS** against the minified runtime
- [x] Build + `go vet ./...` clean
- [x] Merged latest `main`, no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)