### PR TITLE
release/v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-07-14
+
+AI-native UI composition (#57): framework-owned operational components,
+generated apps that ship zero bespoke CSS with an app-owned `DESIGN.md`, an
+adaptive-by-default canonical theme (**BREAKING** — see below), and a
+framework-snapshot UI-quality evaluation harness.
+
 ### Added
 
 - **Framework-owned operational composition.** `ui.RecordSummary` provides one


### PR DESCRIPTION
Rolls the Unreleased section into v0.23.0 (2026-07-14).

Release contents (from #57): `ui.RecordSummary` + `ui.MetricBand` +
`SiteHeaderConfig.MobileBrand`, `DESIGN.md` + `ui-composition-recipes`
generated guidance, zero-app-CSS init scaffold, the framework-snapshot
UI-quality eval harness, and the post-review hardening pass.

**BREAKING:** `theme.Default()` is adaptive (dark palette included),
`ui.Cluster`'s zero value wraps, and `SiteHeader` wraps its Brand slot —
migration notes in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)