### PR TITLE
v0.22.0 — installable PWA + blueprint llm_md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-07-14
+
+First-class installable-PWA support and blueprint-generated LLM page
+documentation (#54).
+
+### Added
+
+- **Installable PWA (`uihost.WithPWA`)** — one opt-in option turns a UIHost
+  app into an installable Progressive Web App: a typed web app manifest at
+  `/manifest.webmanifest` (emitted via `encoding/json`, defaults derived at
+  serve time — name from the app title, `/` start URL/scope, standalone
+  display), a generated service worker at `/service-worker.js`, a CSP-safe
+  external registration script, and an offline fallback screen at
+  `/__gofastr/pwa/offline` (framework default or `PWAConfig.OfflineScreen`;
+  deliberately not wrapped in the app layout — it is precached, so nothing
+  personalized may render into it). The worker is conservative by
+  construction: document navigations are **network-first and never cached**
+  (rendered HTML can be personalized), falling back to the precached offline
+  screen; Cache Storage only ever holds the versioned app shell (runtime,
+  split modules under their content-addressed `?v=` URLs, `app.css`, the
+  offline page + its per-component stylesheets, icons, declared `Precache`
+  extras), matched **exactly** — content-addressed URLs are cache-first
+  (immutable), everything else is network-first so post-deploy HTML never
+  pairs with the previous deployment's runtime/CSS. Sensitive endpoints
+  (SSE, session, signal, action, widgets, `/api`, `/auth`, plus
+  `PWAConfig.DenyPaths` for custom mounts) can never be precached and are
+  never intercepted. Cache names version deterministically — the fingerprint
+  includes the bytes of static-served precache entries, so swapping an icon
+  in place rotates the cache — and activation deletes only obsolete caches
+  owned by the app. Updates never force a reload: no `skipWaiting`; a
+  waiting worker dispatches `gofastr:pwa-update` on `window`. Precached
+  responses are re-wrapped at install time so a static host's redirects
+  can't poison the offline fallback. Verified end-to-end by a serialized
+  Chrome test (registration, installability metadata, offline fallback
+  against a dead server, v1→v2 cache-version cleanup). See `gofastr docs
+  pwa`.
+- **Static export emits the PWA surface** — `ExportStatic` writes the
+  manifest, service worker, registration script, and offline page; under a
+  non-root `BasePath` the manifest URLs, the worker's precache/deny lists,
+  and the registration target are all prefixed, so the exported app installs
+  and works offline from a subpath (GitHub Pages project sites included).
+- **Blueprint `app.pwa`** — `gofastr generate` scaffolds the full surface
+  from one block, including replaceable 192px/512px/maskable placeholder
+  icons (deterministic in-process PNGs colored from `theme_color`, falling
+  back to the theme's `primary` token) so a generated app is installable
+  immediately. A custom `api_prefix` or auth `base_path` flows into
+  `DenyPaths` automatically. Round-trips through `pack`.
+- **Blueprint `app.llm_md`** — emits `uihost.WithPublicLLMMD()` so every
+  registered screen serves its `/llm.md` document plus the `/llm-pages.md`
+  index; app-level and per-screen `NoLLMMD` opt-outs keep working.
+  Independent of `app.pwa` by design; both default off, and existing
+  blueprints generate byte-identical output.
+
 ## [0.21.0] - 2026-07-13
 
 Multi-replica auth durability + a hardened third-party plugin isolation

--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ connected to a running app.
 - [Deployment](framework/docs/content/deploy.md) — single-binary build, graceful shutdown, production checklist
 - [Horizontal scaling](framework/docs/content/scaling.md) — what's process-local by default and the replica-safe alternative for each
 - [Observability](framework/docs/content/observability.md) — metrics and tracing
+- [PWA](framework/docs/content/pwa.md) — installable app manifest + versioned offline shell via `uihost.WithPWA`
 - [Agent-ready](framework/docs/content/agent-ready.md) — the discovery surface for AI agents (llms.txt, agent card, MCP)
 - [Current risk register](framework/docs/content/project-architecture-review.md) — revalidated architecture risks and maintenance rules
 - [Agent notes](framework/docs/content/agent-notes.md) — running notes for AI contributors

--- a/cmd/gofastr/blueprint.go
+++ b/cmd/gofastr/blueprint.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"image"
+	"image/color"
+	"image/png"
 	"io"
 	"math"
 	"net/http"
@@ -67,6 +71,29 @@ type BlueprintApp struct {
 	ThemeDark map[string]string // optional dark-scheme color overrides (app.theme.dark)
 	Auth      BlueprintAuth
 	Admin     BlueprintAdmin
+	PWA       BlueprintPWA
+	// LLMMD emits uihost.WithPublicLLMMD() so every registered screen
+	// serves its /llm.md document (plus the /llm-pages.md index).
+	// Independent of PWA — a screen inventory is schema disclosure, so
+	// it never rides along with another feature.
+	LLMMD bool
+}
+
+// BlueprintPWA configures the generated app's installable-PWA surface
+// (app.pwa). Enabled emits uihost.WithPWA(...) plus replaceable 192px,
+// 512px, and maskable icons under <static>/icons/. Every other field is
+// optional; the framework derives the defaults (name from the app
+// title, start_url/scope "/", standalone display).
+type BlueprintPWA struct {
+	Enabled         bool
+	Name            string
+	ShortName       string
+	Description     string
+	StartURL        string
+	Scope           string
+	Display         string // standalone | fullscreen | minimal-ui | browser
+	ThemeColor      string
+	BackgroundColor string
 }
 
 // BlueprintAdmin configures the auto-generated admin back-office (battery/admin).
@@ -355,7 +382,7 @@ func decodeBlueprintApp(node *coreyaml.Node) (BlueprintApp, error) {
 	if err != nil {
 		return BlueprintApp{}, err
 	}
-	allowed := map[string]bool{"name": true, "module": true, "db": true, "static_dir": true, "output_dir": true, "api_prefix": true, "theme": true, "auth": true, "admin": true}
+	allowed := map[string]bool{"name": true, "module": true, "db": true, "static_dir": true, "output_dir": true, "api_prefix": true, "theme": true, "auth": true, "admin": true, "pwa": true, "llm_md": true}
 	if err := rejectUnknownKeys(m, allowed, "app"); err != nil {
 		return BlueprintApp{}, err
 	}
@@ -405,7 +432,39 @@ func decodeBlueprintApp(node *coreyaml.Node) (BlueprintApp, error) {
 		}
 		app.Admin = admin
 	}
+	if pwaNode := m["pwa"]; pwaNode != nil {
+		pwa, err := decodeBlueprintPWA(pwaNode)
+		if err != nil {
+			return BlueprintApp{}, err
+		}
+		app.PWA = pwa
+	}
+	if v, ok := m["llm_md"]; ok {
+		app.LLMMD = boolValue(v)
+	}
 	return app, nil
+}
+
+func decodeBlueprintPWA(node *coreyaml.Node) (BlueprintPWA, error) {
+	m, err := expectMap(node, "app.pwa")
+	if err != nil {
+		return BlueprintPWA{}, err
+	}
+	allowed := map[string]bool{"enabled": true, "name": true, "short_name": true, "description": true, "start_url": true, "scope": true, "display": true, "theme_color": true, "background_color": true}
+	if err := rejectUnknownKeys(m, allowed, "app.pwa"); err != nil {
+		return BlueprintPWA{}, err
+	}
+	return BlueprintPWA{
+		Enabled:         boolValue(m["enabled"]),
+		Name:            stringValue(m["name"]),
+		ShortName:       stringValue(m["short_name"]),
+		Description:     stringValue(m["description"]),
+		StartURL:        stringValue(m["start_url"]),
+		Scope:           stringValue(m["scope"]),
+		Display:         stringValue(m["display"]),
+		ThemeColor:      stringValue(m["theme_color"]),
+		BackgroundColor: stringValue(m["background_color"]),
+	}, nil
 }
 
 func decodeBlueprintAdmin(node *coreyaml.Node) (BlueprintAdmin, error) {
@@ -1394,6 +1453,19 @@ func validateBlueprint(bp Blueprint) error {
 			return fmt.Errorf("blueprint: entity %q sets multi_tenant: true, but the generator cannot emit a tenant resolver (the strategy — subdomain, JWT claim, user's org — is app-specific). A generated app with none reads empty and stamps an empty tenant on every write. Wire tenant.TenantMiddleware + SetTenantID in your own main (see `gofastr docs multi-tenant`) and drop multi_tenant from the blueprint, or use owner_field for per-user scoping", decl.Name)
 		}
 	}
+	if bp.App.PWA.Enabled {
+		switch bp.App.PWA.Display {
+		case "", "standalone", "fullscreen", "minimal-ui", "browser":
+		default:
+			return fmt.Errorf("blueprint: app.pwa.display %q is not a web-app-manifest display mode; use standalone, fullscreen, minimal-ui, or browser (or omit it for standalone)", bp.App.PWA.Display)
+		}
+		if u := bp.App.PWA.StartURL; u != "" && !strings.HasPrefix(u, "/") {
+			return fmt.Errorf("blueprint: app.pwa.start_url %q must be a root-relative path (start with /)", u)
+		}
+		if s := bp.App.PWA.Scope; s != "" && !strings.HasPrefix(s, "/") {
+			return fmt.Errorf("blueprint: app.pwa.scope %q must be a root-relative path (start with /)", s)
+		}
+	}
 	for key := range bp.App.Theme {
 		if _, ok := blueprintThemeColorPath(key); ok {
 			continue
@@ -1989,6 +2061,10 @@ func renderBlueprintFilesWithOrder(bp Blueprint, entityOrderOffset, screenOrderO
 	// path remains.
 	fontFiles, _ := blueprintFontAssets(bp)
 	files = append(files, fontFiles...)
+	// PWA placeholder icons: generated deterministic PNGs so a fresh
+	// app.pwa blueprint is installable immediately. Replaceable — swap
+	// the files under <static>/icons/ with real branding.
+	files = append(files, blueprintPWAIconAssets(bp)...)
 	sort.Slice(files, func(i, j int) bool { return files[i].name < files[j].name })
 	return files, nil
 }
@@ -2460,6 +2536,34 @@ func renderBlueprintE2ETest(bp Blueprint) string {
 	b.WriteString("\t\t\tt.Errorf(\"public screen %s = %d, want 200\", p, code)\n")
 	b.WriteString("\t\t} else if len(body) < 120 { t.Errorf(\"public screen %s body suspiciously short (%d bytes)\", p, len(body)) }\n")
 	b.WriteString("\t}\n")
+
+	if bp.App.PWA.Enabled {
+		b.WriteString("\n\t// Installable-PWA surface (app.pwa).\n")
+		b.WriteString("\tif code, body := e2eDo(t, http.DefaultClient, \"GET\", base+\"/manifest.webmanifest\", \"\"); code != http.StatusOK || !strings.Contains(body, `\"name\"`) {\n")
+		b.WriteString("\t\tt.Errorf(\"manifest.webmanifest = %d, want 200 with a name\", code)\n")
+		b.WriteString("\t}\n")
+		b.WriteString("\tif code, body := e2eDo(t, http.DefaultClient, \"GET\", base+\"/service-worker.js\", \"\"); code != http.StatusOK || !strings.Contains(body, \"gofastr-pwa-\") {\n")
+		b.WriteString("\t\tt.Errorf(\"service-worker.js = %d, want 200 with a versioned cache\", code)\n")
+		b.WriteString("\t}\n")
+		b.WriteString("\tfor _, p := range []string{\"/icons/icon-192.png\", \"/icons/icon-512.png\", \"/icons/icon-maskable.png\", \"/__gofastr/pwa/register.js\", \"/__gofastr/pwa/offline\"} {\n")
+		b.WriteString("\t\tif code, _ := e2eDo(t, http.DefaultClient, \"GET\", base+p, \"\"); code != http.StatusOK {\n")
+		b.WriteString("\t\t\tt.Errorf(\"pwa asset %s = %d, want 200\", p, code)\n")
+		b.WriteString("\t\t}\n")
+		b.WriteString("\t}\n")
+	}
+
+	if bp.App.LLMMD {
+		b.WriteString("\n\t// Public LLM markdown (app.llm_md): the index and every screen document resolve.\n")
+		b.WriteString("\tif code, body := e2eDo(t, http.DefaultClient, \"GET\", base+\"/llm-pages.md\", \"\"); code != http.StatusOK || body == \"\" {\n")
+		b.WriteString("\t\tt.Errorf(\"llm-pages.md = %d, want 200\", code)\n")
+		b.WriteString("\t}\n")
+		b.WriteString(fmt.Sprintf("\tfor _, p := range %s {\n", goSlice(public)))
+		b.WriteString("\t\tmd := strings.TrimRight(p, \"/\") + \"/llm.md\"\n")
+		b.WriteString("\t\tif code, _ := e2eDo(t, http.DefaultClient, \"GET\", base+md, \"\"); code != http.StatusOK {\n")
+		b.WriteString("\t\t\tt.Errorf(\"llm.md for %s = %d, want 200\", p, code)\n")
+		b.WriteString("\t\t}\n")
+		b.WriteString("\t}\n")
+	}
 
 	if len(gated) > 0 {
 		b.WriteString("\n\t// Gated screens redirect anonymous callers to the login page.\n")
@@ -3626,10 +3730,20 @@ func renderBlueprintMain(bp Blueprint) string {
 	// appBaseCSS ships first so the user's static/app.css (loaded
 	// after) overrides it; it gives the generated entity blocks modern,
 	// responsive defaults out of the box (scrollable tables, form rhythm).
+	// Opt-in host surfaces (PWA, public LLM markdown) append to the same
+	// uihost.New call. Independent by design: enabling one never emits
+	// the other.
+	extraUIOpts := ""
+	if bp.App.PWA.Enabled {
+		extraUIOpts += ", " + blueprintPWAOptionLiteral(bp)
+	}
+	if bp.App.LLMMD {
+		extraUIOpts += ", uihost.WithPublicLLMMD()"
+	}
 	if staticDir != "" {
-		sb.WriteString(fmt.Sprintf("\tfwApp.Mount(uihost.New(site, uihost.WithStaticDir(%q), uihost.WithCustomCSS(fontFaceCSS+appBaseCSS()+uihost.ReadCustomCSSFile(%q))))\n", staticDir, staticDir+"/app.css"))
+		sb.WriteString(fmt.Sprintf("\tfwApp.Mount(uihost.New(site, uihost.WithStaticDir(%q), uihost.WithCustomCSS(fontFaceCSS+appBaseCSS()+uihost.ReadCustomCSSFile(%q))%s))\n", staticDir, staticDir+"/app.css", extraUIOpts))
 	} else {
-		sb.WriteString("\tfwApp.Mount(uihost.New(site, uihost.WithCustomCSS(fontFaceCSS+appBaseCSS())))\n")
+		sb.WriteString(fmt.Sprintf("\tfwApp.Mount(uihost.New(site, uihost.WithCustomCSS(fontFaceCSS+appBaseCSS())%s))\n", extraUIOpts))
 	}
 	if bp.App.Admin.Enabled {
 		// Auto-generated back-office over every CRUD entity. Registered as a
@@ -6562,6 +6676,11 @@ func blueprintEffectiveStaticDir(bp Blueprint) string {
 	if len(blueprintConfiguredFontFamilies(bp.App.Theme)) > 0 {
 		return "static"
 	}
+	// A PWA needs a home for its scaffolded icons (and a serving route
+	// for them), same as self-hosted fonts.
+	if bp.App.PWA.Enabled {
+		return "static"
+	}
 	return ""
 }
 
@@ -6669,6 +6788,149 @@ func blueprintFontAssets(bp Blueprint) (files []generatedFile, missing []string)
 		files = append(files, generatedFile{name: rel, content: string(data)})
 	}
 	return files, missing
+}
+
+// blueprintPWAOptionLiteral renders the uihost.WithPWA(...) call for the
+// generated main.go. Only author-declared fields are emitted (so pack
+// recovers exactly the authored blueprint); the framework applies the
+// defaults at serve time. The icon set always points at the scaffolded
+// placeholder files.
+func blueprintPWAOptionLiteral(bp Blueprint) string {
+	p := bp.App.PWA
+	var fields []string
+	if p.Name != "" {
+		fields = append(fields, fmt.Sprintf("Name: %q", p.Name))
+	}
+	if p.ShortName != "" {
+		fields = append(fields, fmt.Sprintf("ShortName: %q", p.ShortName))
+	}
+	if p.Description != "" {
+		fields = append(fields, fmt.Sprintf("Description: %q", p.Description))
+	}
+	if p.StartURL != "" {
+		fields = append(fields, fmt.Sprintf("StartURL: %q", p.StartURL))
+	}
+	if p.Scope != "" {
+		fields = append(fields, fmt.Sprintf("Scope: %q", p.Scope))
+	}
+	if p.Display != "" {
+		fields = append(fields, "Display: "+blueprintPWADisplayConst(p.Display))
+	}
+	if p.ThemeColor != "" {
+		fields = append(fields, fmt.Sprintf("ThemeColor: %q", p.ThemeColor))
+	}
+	if p.BackgroundColor != "" {
+		fields = append(fields, fmt.Sprintf("BackgroundColor: %q", p.BackgroundColor))
+	}
+	// The framework's built-in deny list covers the default /api and
+	// /auth mounts; a custom api_prefix or auth base_path must follow
+	// its app's real mounts or the never-precache/never-intercept
+	// guarantee silently stops covering the API.
+	var deny []string
+	if prefix := strings.Trim(bp.App.APIPrefix, "/"); prefix != "" && prefix != "api" {
+		deny = append(deny, "/"+prefix)
+	}
+	if bp.App.Auth.Enabled {
+		if base := strings.TrimRight(bp.App.Auth.BasePath, "/"); base != "" && base != "/auth" {
+			deny = append(deny, base)
+		}
+	}
+	if len(deny) > 0 {
+		quoted := make([]string, len(deny))
+		for i, d := range deny {
+			quoted[i] = fmt.Sprintf("%q", d)
+		}
+		fields = append(fields, "DenyPaths: []string{"+strings.Join(quoted, ", ")+"}")
+	}
+	fields = append(fields, `Icons: []uihost.PWAIcon{{Src: "/icons/icon-192.png", Sizes: "192x192", Type: "image/png"}, {Src: "/icons/icon-512.png", Sizes: "512x512", Type: "image/png"}, {Src: "/icons/icon-maskable.png", Sizes: "512x512", Type: "image/png", Purpose: uihost.PWAIconPurposeMaskable}}`)
+	return "uihost.WithPWA(uihost.PWAConfig{" + strings.Join(fields, ", ") + "})"
+}
+
+// blueprintPWADisplayConst maps a validated blueprint display mode to
+// the typed uihost constant emitted into generated code.
+func blueprintPWADisplayConst(display string) string {
+	switch display {
+	case "fullscreen":
+		return "uihost.PWADisplayFullscreen"
+	case "minimal-ui":
+		return "uihost.PWADisplayMinimalUI"
+	case "browser":
+		return "uihost.PWADisplayBrowser"
+	default:
+		return "uihost.PWADisplayStandalone"
+	}
+}
+
+// blueprintPWAIconAssets emits the replaceable placeholder icons an
+// app.pwa blueprint scaffolds: 192px and 512px "any" icons plus a 512px
+// maskable variant, colored from the declared theme_color (falling back
+// to the theme's primary token, then the framework indigo). Generated
+// in-process — deterministic PNG bytes, no network fetch.
+func blueprintPWAIconAssets(bp Blueprint) []generatedFile {
+	if !bp.App.PWA.Enabled {
+		return nil
+	}
+	dir := blueprintEffectiveStaticDir(bp)
+	fill := bp.App.PWA.ThemeColor
+	if fill == "" {
+		fill = bp.App.Theme["primary"]
+	}
+	bg, ok := blueprintParseHexColor(fill)
+	if !ok {
+		bg = color.NRGBA{R: 0x4f, G: 0x46, B: 0xe5, A: 0xff} // indigo fallback
+	}
+	rel := func(name string) string {
+		return filepath.ToSlash(filepath.Join(dir, "icons", name))
+	}
+	return []generatedFile{
+		{name: rel("icon-192.png"), content: string(blueprintPWAIconPNG(192, bg))},
+		{name: rel("icon-512.png"), content: string(blueprintPWAIconPNG(512, bg))},
+		// The maskable icon uses the same full-bleed art: a solid
+		// background with a centered dot keeps all content inside the
+		// mask safe zone regardless of the platform's crop shape.
+		{name: rel("icon-maskable.png"), content: string(blueprintPWAIconPNG(512, bg))},
+	}
+}
+
+// blueprintPWAIconPNG draws the placeholder icon: a solid brand-color
+// square with a centered translucent-white dot, well inside the
+// maskable safe zone.
+func blueprintPWAIconPNG(size int, bg color.NRGBA) []byte {
+	img := image.NewNRGBA(image.Rect(0, 0, size, size))
+	dot := color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xd9}
+	c := float64(size) / 2
+	r := float64(size) * 0.22
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			dx, dy := float64(x)+0.5-c, float64(y)+0.5-c
+			if dx*dx+dy*dy <= r*r {
+				img.SetNRGBA(x, y, dot)
+			} else {
+				img.SetNRGBA(x, y, bg)
+			}
+		}
+	}
+	var buf bytes.Buffer
+	// Encode cannot fail on an in-memory buffer with a valid image.
+	_ = png.Encode(&buf, img)
+	return buf.Bytes()
+}
+
+// blueprintParseHexColor parses #rgb / #rrggbb into an opaque color.
+func blueprintParseHexColor(s string) (color.NRGBA, bool) {
+	s = strings.TrimPrefix(strings.TrimSpace(s), "#")
+	switch len(s) {
+	case 3:
+		s = string([]byte{s[0], s[0], s[1], s[1], s[2], s[2]})
+	case 6:
+	default:
+		return color.NRGBA{}, false
+	}
+	v, err := strconv.ParseUint(s, 16, 32)
+	if err != nil {
+		return color.NRGBA{}, false
+	}
+	return color.NRGBA{R: uint8(v >> 16), G: uint8(v >> 8), B: uint8(v), A: 0xff}, true
 }
 
 // blueprintFontRelPath is the emitted path for a family's woff2 file, matching

--- a/cmd/gofastr/blueprint_pwa_test.go
+++ b/cmd/gofastr/blueprint_pwa_test.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// pwaTestBlueprint loads a minimal blueprint with the given app-block
+// extras (indented two spaces, e.g. the pwa/llm_md lines).
+func pwaTestBlueprint(t *testing.T, appExtras string) Blueprint {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gofastr.yml")
+	yml := "app:\n  name: Demo\n  module: example.com/demo\n" + appExtras + `
+screens:
+  - name: home
+    route: /
+    title: Home
+`
+	if err := os.WriteFile(path, []byte(yml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bp, err := loadBlueprint(path)
+	if err != nil {
+		t.Fatalf("loadBlueprint: %v", err)
+	}
+	return bp
+}
+
+func pwaRenderedMain(t *testing.T, bp Blueprint) (string, []generatedFile) {
+	t.Helper()
+	files, err := renderBlueprintFiles(bp)
+	if err != nil {
+		t.Fatalf("renderBlueprintFiles: %v", err)
+	}
+	for _, f := range files {
+		if f.name == "main.go" {
+			return f.content, files
+		}
+	}
+	t.Fatalf("no main.go in rendered files")
+	return "", nil
+}
+
+const pwaBlockYAML = `  pwa:
+    enabled: true
+    short_name: Dm
+    description: Demo tracker
+    theme_color: "#112233"
+    background_color: "#ffffff"
+    display: minimal-ui
+`
+
+func TestBlueprintDecodesPWA(t *testing.T) {
+	bp := pwaTestBlueprint(t, pwaBlockYAML+"  llm_md: true\n")
+	p := bp.App.PWA
+	if !p.Enabled {
+		t.Fatalf("pwa.enabled should decode, got %#v", p)
+	}
+	if p.ShortName != "Dm" || p.Description != "Demo tracker" {
+		t.Errorf("short_name/description: %#v", p)
+	}
+	if p.ThemeColor != "#112233" || p.BackgroundColor != "#ffffff" {
+		t.Errorf("colors: %#v", p)
+	}
+	if p.Display != "minimal-ui" {
+		t.Errorf("display: %q", p.Display)
+	}
+	if !bp.App.LLMMD {
+		t.Errorf("llm_md should decode true")
+	}
+}
+
+func TestBlueprintRejectsUnknownPWAKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yml")
+	writeTestFile(t, path, "app:\n  name: Demo\n  pwa:\n    enabled: true\n    bogus: 1\n")
+	_, err := loadBlueprint(path)
+	if err == nil || !strings.Contains(err.Error(), `unknown key "bogus"`) {
+		t.Fatalf("loadBlueprint err = %v", err)
+	}
+}
+
+func TestBlueprintRejectsBadPWADisplay(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yml")
+	writeTestFile(t, path, "app:\n  name: Demo\n  pwa:\n    enabled: true\n    display: popup\n")
+	_, err := loadBlueprint(path)
+	if err == nil || !strings.Contains(err.Error(), "app.pwa.display") {
+		t.Fatalf("loadBlueprint err = %v", err)
+	}
+}
+
+func TestBlueprintPWAEmitsWithPWA(t *testing.T) {
+	bp := pwaTestBlueprint(t, pwaBlockYAML)
+	mainGo, files := pwaRenderedMain(t, bp)
+	if !strings.Contains(mainGo, "uihost.WithPWA(uihost.PWAConfig{") {
+		t.Errorf("main.go should emit WithPWA:\n%s", mainGo)
+	}
+	if !strings.Contains(mainGo, "uihost.PWADisplayMinimalUI") {
+		t.Errorf("display should map to the typed constant:\n%s", mainGo)
+	}
+	if !strings.Contains(mainGo, `"/icons/icon-192.png"`) ||
+		!strings.Contains(mainGo, `"/icons/icon-512.png"`) ||
+		!strings.Contains(mainGo, `"/icons/icon-maskable.png"`) {
+		t.Errorf("WithPWA should declare the scaffolded icons:\n%s", mainGo)
+	}
+	if !strings.Contains(mainGo, "uihost.PWAIconPurposeMaskable") {
+		t.Errorf("maskable icon should carry the typed purpose:\n%s", mainGo)
+	}
+	if strings.Contains(mainGo, "WithPublicLLMMD") {
+		t.Errorf("pwa alone must not enable llm_md:\n%s", mainGo)
+	}
+	// Scaffolded icons: replaceable PNG files under the static dir.
+	wantIcons := map[string]bool{
+		"static/icons/icon-192.png":      false,
+		"static/icons/icon-512.png":      false,
+		"static/icons/icon-maskable.png": false,
+	}
+	for _, f := range files {
+		if _, ok := wantIcons[f.name]; ok {
+			wantIcons[f.name] = true
+			if !strings.HasPrefix(f.content, "\x89PNG\r\n\x1a\n") {
+				t.Errorf("%s is not a PNG", f.name)
+			}
+		}
+	}
+	for name, seen := range wantIcons {
+		if !seen {
+			t.Errorf("missing scaffolded icon %s", name)
+		}
+	}
+}
+
+// TestBlueprintPWACustomPrefixesDenied: a custom api_prefix (and a
+// custom auth base_path) must flow into WithPWA's DenyPaths so the
+// service worker's never-precache/never-intercept guarantee follows
+// the app's real mounts, not the /api and /auth defaults.
+func TestBlueprintPWACustomPrefixesDenied(t *testing.T) {
+	bp := pwaTestBlueprint(t, "  api_prefix: v1\n"+pwaBlockYAML+`  auth:
+    enabled: true
+    base_path: /account
+`)
+	mainGo, _ := pwaRenderedMain(t, bp)
+	if !strings.Contains(mainGo, `DenyPaths: []string{"/v1", "/account"}`) {
+		t.Errorf("custom api_prefix + auth base_path should be emitted as DenyPaths:\n%s", mainGo)
+	}
+
+	// Default mounts need no extension — /api and /auth are built in.
+	plain := pwaTestBlueprint(t, pwaBlockYAML)
+	plainMain, _ := pwaRenderedMain(t, plain)
+	if strings.Contains(plainMain, "DenyPaths") {
+		t.Errorf("default prefixes must not emit DenyPaths:\n%s", plainMain)
+	}
+}
+
+func TestBlueprintLLMMDEmitsOption(t *testing.T) {
+	bp := pwaTestBlueprint(t, "  llm_md: true\n")
+	mainGo, files := pwaRenderedMain(t, bp)
+	if !strings.Contains(mainGo, "uihost.WithPublicLLMMD()") {
+		t.Errorf("main.go should emit WithPublicLLMMD:\n%s", mainGo)
+	}
+	if strings.Contains(mainGo, "WithPWA") {
+		t.Errorf("llm_md alone must not enable pwa:\n%s", mainGo)
+	}
+	for _, f := range files {
+		if strings.Contains(f.name, "icons/") {
+			t.Errorf("llm_md alone must not scaffold icons: %s", f.name)
+		}
+	}
+}
+
+func TestBlueprintPWALLMMatrix(t *testing.T) {
+	cases := []struct {
+		name       string
+		extras     string
+		wantPWA    bool
+		wantLLMMMD bool
+	}{
+		{"neither", "", false, false},
+		{"pwa-only", pwaBlockYAML, true, false},
+		{"llm-only", "  llm_md: true\n", false, true},
+		{"both", pwaBlockYAML + "  llm_md: true\n", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mainGo, _ := pwaRenderedMain(t, pwaTestBlueprint(t, tc.extras))
+			if got := strings.Contains(mainGo, "uihost.WithPWA("); got != tc.wantPWA {
+				t.Errorf("WithPWA emitted = %v, want %v", got, tc.wantPWA)
+			}
+			if got := strings.Contains(mainGo, "uihost.WithPublicLLMMD()"); got != tc.wantLLMMMD {
+				t.Errorf("WithPublicLLMMD emitted = %v, want %v", got, tc.wantLLMMMD)
+			}
+		})
+	}
+}
+
+func TestPackReadsPWAAndLLMMD(t *testing.T) {
+	bp := pwaTestBlueprint(t, pwaBlockYAML+"  llm_md: true\n")
+	files, err := renderBlueprintFiles(bp)
+	if err != nil {
+		t.Fatalf("renderBlueprintFiles: %v", err)
+	}
+	dir := t.TempDir()
+	for _, f := range files {
+		full := filepath.Join(dir, f.name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(f.content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := packReadApp(dir)
+	if err != nil {
+		t.Fatalf("packReadApp: %v", err)
+	}
+	if got.PWA != bp.App.PWA {
+		t.Errorf("pack should round-trip the pwa block:\n got %#v\nwant %#v", got.PWA, bp.App.PWA)
+	}
+	if !got.LLMMD {
+		t.Errorf("pack should recover llm_md: true")
+	}
+}
+
+func TestAppToMapSerializesPWAAndLLMMD(t *testing.T) {
+	bp := pwaTestBlueprint(t, pwaBlockYAML+"  llm_md: true\n")
+	m := appToMap(bp.App)
+	pwa, ok := m["pwa"].(map[string]any)
+	if !ok {
+		t.Fatalf("appToMap should emit a pwa block, got %#v", m)
+	}
+	if pwa["display"] != "minimal-ui" || pwa["theme_color"] != "#112233" {
+		t.Errorf("pwa map: %#v", pwa)
+	}
+	if m["llm_md"] != true {
+		t.Errorf("llm_md should serialize, got %#v", m["llm_md"])
+	}
+
+	// Absent features must not add keys (byte-compat for existing blueprints).
+	plain := pwaTestBlueprint(t, "")
+	pm := appToMap(plain.App)
+	if _, has := pm["pwa"]; has {
+		t.Errorf("no pwa key expected when disabled")
+	}
+	if _, has := pm["llm_md"]; has {
+		t.Errorf("no llm_md key expected when disabled")
+	}
+}

--- a/cmd/gofastr/blueprint_test.go
+++ b/cmd/gofastr/blueprint_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -1034,6 +1035,51 @@ func TestBlueprintCLIGeneratesEntireWorkingAppE2E(t *testing.T) {
 	checkBodyContains(t, baseURL+"/", http.StatusOK, "details-section")
 	checkBodyContains(t, baseURL+"/hello.txt", http.StatusOK, "static from generated app")
 
+	// Installable-PWA surface (the fixture enables app.pwa).
+	checkBodyContains(t, baseURL+"/manifest.webmanifest", http.StatusOK, `"name": "Demo"`)
+	checkBodyContains(t, baseURL+"/service-worker.js", http.StatusOK, "gofastr-pwa-")
+	checkBodyContains(t, baseURL+"/icons/icon-192.png", http.StatusOK, "PNG")
+	checkBodyContains(t, baseURL+"/icons/icon-512.png", http.StatusOK, "PNG")
+	checkBodyContains(t, baseURL+"/icons/icon-maskable.png", http.StatusOK, "PNG")
+	checkBodyContains(t, baseURL+"/__gofastr/pwa/offline", http.StatusOK, "offline")
+	checkBodyContains(t, baseURL+"/", http.StatusOK, `<link rel="manifest" href="/manifest.webmanifest">`)
+
+	// LLM markdown (the fixture enables app.llm_md): the index lists the
+	// screens and every screen llm.md link it emits resolves. The /api/llm.md
+	// prose pointer is skipped — it belongs to the entity API surface, not
+	// the screen inventory.
+	idxResp, err := http.Get(baseURL + "/llm-pages.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	idxBody, _ := io.ReadAll(idxResp.Body)
+	idxResp.Body.Close()
+	if idxResp.StatusCode != http.StatusOK {
+		t.Fatalf("/llm-pages.md status = %d", idxResp.StatusCode)
+	}
+	if !strings.Contains(string(idxBody), "[/](") {
+		t.Errorf("/llm-pages.md should list the root screen:\n%s", idxBody)
+	}
+	llmLink := regexp.MustCompile(`\((/[^)]*llm\.md)\)`)
+	seenScreenLink := false
+	for _, m := range llmLink.FindAllStringSubmatch(string(idxBody), -1) {
+		if m[1] == "/api/llm.md" {
+			continue
+		}
+		seenScreenLink = true
+		linkResp, err := http.Get(baseURL + m[1])
+		if err != nil {
+			t.Fatal(err)
+		}
+		linkResp.Body.Close()
+		if linkResp.StatusCode != http.StatusOK {
+			t.Errorf("llm-pages.md link %s = %d, want 200", m[1], linkResp.StatusCode)
+		}
+	}
+	if !seenScreenLink {
+		t.Errorf("/llm-pages.md emitted no screen links:\n%s", idxBody)
+	}
+
 	// CRUD routes mount under the default api_prefix ("api") so root paths
 	// stay free for the generated HTML screens.
 	created := requestJSON(t, http.MethodPost, baseURL+"/api/posts", map[string]any{"title": "HTTP Post", "status": "draft"}, http.StatusCreated)
@@ -1387,6 +1433,11 @@ app:
   name: Demo
   module: example.com/demo
   static_dir: public
+  pwa:
+    enabled: true
+    short_name: Demo
+    theme_color: "#F2AA4C"
+  llm_md: true
   theme:
     background: "#101820"
     primary: "#F2AA4C"

--- a/cmd/gofastr/pack.go
+++ b/cmd/gofastr/pack.go
@@ -153,6 +153,22 @@ func appToMap(a BlueprintApp) map[string]any {
 		putStr(admin, "seed_password", a.Admin.SeedPassword)
 		m["admin"] = admin
 	}
+	if a.PWA.Enabled {
+		pwa := map[string]any{}
+		putBool(pwa, "enabled", a.PWA.Enabled)
+		putStr(pwa, "name", a.PWA.Name)
+		putStr(pwa, "short_name", a.PWA.ShortName)
+		putStr(pwa, "description", a.PWA.Description)
+		putStr(pwa, "start_url", a.PWA.StartURL)
+		putStr(pwa, "scope", a.PWA.Scope)
+		putStr(pwa, "display", a.PWA.Display)
+		putStr(pwa, "theme_color", a.PWA.ThemeColor)
+		putStr(pwa, "background_color", a.PWA.BackgroundColor)
+		m["pwa"] = pwa
+	}
+	if a.LLMMD {
+		m["llm_md"] = true
+	}
 	return m
 }
 
@@ -1326,21 +1342,38 @@ func packReadApp(dir string) (BlueprintApp, error) {
 		return true
 	})
 
-	// Admin config lives in main.go.
+	// Admin, PWA, and LLM-markdown config live in main.go.
 	if mainFile, err := packParseFile(filepath.Join(dir, "main.go")); err == nil {
 		ast.Inspect(mainFile, func(n ast.Node) bool {
-			cl, ok := n.(*ast.CompositeLit)
-			if !ok || astSelLast(cl.Type) != "Config" {
-				return true
+			switch t := n.(type) {
+			case *ast.CompositeLit:
+				switch astSelLast(t.Type) {
+				case "Config":
+					cv := fieldVals(t)
+					if _, ok := cv["PathPrefix"]; !ok {
+						return true // not an admin.Config
+					}
+					app.Admin.Enabled = true
+					app.Admin.Path = astString(cv["PathPrefix"])
+					app.Admin.Role = astString(cv["AdminRole"])
+					app.Admin.LoginPath = astString(cv["LoginPath"])
+				case "PWAConfig":
+					cv := fieldVals(t)
+					app.PWA.Enabled = true
+					app.PWA.Name = astString(cv["Name"])
+					app.PWA.ShortName = astString(cv["ShortName"])
+					app.PWA.Description = astString(cv["Description"])
+					app.PWA.StartURL = astString(cv["StartURL"])
+					app.PWA.Scope = astString(cv["Scope"])
+					app.PWA.Display = packPWADisplay(astSelLast(cv["Display"]))
+					app.PWA.ThemeColor = astString(cv["ThemeColor"])
+					app.PWA.BackgroundColor = astString(cv["BackgroundColor"])
+				}
+			case *ast.CallExpr:
+				if astSelLast(t.Fun) == "WithPublicLLMMD" {
+					app.LLMMD = true
+				}
 			}
-			cv := fieldVals(cl)
-			if _, ok := cv["PathPrefix"]; !ok {
-				return true // not an admin.Config
-			}
-			app.Admin.Enabled = true
-			app.Admin.Path = astString(cv["PathPrefix"])
-			app.Admin.Role = astString(cv["AdminRole"])
-			app.Admin.LoginPath = astString(cv["LoginPath"])
 			return true
 		})
 	}
@@ -1378,6 +1411,23 @@ func packReadDotEnv(path string) map[string]string {
 		return map[string]string{}
 	}
 	return out
+}
+
+// packPWADisplay maps a generated uihost.PWADisplay* constant name back
+// to the blueprint's display string — the reverse of
+// blueprintPWADisplayConst. Unknown/absent → "" (the omitted default).
+func packPWADisplay(constName string) string {
+	switch constName {
+	case "PWADisplayStandalone":
+		return "standalone"
+	case "PWADisplayFullscreen":
+		return "fullscreen"
+	case "PWADisplayMinimalUI":
+		return "minimal-ui"
+	case "PWADisplayBrowser":
+		return "browser"
+	}
+	return ""
 }
 
 // astSelLast returns the trailing identifier of a selector/ident type expr

--- a/core-ui/ARCHITECTURE.md
+++ b/core-ui/ARCHITECTURE.md
@@ -420,6 +420,43 @@ prefix matches the existing `gofastr:navigate` convention. The
 NetworkRetryBanner reads `lastEventAt` for its silence trigger and
 listens for the event to re-probe its health endpoint on reconnect.
 
+### PWA surface (`uihost.WithPWA`)
+
+Opt-in installable-app support lives in `framework/uihost` (see
+`framework/docs/content/pwa.md` for the user guide). The contract with
+the rest of this document:
+
+- **Chrome injection.** `WithPWA` adds `<link rel="manifest">` (+ a
+  `theme-color` meta when configured) to `<head>` and an external
+  `<script src="/__gofastr/pwa/register.js" defer>` before `</body>` —
+  no inline JS, same CSP posture as `runtime.js`. Routes mounted:
+  `/manifest.webmanifest`, `/service-worker.js` (root-scoped),
+  `/__gofastr/pwa/register.js`, `/__gofastr/pwa/offline`.
+- **The service worker never interferes with the runtime's rails.**
+  Its fetch handler has a baked deny list (`/__gofastr/sse`,
+  `/__gofastr/session`, `/__gofastr/signal/*`, `/__gofastr/action`,
+  `/__gofastr/widgets`, `/api/*`, `/auth/*`, plus `PWAConfig.DenyPaths`
+  for custom mounts) and ignores non-GET, so island RPCs, SSE streams,
+  sessions, and auth always hit the network untouched. Documents are
+  network-first and never cached (SSR HTML can be personalized); only
+  the versioned app-shell precache (runtime, split modules under their
+  `?v=<hash>` URLs, app.css, offline page + its per-component
+  stylesheets — never the comp-bundle, whose names-set is per-page —
+  icons, declared extras) lives in Cache Storage, and nothing is added
+  at runtime. Matching is exact: `?v=` content-addressed URLs are
+  cache-first (immutable), everything else is network-first with the
+  cache as offline fallback, so post-deploy HTML never pairs with the
+  old deployment's runtime/CSS.
+- **The offline screen renders through the document shell but NOT the
+  app layout** — it is precached at install time, so nothing
+  personalized may render into it.
+- **Updates never force a reload.** No `skipWaiting`; a waiting worker
+  dispatches `gofastr:pwa-update` on `window` (via register.js) and
+  activates when the old version's tabs close.
+- **Static export** (`framework/static.Builder`) emits the same four
+  assets with `BasePath` baked into the manifest URLs, precache/deny
+  lists, and registration target.
+
 ---
 
 ## Forms

--- a/examples/site/docs_catalog.go
+++ b/examples/site/docs_catalog.go
@@ -105,6 +105,7 @@ var docIntents = []docIntent{
 			{"print", "Print documents", "Server-rendered print-friendly documents + PDF."},
 			{"dev-livereload", "Dev livereload", "SSE-driven reload while you edit — zero config."},
 			{"static-export", "Static-site export", "Render the whole app to static HTML + assets for apex or project-path hosting."},
+			{"pwa", "PWA", "uihost.WithPWA: installable manifest, versioned offline shell, and a safe service worker."},
 			{"interactive-patterns", "Interactive patterns", "The data-fui-* vocabulary: RPC islands, signals, open-widget, optimistic actions."},
 			{"pane-host", "Pane host", "Master-detail split-pane layout that collapses to an overlay drawer on narrow screens."},
 			{"plugin-platform", "Plugin platform", "Host third-party JS plugins in a sandboxed opaque-origin iframe with a capability-gated postMessage protocol."},

--- a/framework/docs/content/blueprints.md
+++ b/framework/docs/content/blueprints.md
@@ -760,6 +760,53 @@ role gets 403. When `seed_email`/`seed_password` are set, the app bootstraps
 that admin account on a fresh database (idempotent — created only when absent),
 so the back-office is reachable on first boot. Requires `app.auth.enabled`.
 
+### Installable PWA (`app.pwa`)
+
+```yaml
+app:
+  pwa:
+    enabled: true
+    name: Meridian          # optional — defaults to app.name at serve time
+    short_name: Meridian    # optional home-screen label
+    description: ...        # optional
+    start_url: /            # optional, default /
+    scope: /                # optional, default /
+    display: standalone     # optional: standalone | fullscreen | minimal-ui | browser
+    theme_color: "#4f46e5"  # optional; also drives the placeholder icon color
+    background_color: "#ffffff"
+```
+
+With `enabled: true` the generated app passes `uihost.WithPWA(...)` to the
+UI host — manifest, service worker, offline screen, registration script;
+see the [PWA guide](pwa.md) for the full runtime behavior — and
+scaffolds three **replaceable placeholder icons** under
+`<static_dir>/icons/`: `icon-192.png`, `icon-512.png`, and
+`icon-maskable.png` (colored from `theme_color`, falling back to the
+theme's `primary` token). A fresh `app.pwa` app is installable
+immediately; swap the PNG files for real branding when you have it.
+When no `static_dir` is set, the generator defaults it to `static/` so
+the icons have a home (same rule as self-hosted fonts). Only the fields
+you declare are emitted into `main.go`; the framework applies defaults
+at serve time. A custom `api_prefix` or auth `base_path` is emitted as
+`DenyPaths` so the service worker's never-precache/never-intercept
+guarantee follows the app's real mounts.
+
+### Public LLM markdown (`app.llm_md`)
+
+```yaml
+app:
+  llm_md: true
+```
+
+Emits `uihost.WithPublicLLMMD()`, which mounts the LLM-friendly page
+documentation on the generated app: `/llm-pages.md` (an index of every
+registered screen) and `/<screen-path>/llm.md` per screen (`/` → `/llm.md`,
+`/docs/` → `/docs/llm.md`). Application-level and per-screen `NoLLMMD`
+opt-outs keep working. Off by default because the documents enumerate every
+screen and its data shape — useful for AI agents in trusted environments,
+schema disclosure elsewhere. `app.pwa` and `app.llm_md` are independent:
+enabling one never emits the other.
+
 ### app.module and the enclosing go.mod
 
 Generated imports are `<app.module>/<output-dir>` — by default the output

--- a/framework/docs/content/overview.md
+++ b/framework/docs/content/overview.md
@@ -115,6 +115,8 @@ that swap just one fragment — no hard refreshes, no client re-render.
 - **[Interactive patterns](/docs/interactive-patterns)** · **[Signal store](/docs/signal-store)** —
   client state that fans out to many consumers from one declaration.
 - **[Forms](/docs/form-module)** — server-validated, island-swapped error states.
+- **[PWA](/docs/pwa)** — installable manifest + a safe offline shell via
+  `uihost.WithPWA`; works on the live server and in static exports.
 - **[Image pipeline](/docs/image)** — pure-Go resize + WebP. **[Print documents](/docs/print)** —
   chrome-free print/PDF. **[Runtime modules](/docs/runtime-minification)** —
   carved per-feature so a page ships only the JS it uses.

--- a/framework/docs/content/pwa.md
+++ b/framework/docs/content/pwa.md
@@ -1,0 +1,174 @@
+# PWA — installable app + offline shell
+
+`uihost.WithPWA` turns a UIHost app into an installable Progressive Web
+App: it serves a typed web app manifest, a CSP-safe external service
+worker with a versioned app-shell precache, an offline fallback screen,
+and the registration script. Apps opt in with one option — no hand-wired
+head tags, caching rules, or registration scripts.
+
+```go
+site := app.NewApp("Meridian")
+// ... register screens ...
+fwApp.Mount(uihost.New(site,
+    uihost.WithStaticDir("static"),
+    uihost.WithPWA(uihost.PWAConfig{
+        ShortName:  "Meridian",
+        ThemeColor: "#4f46e5",
+        Icons: []uihost.PWAIcon{
+            {Src: "/icons/icon-192.png", Sizes: "192x192", Type: "image/png"},
+            {Src: "/icons/icon-512.png", Sizes: "512x512", Type: "image/png"},
+            {Src: "/icons/icon-maskable.png", Sizes: "512x512", Type: "image/png", Purpose: uihost.PWAIconPurposeMaskable},
+        },
+    }),
+))
+```
+
+Chromium's installability check needs HTTPS (or localhost), a manifest
+with a name, and 192px + 512px icons — supply the icon files as static
+assets. Blueprint-generated apps scaffold placeholder icons
+automatically (see [Blueprints](/docs/blueprints), `app.pwa`).
+
+## What gets mounted
+
+| Route | Purpose | Headers |
+|-------|---------|---------|
+| `/manifest.webmanifest` | The web app manifest, generated from `PWAConfig` via `encoding/json` (all values escaped) | `application/manifest+json`, `no-cache` |
+| `/service-worker.js` | The generated worker. Served from the root so its default scope covers the whole app | `application/javascript`, `no-cache` (browsers re-fetch it to detect updates) |
+| `/__gofastr/pwa/register.js` | External registration script, injected before `</body>` on every page — CSP-safe under the default `default-src 'self'` policy (no inline JS) | `application/javascript`, `no-cache` |
+| `/__gofastr/pwa/offline` | The offline fallback page, precached at install time | `text/html`, `no-cache` |
+
+Every rendered page also gains `<link rel="manifest">` and, when
+`ThemeColor` is set, a `<meta name="theme-color">` in `<head>`.
+
+Without `WithPWA` none of these routes or tags exist — existing apps
+are unchanged.
+
+## PWAConfig
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `Name` | the core-ui app title (`app.NewApp(name)`) | Manifest `name` |
+| `ShortName` | omitted | Home-screen label |
+| `Description` | omitted | |
+| `StartURL` | `/` | |
+| `Scope` | `/` | |
+| `ID` | `StartURL` | Stable app identity across renames |
+| `Display` | `PWADisplayStandalone` | Also `PWADisplayFullscreen`, `PWADisplayMinimalUI`, `PWADisplayBrowser` |
+| `ThemeColor` / `BackgroundColor` | omitted | `ThemeColor` also emits the head meta tag |
+| `Icons` | none | `PWAIcon{Src, Sizes, Type, Purpose}`; purposes: `PWAIconPurposeAny`, `PWAIconPurposeMaskable`, `PWAIconPurposeMonochrome` |
+| `Precache` | none | Extra same-origin paths to keep available offline |
+| `OfflineScreen` | framework default | A `component.Component` rendered at `/__gofastr/pwa/offline` |
+| `DenyPaths` | none | App-specific mounts to add to the sensitive-path deny list (e.g. a CRUD API at a custom prefix); never precached, never intercepted |
+
+## The caching model
+
+The generated worker is deliberately conservative:
+
+- **Documents are network-first and never cached.** Rendered HTML can
+  be personalized, so navigations always hit the server; when the
+  network is unavailable the precached offline screen renders instead.
+- **The cache holds exactly the precache set** — the goFastr runtime
+  (`runtime.js`, split modules under their content-addressed
+  `?v=<hash>` URLs, `color-scheme.js`, `actions.js`, `app.css`), the
+  manifest, the offline page plus the per-component stylesheets it
+  links, declared icons, and your `Precache` entries. Nothing is ever
+  added to Cache Storage at runtime, and precached responses are
+  re-wrapped at install time so a static host's redirects can't poison
+  the offline fallback.
+- **Online always means fresh.** URLs are matched exactly. Only
+  content-addressed assets (`?v=<hash>`) are served cache-first —
+  they're immutable, and a new deployment's URLs miss the old cache.
+  Every other asset is network-first, with the cache answering only
+  when the network is gone — so after a deploy, new HTML never runs
+  against the previous deployment's runtime or CSS.
+- **Sensitive endpoints are never intercepted and can never be
+  precached.** `/__gofastr/sse`, `/__gofastr/session`,
+  `/__gofastr/signal/*`, `/__gofastr/action`, `/__gofastr/widgets`,
+  `/api/*`, and `/auth/*` are on a deny list baked into the worker;
+  `Precache` entries that point at them (or at another origin) are
+  dropped. Apps that mount their API or auth elsewhere extend the list
+  with `DenyPaths` (blueprint-generated apps do this automatically for
+  a custom `api_prefix` / auth `base_path`).
+- **Cache names are versioned deterministically.** The name is
+  `gofastr-pwa-<app-slug>-<fingerprint>` where the fingerprint hashes
+  the manifest, the precache URL list, the shell asset bodies, and the
+  bytes of every precache entry served from the host's static
+  storage — swapping an icon in place rotates the version. A new
+  deployment installs a fresh cache; on activation the worker deletes
+  only obsolete caches carrying this app's `gofastr-pwa-<app-slug>-`
+  prefix. (An asset served from outside static storage — a reverse
+  proxy, say — contributes only its URL; give it a new path or query
+  when it changes.)
+
+## Offline screen
+
+The default screen is a minimal "You're offline" notice rendered
+through the standard document shell (theme bootstrap, `app.css`), so it
+follows your theme. Pass `OfflineScreen` to replace it:
+
+```go
+uihost.WithPWA(uihost.PWAConfig{OfflineScreen: myOfflineScreen{}})
+```
+
+The page is precached at service-worker install time, so it must not
+render personalized content — for that reason it is deliberately **not**
+wrapped in the app layout (a layout may embed per-user chrome).
+
+## Update behavior
+
+Registration runs on every page load, which doubles as the update
+check. A new deployment installs its worker and cache in the
+background, but the framework never calls `skipWaiting` — the new
+worker activates once every tab running the old version closes, so an
+open app is never yanked onto new code mid-session. To offer a "new
+version available — reload" prompt, listen for the window event the
+registration script dispatches when an update is installed and waiting:
+
+```js
+window.addEventListener("gofastr:pwa-update", function (e) {
+  // e.detail.registration is the ServiceWorkerRegistration
+  showUpdateBanner();
+});
+```
+
+(Ship that listener as an external script via `WithExtraScripts` — the
+default CSP blocks inline JS.)
+
+## Static export
+
+`App.ExportStatic` emits the full PWA surface alongside the pages:
+`manifest.webmanifest`, `service-worker.js`,
+`__gofastr/pwa/register.js`, and `__gofastr/pwa/offline/index.html`.
+Under a non-root `BasePath` (e.g. a GitHub Pages project site) the
+manifest's `start_url`/`scope`/`id`/icon paths, the worker's precache
+list and deny list, and the registration target are all prefixed, so
+the exported app installs and works offline from the subpath. See
+[Static-site export](/docs/static-export).
+
+## Blueprint support
+
+`gofastr generate` scaffolds the whole surface from an `app.pwa` block —
+including replaceable placeholder icons. See
+[Blueprints](/docs/blueprints).
+
+## Common mistakes
+
+- **Declaring `Icons` that don't resolve.** Icon paths are added to the
+  precache; if a file 404s, `cache.addAll` rejects and the worker never
+  installs. Put the files in your static dir first, then declare them.
+- **Precaching API responses.** `Precache: []string{"/api/products"}`
+  is silently dropped — the shell cache is for assets, never data. If
+  you need offline data, that's application logic, not the app shell.
+  If your API lives at a custom prefix, list it in `DenyPaths` so the
+  same guarantee covers it.
+- **Expecting pages to work offline.** Only the shell and the offline
+  screen are cached. Navigations are network-first by design; rendered
+  pages are never stored (they can be personalized). An offline visit
+  to any page shows the offline screen.
+- **Forcing updates with `skipWaiting` from your own script.** The
+  no-forced-reload behavior is deliberate; if you must switch
+  immediately, prompt the user from the `gofastr:pwa-update` event and
+  reload after they accept.
+- **Rendering per-user content into a custom `OfflineScreen`.** The
+  page is cached at install time under the installing user's session —
+  keep it generic.

--- a/framework/docs/content/static-export.md
+++ b/framework/docs/content/static-export.md
@@ -50,6 +50,12 @@ go build -o site ./examples/site/
 - `/__gofastr/app.css` and `/__gofastr/comp/<name>.css` — global and
   per-component stylesheets.
 - Per-route `llm.md` (unless `NoLLMMD` is set).
+- With [`uihost.WithPWA`](pwa.md): `manifest.webmanifest`,
+  `service-worker.js`, `__gofastr/pwa/register.js`, and
+  `__gofastr/pwa/offline/index.html`. Under `--export-base` the
+  manifest's `start_url`/`scope`/`id`/icon paths, the worker's precache
+  and deny lists, and the registration target are all prefixed, so the
+  exported app installs and works offline from the subpath.
 
 Dynamic routes require the screen to implement `StaticPathsProvider`:
 

--- a/framework/static/builder.go
+++ b/framework/static/builder.go
@@ -184,6 +184,15 @@ func (b *Builder) Build(ctx context.Context) (Result, error) {
 		return res, err
 	}
 
+	// PWA surface — manifest, service worker, registration script, and
+	// offline fallback, mirroring the live WithPWA routes. The uihost
+	// generators take BasePath directly (manifest start_url/scope/id,
+	// worker precache list, and registration target must all resolve
+	// under the mount path), so none of these go through rewriteJSAsset.
+	if err := b.dumpPWAAssets(&res); err != nil {
+		return res, err
+	}
+
 	// Static assets — either filesystem dir or embedded FS.
 	if dir := b.Host.StaticDir(); dir != "" {
 		if err := copyDir(dir, b.OutDir, &res, b.log); err != nil {
@@ -306,12 +315,7 @@ func validateParamValue(key, v string) error {
 //     set, every root-absolute asset/nav URL is rewritten to resolve
 //     under the mount path.
 func (b *Builder) applyStaticMode(page string) string {
-	// Stamp <html>. The first "<html" in the document is always the
-	// real root element (it precedes any body content); the marker is
-	// value-agnostic, so a bare boolean attribute suffices.
-	if i := strings.Index(page, "<html"); i >= 0 {
-		page = page[:i+len("<html")] + " data-fui-static" + page[i+len("<html"):]
-	}
+	page = stampStatic(page)
 	page = b.rewriteBaseURLs(page)
 	notice := string(ui.Banner(ui.BannerConfig{
 		Title:       "Static preview",
@@ -326,6 +330,17 @@ func (b *Builder) applyStaticMode(page string) string {
 			at := j + k + 1
 			page = page[:at] + notice + page[at:]
 		}
+	}
+	return page
+}
+
+// stampStatic marks <html> with data-fui-static — the runtime's
+// static-mode switch. The first "<html" in the document is always the
+// real root element (it precedes any body content); the marker is
+// value-agnostic, so a bare boolean attribute suffices.
+func stampStatic(page string) string {
+	if i := strings.Index(page, "<html"); i >= 0 {
+		return page[:i+len("<html")] + " data-fui-static" + page[i+len("<html"):]
 	}
 	return page
 }
@@ -400,6 +415,53 @@ func (b *Builder) dumpWidgetAssets() error {
 			return err
 		}
 		b.log("wrote widget %s (chrome + css)", d.Name)
+	}
+	return nil
+}
+
+// dumpPWAAssets emits the WithPWA surface for a serverless deploy:
+// manifest.webmanifest, service-worker.js, the registration script, and
+// the offline fallback page (as offline/index.html so a plain static
+// server resolves the extension-less precache URL). No-op when the host
+// did not opt into WithPWA.
+func (b *Builder) dumpPWAAssets(res *Result) error {
+	if !b.Host.PWAEnabled() {
+		return nil
+	}
+	manifest, err := b.Host.PWAManifestJSON(b.BasePath)
+	if err != nil {
+		return fmt.Errorf("static: pwa manifest: %w", err)
+	}
+	sw, err := b.Host.PWAServiceWorkerJS(b.BasePath)
+	if err != nil {
+		return fmt.Errorf("static: pwa service worker: %w", err)
+	}
+	// The offline page is rendered basePath-neutral by the host; its
+	// asset links get the same base rewrite as every exported page. It
+	// also gets the data-fui-static stamp so the runtime's static-mode
+	// guards apply, but not the "run locally" banner — an offline
+	// fallback is not a demo page.
+	offline := b.rewriteBaseURLs(stampStatic(b.Host.PWAOfflineHTML()))
+	files := []struct {
+		urlPath string
+		relFile string
+		body    []byte
+	}{
+		{"/manifest.webmanifest", "manifest.webmanifest", manifest},
+		{"/service-worker.js", "service-worker.js", []byte(sw)},
+		{"/__gofastr/pwa/register.js", filepath.Join("__gofastr", "pwa", "register.js"), []byte(b.Host.PWARegisterJS(b.BasePath))},
+		{"/__gofastr/pwa/offline", filepath.Join("__gofastr", "pwa", "offline", "index.html"), []byte(offline)},
+	}
+	for _, f := range files {
+		dst := filepath.Join(b.OutDir, f.relFile)
+		if err := b.ensureContained(dst); err != nil {
+			return err
+		}
+		if err := writeFile(dst, f.body); err != nil {
+			return err
+		}
+		res.Assets = append(res.Assets, f.urlPath)
+		b.log("wrote %s", f.urlPath)
 	}
 	return nil
 }

--- a/framework/static/builder_pwa_test.go
+++ b/framework/static/builder_pwa_test.go
@@ -1,0 +1,208 @@
+package static
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	coreapp "github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/core-ui/component"
+	"github.com/DonaldMurillo/gofastr/core-ui/registry"
+	"github.com/DonaldMurillo/gofastr/core-ui/style"
+	"github.com/DonaldMurillo/gofastr/core/render"
+	"github.com/DonaldMurillo/gofastr/framework/uihost"
+)
+
+// buildPWASite exports a minimal WithPWA app. An optional offline
+// screen component overrides the framework default.
+func buildPWASite(t *testing.T, basePath string, offline ...component.Component) string {
+	t.Helper()
+	var offlineScreen component.Component
+	if len(offline) > 0 {
+		offlineScreen = offline[0]
+	}
+	// Real static assets behind the declared icon + Precache paths —
+	// entries that don't resolve would fail service-worker install.
+	staticDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(staticDir, "icons"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for rel, body := range map[string]string{
+		filepath.Join("icons", "icon-192.png"): "png-192",
+		"hero.png":                             "png-hero",
+	} {
+		if err := os.WriteFile(filepath.Join(staticDir, rel), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	a := coreapp.NewApp("Meridian")
+	a.Register("/", &homeScreen{}, nil)
+	host := uihost.New(a,
+		uihost.WithStaticDir(staticDir),
+		uihost.WithPWA(uihost.PWAConfig{
+			ThemeColor:    "#112233",
+			Icons:         []uihost.PWAIcon{{Src: "/icons/icon-192.png", Sizes: "192x192", Type: "image/png"}},
+			Precache:      []string{"/hero.png"},
+			OfflineScreen: offlineScreen,
+		}))
+	out := t.TempDir()
+	if _, err := (&Builder{Host: host, OutDir: out, BasePath: basePath}).Build(context.Background()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	return out
+}
+
+func readOut(t *testing.T, out string, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(out, filepath.FromSlash(rel)))
+	if err != nil {
+		t.Fatalf("expected %s in export: %v", rel, err)
+	}
+	return string(b)
+}
+
+func TestBuildEmitsPWAAssets(t *testing.T) {
+	out := buildPWASite(t, "")
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(readOut(t, out, "manifest.webmanifest")), &m); err != nil {
+		t.Fatalf("manifest not valid JSON: %v", err)
+	}
+	if m["start_url"] != "/" || m["scope"] != "/" {
+		t.Errorf("apex export should keep root start_url/scope, got %v / %v", m["start_url"], m["scope"])
+	}
+
+	sw := readOut(t, out, "service-worker.js")
+	if !strings.Contains(sw, `"/__gofastr/runtime.js"`) || !strings.Contains(sw, `"/hero.png"`) {
+		t.Errorf("sw precache should list shell + declared assets:\n%s", sw)
+	}
+
+	reg := readOut(t, out, "__gofastr/pwa/register.js")
+	if !strings.Contains(reg, `register("/service-worker.js"`) {
+		t.Errorf("register.js should target the root worker:\n%s", reg)
+	}
+
+	offline := readOut(t, out, "__gofastr/pwa/offline/index.html")
+	if !strings.Contains(strings.ToLower(offline), "offline") {
+		t.Errorf("offline page should render the offline screen:\n%s", offline)
+	}
+
+	page := readOut(t, out, "index.html")
+	if !strings.Contains(page, `<link rel="manifest" href="/manifest.webmanifest">`) {
+		t.Errorf("exported page should link the manifest:\n%s", page)
+	}
+}
+
+func TestBuildPWABasePath(t *testing.T) {
+	out := buildPWASite(t, "/sub")
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(readOut(t, out, "manifest.webmanifest")), &m); err != nil {
+		t.Fatalf("manifest not valid JSON: %v", err)
+	}
+	if m["start_url"] != "/sub/" || m["scope"] != "/sub/" || m["id"] != "/sub/" {
+		t.Errorf("base path should prefix start_url/scope/id, got %v / %v / %v", m["start_url"], m["scope"], m["id"])
+	}
+	icons := m["icons"].([]any)
+	if icons[0].(map[string]any)["src"] != "/sub/icons/icon-192.png" {
+		t.Errorf("icon src should be base-prefixed, got %v", icons[0])
+	}
+
+	sw := readOut(t, out, "service-worker.js")
+	for _, want := range []string{
+		`"/sub/__gofastr/runtime.js"`,
+		`"/sub/hero.png"`,
+		`"/sub/__gofastr/pwa/offline"`,
+	} {
+		if !strings.Contains(sw, want) {
+			t.Errorf("sw should carry base-prefixed precache entry %s:\n%s", want, sw)
+		}
+	}
+	if strings.Contains(sw, `"/__gofastr/runtime.js"`) {
+		t.Errorf("sw must not keep unprefixed shell entries under a base path:\n%s", sw)
+	}
+
+	reg := readOut(t, out, "__gofastr/pwa/register.js")
+	if !strings.Contains(reg, `register("/sub/service-worker.js"`) || !strings.Contains(reg, `scope: "/sub/"`) {
+		t.Errorf("register.js should target the base-prefixed worker + scope:\n%s", reg)
+	}
+
+	offline := readOut(t, out, "__gofastr/pwa/offline/index.html")
+	if !strings.Contains(offline, `href="/sub/__gofastr/app.css"`) {
+		t.Errorf("offline page assets should be base-prefixed:\n%s", offline)
+	}
+}
+
+// pwaStyledOffline renders two styled components — enough that the old
+// bundle=true offline chrome would emit the (never-exported)
+// comp-bundle URL into the precache.
+type pwaStyledOffline struct{ styles []*registry.Style }
+
+func (c pwaStyledOffline) Render() render.HTML {
+	out := render.HTML("<p>offline</p>")
+	for _, st := range c.styles {
+		out += st.WrapHTML(render.HTML(`<div class="x">x</div>`))
+	}
+	return out
+}
+
+// TestBuildPWAPrecacheEntriesAllResolve: every URL the exported service
+// worker precaches must exist as a file in the export — one 404 rejects
+// the whole install and kills the PWA surface. The styled offline
+// screen is what used to push an inexistent comp-bundle URL into the
+// precache.
+func TestBuildPWAPrecacheEntriesAllResolve(t *testing.T) {
+	styles := make([]*registry.Style, 2)
+	for i := range styles {
+		name := fmt.Sprintf("pwa-ssg-comp-%d", ssgNameSeq.Add(1))
+		styles[i] = registry.RegisterStyle(name, func(theme style.Theme) string {
+			return style.NewComponentSheet(name, theme).
+				Rule(".x").Set("color", "red").End().
+				MustBuild()
+		})
+	}
+	out := buildPWASite(t, "/sub", pwaStyledOffline{styles})
+	sw := readOut(t, out, "service-worker.js")
+	i := strings.Index(sw, "var PRECACHE = ")
+	if i < 0 {
+		t.Fatalf("no PRECACHE in sw:\n%s", sw)
+	}
+	line := sw[i+len("var PRECACHE = "):]
+	line = line[:strings.Index(line, ";\n")]
+	var precache []string
+	if err := json.Unmarshal([]byte(line), &precache); err != nil {
+		t.Fatalf("PRECACHE not JSON: %v", err)
+	}
+	for _, u := range precache {
+		p := strings.TrimPrefix(u, "/sub")
+		if q := strings.IndexAny(p, "?#"); q >= 0 {
+			p = p[:q] // static hosts ignore the query
+		}
+		rel := strings.TrimPrefix(p, "/")
+		if p == "/__gofastr/pwa/offline" {
+			rel = "__gofastr/pwa/offline/index.html"
+		}
+		if _, err := os.Stat(filepath.Join(out, filepath.FromSlash(rel))); err != nil {
+			t.Errorf("precached URL %s has no file in the export (%s): install would 404", u, rel)
+		}
+	}
+}
+
+func TestBuildNoPWAAssetsWithoutOption(t *testing.T) {
+	a := coreapp.NewApp("x")
+	a.Register("/", &homeScreen{}, nil)
+	host := uihost.New(a)
+	out := t.TempDir()
+	if _, err := (&Builder{Host: host, OutDir: out}).Build(context.Background()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	for _, rel := range []string{"manifest.webmanifest", "service-worker.js", "__gofastr/pwa/register.js", "__gofastr/pwa/offline/index.html"} {
+		if _, err := os.Stat(filepath.Join(out, filepath.FromSlash(rel))); err == nil {
+			t.Errorf("%s should not exist without WithPWA", rel)
+		}
+	}
+}

--- a/framework/uihost/pwa.go
+++ b/framework/uihost/pwa.go
@@ -1,0 +1,661 @@
+package uihost
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	stdhtml "html"
+	"io/fs"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/component"
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
+	"github.com/DonaldMurillo/gofastr/core-ui/runtime"
+	"github.com/DonaldMurillo/gofastr/core-ui/widget"
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+// ─── PWA ───────────────────────────────────────────────────────────
+//
+// WithPWA turns a UIHost app into an installable Progressive Web App:
+// a typed web app manifest, a CSP-safe external service worker with a
+// versioned app-shell precache, an offline fallback screen, and the
+// registration script — without the host app hand-wiring any of it.
+//
+// The service worker is deliberately conservative: document navigations
+// are network-first and NEVER cached (rendered HTML can be
+// personalized), and only the goFastr runtime/app shell, the manifest,
+// declared icons, explicit Precache entries, and the offline screen
+// live in Cache Storage. API, auth, session, action, signal, and SSE
+// endpoints are never intercepted and can never be precached.
+
+// PWADisplay is the manifest display mode.
+type PWADisplay string
+
+// Typed constants for the common manifest display modes.
+const (
+	PWADisplayStandalone PWADisplay = "standalone"
+	PWADisplayFullscreen PWADisplay = "fullscreen"
+	PWADisplayMinimalUI  PWADisplay = "minimal-ui"
+	PWADisplayBrowser    PWADisplay = "browser"
+)
+
+// PWAIconPurpose is the manifest icon purpose.
+type PWAIconPurpose string
+
+// Typed constants for the common manifest icon purposes.
+const (
+	PWAIconPurposeAny        PWAIconPurpose = "any"
+	PWAIconPurposeMaskable   PWAIconPurpose = "maskable"
+	PWAIconPurposeMonochrome PWAIconPurpose = "monochrome"
+)
+
+// PWAIcon declares one manifest icon. Src must be a same-origin
+// root-absolute path (usually a static asset, e.g. "/static/icon-192.png").
+// Chromium's installability check needs at least a 192x192 and a 512x512
+// icon; add a maskable variant for adaptive home-screen shapes.
+type PWAIcon struct {
+	Src     string
+	Sizes   string // e.g. "192x192"
+	Type    string // e.g. "image/png"
+	Purpose PWAIconPurpose
+}
+
+// PWAConfig configures WithPWA. Every field is optional; sensible
+// defaults are derived at serve time:
+//
+//   - Name defaults to the core-ui app title.
+//   - StartURL and Scope default to "/".
+//   - ID defaults to StartURL.
+//   - Display defaults to standalone.
+//   - OfflineScreen defaults to a framework-provided offline notice.
+type PWAConfig struct {
+	ID              string
+	Name            string
+	ShortName       string
+	Description     string
+	StartURL        string
+	Scope           string
+	Display         PWADisplay
+	ThemeColor      string
+	BackgroundColor string
+	Icons           []PWAIcon
+
+	// Precache lists extra same-origin root-absolute paths (static
+	// assets, fonts, hero images) to keep available offline alongside
+	// the runtime/app shell. Entries that point at sensitive framework
+	// endpoints (API, auth, session, action, signal, SSE) or at another
+	// origin are dropped — the app-shell cache can never hold them.
+	Precache []string
+
+	// OfflineScreen renders the offline fallback page served at
+	// /__gofastr/pwa/offline and shown when a navigation fails with no
+	// network. The page is precached at service-worker install time, so
+	// it must not render personalized content; it is deliberately NOT
+	// wrapped in the app layout for the same reason. Nil uses the
+	// framework default.
+	OfflineScreen component.Component
+
+	// DenyPaths extends the built-in sensitive-path deny list
+	// (/__gofastr/{sse,session,signal,action,widgets}, /api, /auth)
+	// with app-specific mounts — e.g. a CRUD API at a custom prefix or
+	// an auth battery at a custom base path. Listed paths (and
+	// everything under them) can never be precached and are never
+	// intercepted by the service worker. Root-relative; a bare "/" is
+	// ignored (it would deny the whole app).
+	DenyPaths []string
+}
+
+// WithPWA opts the host into the installable-PWA surface: it mounts
+// /manifest.webmanifest, /service-worker.js, /__gofastr/pwa/register.js,
+// and /__gofastr/pwa/offline, and injects the manifest link + external
+// registration script into every rendered page. The injection rides
+// the generic headTags/extraScripts rails (all values are fixed at
+// option time), so chrome assembly has a single code path.
+func WithPWA(cfg PWAConfig) Option {
+	return func(ds *UIHost) {
+		ds.pwaConfig = &cfg
+		ds.headTags = append(ds.headTags, `<link rel="manifest" href="/manifest.webmanifest">`)
+		if cfg.ThemeColor != "" {
+			ds.headTags = append(ds.headTags, fmt.Sprintf(`<meta name="theme-color" content="%s">`, stdhtml.EscapeString(cfg.ThemeColor)))
+		}
+		ds.extraScripts = append(ds.extraScripts, "/__gofastr/pwa/register.js")
+	}
+}
+
+// PWAEnabled reports whether WithPWA was configured. The static builder
+// uses it to decide whether to emit the PWA assets.
+func (ds *UIHost) PWAEnabled() bool {
+	return ds.pwaConfig != nil
+}
+
+// resolvedPWA returns the config with defaults applied. Called at serve
+// time so ds.App (the Name source) is guaranteed populated.
+func (ds *UIHost) resolvedPWA() PWAConfig {
+	cfg := *ds.pwaConfig
+	if cfg.Name == "" {
+		if ds.App != nil && ds.App.Name != "" {
+			cfg.Name = ds.App.Name
+		} else {
+			cfg.Name = "GoFastr App"
+		}
+	}
+	if cfg.StartURL == "" {
+		cfg.StartURL = "/"
+	}
+	if cfg.Scope == "" {
+		cfg.Scope = "/"
+	}
+	if cfg.Display == "" {
+		cfg.Display = PWADisplayStandalone
+	}
+	if cfg.ID == "" {
+		cfg.ID = cfg.StartURL
+	}
+	return cfg
+}
+
+// pwaSensitivePaths are framework endpoints that must never be
+// intercepted for caching or precached: they carry credentials,
+// per-user state, or live streams. Matched as exact path or path
+// prefix + "/" so /__gofastr/actions.js (a shell asset) stays allowed
+// while /__gofastr/action (the server-action endpoint) is denied.
+var pwaSensitivePaths = []string{
+	"/__gofastr/sse",
+	"/__gofastr/session",
+	"/__gofastr/signal",
+	"/__gofastr/action",
+	"/__gofastr/widgets",
+	"/api",
+	"/auth",
+}
+
+// pwaDenyPaths returns the effective deny list: the built-in sensitive
+// framework endpoints plus normalized config DenyPaths entries.
+func pwaDenyPaths(cfg PWAConfig) []string {
+	deny := append([]string(nil), pwaSensitivePaths...)
+	for _, d := range cfg.DenyPaths {
+		d = strings.TrimRight(strings.TrimSpace(d), "/")
+		if d == "" || !strings.HasPrefix(d, "/") {
+			continue // "" was a bare "/" (denies everything) or a non-root-relative value
+		}
+		deny = append(deny, d)
+	}
+	return deny
+}
+
+// pwaAllowedPrecache reports whether a Precache entry may enter the
+// app-shell cache: same-origin root-absolute paths only, never a
+// denied endpoint.
+func pwaAllowedPrecache(p string, deny []string) bool {
+	if !strings.HasPrefix(p, "/") || strings.HasPrefix(p, "//") {
+		return false
+	}
+	clean := p
+	if i := strings.IndexAny(clean, "?#"); i >= 0 {
+		clean = clean[:i]
+	}
+	for _, d := range deny {
+		if clean == d || strings.HasPrefix(clean, d+"/") {
+			return false
+		}
+	}
+	return true
+}
+
+// pwaAssetURL matches root-absolute src/href attribute values in the
+// rendered offline page so its stylesheet/script dependencies join the
+// precache and the page renders styled with no network.
+var pwaAssetURL = regexp.MustCompile(`(?:src|href)="(/[^"]+)"`)
+
+// pwaPrecachePaths returns the deduplicated, sorted, basePath-neutral
+// precache manifest: the runtime/app shell, the offline screen and its
+// asset dependencies, the web manifest, declared icons, and the
+// filtered user Precache list. The service worker matches URLs
+// exactly, so entries the client requests with a content-addressed
+// ?v=<hash> (split runtime modules, component CSS) are listed with
+// that exact query.
+func (ds *UIHost) pwaPrecachePaths(cfg PWAConfig, offlineHTML string) []string {
+	set := map[string]bool{
+		"/__gofastr/runtime.js":      true,
+		"/__gofastr/color-scheme.js": true,
+		"/manifest.webmanifest":      true,
+		pwaOfflinePath:               true,
+	}
+	if ds.App != nil {
+		set["/__gofastr/app.css"] = true
+	}
+	if ds.GetActionJS() != "" {
+		set["/__gofastr/actions.js"] = true
+	}
+	// Split runtime modules are demand-loaded parts of the shell; an
+	// offline app still needs theme switching, widgets, toasts, etc.
+	// The loader requests them as <name>.js?v=<hash>, so cache them
+	// under that exact URL.
+	for _, name := range runtime.ModuleNames() {
+		u := "/__gofastr/runtime/" + name + ".js"
+		if hash := widget.RuntimeModuleHash(name); hash != "" {
+			u += "?v=" + hash
+		}
+		set[u] = true
+	}
+	deny := pwaDenyPaths(cfg)
+	// Whatever the offline page links (per-component CSS, app.css) must
+	// be cached with it or it renders unstyled when the network is gone.
+	for _, m := range pwaAssetURL.FindAllStringSubmatch(offlineHTML, -1) {
+		if pwaAllowedPrecache(m[1], deny) {
+			set[m[1]] = true
+		}
+	}
+	for _, icon := range cfg.Icons {
+		if pwaAllowedPrecache(icon.Src, deny) {
+			set[icon.Src] = true
+		}
+	}
+	for _, p := range cfg.Precache {
+		if pwaAllowedPrecache(p, deny) {
+			set[p] = true
+		}
+	}
+	out := make([]string, 0, len(set))
+	for p := range set {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// pwaPrefix prepends basePath to a root-absolute same-origin path.
+// External, protocol-relative, and already-relative values pass through
+// untouched. No-op for the live server (basePath == "").
+func pwaPrefix(basePath, p string) string {
+	if basePath == "" || !strings.HasPrefix(p, "/") || strings.HasPrefix(p, "//") {
+		return p
+	}
+	return basePath + p
+}
+
+// pwaManifestDoc is the typed web app manifest shape. Emitted via
+// encoding/json so every field is escaped correctly.
+type pwaManifestDoc struct {
+	ID              string            `json:"id"`
+	Name            string            `json:"name"`
+	ShortName       string            `json:"short_name,omitempty"`
+	Description     string            `json:"description,omitempty"`
+	StartURL        string            `json:"start_url"`
+	Scope           string            `json:"scope"`
+	Display         string            `json:"display"`
+	ThemeColor      string            `json:"theme_color,omitempty"`
+	BackgroundColor string            `json:"background_color,omitempty"`
+	Icons           []pwaManifestIcon `json:"icons,omitempty"`
+}
+
+type pwaManifestIcon struct {
+	Src     string `json:"src"`
+	Sizes   string `json:"sizes,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Purpose string `json:"purpose,omitempty"`
+}
+
+// PWAManifestJSON renders the web app manifest. basePath prefixes
+// start_url, scope, id, and same-origin icon paths for static exports
+// mounted under a subpath; pass "" for the live server.
+func (ds *UIHost) PWAManifestJSON(basePath string) ([]byte, error) {
+	if ds.pwaConfig == nil {
+		return nil, fmt.Errorf("uihost: PWA not configured")
+	}
+	cfg := ds.resolvedPWA()
+	doc := pwaManifestDoc{
+		ID:              pwaPrefix(basePath, cfg.ID),
+		Name:            cfg.Name,
+		ShortName:       cfg.ShortName,
+		Description:     cfg.Description,
+		StartURL:        pwaPrefix(basePath, cfg.StartURL),
+		Scope:           pwaPrefix(basePath, cfg.Scope),
+		Display:         string(cfg.Display),
+		ThemeColor:      cfg.ThemeColor,
+		BackgroundColor: cfg.BackgroundColor,
+	}
+	for _, icon := range cfg.Icons {
+		doc.Icons = append(doc.Icons, pwaManifestIcon{
+			Src:     pwaPrefix(basePath, icon.Src),
+			Sizes:   icon.Sizes,
+			Type:    icon.Type,
+			Purpose: string(icon.Purpose),
+		})
+	}
+	return json.MarshalIndent(doc, "", "  ")
+}
+
+const pwaOfflinePath = "/__gofastr/pwa/offline"
+
+// PWAOfflineHTML renders the offline fallback page: the configured (or
+// default) offline screen inside the standard document shell with the
+// usual chrome (theme bootstrap, app.css, runtime). It is deliberately
+// NOT wrapped in the app layout — the page is precached at
+// service-worker install time, so nothing personalized may render into
+// it. Returns "" when WithPWA was not configured.
+func (ds *UIHost) PWAOfflineHTML() string {
+	if ds.pwaConfig == nil {
+		return ""
+	}
+	cfg := ds.resolvedPWA()
+	var body render.HTML
+	if cfg.OfflineScreen != nil {
+		body = cfg.OfflineScreen.Render()
+	} else {
+		// Minimal semantic HTML, same treatment as the bare 404
+		// fallback: typography comes from app.css, no component CSS.
+		// (uihost deliberately does not import framework/ui — linking
+		// it would force its LoadAlways styles into every host's CSS
+		// bundle. Apps that want a richer screen pass OfflineScreen.)
+		body = html.Heading(html.HeadingConfig{Level: 1}, render.Text("You're offline")) +
+			html.Paragraph(html.TextConfig{}, render.Text("This page isn't available without a connection. Reconnect and try again."))
+	}
+	shell := fmt.Sprintf(
+		`<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Offline — %s</title></head><body><main role="main">%s</main></body></html>`,
+		stdhtml.EscapeString(cfg.Name), string(body))
+	// bundle=false (same as RenderStaticPage): component CSS must be
+	// direct per-component links. The bundle URL depends on the page's
+	// component set — precaching it would answer every OTHER page's
+	// bundle request with the offline page's set, and static exports
+	// don't emit the bundle endpoint at all.
+	return ds.injectChromeMode(shell, pwaOfflinePath, "", "", false)
+}
+
+// pwaVersion fingerprints the deployment: the manifest, the precache
+// URL list (content-addressed framework assets carry their hash in the
+// URL), the offline page, the shell asset bodies, and the bytes of
+// every precache entry resolvable from the host's static storage —
+// so swapping an icon or a precached asset in place (same path, new
+// bytes) rotates the cache. Entries served from elsewhere (a reverse
+// proxy) contribute their URL only; give those a new path or query to
+// bust returning clients. Identical deployments produce identical
+// service workers.
+func (ds *UIHost) pwaVersion(manifest []byte, precache []string, offlineHTML string) string {
+	h := sha256.New()
+	h.Write(manifest)
+	for _, p := range precache {
+		h.Write([]byte(p))
+		h.Write([]byte{0})
+		if !strings.HasPrefix(p, "/__gofastr/") && p != "/manifest.webmanifest" {
+			if b := ds.pwaStaticBytes(p); b != nil {
+				h.Write(b)
+				h.Write([]byte{0})
+			}
+		}
+	}
+	h.Write([]byte(offlineHTML))
+	h.Write([]byte(runtime.MustRuntimeJS()))
+	h.Write([]byte(ds.AppCSS()))
+	h.Write([]byte(ds.GetActionJS()))
+	return hex.EncodeToString(h.Sum(nil))[:12]
+}
+
+// pwaStaticBytes resolves a precache path against the host's static
+// storage (embedded FS first, then the static dir) and returns its
+// bytes, or nil when the path isn't served from static storage. The
+// path is cleaned to its root-relative form, so traversal segments
+// can't escape the static root.
+func (ds *UIHost) pwaStaticBytes(p string) []byte {
+	if i := strings.IndexAny(p, "?#"); i >= 0 {
+		p = p[:i]
+	}
+	rel := strings.TrimPrefix(path.Clean("/"+p), "/")
+	if rel == "" || rel == "." {
+		return nil
+	}
+	if ds.staticFS != nil {
+		if b, err := fs.ReadFile(ds.staticFS, rel); err == nil {
+			return b
+		}
+	}
+	if ds.staticDir != "" {
+		if b, err := os.ReadFile(filepath.Join(ds.staticDir, filepath.FromSlash(rel))); err == nil {
+			return b
+		}
+	}
+	return nil
+}
+
+// pwaSlug derives the cache-ownership slug from the app name so
+// activate only ever deletes caches belonging to this application.
+func pwaSlug(name string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(name) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == ' ' || r == '-' || r == '_':
+			b.WriteByte('-')
+		}
+	}
+	slug := strings.Trim(b.String(), "-")
+	if slug == "" {
+		slug = "app"
+	}
+	return slug
+}
+
+// PWAServiceWorkerJS generates the service worker. The worker precaches
+// the app shell under a deterministically versioned cache name, keeps
+// document navigations network-first with the offline screen as
+// fallback, never caches anything at runtime, and on activate deletes
+// only obsolete caches owned by this application. It never calls
+// skipWaiting — a new worker activates once existing tabs release the
+// old one; pages hear about a waiting update via the
+// "gofastr:pwa-update" window event dispatched by register.js.
+func (ds *UIHost) PWAServiceWorkerJS(basePath string) (string, error) {
+	if ds.pwaConfig == nil {
+		return "", fmt.Errorf("uihost: PWA not configured")
+	}
+	cfg := ds.resolvedPWA()
+	offlineHTML := ds.PWAOfflineHTML()
+	manifest, err := ds.PWAManifestJSON("")
+	if err != nil {
+		return "", err
+	}
+	precache := ds.pwaPrecachePaths(cfg, offlineHTML)
+	version := ds.pwaVersion(manifest, precache, offlineHTML)
+	prefix := "gofastr-pwa-" + pwaSlug(cfg.Name) + "-"
+
+	prefixed := make([]string, len(precache))
+	for i, p := range precache {
+		prefixed[i] = pwaPrefix(basePath, p)
+	}
+	precacheJSON, err := json.Marshal(prefixed)
+	if err != nil {
+		return "", err
+	}
+	deny := pwaDenyPaths(cfg)
+	denyExact := make([]string, len(deny))
+	denyPrefix := make([]string, len(deny))
+	for i, d := range deny {
+		denyExact[i] = pwaPrefix(basePath, d)
+		denyPrefix[i] = pwaPrefix(basePath, d) + "/"
+	}
+	denyExactJSON, err := json.Marshal(denyExact)
+	if err != nil {
+		return "", err
+	}
+	denyPrefixJSON, err := json.Marshal(denyPrefix)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(pwaServiceWorkerTemplate,
+		prefix+version,
+		prefix,
+		pwaPrefix(basePath, pwaOfflinePath),
+		precacheJSON,
+		denyExactJSON,
+		denyPrefixJSON,
+	), nil
+}
+
+// pwaServiceWorkerTemplate is the generated worker source. Kept ES5-safe
+// and dependency-free; all dynamic values arrive as JSON literals.
+const pwaServiceWorkerTemplate = `/* goFastr service worker — generated by uihost.WithPWA. Do not edit. */
+var CACHE_NAME = %q;
+var CACHE_PREFIX = %q;
+var OFFLINE_URL = %q;
+var PRECACHE = %s;
+var DENY_EXACT = %s;
+var DENY_PREFIX = %s;
+
+self.addEventListener("install", function (event) {
+  // Each response is re-wrapped into a fresh Response before caching:
+  // static hosts answer the extension-less offline URL with a 301 to
+  // its index.html, and a cached redirected response is rejected when
+  // used to answer a navigation fetch (redirect mode "manual").
+  event.waitUntil(caches.open(CACHE_NAME).then(function (cache) {
+    return Promise.all(PRECACHE.map(function (u) {
+      return fetch(u, { cache: "no-cache" }).then(function (r) {
+        if (!r.ok) throw new Error("precache " + u + ": " + r.status);
+        return r.blob().then(function (body) {
+          return cache.put(u, new Response(body, { status: 200, headers: r.headers }));
+        });
+      });
+    }));
+  }));
+});
+
+self.addEventListener("activate", function (event) {
+  event.waitUntil(caches.keys().then(function (names) {
+    return Promise.all(names.filter(function (n) {
+      return n.indexOf(CACHE_PREFIX) === 0 && n !== CACHE_NAME;
+    }).map(function (n) { return caches.delete(n); }));
+  }).then(function () { return self.clients.claim(); }));
+});
+
+function denied(pathname) {
+  if (DENY_EXACT.indexOf(pathname) !== -1) return true;
+  for (var i = 0; i < DENY_PREFIX.length; i++) {
+    if (pathname.indexOf(DENY_PREFIX[i]) === 0) return true;
+  }
+  return false;
+}
+
+self.addEventListener("fetch", function (event) {
+  var req = event.request;
+  if (req.method !== "GET") return;
+  var url = new URL(req.url);
+  if (url.origin !== self.location.origin) return;
+  if (denied(url.pathname)) return;
+  if (req.mode === "navigate") {
+    // Documents are network-first and never cached — rendered HTML can
+    // be personalized. Offline falls back to the precached screen.
+    event.respondWith(fetch(req).catch(function () {
+      return caches.match(OFFLINE_URL, { cacheName: CACHE_NAME });
+    }));
+    return;
+  }
+  // Assets. URLs are matched exactly; nothing is ever added to the
+  // cache at runtime, so Cache Storage only ever holds the versioned
+  // app shell. Content-addressed URLs (?v=<hash>) are immutable:
+  // cache-first, and a new deployment's URLs miss the old cache and
+  // reach the network. Everything else is network-first so fresh HTML
+  // never pairs with a previous deployment's runtime/CSS — the cache
+  // answers only when the network is gone.
+  if (url.searchParams.has("v")) {
+    event.respondWith(caches.match(req, { cacheName: CACHE_NAME }).then(function (hit) {
+      return hit || fetch(req);
+    }));
+    return;
+  }
+  event.respondWith(fetch(req).catch(function (err) {
+    return caches.match(req, { cacheName: CACHE_NAME }).then(function (hit) {
+      if (hit) return hit;
+      throw err;
+    });
+  }));
+});
+`
+
+// PWARegisterJS generates the external, CSP-safe registration script.
+// Registration on every page load doubles as the update check; when a
+// new worker is installed and waiting behind a controlling one, the
+// script dispatches "gofastr:pwa-update" on window so apps can show an
+// "update available" prompt. Returns "" when WithPWA was not configured.
+func (ds *UIHost) PWARegisterJS(basePath string) string {
+	if ds.pwaConfig == nil {
+		return ""
+	}
+	cfg := ds.resolvedPWA()
+	return fmt.Sprintf(pwaRegisterTemplate,
+		pwaPrefix(basePath, "/service-worker.js"),
+		pwaPrefix(basePath, cfg.Scope),
+	)
+}
+
+const pwaRegisterTemplate = `/* goFastr PWA registration — generated by uihost.WithPWA. Do not edit. */
+(function () {
+  if (!("serviceWorker" in navigator)) return;
+  window.addEventListener("load", function () {
+    navigator.serviceWorker.register(%q, { scope: %q }).then(function (reg) {
+      reg.addEventListener("updatefound", function () {
+        var next = reg.installing;
+        if (!next) return;
+        next.addEventListener("statechange", function () {
+          if (next.state === "installed" && navigator.serviceWorker.controller) {
+            window.dispatchEvent(new CustomEvent("gofastr:pwa-update", { detail: { registration: reg } }));
+          }
+        });
+      });
+    }).catch(function () { /* registration is best-effort */ });
+  });
+})();
+`
+
+// ─── Handlers ──────────────────────────────────────────────────────
+
+func (ds *UIHost) handlePWAManifest(w http.ResponseWriter, _ *http.Request) {
+	body, err := ds.PWAManifestJSON("")
+	if err != nil {
+		http.Error(w, "pwa not configured", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/manifest+json")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Write(body)
+}
+
+func (ds *UIHost) handlePWAServiceWorker(w http.ResponseWriter, _ *http.Request) {
+	// The worker is deployment-constant, but generating it renders the
+	// offline page and hashes the shell assets — too much to repeat on
+	// every update check (browsers re-fetch the worker on page loads).
+	// Memoized on first request: by then the app has rendered at least
+	// one page, so the style registries have settled (same reasoning
+	// as the deployment fingerprint itself).
+	ds.pwaSWOnce.Do(func() {
+		ds.pwaSW, ds.pwaSWErr = ds.PWAServiceWorkerJS("")
+	})
+	if ds.pwaSWErr != nil {
+		http.Error(w, "pwa not configured", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+	// The browser re-fetches the worker to detect updates; long-lived
+	// caching here would pin every client to a stale deployment.
+	w.Header().Set("Cache-Control", "no-cache")
+	fmt.Fprint(w, ds.pwaSW)
+}
+
+func (ds *UIHost) handlePWARegisterJS(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache")
+	fmt.Fprint(w, ds.PWARegisterJS(""))
+}
+
+func (ds *UIHost) handlePWAOffline(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache")
+	fmt.Fprint(w, ds.PWAOfflineHTML())
+}

--- a/framework/uihost/pwa_chrome_e2e_test.go
+++ b/framework/uihost/pwa_chrome_e2e_test.go
@@ -1,0 +1,222 @@
+package uihost
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/app"
+)
+
+// TestPWAChromeE2E drives the full PWA lifecycle in a real Chrome:
+// registration + installability metadata, offline fallback against a
+// genuinely dead server (listener closed — no CDP network emulation,
+// which does not reliably reach service-worker fetches), and
+// cache-version cleanup across a v1 → v2 deployment on the same origin.
+// Serialized by design: phases share one browser and one origin.
+func TestPWAChromeE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots Chrome")
+	}
+
+	makeHost := func(extraCSS string) *UIHost {
+		a := app.NewApp("PWA Demo")
+		a.Register("/", &plainComp{}, nil)
+		a.Register("/other", &plainComp{}, nil)
+		opts := []Option{WithPWA(PWAConfig{ThemeColor: "#112233"})}
+		if extraCSS != "" {
+			// Changing app.css rotates the deployment fingerprint —
+			// this is what makes v2 a "new asset fingerprint" deploy.
+			opts = append(opts, WithCustomCSS(extraCSS))
+		}
+		return New(a, opts...)
+	}
+
+	var current atomic.Pointer[UIHost]
+	current.Store(makeHost(""))
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current.Load().ServeHTTP(w, r)
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	base := "http://" + addr
+	srv := &http.Server{Handler: handler}
+	go srv.Serve(ln)
+
+	allocOpts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.Flag("headless", true),
+		chromedp.Flag("disable-gpu", true),
+		chromedp.Flag("no-sandbox", true),
+		chromedp.WSURLReadTimeout(90*time.Second),
+	)
+	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), allocOpts...)
+	defer allocCancel()
+	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
+	defer browserCancel()
+	ctx, cancel := context.WithTimeout(browserCtx, 120*time.Second)
+	defer cancel()
+
+	poll := func(expr string, timeout time.Duration) error {
+		deadline := time.Now().Add(timeout)
+		for {
+			var ok bool
+			if err := chromedp.Run(ctx, chromedp.Evaluate(expr, &ok)); err != nil {
+				return err
+			}
+			if ok {
+				return nil
+			}
+			if time.Now().After(deadline) {
+				return fmt.Errorf("timeout waiting for %s", expr)
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+
+	// ── Phase 1: registration + installability metadata ─────────────
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(base+"/"),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+	var hasManifestLink bool
+	if err := chromedp.Run(ctx, chromedp.Evaluate(
+		`!!document.querySelector('link[rel="manifest"][href="/manifest.webmanifest"]')`, &hasManifestLink)); err != nil {
+		t.Fatal(err)
+	}
+	if !hasManifestLink {
+		t.Errorf("page should carry the manifest link")
+	}
+	if err := chromedp.Run(ctx, chromedp.Evaluate(
+		`fetch('/manifest.webmanifest').then(r => r.json()).then(m => { window.__m = m; }); true`, nil)); err != nil {
+		t.Fatal(err)
+	}
+	if err := poll(`!!window.__m`, 10*time.Second); err != nil {
+		t.Fatalf("manifest fetch: %v", err)
+	}
+	var manifest map[string]any
+	if err := chromedp.Run(ctx, chromedp.Evaluate(`window.__m`, &manifest)); err != nil {
+		t.Fatal(err)
+	}
+	if manifest["name"] != "PWA Demo" || manifest["start_url"] != "/" ||
+		manifest["scope"] != "/" || manifest["display"] != "standalone" ||
+		manifest["theme_color"] != "#112233" {
+		t.Errorf("installability metadata wrong: %v", manifest)
+	}
+
+	// Registration: register.js runs on load; the worker precaches the
+	// shell, activates, and claims the page.
+	if err := poll(`!!(navigator.serviceWorker && navigator.serviceWorker.controller)`, 30*time.Second); err != nil {
+		t.Fatalf("service worker never took control: %v", err)
+	}
+	cacheKeys := func() []string {
+		if err := chromedp.Run(ctx, chromedp.Evaluate(
+			`caches.keys().then(k => { window.__ck = k; }); true`, nil)); err != nil {
+			t.Fatal(err)
+		}
+		if err := poll(`Array.isArray(window.__ck)`, 10*time.Second); err != nil {
+			t.Fatalf("caches.keys: %v", err)
+		}
+		var keys []string
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`window.__ck`, &keys)); err != nil {
+			t.Fatal(err)
+		}
+		if err := chromedp.Run(ctx, chromedp.Evaluate(`delete window.__ck; true`, nil)); err != nil {
+			t.Fatal(err)
+		}
+		return keys
+	}
+	v1Keys := cacheKeys()
+	if len(v1Keys) != 1 || !strings.HasPrefix(v1Keys[0], "gofastr-pwa-pwa-demo-") {
+		t.Fatalf("expected one owned cache, got %v", v1Keys)
+	}
+	v1Cache := v1Keys[0]
+
+	// ── Phase 2: offline fallback against a dead server ─────────────
+	if err := srv.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(base+"/other"),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("offline navigation: %v", err)
+	}
+	var offlineBody string
+	if err := chromedp.Run(ctx, chromedp.Evaluate(`document.body.innerText`, &offlineBody)); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(offlineBody, "You're offline") {
+		t.Errorf("offline navigation should render the offline screen, got: %q", offlineBody)
+	}
+
+	// ── Phase 3: v2 deploy → new cache version, old cache removed ───
+	current.Store(makeHost("/* v2 */"))
+	var ln2 net.Listener
+	for deadline := time.Now().Add(10 * time.Second); ; {
+		ln2, err = net.Listen("tcp", addr)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("rebind %s: %v", addr, err)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	srv2 := &http.Server{Handler: handler}
+	go srv2.Serve(ln2)
+	defer srv2.Close()
+
+	// A normal page load re-registers, which doubles as the update
+	// check; the v2 worker installs its cache and waits.
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(base+"/"),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("v2 navigate: %v", err)
+	}
+	if err := poll(`(function(){ caches.keys().then(k => { window.__n = k.length; }); return window.__n === 2; })()`, 30*time.Second); err != nil {
+		t.Fatalf("v2 install never created its cache: %v", err)
+	}
+
+	// The old worker keeps controlling until its clients go away — no
+	// forced skipWaiting. Release the origin (about:blank), let the v2
+	// worker activate and clean up, then come back and verify only the
+	// v2 cache remains.
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if err := chromedp.Run(ctx,
+			chromedp.Navigate("about:blank"),
+			chromedp.Sleep(500*time.Millisecond),
+			chromedp.Navigate(base+"/"),
+			chromedp.WaitReady("body", chromedp.ByQuery),
+		); err != nil {
+			t.Fatalf("release/return cycle: %v", err)
+		}
+		keys := cacheKeys()
+		if len(keys) == 1 {
+			if keys[0] == v1Cache {
+				t.Fatalf("v2 activation kept the OLD cache: %v", keys)
+			}
+			if !strings.HasPrefix(keys[0], "gofastr-pwa-pwa-demo-") {
+				t.Fatalf("surviving cache not owned by the app: %v", keys)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("old cache never cleaned up, still: %v", keys)
+		}
+	}
+}

--- a/framework/uihost/pwa_test.go
+++ b/framework/uihost/pwa_test.go
@@ -1,0 +1,577 @@
+package uihost
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
+	"github.com/DonaldMurillo/gofastr/core-ui/registry"
+	"github.com/DonaldMurillo/gofastr/core-ui/style"
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+func pwaGet(t *testing.T, ds *UIHost, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", path, nil)
+	w := httptest.NewRecorder()
+	ds.ServeHTTP(w, req)
+	return w
+}
+
+func pwaManifest(t *testing.T, ds *UIHost) map[string]any {
+	t.Helper()
+	w := pwaGet(t, ds, "/manifest.webmanifest")
+	if w.Code != 200 {
+		t.Fatalf("manifest: expected 200, got %d", w.Code)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &m); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v\n%s", err, w.Body.String())
+	}
+	return m
+}
+
+func TestPWARoutes404WithoutOption(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a)
+	for _, p := range []string{
+		"/manifest.webmanifest",
+		"/service-worker.js",
+		"/__gofastr/pwa/register.js",
+		"/__gofastr/pwa/offline",
+	} {
+		if w := pwaGet(t, ds, p); w.Code == 200 {
+			t.Errorf("%s should not be served without WithPWA, got 200", p)
+		}
+	}
+}
+
+func TestPWAManifestDefaults(t *testing.T) {
+	a := app.NewApp("Meridian")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{}))
+	m := pwaManifest(t, ds)
+	if m["name"] != "Meridian" {
+		t.Errorf("name should default to the app name, got %v", m["name"])
+	}
+	if m["start_url"] != "/" {
+		t.Errorf("start_url should default to /, got %v", m["start_url"])
+	}
+	if m["scope"] != "/" {
+		t.Errorf("scope should default to /, got %v", m["scope"])
+	}
+	if m["display"] != "standalone" {
+		t.Errorf("display should default to standalone, got %v", m["display"])
+	}
+	if m["id"] != "/" {
+		t.Errorf("id should default to start_url, got %v", m["id"])
+	}
+}
+
+func TestPWAManifestFull(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{
+		ID:              "/app",
+		Name:            "Acme Tracker",
+		ShortName:       "Acme",
+		Description:     "Track the things",
+		StartURL:        "/app",
+		Scope:           "/app",
+		Display:         PWADisplayMinimalUI,
+		ThemeColor:      "#112233",
+		BackgroundColor: "#ffffff",
+		Icons: []PWAIcon{
+			{Src: "/static/icon-192.png", Sizes: "192x192", Type: "image/png"},
+			{Src: "/static/icon-maskable.png", Sizes: "512x512", Type: "image/png", Purpose: PWAIconPurposeMaskable},
+		},
+	}))
+	m := pwaManifest(t, ds)
+	if m["short_name"] != "Acme" || m["description"] != "Track the things" {
+		t.Errorf("short_name/description missing: %v", m)
+	}
+	if m["display"] != "minimal-ui" {
+		t.Errorf("display: got %v", m["display"])
+	}
+	if m["theme_color"] != "#112233" || m["background_color"] != "#ffffff" {
+		t.Errorf("colors: got %v / %v", m["theme_color"], m["background_color"])
+	}
+	icons, ok := m["icons"].([]any)
+	if !ok || len(icons) != 2 {
+		t.Fatalf("expected 2 icons, got %v", m["icons"])
+	}
+	second := icons[1].(map[string]any)
+	if second["purpose"] != "maskable" {
+		t.Errorf("expected maskable purpose, got %v", second["purpose"])
+	}
+	first := icons[0].(map[string]any)
+	if _, has := first["purpose"]; has {
+		t.Errorf("empty purpose should be omitted, got %v", first)
+	}
+}
+
+func TestPWAManifestEscapesJSON(t *testing.T) {
+	name := `Acme "Co" </script>`
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{Name: name}))
+	m := pwaManifest(t, ds)
+	if m["name"] != name {
+		t.Errorf("name should round-trip through JSON escaping, got %v", m["name"])
+	}
+	body := pwaGet(t, ds, "/manifest.webmanifest").Body.String()
+	if strings.Contains(body, "</script>") {
+		t.Errorf("manifest must not contain a raw </script>: %s", body)
+	}
+}
+
+func TestPWAManifestHeaders(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{}))
+	w := pwaGet(t, ds, "/manifest.webmanifest")
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "application/manifest+json") {
+		t.Errorf("expected application/manifest+json, got %q", ct)
+	}
+	if cc := w.Header().Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("expected no-cache, got %q", cc)
+	}
+}
+
+func TestPWAServiceWorkerServed(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{}))
+	w := pwaGet(t, ds, "/service-worker.js")
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "javascript") {
+		t.Errorf("expected javascript content type, got %q", ct)
+	}
+	if cc := w.Header().Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("service worker must be no-cache, got %q", cc)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "gofastr-pwa-") {
+		t.Errorf("cache name should carry the gofastr-pwa- ownership prefix:\n%s", body)
+	}
+	if !strings.Contains(body, "/__gofastr/pwa/offline") {
+		t.Errorf("service worker should reference the offline fallback:\n%s", body)
+	}
+	if strings.Contains(body, "skipWaiting") {
+		t.Errorf("service worker must not force skipWaiting:\n%s", body)
+	}
+}
+
+func TestPWAServiceWorkerPrecache(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{
+		Precache: []string{"/static/hero.png"},
+		Icons:    []PWAIcon{{Src: "/static/icon-192.png", Sizes: "192x192", Type: "image/png"}},
+	}))
+	body := pwaGet(t, ds, "/service-worker.js").Body.String()
+	for _, want := range []string{
+		"/__gofastr/runtime.js",
+		"/__gofastr/color-scheme.js",
+		"/__gofastr/app.css",
+		"/static/hero.png",
+		"/static/icon-192.png",
+	} {
+		if !strings.Contains(body, `"`+want+`"`) {
+			t.Errorf("precache should include %s:\n%s", want, body)
+		}
+	}
+}
+
+func TestPWAServiceWorkerDeterministic(t *testing.T) {
+	build := func(precache ...string) string {
+		a := app.NewApp("x")
+		a.Register("/", &plainComp{}, nil)
+		ds := New(a, WithPWA(PWAConfig{Precache: precache}))
+		return pwaGet(t, ds, "/service-worker.js").Body.String()
+	}
+	one, two := build("/static/a.png"), build("/static/a.png")
+	if one != two {
+		t.Errorf("identical config must produce identical service-worker bytes")
+	}
+	cacheName := func(sw string) string {
+		i := strings.Index(sw, "gofastr-pwa-")
+		if i < 0 {
+			t.Fatalf("no cache name in sw:\n%s", sw)
+		}
+		return sw[i : i+strings.IndexAny(sw[i:], `"'`)]
+	}
+	if cacheName(one) == cacheName(build("/static/b.png")) {
+		t.Errorf("changed precache set must rotate the cache version")
+	}
+}
+
+func TestPWAPrecacheDropsSensitive(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{Precache: []string{
+		"/__gofastr/sse",
+		"/__gofastr/session",
+		"/__gofastr/signal/x",
+		"/__gofastr/action",
+		"/api/users",
+		"/auth/login",
+		"https://evil.example/x.js",
+		"//evil.example/x.js",
+		"relative/no-slash",
+		"/static/ok.png",
+	}}))
+	body := pwaGet(t, ds, "/service-worker.js").Body.String()
+	// Parse the PRECACHE array out of the worker source — the deny
+	// list legitimately repeats the sensitive paths, so asserting on
+	// the whole body would be meaningless.
+	i := strings.Index(body, "var PRECACHE = ")
+	if i < 0 {
+		t.Fatalf("no PRECACHE array in sw:\n%s", body)
+	}
+	line := body[i+len("var PRECACHE = "):]
+	line = line[:strings.Index(line, ";\n")]
+	var precache []string
+	if err := json.Unmarshal([]byte(line), &precache); err != nil {
+		t.Fatalf("PRECACHE is not a JSON array: %v\n%s", err, line)
+	}
+	got := map[string]bool{}
+	for _, p := range precache {
+		got[p] = true
+	}
+	// The only precache survivor from the list above is /static/ok.png.
+	if !got["/static/ok.png"] {
+		t.Errorf("safe static entry should survive: %v", precache)
+	}
+	for _, banned := range []string{
+		"/__gofastr/sse",
+		"/__gofastr/session",
+		"/__gofastr/signal/x",
+		"/__gofastr/action",
+		"/api/users",
+		"/auth/login",
+		"https://evil.example/x.js",
+		"//evil.example/x.js",
+		"relative/no-slash",
+	} {
+		if got[banned] {
+			t.Errorf("sensitive/unsafe precache entry %s must be dropped: %v", banned, precache)
+		}
+	}
+}
+
+func TestPWAServiceWorkerDenyList(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{}))
+	body := pwaGet(t, ds, "/service-worker.js").Body.String()
+	for _, deny := range []string{
+		"/__gofastr/sse",
+		"/__gofastr/session",
+		"/__gofastr/signal/",
+		"/__gofastr/action",
+		"/api/",
+		"/auth/",
+	} {
+		if !strings.Contains(body, deny) {
+			t.Errorf("fetch deny-list should cover %s:\n%s", deny, body)
+		}
+	}
+}
+
+func TestPWARegisterScript(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{}))
+	w := pwaGet(t, ds, "/__gofastr/pwa/register.js")
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "javascript") {
+		t.Errorf("expected javascript content type, got %q", ct)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `register("/service-worker.js"`) {
+		t.Errorf("register.js should register the root service worker:\n%s", body)
+	}
+	if !strings.Contains(body, "gofastr:pwa-update") {
+		t.Errorf("register.js should dispatch the update event:\n%s", body)
+	}
+	if strings.Contains(body, "skipWaiting") {
+		t.Errorf("register.js must not force skipWaiting:\n%s", body)
+	}
+}
+
+func TestPWAOfflineDefault(t *testing.T) {
+	a := app.NewApp("Meridian")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{}))
+	w := pwaGet(t, ds, "/__gofastr/pwa/offline")
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+		t.Errorf("expected html content type, got %q", ct)
+	}
+	body := w.Body.String()
+	if !strings.Contains(strings.ToLower(body), "offline") {
+		t.Errorf("default offline screen should mention being offline:\n%s", body)
+	}
+	if !strings.Contains(body, "/__gofastr/app.css") {
+		t.Errorf("offline page should carry the app chrome (app.css):\n%s", body)
+	}
+}
+
+type offlineMarkerComp struct{}
+
+func (offlineMarkerComp) Render() render.HTML {
+	return html.Div(html.DivConfig{}, render.Text("custom-offline-marker"))
+}
+
+func TestPWAOfflineCustomScreen(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{OfflineScreen: offlineMarkerComp{}}))
+	body := pwaGet(t, ds, "/__gofastr/pwa/offline").Body.String()
+	if !strings.Contains(body, "custom-offline-marker") {
+		t.Errorf("configured OfflineScreen should render:\n%s", body)
+	}
+}
+
+func TestPWAHeadTags(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{ThemeColor: "#123456"}))
+	body := pwaGet(t, ds, "/").Body.String()
+	if !strings.Contains(body, `<link rel="manifest" href="/manifest.webmanifest">`) {
+		t.Errorf("page should link the manifest:\n%s", body)
+	}
+	if !strings.Contains(body, `src="/__gofastr/pwa/register.js"`) {
+		t.Errorf("page should load the external register script:\n%s", body)
+	}
+	if !strings.Contains(body, `<meta name="theme-color" content="#123456">`) {
+		t.Errorf("page should carry the PWA theme color:\n%s", body)
+	}
+}
+
+// pwaSWPrecache parses the PRECACHE JSON array out of a generated
+// service worker.
+func pwaSWPrecache(t *testing.T, sw string) []string {
+	t.Helper()
+	i := strings.Index(sw, "var PRECACHE = ")
+	if i < 0 {
+		t.Fatalf("no PRECACHE array in sw:\n%s", sw)
+	}
+	line := sw[i+len("var PRECACHE = "):]
+	line = line[:strings.Index(line, ";\n")]
+	var precache []string
+	if err := json.Unmarshal([]byte(line), &precache); err != nil {
+		t.Fatalf("PRECACHE is not a JSON array: %v\n%s", err, line)
+	}
+	return precache
+}
+
+var pwaStyleSeq atomic.Int64
+
+// newPWAStyles registers n unique component styles (NOT LoadAlways —
+// the process-global registry has no reset, and eager styles would
+// leak into every other test's CSS bundle; unique names per test run,
+// same convention as framework/static's registry tests).
+func newPWAStyles(t *testing.T, n int) []*registry.Style {
+	t.Helper()
+	styles := make([]*registry.Style, n)
+	for i := range styles {
+		name := fmt.Sprintf("pwa-comp-%d", pwaStyleSeq.Add(1))
+		styles[i] = registry.RegisterStyle(name, func(theme style.Theme) string {
+			return style.NewComponentSheet(name, theme).
+				Rule(".x").Set("color", "red").End().
+				MustBuild()
+		})
+	}
+	return styles
+}
+
+// styledOfflineComp renders two styled components — enough to trigger
+// bundling on the offline page under the old bundle=true chrome.
+type styledOfflineComp struct{ styles []*registry.Style }
+
+func (c styledOfflineComp) Render() render.HTML {
+	out := render.HTML("<p>offline</p>")
+	for _, st := range c.styles {
+		out += st.WrapHTML(render.HTML(`<div class="x">x</div>`))
+	}
+	return out
+}
+
+// TestPWAOfflineNoBundleCSS: the offline page must link per-component
+// CSS directly, never the query-parameterized bundle endpoint — the
+// bundle URL depends on the page's component set, poisons the cache
+// for every other page's bundle request, and does not exist at all in
+// static exports.
+func TestPWAOfflineNoBundleCSS(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{OfflineScreen: styledOfflineComp{newPWAStyles(t, 2)}}))
+	offline := ds.PWAOfflineHTML()
+	if strings.Contains(offline, "comp-bundle.css") {
+		t.Errorf("offline page must not reference the bundle endpoint:\n%s", offline)
+	}
+	if !strings.Contains(offline, "/__gofastr/comp/") {
+		t.Errorf("offline page should link per-component CSS directly:\n%s", offline)
+	}
+	sw, err := ds.PWAServiceWorkerJS("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range pwaSWPrecache(t, sw) {
+		if strings.Contains(p, "comp-bundle.css") {
+			t.Errorf("precache must not contain a bundle URL: %s", p)
+		}
+	}
+}
+
+// TestPWAServiceWorkerExactMatching: no ignoreSearch — matching a
+// content-addressed URL against a different version's body serves
+// stale code; split-module precache entries must instead carry their
+// real ?v=<hash> so exact matching works offline.
+func TestPWAServiceWorkerExactMatching(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{}))
+	sw, err := ds.PWAServiceWorkerJS("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(sw, "ignoreSearch") {
+		t.Errorf("service worker must match URLs exactly (no ignoreSearch):\n%s", sw)
+	}
+	sawModule := false
+	for _, p := range pwaSWPrecache(t, sw) {
+		if strings.HasPrefix(p, "/__gofastr/runtime/") {
+			sawModule = true
+			if !strings.Contains(p, "?v=") {
+				t.Errorf("module precache entry should be content-addressed: %s", p)
+			}
+		}
+	}
+	if !sawModule {
+		t.Errorf("precache should include the split runtime modules")
+	}
+}
+
+// TestPWAServiceWorkerRewrapsPrecache: install must store re-wrapped
+// responses (cache.put + new Response), not cache.addAll — a static
+// host answers the extension-less offline URL with a 301, and a cached
+// redirected response is rejected for navigation fetches.
+func TestPWAServiceWorkerRewrapsPrecache(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{}))
+	sw, err := ds.PWAServiceWorkerJS("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(sw, "addAll") {
+		t.Errorf("install must not use cache.addAll (keeps the redirected flag):\n%s", sw)
+	}
+	if !strings.Contains(sw, "cache.put") || !strings.Contains(sw, "new Response") {
+		t.Errorf("install should cache.put re-wrapped responses:\n%s", sw)
+	}
+}
+
+// TestPWAVersionTracksAssetBytes: replacing a precached static asset
+// in place (same path, new bytes — e.g. swapping the placeholder icons
+// for real branding) must rotate the cache version.
+func TestPWAVersionTracksAssetBytes(t *testing.T) {
+	build := func(iconBytes []byte) string {
+		dir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(dir, "icons"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "icons", "icon-192.png"), iconBytes, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		a := app.NewApp("x")
+		a.Register("/", &plainComp{}, nil)
+		ds := New(a,
+			WithStaticDir(dir),
+			WithPWA(PWAConfig{Icons: []PWAIcon{{Src: "/icons/icon-192.png", Sizes: "192x192", Type: "image/png"}}}),
+		)
+		sw, err := ds.PWAServiceWorkerJS("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return sw
+	}
+	one := build([]byte("placeholder-png"))
+	two := build([]byte("real-branding-png"))
+	name := func(sw string) string {
+		i := strings.Index(sw, "gofastr-pwa-")
+		return sw[i : i+strings.IndexAny(sw[i:], `"'`)]
+	}
+	if name(one) == name(two) {
+		t.Errorf("changed asset bytes at the same path must rotate the cache version")
+	}
+}
+
+// TestPWADenyPathsExtendDenyList: apps with a custom API prefix (or
+// auth mount) extend the sensitive-path deny list; entries are both
+// un-precacheable and never intercepted.
+func TestPWADenyPathsExtendDenyList(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{
+		DenyPaths: []string{"/v1"},
+		Precache:  []string{"/v1/products", "/static/ok.png"},
+	}))
+	sw, err := ds.PWAServiceWorkerJS("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range pwaSWPrecache(t, sw) {
+		if p == "/v1/products" {
+			t.Errorf("DenyPaths entry must be un-precacheable: %v", p)
+		}
+	}
+	if !strings.Contains(sw, `"/v1"`) || !strings.Contains(sw, `"/v1/"`) {
+		t.Errorf("deny arrays should carry the custom path:\n%s", sw)
+	}
+}
+
+func TestPWAGeneratorsNilSafeWithoutOption(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a)
+	if got := ds.PWARegisterJS(""); got != "" {
+		t.Errorf("PWARegisterJS without WithPWA should return empty, got %q", got)
+	}
+	if got := ds.PWAOfflineHTML(); got != "" {
+		t.Errorf("PWAOfflineHTML without WithPWA should return empty, got %q", got)
+	}
+	if _, err := ds.PWAManifestJSON(""); err == nil {
+		t.Errorf("PWAManifestJSON without WithPWA should error")
+	}
+	if _, err := ds.PWAServiceWorkerJS(""); err == nil {
+		t.Errorf("PWAServiceWorkerJS without WithPWA should error")
+	}
+}
+
+func TestPWANoHeadTagsWithoutOption(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a)
+	body := pwaGet(t, ds, "/").Body.String()
+	if strings.Contains(body, "manifest.webmanifest") || strings.Contains(body, "/__gofastr/pwa/") {
+		t.Errorf("no PWA markup should be emitted without WithPWA:\n%s", body)
+	}
+}

--- a/framework/uihost/uihost.go
+++ b/framework/uihost/uihost.go
@@ -87,6 +87,10 @@ type UIHost struct {
 	sitemapConfig  *SitemapConfig                       // when set, /sitemap.xml lists every reachable route
 	robotsConfig   *RobotsConfig                        // when set, /robots.txt is served from this config
 	agentReady     *agentReadyConfig                    // when set, the agent-discovery surface (/llms.txt, agent card, Link headers, markdown negotiation) is served
+	pwaConfig      *PWAConfig                           // when set, the installable-PWA surface (manifest, service worker, offline screen) is served
+	pwaSWOnce      sync.Once                            // guards the memoized service-worker body below
+	pwaSW          string                               // deployment-constant service worker, computed on first request
+	pwaSWErr       error                                // paired with pwaSW
 
 	// standalone is a private router lazily mounted on first ServeHTTP call,
 	// so the host can satisfy http.Handler when it is used outside a
@@ -1846,6 +1850,15 @@ func (ds *UIHost) Mount(r *router.Router) {
 	}
 	if ds.robotsConfig != nil {
 		r.Get("/robots.txt", http.HandlerFunc(ds.handleRobots))
+	}
+	// Installable-PWA surface — only mounted via WithPWA. The manifest
+	// and worker live at the root so the worker's default scope covers
+	// the whole app.
+	if ds.pwaConfig != nil {
+		r.Get("/manifest.webmanifest", http.HandlerFunc(ds.handlePWAManifest))
+		r.Get("/service-worker.js", http.HandlerFunc(ds.handlePWAServiceWorker))
+		r.Get("/__gofastr/pwa/register.js", http.HandlerFunc(ds.handlePWARegisterJS))
+		r.Get("/__gofastr/pwa/offline", http.HandlerFunc(ds.handlePWAOffline))
 	}
 	// Agent-discovery surface (/llms.txt, /.well-known/agent-card.json,
 	// legacy /.well-known/agent.json). Opt-in via WithAgentReady or the


### PR DESCRIPTION
Closes #54.

## What's in this release

- **`uihost.WithPWA`** (95ba3928) — installable manifest, generated service worker with a versioned app-shell precache, CSP-safe external registration, and an offline fallback screen. Navigations network-first and never cached; exact-match caching with content-addressed URLs cache-first; sensitive endpoints (+ `DenyPaths`) never precached or intercepted; deterministic cache versioning that hashes static asset bytes; no `skipWaiting` — updates surface via `gofastr:pwa-update`. Serialized Chrome E2E covers registration, installability metadata, offline fallback, and cache-version cleanup.
- **Static export** (877376f0) — emits the PWA surface with `BasePath` baked into manifest URLs, precache/deny lists, and the registration target; a resolve-everything test pins that each precached URL exists in the export.
- **Blueprint `app.pwa` + `app.llm_md`** (a754d0ed) — one-block scaffold with replaceable placeholder icons; custom `api_prefix`/auth `base_path` flow into `DenyPaths`; `app.llm_md` emits `WithPublicLLMMD()`. Independent features, byte-compatible for existing blueprints, pack round-trip green.

## Verification

- `./scripts/test-all.sh` green (164 packages, no cache), coverage floors hold, gofmt/vet clean.
- 16-agent adversarial review round: 6 correctness findings confirmed and fixed with red tests first (bundle-free offline chrome, exact SW matching, redirect-safe precache, byte-sensitive versioning, extensible deny list) + 3 cleanups applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)