### PR TITLE
feat: dev-experience overhaul + static site as an app

### DIFF
--- a/.claude/skills/gofastr-host/SKILL.md
+++ b/.claude/skills/gofastr-host/SKILL.md
@@ -54,7 +54,7 @@ generate both the TOC and the `agents/` detail files. Refresh with
 
 | Task phrasing | Use this |
 |---|---|
-| audit trail, who-did-what, compliance log | `framework.WithAuditLog(cfg)` |
+| audit trail, who-did-what, compliance log | `app.WithAuditLog(cfg)` (chained *App method) |
 | admin pages, ops dashboard, queue browser | `battery/admin` |
 | login, signup, session, CSRF, bcrypt, "require admin" | `battery/auth` |
 | send notification, password reset link, fan-out across channels | `battery/notify` |
@@ -93,7 +93,8 @@ generate both the TOC and the `agents/` detail files. Refresh with
 
 ## Project shape
 
-- `main.go` builds the App: `framework.NewApp(WithDB, WithConfig, WithAuditLog, …)`.
+- `main.go` builds the App: `framework.NewApp(WithDB, WithConfig, …)`; chained
+  methods like `app.WithAuditLog(cfg)` come after.
 - `entities/` declares `EntityConfig`s — use `Seed` + `SeedFS` instead
   of hand-rolled `seedIfEmpty` helpers.
 - `screens/` is one screen per page; in-page state changes are island

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,74 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+
+- **Hot reload now reaches every HTML surface.** `framework.NewApp` mounts
+  dev-only middleware (active only under `gofastr dev`'s `GOFASTR_DEV=1`)
+  that splices the livereload client into full HTML documents — responses
+  declaring `Content-Type: text/html` that contain `</body>` and don't
+  already carry the tag. `static.Handler` file serving (the SPA and
+  static-site shapes), widget-server pages, and hand-rolled handlers that
+  set the type now auto-refresh like uihost screens. Fragments (island
+  swaps, SPA-nav partials), compressed bodies, HEAD/Range requests,
+  WebSocket upgrades, JSON/SSE/streams, and flushed progressive HTML all
+  pass through untouched.
+- **HMR-readiness evals.** An examples sweep boots every runnable example
+  under `GOFASTR_DEV=1` and asserts the livereload endpoint plus client
+  injection; a blueprint dev-loop e2e generates an app, runs it under
+  `gofastr dev`, edits a screen, and asserts the rebuilt content serves; a
+  docs tripwire pins that the dev-loop docs lead with `gofastr dev`.
+- **Static site as an app: full-site offline PWA for static exports.**
+  A static export with `uihost.WithPWA` now emits a full-site service
+  worker (`PWAStaticServiceWorkerJS`): the exported page set is closed and
+  immutable, so the whole site — pages, widget chrome, `llm.md`, component
+  stylesheets under their versioned `?v=` URLs — is precached at install
+  and navigations are cache-first (trailing-slash tolerant) — land once,
+  install the app, and the whole site works offline, including
+  never-visited pages. User static-dir files precache best-effort so one
+  un-servable file cannot brick the install; the cache version
+  fingerprints the exported tree (unchanged rebuilds stay byte-identical);
+  static caches use their own `gofastr-pwa-static-…` prefix so live and
+  static deployments on one origin never delete each other's caches; and
+  a user-supplied manifest or worker in the static dir wins over the
+  generated one. The live app's conservative network-first worker is
+  unchanged and deny rules apply to both. Proven by a Chrome e2e:
+  install, kill the server, navigate to a never-visited page, get its
+  real content.
+- **Non-deterministic dev-loop funnel signal in the UI-quality eval.**
+  Builders now get the snapshot's own `gofastr` CLI first on PATH via a
+  logging shim (previously `gofastr docs`/`gofastr dev` depended on a
+  possibly version-mismatched global install), the builder prompt stays
+  neutral about dev commands, and each candidate records whether the blind
+  builder discovered `gofastr dev` from the generated guidance alone —
+  surfaced in `result.json` and the leaderboard as funnel telemetry.
+
+### Changed
+
+- **`gofastr migrate` honors an exported `DATABASE_URL`.** The docs always
+  promised the 12-factor pattern, but only `--db-url=` and a `.env` file
+  worked; the process environment now sits between them (flag > env > .env,
+  matching the framework's dotenv precedence).
+- **Documentation-accuracy sweep** (77 guidance surfaces audited against the
+  code): the audit-log example now shows the real chained
+  `app.WithAuditLog(cfg)` wiring instead of a NewApp option that never
+  compiled (framework agents file + host skill); the ecommerce example's
+  README pointed at a `gen/` directory that hasn't existed since it moved to
+  `output_dir: app`; the notify battery no longer advertises a nonexistent
+  `WebhookChannel` (signed outbound webhooks are `battery/webhook`);
+  `pack` is no longer marked *(future)* in the architecture doc; the
+  migrations quick-reference shows the required `--from=`; and the harness
+  docs (and one error string) now say plainly that `verify-ack`,
+  `conformance`, `ack`, `token`, and `--auth-token-file` are specified but
+  not yet wired into the CLI.
+- **The development loop funnels to `gofastr dev`.** `go run .` never
+  hot-reloads (only `gofastr dev` sets `GOFASTR_DEV=1`), yet the
+  highest-traffic guidance led with it. `ui-getting-started`,
+  `tutorial-blueprint-app`, `project-structure`, the README quickstart, the
+  post-`generate` next-steps output, the generated AGENTS.md trigger row,
+  and the UI-eval builder prompt now lead with `gofastr dev` for iteration,
+  keeping `go run .`/`go build` for one-shot runs and production.
+
 ## [0.23.0] - 2026-07-14
 
 AI-native UI composition (#57): framework-owned operational components,

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ commit. From an empty directory containing that `gofastr.yml`:
 go mod init example.com/blog
 gofastr generate --from=gofastr.yml    # scaffolds main.go + app.go + screens.go + entities/ — owned Go you commit
 go mod tidy                            # pulls gofastr from the module proxy
-go run .                               # users + posts CRUD under /api, OpenAPI, MCP — live on :8080
+gofastr dev                            # hot-reload dev server — users + posts CRUD under /api, OpenAPI, MCP on :8080
 ```
 
 The blueprint mounts its REST API under `/api` by default (`GET /api/posts`),
@@ -371,9 +371,9 @@ shared across the whole `go test` invocation so cold-start is amortised.
 
 ## Surfaces
 
-### `core/` — eighteen stdlib-first primitives
+### `core/` — nineteen stdlib-first primitives
 
-`config`, `dotenv`, `featureflag`, `handler`, `i18n`, `markdown`, `mcp`, `middleware`, `migrate`, `openapi`, `query`, `render`, `router`, `schema`, `static`, `stream`, `upload`, `yaml`. Each is independently usable; the framework just composes them. All are stdlib-only except `core/middleware/tracing.go` (OpenTelemetry).
+`config`, `dotenv`, `fanout`, `featureflag`, `handler`, `i18n`, `markdown`, `mcp`, `middleware`, `migrate`, `openapi`, `query`, `render`, `router`, `schema`, `static`, `stream`, `upload`, `yaml`. Each is independently usable; the framework just composes them. All are stdlib-only except `core/middleware/tracing.go` (OpenTelemetry).
 
 ### `framework/` — opinionated entity layer
 

--- a/battery/notify/agents.md
+++ b/battery/notify/agents.md
@@ -6,8 +6,9 @@ Notifier renders per-channel templates and fans them out across the
 channels the routing function selects.
 
 **Use this when** the prompt mentions: send notification, email user,
-in-app notice, password reset link, "send a magic link", webhook
-trigger, "tell the user X happened".
+in-app notice, password reset link, "send a magic link", "tell the
+user X happened". (Outbound webhook triggers belong to
+`battery/webhook`.)
 
 **Import:** `github.com/DonaldMurillo/gofastr/battery/notify`
 
@@ -35,10 +36,11 @@ emailCh := notify.NewEmailChannel(emailSender, "noreply@example.com")
 n := notify.New(notify.WithTemplater(tmpl), notify.WithChannel(emailCh))
 ```
 
-**Don't reinvent** password-reset URL printing, magic-link sending,
-admin "your job finished" notices, or webhook fan-out. The same code
-path swaps `LoggerChannel` → `EmailChannel` → `WebhookChannel` without
-changing the call site.
+**Don't reinvent** password-reset URL printing, magic-link sending, or
+admin "your job finished" notices. The same code path swaps
+`LoggerChannel` → `EmailChannel` without changing the call site, and a
+custom sink is one small `Channel` implementation away. For signed
+outbound webhooks with retry, use `battery/webhook` directly.
 
 **For PHI-bearing apps:** templates are rendered with `Data` you pass
 in — don't put PHI in `Data` if the channel writes to a long-lived

--- a/cmd/gofastr/cov_migrate_test.go
+++ b/cmd/gofastr/cov_migrate_test.go
@@ -206,3 +206,24 @@ func TestParseMigrateGenOptions(t *testing.T) {
 		t.Fatalf("default snapshot = %q", def.snapshotPath)
 	}
 }
+
+// The docs promise the 12-factor pattern: `export DATABASE_URL=…` must reach
+// `gofastr migrate` without a .env file. Precedence follows the framework's
+// dotenv rule — flag beats process env beats .env file.
+func TestGetMigrateDBURLFromProcessEnv(t *testing.T) {
+	dir := t.TempDir()
+	covT_chdir(t, dir)
+	t.Setenv("DATABASE_URL", "from-process-env")
+	if got := getMigrateDBURL(nil); got != "from-process-env" {
+		t.Fatalf("exported DATABASE_URL ignored, got %q", got)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("DATABASE_URL=from-file\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := getMigrateDBURL(nil); got != "from-process-env" {
+		t.Fatalf("process env must beat the .env file, got %q", got)
+	}
+	if got := getMigrateDBURL([]string{"--db-url=from-flag"}); got != "from-flag" {
+		t.Fatalf("flag must beat everything, got %q", got)
+	}
+}

--- a/cmd/gofastr/dev_blueprint_e2e_test.go
+++ b/cmd/gofastr/dev_blueprint_e2e_test.go
@@ -1,0 +1,173 @@
+package main
+
+// End-to-end HMR-readiness gate for the blueprint surface: a generated app
+// run under `gofastr dev` must serve the livereload client, expose the SSE
+// endpoint, and rebuild+serve edited content — the same contract the init
+// scaffold already proves in dev_e2e_test.go. Gated by -short (slow — two Go
+// compiles + a dev-watch loop).
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestE2E_DevLoop_BlueprintApp(t *testing.T) {
+	if testing.Short() {
+		t.Skip("dev-loop e2e: compiles and serves a generated app")
+	}
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	goVersion, err := repoGoVersion(repoRoot)
+	if err != nil {
+		t.Fatalf("repoGoVersion: %v", err)
+	}
+	goMod := "module example.com/demo\n\ngo " + goVersion + "\n\nrequire github.com/DonaldMurillo/gofastr v0.0.0\n\nreplace github.com/DonaldMurillo/gofastr => " + repoRoot + "\n"
+	writeTestFile(t, filepath.Join(dir, "go.mod"), goMod)
+	if err := copyGoSum(repoRoot, dir); err != nil {
+		t.Fatalf("copy go.sum: %v", err)
+	}
+	writeTestFile(t, filepath.Join(dir, "gofastr.yml"), testBlueprintYAML())
+
+	generate := exec.Command("go", "run", filepath.Join(repoRoot, "cmd", "gofastr"), "generate", "--from=gofastr.yml")
+	generate.Dir = dir
+	if output, err := generate.CombinedOutput(); err != nil {
+		t.Fatalf("gofastr generate failed: %v\n%s", err, output)
+	}
+	// The generated app pulls new imports (driver, batteries); `gofastr dev`
+	// builds with the plain toolchain, so the user flow requires a tidy first.
+	tidy := exec.Command("go", "mod", "tidy")
+	tidy.Dir = dir
+	if output, err := tidy.CombinedOutput(); err != nil {
+		t.Fatalf("go mod tidy: %v\n%s", err, output)
+	}
+
+	// Boot the generated app under `gofastr dev` — the path the guidance
+	// funnels users to, and the only one that enables livereload.
+	bin := buildGofastrBinary(t)
+	port := nextE2EPort()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dev := exec.CommandContext(ctx, bin, "dev", "-p", port, "--dir", dir)
+	dev.Env = append(os.Environ(),
+		"PORT=localhost:"+port,
+		"DATABASE_URL=file:"+filepath.Join(dir, "devloop.db"),
+	)
+	var devOut syncBuffer
+	dev.Stdout = &devOut
+	dev.Stderr = &devOut
+	dev.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := dev.Start(); err != nil {
+		t.Fatalf("start gofastr dev: %v", err)
+	}
+	pid := dev.Process.Pid
+	t.Cleanup(func() {
+		cancel()
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		_ = dev.Wait()
+	})
+
+	base := "http://localhost:" + port
+	body := waitForBody(t, base+"/", 90*time.Second, &devOut)
+
+	// HMR-ready contract, part 1: the page carries the livereload client and
+	// the SSE endpoint answers.
+	if !strings.Contains(body, "/__livereload.js") {
+		t.Fatalf("generated page does not inject the livereload client:\n%s", clip(body))
+	}
+	resp, err := http.Get(base + "/__livereload.js")
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("livereload client script: err=%v status=%v", err, resp)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	// HMR-ready contract, part 2: editing generated source rebuilds and the
+	// new content serves without any manual restart.
+	const marker = "HMR-LOOP-ALIVE"
+	if !strings.Contains(body, "Generated from YAML.") {
+		t.Fatalf("fixture heading missing from generated page:\n%s", clip(body))
+	}
+	edited := false
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(src), "Generated from YAML.") {
+			continue
+		}
+		next := strings.Replace(string(src), "Generated from YAML.", "Generated from YAML. "+marker, 1)
+		if err := os.WriteFile(path, []byte(next), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		edited = true
+		break
+	}
+	if !edited {
+		t.Fatal("no generated .go file contains the fixture heading to edit")
+	}
+
+	deadline := time.Now().Add(120 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(base + "/")
+		if err == nil {
+			b, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if strings.Contains(string(b), marker) {
+				return // rebuilt and serving the edit — HMR loop alive
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("edited content never served after rebuild window; dev output:\n%s", devOut.String())
+}
+
+// waitForBody polls url until it returns 200 and yields the body.
+func waitForBody(t *testing.T, url string, timeout time.Duration, devOut *syncBuffer) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			b, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr == nil && resp.StatusCode == http.StatusOK {
+				return string(b)
+			}
+			last = fmt.Sprintf("status=%d", resp.StatusCode)
+		} else {
+			last = err.Error()
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("server never became ready (%s); dev output:\n%s", last, devOut.String())
+	return ""
+}
+
+func clip(s string) string {
+	if len(s) > 2000 {
+		return s[:2000] + "…"
+	}
+	return s
+}

--- a/cmd/gofastr/dev_e2e_test.go
+++ b/cmd/gofastr/dev_e2e_test.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -51,7 +52,7 @@ type devHarness struct {
 	port       string
 	cmd        *exec.Cmd
 	cancelFunc context.CancelFunc
-	output     strings.Builder
+	output     syncBuffer
 }
 
 func newDevHarness(t *testing.T) *devHarness {
@@ -424,4 +425,24 @@ func TestE2E_HotReload_BrowserAutoRefreshes(t *testing.T) {
 	_ = chromedp.Run(ctx, chromedp.Text("h1", &finalTitle, chromedp.ByQuery))
 	t.Fatalf("browser never saw 'RELOADED_TITLE' after 45s. Final h1 = %q.\nDev output:\n%s",
 		finalTitle, h.output.String())
+}
+
+// syncBuffer is a mutex-guarded writer for capturing live child-process
+// output: os/exec's copy goroutine writes while the test goroutine reads on
+// failure paths, which races on a bare strings.Builder under -race.
+type syncBuffer struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
 }

--- a/cmd/gofastr/embedded/gofastr-host-skill.md
+++ b/cmd/gofastr/embedded/gofastr-host-skill.md
@@ -54,7 +54,7 @@ generate both the TOC and the `agents/` detail files. Refresh with
 
 | Task phrasing | Use this |
 |---|---|
-| audit trail, who-did-what, compliance log | `framework.WithAuditLog(cfg)` |
+| audit trail, who-did-what, compliance log | `app.WithAuditLog(cfg)` (chained *App method) |
 | admin pages, ops dashboard, queue browser | `battery/admin` |
 | login, signup, session, CSRF, bcrypt, "require admin" | `battery/auth` |
 | send notification, password reset link, fan-out across channels | `battery/notify` |
@@ -93,7 +93,8 @@ generate both the TOC and the `agents/` detail files. Refresh with
 
 ## Project shape
 
-- `main.go` builds the App: `framework.NewApp(WithDB, WithConfig, WithAuditLog, …)`.
+- `main.go` builds the App: `framework.NewApp(WithDB, WithConfig, …)`; chained
+  methods like `app.WithAuditLog(cfg)` come after.
 - `entities/` declares `EntityConfig`s — use `Seed` + `SeedFS` instead
   of hand-rolled `seedIfEmpty` helpers.
 - `screens/` is one screen per page; in-page state changes are island

--- a/cmd/gofastr/generate.go
+++ b/cmd/gofastr/generate.go
@@ -764,6 +764,16 @@ func generateBlueprint(bp Blueprint, options generateOptions) {
 		return
 	}
 	success("Generated %d file(s) in %s", len(files), displayDir)
+	devCmd := "gofastr dev"
+	if outDir != "" && outDir != "." {
+		// output_dir blueprints put the app in a subpackage — plain
+		// `gofastr dev` would watch/build a root with no main package.
+		devCmd = "gofastr dev --dir " + outDir
+	}
+	fmt.Println()
+	fmt.Println("  Next steps:")
+	fmt.Println("    go mod tidy          — the generated code pulls new imports")
+	fmt.Printf("    %-20s — dev server with hot-reload\n", devCmd)
 }
 
 type generatedFile struct {

--- a/cmd/gofastr/migrate_cmd.go
+++ b/cmd/gofastr/migrate_cmd.go
@@ -277,6 +277,12 @@ func getMigrateDBURL(args []string) string {
 			return strings.TrimPrefix(a, "--db-url=")
 		}
 	}
+	// The exported env var is the 12-factor path the docs promise.
+	// Precedence follows the framework's dotenv rule: the process
+	// environment always beats file values.
+	if v := os.Getenv("DATABASE_URL"); v != "" {
+		return v
+	}
 	// Check .env file via the shared parser — handles quoted values,
 	// escapes, and the `export` prefix that the prior ad-hoc 1-key
 	// scanner mishandled.

--- a/cmd/gofastr/readme_quickstart_test.go
+++ b/cmd/gofastr/readme_quickstart_test.go
@@ -133,7 +133,10 @@ func TestReadmeQuickstartShapeIsStable(t *testing.T) {
 			t.Fatalf("README blueprint block lost %q — the quickstart yaml must stay a real relation-bearing blueprint:\n%s", want, yamlBlock)
 		}
 	}
-	for _, want := range []string{"go mod init", "gofastr generate --from=gofastr.yml", "go mod tidy", "go run ."} {
+	// `gofastr dev`, not `go run .`: only the dev server hot-reloads, and the
+	// quickstart is the development on-ramp. TestReadmeQuickstartBlueprintRuns
+	// keeps the sequence executable by building and booting the same app.
+	for _, want := range []string{"go mod init", "gofastr generate --from=gofastr.yml", "go mod tidy", "gofastr dev"} {
 		if !strings.Contains(bashBlock, want) {
 			t.Fatalf("README quickstart command sequence lost %q — the documented path must stay the executable path:\n%s", want, bashBlock)
 		}

--- a/evals/ui-quality/README.md
+++ b/evals/ui-quality/README.md
@@ -74,7 +74,16 @@ result or used as variant names.
 - Candidates are isolated Git workspaces containing the normal scaffold plus a
   neutral `EVAL_TASK.md`.
 - The builder prompt does not prescribe layouts, aesthetics, component choices,
-  or exceptions to GoFastr's ownership rules.
+  or exceptions to GoFastr's ownership rules — nor does it name any dev
+  command.
+- Builders get the snapshot's own `gofastr` CLI first on PATH through a
+  logging shim, so `gofastr docs` / `gofastr dev` always match the framework
+  under evaluation (a globally installed CLI would leak another version into
+  the treatment). The shim log is recorded per candidate
+  (`cli-invocations.log`) and produces a non-deterministic dev-loop funnel
+  signal in results and the leaderboard: whether the builder discovered
+  `gofastr dev` from the generated guidance alone, and how many CLI calls it
+  made.
 - The generated onboarding fingerprint is captured before the builder and
   checked afterward. Mutation is contamination and fails the candidate.
 - The framework snapshot and built CLI are fingerprinted before the matrix and

--- a/evals/ui-quality/internal/evalrunner/aggregate.go
+++ b/evals/ui-quality/internal/evalrunner/aggregate.go
@@ -241,6 +241,8 @@ func leaderboardMarkdown(summary Summary) string {
 		fmt.Fprintf(&b, "Holistic %.2f (minimum %.2f); mobile %.2f (minimum %.2f); holistic/mobile shadcn consensus `%t`/`%t`; technical pass `%t`; quality pass `%t`.\n\n",
 			c.Overall, c.MinimumDimension, c.MobileOverall, c.MobileMinimumDimension,
 			c.HolisticShadcnConsensus, c.MobileShadcnConsensus, c.TechnicalPassed, c.QualityPassed)
+		fmt.Fprintf(&b, "Dev-loop funnel (non-deterministic): builder invoked `gofastr dev` `%t`; %d gofastr CLI call(s) total.\n\n",
+			c.BuilderUsedDevServer, c.BuilderCLICalls)
 		if len(c.Weakest) > 0 {
 			b.WriteString("Weakest visible decisions:\n\n")
 			for _, item := range c.Weakest {

--- a/evals/ui-quality/internal/evalrunner/clishim.go
+++ b/evals/ui-quality/internal/evalrunner/clishim.go
@@ -1,0 +1,63 @@
+package evalrunner
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// installCLIShim writes a `gofastr` wrapper into dir that appends each
+// invocation's arguments to logPath and then execs realBin. Prepending dir to
+// the builder's PATH gives every candidate the SNAPSHOT's CLI (guidance tells
+// agents to run `gofastr docs` / `gofastr dev`; a globally installed gofastr
+// would leak a different framework version into the treatment) and records a
+// precise, non-deterministic funnel signal: the harness prompt names no
+// command, so any `gofastr dev` in the log was discovered from the generated
+// guidance alone. Transcript grepping cannot provide this signal — an agent
+// merely READING the guidance echoes the command into its transcript.
+func installCLIShim(dir, realBin, logPath string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	if runtime.GOOS == "windows" {
+		shim := "@echo off\r\n" +
+			">> \"" + logPath + "\" echo %*\r\n" +
+			"\"" + realBin + "\" %*\r\n"
+		return os.WriteFile(filepath.Join(dir, "gofastr.cmd"), []byte(shim), 0o755)
+	}
+	shim := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> \"" + logPath + "\"\n" +
+		"exec \"" + realBin + "\" \"$@\"\n"
+	return os.WriteFile(filepath.Join(dir, "gofastr"), []byte(shim), 0o755)
+}
+
+// cliInvocationStats reads a shim log and reports how many times the builder
+// invoked the gofastr CLI and whether any invocation was the dev server.
+// A missing log means zero invocations, not an error — the builder simply
+// never reached for the CLI.
+func cliInvocationStats(logPath string) (calls int, usedDev bool) {
+	f, err := os.Open(logPath)
+	if err != nil {
+		return 0, false
+	}
+	defer f.Close()
+	reader := bufio.NewReader(f)
+	for {
+		line, readErr := reader.ReadString('\n')
+		if fields := strings.Fields(line); len(fields) > 0 {
+			calls++
+			if fields[0] == "dev" {
+				usedDev = true
+			}
+		}
+		if readErr == io.EOF {
+			return calls, usedDev
+		}
+		if readErr != nil {
+			return calls, usedDev
+		}
+	}
+}

--- a/evals/ui-quality/internal/evalrunner/clishim_test.go
+++ b/evals/ui-quality/internal/evalrunner/clishim_test.go
@@ -1,0 +1,73 @@
+package evalrunner
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCLIShimLogsAndExecsRealBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh-based shim exec test; the .cmd variant is exercised on Windows runs")
+	}
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real-gofastr")
+	if err := os.WriteFile(real, []byte("#!/bin/sh\necho REAL-RAN $1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(dir, "cli.log")
+	shimDir := filepath.Join(dir, "shim")
+	if err := installCLIShim(shimDir, real, logPath); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command(filepath.Join(shimDir, "gofastr"), "docs", "ui-composition-recipes").CombinedOutput()
+	if err != nil {
+		t.Fatalf("shim exec: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "REAL-RAN docs") {
+		t.Fatalf("shim did not exec the real binary: %q", out)
+	}
+	if _, err := exec.Command(filepath.Join(shimDir, "gofastr"), "dev", "-p", "1").CombinedOutput(); err != nil {
+		t.Fatalf("second shim exec: %v", err)
+	}
+
+	calls, usedDev := cliInvocationStats(logPath)
+	if calls != 2 || !usedDev {
+		b, _ := os.ReadFile(logPath)
+		t.Fatalf("stats = (%d, %t), want (2, true); log:\n%s", calls, usedDev, b)
+	}
+}
+
+func TestCLIInvocationStatsMissingLogMeansZero(t *testing.T) {
+	calls, usedDev := cliInvocationStats(filepath.Join(t.TempDir(), "never-written.log"))
+	if calls != 0 || usedDev {
+		t.Fatalf("missing log must read as no invocations, got (%d, %t)", calls, usedDev)
+	}
+}
+
+func TestCLIInvocationStatsDistinguishesDevFromOtherSubcommands(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "cli.log")
+	if err := os.WriteFile(logPath, []byte("docs ui-composition-recipes\ntheme init\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	calls, usedDev := cliInvocationStats(logPath)
+	if calls != 2 || usedDev {
+		t.Fatalf("docs/theme-only log must not count as dev usage, got (%d, %t)", calls, usedDev)
+	}
+}
+
+// The funnel signal must reach the human-readable output, not just JSON.
+func TestLeaderboardReportsDevLoopFunnel(t *testing.T) {
+	summary := Summary{Candidates: []CandidateResult{{
+		VariantID: "working-tree", ScenarioID: "s", Repetition: 1,
+		BuilderCLICalls: 3, BuilderUsedDevServer: true,
+	}}}
+	md := leaderboardMarkdown(summary)
+	if !strings.Contains(md, "builder invoked `gofastr dev` `true`") || !strings.Contains(md, "3 gofastr CLI call(s)") {
+		t.Fatalf("leaderboard missing dev-loop funnel line:\n%s", md)
+	}
+}

--- a/evals/ui-quality/internal/evalrunner/codex.go
+++ b/evals/ui-quality/internal/evalrunner/codex.go
@@ -156,9 +156,10 @@ Rules for evaluation integrity:
 - Keep the generated PORT environment-variable startup contract working.
 - Do not require external services, API keys, or a network connection at runtime.
 - Finish the implementation, run gofmt and go test ./..., and fix failures.
-- Follow the generated project's UI verification workflow. You may launch the
-  app temporarily for local visual review, but stop it before finishing; the
-  harness owns the final runtime health checks and evidence captures.
+- Follow the generated project's UI verification workflow and its documented
+  development loop. You may run the app for local visual review, but stop
+  every server before finishing; the harness owns the final runtime health
+  checks and evidence captures.
 - Work to a 25-minute implementation budget. After the app builds and tests,
   make at most two bounded visual-review passes. Inspect each required route at
   one desktop and one mobile size and fix the most material visible issues.

--- a/evals/ui-quality/internal/evalrunner/runner.go
+++ b/evals/ui-quality/internal/evalrunner/runner.go
@@ -485,18 +485,31 @@ func executeCandidate(ctx context.Context, suite *Suite, opts Options, gofastrBi
 		}
 		result.GuidanceFingerprint = guidanceFingerprint
 
+		// The snapshot's own CLI goes first on the builder's PATH via a
+		// logging shim: the generated guidance tells agents to run
+		// `gofastr docs` / `gofastr dev`, and a globally installed gofastr
+		// would leak a different framework version into the treatment. The
+		// shim log doubles as the non-deterministic dev-loop funnel signal.
+		cliLog := filepath.Join(mapping.ResultDir, "cli-invocations.log")
+		shimDir := filepath.Join(mapping.ResultDir, "cli")
+		if err := installCLIShim(shimDir, gofastrBin, cliLog); err != nil {
+			result.TechnicalIssues = append(result.TechnicalIssues, "install CLI shim: "+err.Error())
+			return result
+		}
 		buildOutput := filepath.Join(mapping.ResultDir, "builder-final.md")
 		inv := agentRequest{
 			Config: suite.Agents.Builder,
 			Env: append(append([]string(nil), builderEnv...),
 				"GOCACHE="+filepath.Join(mapping.Workspace, ".cache", "go-build"),
-				"GOFLAGS=-buildvcs=false"),
+				"GOFLAGS=-buildvcs=false",
+				"PATH="+shimDir+string(os.PathListSeparator)+os.Getenv("PATH")),
 			Workspace: mapping.Workspace, OutputPath: buildOutput, Prompt: builderPrompt(), LogPath: filepath.Join(mapping.ResultDir, "builder.log"),
 		}
 		builderStarted := time.Now()
 		builderErr := runAgent(ctx, inv)
 		result.BuilderDuration = time.Since(builderStarted).Seconds()
 		_, result.BuilderTokens = builderMetricsFromArtifacts(mapping.ResultDir)
+		result.BuilderCLICalls, result.BuilderUsedDevServer = cliInvocationStats(cliLog)
 		integrityErr := verifyFrameworkIntegrity(variant.FrameworkRoot, gofastrBin, mapping.FrameworkFingerprint)
 		if integrityErr != nil {
 			result.TechnicalIssues = append(result.TechnicalIssues, "framework integrity after builder: "+integrityErr.Error())

--- a/evals/ui-quality/internal/evalrunner/types.go
+++ b/evals/ui-quality/internal/evalrunner/types.go
@@ -70,24 +70,30 @@ type CandidateMapping struct {
 }
 
 type CandidateResult struct {
-	BlindID                 string             `json:"blind_id"`
-	VariantID               string             `json:"variant_id"`
-	ScenarioID              string             `json:"scenario_id"`
-	Repetition              int                `json:"repetition"`
-	BuilderFingerprint      string             `json:"builder_fingerprint"`
-	FrameworkRoot           string             `json:"framework_root"`
-	FrameworkFingerprint    string             `json:"framework_fingerprint"`
-	GuidanceFingerprint     string             `json:"scaffold_guidance_fingerprint"`
-	ProtocolFingerprint     string             `json:"protocol_fingerprint"`
-	WorkspaceFingerprint    string             `json:"workspace_fingerprint"`
-	BuilderProvenance       AgentProvenance    `json:"builder_provenance"`
-	BuilderModel            string             `json:"builder_model"`
-	HolisticJudgeModel      string             `json:"holistic_judge_model"`
-	MobileJudgeModel        string             `json:"mobile_judge_model"`
-	HolisticJudgeProvenance AgentProvenance    `json:"holistic_judge_provenance"`
-	MobileJudgeProvenance   AgentProvenance    `json:"mobile_judge_provenance"`
-	BuilderDuration         float64            `json:"builder_duration_seconds,omitempty"`
-	BuilderTokens           int64              `json:"builder_tokens,omitempty"`
+	BlindID                 string          `json:"blind_id"`
+	VariantID               string          `json:"variant_id"`
+	ScenarioID              string          `json:"scenario_id"`
+	Repetition              int             `json:"repetition"`
+	BuilderFingerprint      string          `json:"builder_fingerprint"`
+	FrameworkRoot           string          `json:"framework_root"`
+	FrameworkFingerprint    string          `json:"framework_fingerprint"`
+	GuidanceFingerprint     string          `json:"scaffold_guidance_fingerprint"`
+	ProtocolFingerprint     string          `json:"protocol_fingerprint"`
+	WorkspaceFingerprint    string          `json:"workspace_fingerprint"`
+	BuilderProvenance       AgentProvenance `json:"builder_provenance"`
+	BuilderModel            string          `json:"builder_model"`
+	HolisticJudgeModel      string          `json:"holistic_judge_model"`
+	MobileJudgeModel        string          `json:"mobile_judge_model"`
+	HolisticJudgeProvenance AgentProvenance `json:"holistic_judge_provenance"`
+	MobileJudgeProvenance   AgentProvenance `json:"mobile_judge_provenance"`
+	BuilderDuration         float64         `json:"builder_duration_seconds,omitempty"`
+	BuilderTokens           int64           `json:"builder_tokens,omitempty"`
+	// BuilderCLICalls / BuilderUsedDevServer come from the PATH shim's
+	// invocation log — a non-deterministic funnel signal: the harness
+	// prompt names no command, so a `gofastr dev` here means the builder
+	// discovered the hot-reload loop from the generated guidance alone.
+	BuilderCLICalls         int                `json:"builder_cli_calls"`
+	BuilderUsedDevServer    bool               `json:"builder_used_dev_server"`
 	BuildSucceeded          bool               `json:"build_succeeded"`
 	TestsSucceeded          bool               `json:"tests_succeeded"`
 	ServerSucceeded         bool               `json:"server_succeeded"`

--- a/examples/ecommerce/README.md
+++ b/examples/ecommerce/README.md
@@ -5,7 +5,7 @@ thesis: a complete storefront described **once** in
 [`gofastr.yml`](gofastr.yml) — 5 related entities (categories, products,
 orders, order_items, reviews), a themed 8-screen UI, custom endpoints,
 seed data, middleware, and a plugin — emitted as runnable Go by a single
-command. Nothing under `gen/` is hand-written.
+command. Nothing under `app/` is hand-written.
 
 ## What it proves
 
@@ -13,7 +13,7 @@ One blueprint fans out into every surface: auto-migrated SQL schema,
 REST CRUD with validation and cursor pagination, OpenAPI, 25 MCP tools
 for agents, and a server-rendered themed storefront. All of it is
 asserted live by [`flagship_test.go`](flagship_test.go), which
-regenerates `gen/` from the blueprint, builds the binary, boots it, and
+regenerates `app/` from the blueprint, builds the binary, boots it, and
 hits each surface — so the proof never depends on a stale checkout.
 
 ## Secure by default
@@ -31,11 +31,12 @@ shipped insecure and how it was fixed is in
 
 ```sh
 cd examples/ecommerce
-gofastr generate --from=gofastr.yml   # re-emits gen/ from the blueprint
-go run ./gen                          # serves on localhost:8080
+gofastr generate --from=gofastr.yml --force   # re-emits app/ from the blueprint (output_dir: app)
+gofastr dev --dir app                         # hot-reload dev server on localhost:8080
 ```
 
-`gen/` is gitignored — generated code is regenerated, not committed.
+`app/` is committed, owned Go — `output_dir: app` in the blueprint puts the
+app in a subpackage so the example also hosts its own test files.
 
 ## Read next
 

--- a/examples/livereload_e2e_test.go
+++ b/examples/livereload_e2e_test.go
@@ -1,0 +1,178 @@
+package main
+
+// HMR-readiness sweep: every runnable example, booted the way `gofastr dev`
+// boots it (GOFASTR_DEV=1), must expose the livereload endpoint, and every
+// example that serves HTML must inject the livereload client into its pages —
+// otherwise the developer editing that surface gets no browser refresh and
+// silently loses the framework's hot-reload loop.
+//
+// Gated by -short (compiles and boots each example).
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type exampleSurface struct {
+	name string // directory under examples/
+	pkg  string // package to build, relative to repo root
+	// fixedAddr is set for examples that ignore PORT and bind a constant.
+	fixedAddr string
+	// page is the HTML page asserted to carry the livereload client;
+	// empty for API-only surfaces (endpoint check only).
+	page string
+	env  []string
+}
+
+func TestExamplesAreHMRReady(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots every example")
+	}
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	surfaces := []exampleSurface{
+		{name: "site", pkg: "./examples/site", page: "/"},
+		{name: "meridian", pkg: "./examples/meridian", page: "/"},
+		{name: "backoffice", pkg: "./examples/backoffice", page: "/"},
+		{name: "spa", pkg: "./examples/spa", fixedAddr: "127.0.0.1:3090", page: "/"},
+		{name: "static-site", pkg: "./examples/static-site", fixedAddr: "127.0.0.1:3070", page: "/"},
+		{name: "ecommerce", pkg: "./examples/ecommerce/app", page: "/"},
+		// API-only surfaces: no HTML pages, so only the SSE endpoint applies.
+		{name: "blog", pkg: "./examples/blog", page: ""},
+		{name: "api-tour", pkg: "./examples/api-tour", page: ""},
+	}
+	for _, s := range surfaces {
+		t.Run(s.name, func(t *testing.T) {
+			assertHMRReady(t, repoRoot, s)
+		})
+	}
+}
+
+func assertHMRReady(t *testing.T, repoRoot string, s exampleSurface) {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), s.name)
+	build := exec.Command("go", "build", "-o", bin, s.pkg)
+	build.Dir = repoRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build %s: %v\n%s", s.pkg, err, out)
+	}
+
+	addr := s.fixedAddr
+	if addr == "" {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr = ln.Addr().String()
+		_ = ln.Close()
+	} else if ln, err := net.Listen("tcp", addr); err != nil {
+		t.Skipf("fixed address %s busy on this machine: %v", addr, err)
+	} else {
+		_ = ln.Close()
+	}
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Dir = filepath.Join(repoRoot, strings.TrimPrefix(s.pkg, "./"))
+	cmd.Env = append(os.Environ(),
+		"GOFASTR_DEV=1", // what `gofastr dev` sets on the child
+		"PORT="+port,
+		"DATABASE_URL=file:"+filepath.Join(t.TempDir(), s.name+".db"),
+	)
+	cmd.Env = append(cmd.Env, s.env...)
+	var out syncBuffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start %s: %v", s.name, err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		_ = cmd.Wait()
+	})
+
+	base := "http://" + net.JoinHostPort("127.0.0.1", port)
+	if !waitFor200(base+"/healthz", 60*time.Second) && !waitFor200(base+"/", 15*time.Second) {
+		t.Fatalf("%s never became ready on %s; output:\n%s", s.name, base, out.String())
+	}
+
+	// Contract 1 (every framework app): the livereload endpoint is wired.
+	resp, err := http.Get(base + "/__livereload.js")
+	if err != nil {
+		t.Fatalf("%s livereload client script: %v", s.name, err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("%s: /__livereload.js = %d under GOFASTR_DEV=1 — the dev SSE surface is not wired", s.name, resp.StatusCode)
+	}
+
+	// Contract 2 (HTML-serving apps): pages inject the livereload client so
+	// the browser actually refreshes after `gofastr dev` rebuilds.
+	if s.page == "" {
+		return
+	}
+	pageResp, err := http.Get(base + s.page)
+	if err != nil {
+		t.Fatalf("%s GET %s: %v", s.name, s.page, err)
+	}
+	body, _ := io.ReadAll(pageResp.Body)
+	_ = pageResp.Body.Close()
+	if pageResp.StatusCode != http.StatusOK {
+		t.Fatalf("%s GET %s = %d", s.name, s.page, pageResp.StatusCode)
+	}
+	if !strings.Contains(string(body), "/__livereload.js") {
+		t.Errorf("%s: %s does not inject the livereload client under GOFASTR_DEV=1 — edits rebuild but the browser never refreshes", s.name, s.page)
+	}
+}
+
+func waitFor200(url string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return true
+			}
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	return false
+}
+
+// syncBuffer guards live child-process output against the -race data race
+// between os/exec's copy goroutine and failure-path reads.
+type syncBuffer struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}

--- a/framework/ARCHITECTURE.md
+++ b/framework/ARCHITECTURE.md
@@ -25,7 +25,7 @@ subpackage needs to back-import the framework root.
 
 ## The blueprint is a generator, not a source of truth
 
-> Read this before changing `cmd/gofastr` (`generate`, `migrate`, future
+> Read this before changing `cmd/gofastr` (`generate`, `migrate`,
 > `pack`), the generated-output layout, or how the project is positioned.
 > This is what the code now does. Anything that still contradicts it —
 > `gen/` output, `clean`-rewrite — is legacy to remove, not progress
@@ -56,7 +56,7 @@ treated as canonical for a running app.
 | move | direction | standing |
 |---|---|---|
 | `generate` | YAML → owned Go | one-way on-ramp; scaffold then leave behind |
-| `pack` *(future)* | owned Go → YAML | one-way, lossy off-ramp; snapshot of *shape* |
+| `pack` | owned Go → YAML | one-way, lossy off-ramp; snapshot of *shape* |
 | `migrate generate` | a schema → reviewable versioned SQL | a **separate action**; takes its schema from an opt-in source (blueprint `--from`, owned Go, or a live DB). Emits a migration file you review and commit — it does not treat any source as authoritative-over-the-world. |
 | `migrate diff --from=<blueprint>` | — | **deleted** — it *applied* the blueprint onto a live DB, making the blueprint authoritative over the running database. |
 

--- a/framework/agents.md
+++ b/framework/agents.md
@@ -2,20 +2,23 @@
 
 App-level helpers worth surfacing to AI agents alongside the batteries.
 
+**Use this when** the prompt mentions: audit trail / who did what, hot
+reload, dev server, browser auto-refresh, livereload, run the app while
+developing, `.env` loading, live app introspection.
+
 ## `framework.WithAuditLog(cfg)` — automatic CRUD audit
 
 **Use this when** the prompt mentions: audit trail, who did what, track
 changes, compliance log, history of modifications, admin accountability.
 
 ```go
-app := framework.NewApp(
-    framework.WithDB(db),
-    framework.WithAuditLog(framework.AuditConfig{
-        Actor:    func(ctx context.Context) string { return currentUserID(ctx) },
-        Entities: []string{"users", "orders"},   // restrict to non-PHI entities
-        Redact:   nil,                            // optional func(entityName, row) row to redact JSON diff
-    }),
-)
+// WithAuditLog is a chained *App method, not a NewApp option.
+app := framework.NewApp(framework.WithDB(db))
+app.WithAuditLog(framework.AuditConfig{
+    Actor:    func(ctx context.Context) string { return currentUserID(ctx) },
+    Entities: []string{"users", "orders"},   // restrict to non-PHI entities
+    Redact:   nil,                            // optional func(entityName, row) row to redact JSON diff
+})
 ```
 
 Writes one `audit_log` row per AfterCreate / AfterUpdate / AfterDelete
@@ -37,9 +40,15 @@ not arbitrary domain events.
 
 ## `framework/dev` — auto-wired livereload
 
-`gofastr dev` rebuilds the binary; `framework.NewApp` + `uihost.New`
-auto-wire `/__livereload` + `/__livereload.js` so every open tab
-refreshes when the new binary boots. No host code needed.
+**Develop with `gofastr dev`, not `go run .`** — it is the only
+first-party command that sets `GOFASTR_DEV=1`, so plain `go run .` never
+hot-reloads. `gofastr dev` rebuilds the binary on save;
+`framework.NewApp` auto-wires `/__livereload` + `/__livereload.js`, and
+full HTML documents get the reload client — uihost screens inject it
+themselves, and dev middleware splices it into any other response that
+declares `Content-Type: text/html` and contains `</body>` (static file
+serving, widget pages, hand-rolled handlers that set the type). So every
+open tab refreshes when the new binary boots. No host code needed.
 
 **Disable:** `GOFASTR_DEV_LIVERELOAD=0` (keeps rebuild loop). Production
 is hard-killed by `GOFASTR_ENV=production`.

--- a/framework/dev/htmlinject.go
+++ b/framework/dev/htmlinject.go
@@ -1,0 +1,180 @@
+package dev
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/DonaldMurillo/gofastr/core/router"
+)
+
+// LiveReloadHTMLInjector returns dev-only middleware that splices the
+// livereload client into full HTML documents that don't already carry it.
+// uihost pages inject the script themselves; this covers every OTHER way an
+// app serves a page under `gofastr dev` — static.Handler file serving (the
+// SPA and static-site shapes), widget-server pages, hand-rolled handlers
+// that set a text/html Content-Type — so "edit → rebuild → browser
+// refreshes" holds across the whole surface, not just uihost screens.
+//
+// What is deliberately left alone:
+//   - responses without an explicit text/html Content-Type (no sniffing);
+//   - fragments: anything without a closing </body> (island RPC swaps,
+//     SPA-nav partials) — an appended script node would corrupt the DOM the
+//     runtime swaps them into;
+//   - encoded bodies (Content-Encoding) — opaque bytes even when labeled
+//     HTML;
+//   - HEAD and Range requests — http.ServeFile/ServeContent semantics
+//     (real Content-Length with no body, 206 byte ranges) must survive;
+//   - streams: SSE and anything the handler Flushes pass through
+//     unbuffered, and a Flush mid-HTML abandons injection so progressive
+//     rendering keeps painting;
+//   - hijacked connections (WebSocket upgrades) — Hijack is forwarded and
+//     the wrapper never writes afterwards.
+func LiveReloadHTMLInjector() router.Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodHead || r.Header.Get("Range") != "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			iw := &injectWriter{rw: w, status: http.StatusOK}
+			next.ServeHTTP(iw, r)
+			iw.finish()
+		})
+	}
+}
+
+type injectWriter struct {
+	rw         http.ResponseWriter
+	status     int
+	decided    bool
+	buffering  bool
+	sentHeader bool
+	hijacked   bool
+	buf        bytes.Buffer
+}
+
+func (w *injectWriter) Header() http.Header { return w.rw.Header() }
+
+// Unwrap lets http.ResponseController reach the underlying writer.
+func (w *injectWriter) Unwrap() http.ResponseWriter { return w.rw }
+
+func (w *injectWriter) decide() {
+	if w.decided {
+		return
+	}
+	w.decided = true
+	h := w.Header()
+	ct := h.Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/html") {
+		return
+	}
+	if ce := h.Get("Content-Encoding"); ce != "" && !strings.EqualFold(ce, "identity") {
+		return // opaque compressed bytes — never splice or re-measure
+	}
+	if h.Get("X-Gofastr-Partial") != "" {
+		return // SPA-nav partial: a fragment by contract
+	}
+	w.buffering = true
+}
+
+func (w *injectWriter) WriteHeader(status int) {
+	w.decide()
+	w.status = status
+	if !w.buffering && !w.sentHeader {
+		w.rw.WriteHeader(status)
+		w.sentHeader = true
+	}
+}
+
+func (w *injectWriter) Write(p []byte) (int, error) {
+	if w.hijacked {
+		return 0, http.ErrHijacked
+	}
+	w.decide()
+	if w.buffering {
+		return w.buf.Write(p)
+	}
+	if !w.sentHeader {
+		w.rw.WriteHeader(w.status)
+		w.sentHeader = true
+	}
+	return w.rw.Write(p)
+}
+
+// Flush is a streaming signal. For buffered HTML it means the handler wants
+// progressive rendering: release the buffered prefix raw, abandon injection
+// for this response, and stream from here on. For everything else forward
+// to the underlying Flusher (SSE heartbeats, chunked APIs).
+func (w *injectWriter) Flush() {
+	if w.hijacked {
+		return
+	}
+	w.decide()
+	if w.buffering {
+		w.buffering = false
+		if !w.sentHeader {
+			w.rw.WriteHeader(w.status)
+			w.sentHeader = true
+		}
+		if w.buf.Len() > 0 {
+			_, _ = w.rw.Write(w.buf.Bytes())
+			w.buf.Reset()
+		}
+	}
+	if f, ok := w.rw.(http.Flusher); ok {
+		if !w.sentHeader {
+			w.rw.WriteHeader(w.status)
+			w.sentHeader = true
+		}
+		f.Flush()
+	}
+}
+
+// Hijack forwards connection takeover (WebSocket upgrades — core/stream
+// asserts http.Hijacker directly). After a hijack the wrapper never writes.
+func (w *injectWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := w.rw.(http.Hijacker)
+	if !ok {
+		return nil, nil, errors.New("dev: underlying ResponseWriter does not support hijacking")
+	}
+	conn, rw, err := hj.Hijack()
+	if err == nil {
+		w.hijacked = true
+		w.buf.Reset()
+	}
+	return conn, rw, err
+}
+
+const liveReloadScriptTag = `<script src="` + LiveReloadScriptURL + `" defer></script>`
+
+func (w *injectWriter) finish() {
+	if w.hijacked || !w.buffering {
+		return
+	}
+	body := w.buf.Bytes()
+	// Full documents only: splice before the LAST </body>. Fragments pass
+	// through byte-for-byte. The guard matches the script TAG, not the bare
+	// URL, so a page that merely mentions the URL in prose still gets the
+	// client.
+	if i := bytes.LastIndex(body, []byte("</body>")); i >= 0 &&
+		!bytes.Contains(body, []byte(`src="`+LiveReloadScriptURL+`"`)) {
+		spliced := make([]byte, 0, len(body)+len(liveReloadScriptTag))
+		spliced = append(spliced, body[:i]...)
+		spliced = append(spliced, liveReloadScriptTag...)
+		spliced = append(spliced, body[i:]...)
+		body = spliced
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	}
+	if !w.sentHeader {
+		w.rw.WriteHeader(w.status)
+		w.sentHeader = true
+	}
+	if len(body) > 0 {
+		_, _ = w.rw.Write(body)
+	}
+}

--- a/framework/dev/htmlinject_test.go
+++ b/framework/dev/htmlinject_test.go
@@ -1,0 +1,233 @@
+package dev
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func injectedReq(t *testing.T, req *http.Request, handler http.HandlerFunc) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	LiveReloadHTMLInjector()(handler).ServeHTTP(rec, req)
+	return rec
+}
+
+func injected(t *testing.T, handler http.HandlerFunc) *httptest.ResponseRecorder {
+	t.Helper()
+	return injectedReq(t, httptest.NewRequest(http.MethodGet, "/", nil), handler)
+}
+
+func TestInjectorAddsScriptBeforeBodyClose(t *testing.T) {
+	rec := injected(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte("<html><body><h1>raw file</h1></body></html>"))
+	})
+	body := rec.Body.String()
+	if !strings.Contains(body, `<script src="`+LiveReloadScriptURL+`"`) {
+		t.Fatalf("script not injected:\n%s", body)
+	}
+	if !strings.Contains(body, `</script></body></html>`) {
+		t.Fatalf("script must land before </body>:\n%s", body)
+	}
+	if cl := rec.Header().Get("Content-Length"); cl != "" {
+		if n, _ := strconv.Atoi(cl); n != len(body) {
+			t.Fatalf("Content-Length %s does not match injected body %d", cl, len(body))
+		}
+	}
+}
+
+// Fragments — island RPC responses, SPA-nav partials (X-Gofastr-Partial), any
+// HTML without </body> — are swapped into a live DOM by the runtime; an
+// appended script node would corrupt :last-child styling and the screen
+// cache. No </body>, no injection.
+func TestInjectorLeavesFragmentsAlone(t *testing.T) {
+	rec := injected(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("X-Gofastr-Partial", "true")
+		_, _ = w.Write([]byte("<h1>fragment</h1>"))
+	})
+	if strings.Contains(rec.Body.String(), LiveReloadScriptURL) {
+		t.Fatalf("fragment was injected:\n%s", rec.Body.String())
+	}
+	if rec.Body.String() != "<h1>fragment</h1>" {
+		t.Fatalf("fragment bytes modified:\n%s", rec.Body.String())
+	}
+}
+
+func TestInjectorSkipsPagesThatAlreadyHaveTheClient(t *testing.T) {
+	page := `<html><body><script src="` + LiveReloadScriptURL + `" defer></script></body></html>`
+	rec := injected(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(page))
+	})
+	if got := strings.Count(rec.Body.String(), LiveReloadScriptURL); got != 1 {
+		t.Fatalf("uihost-style page double-injected (%d occurrences):\n%s", got, rec.Body.String())
+	}
+}
+
+// A page that merely MENTIONS the livereload URL in prose or a code sample
+// (the docs site rendering dev-livereload.md) still needs the real client.
+func TestInjectorGuardMatchesScriptTagNotProse(t *testing.T) {
+	page := `<html><body><p>The client lives at ` + LiveReloadScriptURL + `.</p></body></html>`
+	rec := injected(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(page))
+	})
+	if !strings.Contains(rec.Body.String(), `<script src="`+LiveReloadScriptURL+`"`) {
+		t.Fatalf("prose mention suppressed injection:\n%s", rec.Body.String())
+	}
+}
+
+func TestInjectorPassesThroughNonHTMLUntouched(t *testing.T) {
+	rec := injected(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	if rec.Code != http.StatusCreated || rec.Body.String() != `{"ok":true}` {
+		t.Fatalf("non-HTML response modified: code=%d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// Compressed bodies are opaque bytes even when labeled text/html — a host
+// gzip middleware sitting inside the injector must pass through unmodified.
+func TestInjectorSkipsEncodedBodies(t *testing.T) {
+	rec := injected(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write([]byte("\x1f\x8bfake-gzip-bytes"))
+	})
+	if rec.Body.String() != "\x1f\x8bfake-gzip-bytes" {
+		t.Fatalf("encoded body modified:\n%q", rec.Body.String())
+	}
+}
+
+// HEAD responses (http.ServeFile sets the real file's Content-Length with no
+// body) and Range requests must never be buffered or rewritten.
+func TestInjectorLeavesHeadAndRangeAlone(t *testing.T) {
+	head := injectedReq(t, httptest.NewRequest(http.MethodHead, "/page.html", nil), func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Content-Length", "12345")
+		w.WriteHeader(http.StatusOK)
+	})
+	if got := head.Header().Get("Content-Length"); got != "12345" {
+		t.Fatalf("HEAD Content-Length clobbered: %q", got)
+	}
+	if head.Body.Len() != 0 {
+		t.Fatalf("HEAD response grew a body: %q", head.Body.String())
+	}
+
+	rangeReq := httptest.NewRequest(http.MethodGet, "/page.html", nil)
+	rangeReq.Header.Set("Range", "bytes=0-3")
+	ranged := injectedReq(t, rangeReq, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Content-Range", "bytes 0-3/100")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte("<htm"))
+	})
+	if ranged.Body.String() != "<htm" || ranged.Code != http.StatusPartialContent {
+		t.Fatalf("ranged response modified: code=%d body=%q", ranged.Code, ranged.Body.String())
+	}
+}
+
+func TestInjectorStreamsSSEWithFlush(t *testing.T) {
+	flushes := 0
+	rec := httptest.NewRecorder()
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		f, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("injector must expose Flusher for non-HTML streams")
+		}
+		_, _ = w.Write([]byte("data: one\n\n"))
+		f.Flush()
+		flushes++
+		_, _ = w.Write([]byte("data: two\n\n"))
+		f.Flush()
+		flushes++
+	}
+	LiveReloadHTMLInjector()(http.HandlerFunc(handler)).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if flushes != 2 || !rec.Flushed {
+		t.Fatalf("SSE stream not flushed through the injector (handler flushes=%d, recorder flushed=%v)", flushes, rec.Flushed)
+	}
+	if strings.Contains(rec.Body.String(), LiveReloadScriptURL) {
+		t.Fatalf("SSE stream must never be injected:\n%s", rec.Body.String())
+	}
+}
+
+// An explicit Flush on an HTML response is a streaming signal: the buffered
+// prefix goes out raw, injection is abandoned, and later writes+flushes
+// stream through — progressive server-rendered pages keep painting in dev.
+func TestInjectorFlushSwitchesHTMLToStreaming(t *testing.T) {
+	rec := httptest.NewRecorder()
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body><p>first paint</p>"))
+		w.(http.Flusher).Flush()
+		if !rec.Flushed {
+			t.Fatal("flush did not reach the wire — progressive HTML stopped painting")
+		}
+		if got := rec.Body.String(); got != "<html><body><p>first paint</p>" {
+			t.Fatalf("buffered prefix not released on flush: %q", got)
+		}
+		_, _ = w.Write([]byte("<p>second paint</p></body></html>"))
+	}
+	LiveReloadHTMLInjector()(http.HandlerFunc(handler)).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	body := rec.Body.String()
+	if strings.Contains(body, LiveReloadScriptURL) {
+		t.Fatalf("streamed HTML must not be spliced:\n%s", body)
+	}
+	if !strings.HasSuffix(body, "</body></html>") {
+		t.Fatalf("streamed tail lost:\n%s", body)
+	}
+}
+
+func TestInjectorPreservesHTMLStatusCode(t *testing.T) {
+	rec := injected(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("<html><body>not found</body></html>"))
+	})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("HTML status rewritten: %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), LiveReloadScriptURL) {
+		t.Fatal("styled error pages are part of the dev loop too — inject them")
+	}
+}
+
+// hijackableRecorder lets a WebSocket-style handler assert http.Hijacker
+// through the wrapper (core/stream.Upgrade does exactly this).
+type hijackableRecorder struct {
+	*httptest.ResponseRecorder
+	hijacked bool
+}
+
+func (h *hijackableRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h.hijacked = true
+	return nil, nil, errors.New("fake hijack: no real conn in tests")
+}
+
+func TestInjectorForwardsHijackForWebSockets(t *testing.T) {
+	rec := &hijackableRecorder{ResponseRecorder: httptest.NewRecorder()}
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("injector hides http.Hijacker — WebSocket upgrades break under gofastr dev")
+		}
+		_, _, _ = hj.Hijack()
+	}
+	LiveReloadHTMLInjector()(http.HandlerFunc(handler)).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ws", nil))
+	if !rec.hijacked {
+		t.Fatal("Hijack not forwarded to the underlying writer")
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("injector wrote to a hijacked response: %q", rec.Body.String())
+	}
+}

--- a/framework/dev/livereload.go
+++ b/framework/dev/livereload.go
@@ -152,6 +152,12 @@ func RegisterLiveReload(r *router.Router) {
 		w.Header().Set("Cache-Control", "no-store")
 		_, _ = w.Write([]byte(liveReloadJS))
 	}))
+
+	// HTML responses that don't already carry the client get it injected, so
+	// non-uihost surfaces (static file serving, widget pages, hand-rolled
+	// handlers) refresh in the browser too. Guarded by the same `registered`
+	// map above, so the middleware mounts at most once per router.
+	r.Use(LiveReloadHTMLInjector())
 }
 
 // MaybeRegisterLiveReload calls RegisterLiveReload only if LiveReloadEnabled()

--- a/framework/docs/content/dev-livereload.md
+++ b/framework/docs/content/dev-livereload.md
@@ -39,6 +39,16 @@ When enabled:
 - `uihost.New()` auto-appends `/__livereload.js` to the `extraScripts`
   list so every rendered page links to the client script before
   `</body>`. CSP-safe — it's a `<script src="...">`, no inline JS.
+- For every OTHER way an app serves a page — `static.Handler` file
+  serving (SPA shells, exported static pages), widget-server pages,
+  hand-rolled handlers — `framework.NewApp` mounts dev-only middleware
+  that splices the same `<script src>` into responses that declare
+  `Content-Type: text/html` (no sniffing — set the type) and are full
+  documents (contain `</body>`) and don't already carry the tag.
+  Fragments (island RPC swaps, SPA-nav partials), compressed bodies,
+  HEAD/Range requests, and non-HTML responses (JSON, SSE, streams) pass
+  through untouched and unbuffered; a handler that Flushes mid-HTML
+  streams from that point on, uninjected.
 
 One persistent SSE connection per tab, near-zero idle traffic, no
 polling.

--- a/framework/docs/content/harness-architecture.md
+++ b/framework/docs/content/harness-architecture.md
@@ -1248,6 +1248,10 @@ CI engineers verify acks without launching the agent loop using:
 gofastr harness verify-ack             # exits non-zero on hash drift
 ```
 
+(`verify-ack` is specified here but not yet wired into `cmd/gofastr` —
+today the CLI dispatches only the `mcp` and `creds` subcommands, and
+anything else starts an interactive session.)
+
 Drift between the lockfile and live content **fails the CI run
 explicitly** with the changed file paths in the error — never
 silently approves.
@@ -1464,6 +1468,10 @@ gofastr harness conformance --against http://localhost:8080
 gofastr harness conformance --against unix:///path/to/control.sock
 gofastr harness conformance --against stdio:///usr/local/bin/some-other-harness
 ```
+
+(The `conformance` subcommand is specified here but not yet wired into
+`cmd/gofastr`; the suite itself lives in `control/conformance/` and runs
+via `go test`.)
 
 The suite is versioned alongside `protocol_version`. v0.1's suite
 runs against v0.1 servers; v0.2 adds new scenarios behind the
@@ -2259,6 +2267,11 @@ the user contract. Both are stable within a minor release.
 
 Plugin-introduced errors use `Reason: Custom:<namespace>:<code>`
 with a `string` payload field the client surfaces verbatim.
+
+Two of the remediation strings above reference `gofastr harness token`
+and `gofastr harness ack` — specified subcommands that are not yet
+wired into `cmd/gofastr` (which today dispatches only `mcp` and
+`creds`).
 
 ---
 

--- a/framework/docs/content/harness-e2e-testing.md
+++ b/framework/docs/content/harness-e2e-testing.md
@@ -125,13 +125,17 @@ In a Claude Code conversation:
 
 ```bash
 # Start the harness with the WS listener.
-gofastr harness --listen 127.0.0.1:8421 --auth-token-file ~/.config/gofastr/harness/ci-token.json &
+gofastr harness --listen 127.0.0.1:8421 &
 
-# In another terminal, mint a token via the auth flow (see
-# control/auth/issuance.go) and connect with `websocat` or a small
-# WebSocket client:
+# Token issuance requires the interactive confirmation channel (a code
+# printed to the harness TTY — see control/auth/issuance.go), so mint
+# the token from that interactive session, then connect with `websocat`
+# or a small WebSocket client:
 websocat -H 'X-Harness-Token: <token>' ws://127.0.0.1:8421/v1/ws?session=sess_...
 ```
+
+There is no headless token-file flag yet — fully non-interactive CI
+setups must mint interactively once and reuse the token.
 
 ## 5. What this guide does NOT cover
 

--- a/framework/docs/content/migrations.md
+++ b/framework/docs/content/migrations.md
@@ -90,7 +90,7 @@ See "Migration groups" below for semantics.
 gofastr migrate up                       # uses DATABASE_URL or .env
 gofastr migrate status --db-url=file:app.db
 gofastr migrate down 1
-gofastr migrate generate add_email       # write a versioned migration file from entity changes
+gofastr migrate generate add_email --from=gofastr.yml   # write a versioned migration file from entity changes
 gofastr migrate force 7                  # mark version 7 cleanly applied
 gofastr migrate force 7 --not-applied    # treat version 7 as pending again
 ```

--- a/framework/docs/content/project-structure.md
+++ b/framework/docs/content/project-structure.md
@@ -48,9 +48,10 @@ small apps never need more than this.
 a subpackage** instead of the module root — useful when the repo is a monorepo or
 an example that also hosts its own Go test package and you want the app to live
 under, say, `app/`. The flagship [`examples/ecommerce`](https://github.com/DonaldMurillo/gofastr/tree/main/examples/ecommerce)
-uses `output_dir: app` for exactly this reason; you build and run it with
-`go run ./app`. The subpackage is still owned Go — `--out` only changes *where*
-the scaffold lands, not whether you own it.
+uses `output_dir: app` for exactly this reason; develop it with
+`gofastr dev --dir app` (hot reload) or run it once with `go run ./app`. The
+subpackage is still owned Go — `--out` only changes *where* the scaffold
+lands, not whether you own it.
 
 **2. Domain packages (`internal/<domain>/`), when real per-feature logic
 appears.** When a feature grows hooks, custom endpoints, background work, or

--- a/framework/docs/content/pwa.md
+++ b/framework/docs/content/pwa.md
@@ -100,6 +100,31 @@ The generated worker is deliberately conservative:
   proxy, say — contributes only its URL; give it a new path or query
   when it changes.)
 
+## Static exports: the full-site worker
+
+The rules above protect a LIVE app, where rendered HTML can be
+personalized. A [static export](static-export.md) has no such concern —
+the page set is closed and every byte is immutable — so the exported
+`service-worker.js` flips strategy: the whole site is precached at
+install — every page, every framework asset (including component
+stylesheets under their versioned `?v=` URLs), the shell — and
+navigations are served cache-first, tolerating static hosts' trailing-
+slash redirects, with the network as fallback. Land once, install the
+app, and every page works offline — including pages never visited.
+
+User static-dir files are precached best-effort: one un-servable file
+does not fail the install and pin clients to a previous deployment.
+The cache version fingerprints the exported content, so any redeploy
+(even a text-only edit) rotates the cache through the normal
+worker-update cycle, and the static worker's caches use a separate
+`gofastr-pwa-static-…` prefix carrying the base path, so a live
+deployment and static exports on one origin never delete each other's
+caches. The deny list (`/api`, `/auth`, framework session/SSE paths,
+plus your `DenyPaths`) applies unchanged. If the app's static dir
+ships its own `manifest.webmanifest` or `service-worker.js`, the
+export keeps the user-supplied file.
+
+
 ## Offline screen
 
 The default screen is a minimal "You're offline" notice rendered

--- a/framework/docs/content/static-export.md
+++ b/framework/docs/content/static-export.md
@@ -57,6 +57,25 @@ go build -o site ./examples/site/
   and deny lists, and the registration target are all prefixed, so the
   exported app installs and works offline from the subpath.
 
+  A static export gets the **full-site worker**, not the live app's
+  conservative one: the exported page set is closed and immutable, so
+  the worker precaches the whole site at install — every page, every
+  framework asset (widget chrome, `llm.md`, component stylesheets under
+  their versioned `?v=` URLs), the shell — and serves navigations
+  cache-first, tolerating static hosts' trailing-slash redirects. A
+  visitor who lands once has the entire site cached — install the PWA
+  and every page works offline, including pages never visited. User
+  static-dir files are precached best-effort so one un-servable file
+  cannot brick the install. The worker's cache version fingerprints the
+  exported content, so a redeploy (even one that only edits page text)
+  ships byte-different worker JS and the fresh export replaces the old
+  cache; an unchanged rebuild reproduces identical worker bytes. Static
+  caches live under their own `gofastr-pwa-static-…` prefix, so a live
+  deployment on the same origin never deletes them. Denied endpoints
+  (`/api`, `/auth`, framework session/SSE paths) are still never
+  precached or intercepted, and a user-supplied `manifest.webmanifest`
+  or `service-worker.js` in the static dir wins over the generated one.
+
 Dynamic routes require the screen to implement `StaticPathsProvider`:
 
 ```go

--- a/framework/docs/content/tutorial-blueprint-app.md
+++ b/framework/docs/content/tutorial-blueprint-app.md
@@ -92,8 +92,8 @@ Validate, generate, run:
 ```bash
 gofastr validate gofastr.yml
 gofastr generate --from=gofastr.yml   # scaffolds owned Go: main.go + app.go + screens_register.go + screen_*.go + entities/
-go mod tidy
-go run .
+go mod tidy                           # the scaffold pulls new imports; dev builds need this first
+gofastr dev                           # dev server with hot reload — the loop for everything below
 ```
 
 The scaffold is normal, owned Go — a flat `package main` at the module root:
@@ -197,13 +197,10 @@ line in `RegisterGenerated`:
 		}))
 ```
 
-Restart. Auto-migrate converges the schema on boot — it adds the new
+Save — `gofastr dev` rebuilds and restarts the server automatically.
+Auto-migrate converges the schema on the new boot: it adds the new
 `user_id` column to the existing `notes` table (additive only; it never
-drops or retypes):
-
-```bash
-go run .
-```
+drops or retypes).
 
 Prefer to review schema changes before they run rather than lean on boot
 auto-migrate? Generate a versioned migration from the owned entities and
@@ -311,12 +308,8 @@ screen:
 	site.Register("/about", &AboutScreen{}, nil)
 ```
 
-Restart, then verify the full model — log in again so the session
-reflects Ana's new role:
-
-```bash
-go run .
-```
+Save — the dev server rebuilds — then verify the full model. Log in
+again so the session reflects Ana's new role:
 
 ```bash
 curl -s -c ana.jar -X POST http://localhost:8080/auth/login \

--- a/framework/docs/content/ui-getting-started.md
+++ b/framework/docs/content/ui-getting-started.md
@@ -13,8 +13,12 @@ gofastr init myapp
 cd myapp
 
 go mod tidy   # resolves github.com/DonaldMurillo/gofastr from the module proxy
-go run .
+gofastr dev   # dev server with hot reload — edit a screen, the browser refreshes
 ```
+
+`gofastr dev` is the development loop: it watches `.go/.js/.css/.html`,
+rebuilds, and auto-refreshes the browser. Plain `go run .` also works but
+never reloads — use it for one-shot checks, not iteration.
 
 Only add a `replace` directive pointing at a local checkout if you are
 hacking on the framework itself and want your app to pick up unreleased
@@ -95,7 +99,7 @@ Keep the generated `DarkColors` complete when changing brand colors; rendering
 Booting with a half-populated typed theme panics at startup with a field path
 naming the missing piece.
 
-`go run .` — visit <http://localhost:8080/__gofastr/app.css> to confirm your tokens are emitted as `:root` custom properties.
+With `gofastr dev` running, visit <http://localhost:8080/__gofastr/app.css> to confirm your tokens are emitted as `:root` custom properties — token edits hot-reload like any other change.
 
 ---
 

--- a/framework/docs/docs_test.go
+++ b/framework/docs/docs_test.go
@@ -187,3 +187,30 @@ func TestSearchWithLimit(t *testing.T) {
 		t.Errorf("SearchWithLimit returned %d hits, want <= 5", len(hits))
 	}
 }
+
+// The development loop must funnel to `gofastr dev` (hot reload): livereload
+// only activates under GOFASTR_DEV=1, which only `gofastr dev` sets, so a doc
+// that leads with `go run .` silently costs the reader the entire HMR
+// experience. Every dev-loop-critical topic must mention gofastr dev BEFORE
+// its first `go run`.
+func TestDevLoopDocsLeadWithGofastrDev(t *testing.T) {
+	for _, topic := range []string{
+		"ui-getting-started",
+		"tutorial-blueprint-app",
+		"project-structure",
+	} {
+		body, err := Get(topic)
+		if err != nil {
+			t.Fatalf("Get(%q): %v", topic, err)
+		}
+		dev := strings.Index(string(body), "gofastr dev")
+		run := strings.Index(string(body), "go run ")
+		if dev < 0 {
+			t.Errorf("%s: never mentions `gofastr dev` — the doc funnels readers into a no-reload loop", topic)
+			continue
+		}
+		if run >= 0 && run < dev {
+			t.Errorf("%s: `go run` (byte %d) appears before `gofastr dev` (byte %d) — the hot-reload path must lead", topic, run, dev)
+		}
+	}
+}

--- a/framework/harness/control/auth/issuance.go
+++ b/framework/harness/control/auth/issuance.go
@@ -147,7 +147,8 @@ func generateCode() (string, error) {
 
 // Errors surfaced as user-facing strings per § User-facing errors.
 var (
-	ErrNoChannel    = errors.New("auth: token issuance requires an interactive confirmation channel; see --auth-token-file for headless setups")
+	// No --auth-token-file flag exists (yet) — do not point users at it.
+	ErrNoChannel    = errors.New("auth: token issuance requires an interactive confirmation channel; mint the token from an interactive harness session and reuse it for headless setups")
 	ErrUnknownMint  = errors.New("auth: unknown mint ID")
 	ErrCodeMismatch = errors.New("auth: confirmation code mismatch")
 	ErrCodeExpired  = errors.New("auth: confirmation code expired (60s window)")

--- a/framework/static/builder.go
+++ b/framework/static/builder.go
@@ -2,6 +2,8 @@ package static
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/fs"
@@ -107,6 +109,7 @@ func (b *Builder) Build(ctx context.Context) (Result, error) {
 				if err := writeFile(dst, []byte(md)); err != nil {
 					return res, err
 				}
+				res.Assets = append(res.Assets, "/"+filepath.ToSlash(pathToLLMFile(p)))
 				b.log("wrote llm.md for %s -> %s", p, dst)
 			}
 		}
@@ -115,6 +118,7 @@ func (b *Builder) Build(ctx context.Context) (Result, error) {
 		if err := writeFile(filepath.Join(b.OutDir, "llm-pages.md"), []byte(indexMD)); err != nil {
 			return res, err
 		}
+		res.Assets = append(res.Assets, "/llm-pages.md")
 		b.log("wrote llm-pages.md index")
 	}
 
@@ -179,19 +183,16 @@ func (b *Builder) Build(ctx context.Context) (Result, error) {
 
 	// Widget catalog + chrome + CSS — dumped as query-free files so the
 	// runtime's data-fui-open overlays resolve against the static tree
-	// instead of 404'ing against the live widget endpoints.
-	if err := b.dumpWidgetAssets(); err != nil {
+	// instead of 404'ing against the live widget endpoints. Recorded in
+	// res.Assets so the full-site worker precaches them — overlays must
+	// keep opening offline.
+	if err := b.dumpWidgetAssets(&res); err != nil {
 		return res, err
 	}
 
-	// PWA surface — manifest, service worker, registration script, and
-	// offline fallback, mirroring the live WithPWA routes. The uihost
-	// generators take BasePath directly (manifest start_url/scope/id,
-	// worker precache list, and registration target must all resolve
-	// under the mount path), so none of these go through rewriteJSAsset.
-	if err := b.dumpPWAAssets(&res); err != nil {
-		return res, err
-	}
+	// Everything recorded so far is framework-generated and precached
+	// atomically; user static-dir files below are precached best-effort.
+	frameworkAssetCount := len(res.Assets)
 
 	// Static assets — either filesystem dir or embedded FS.
 	if dir := b.Host.StaticDir(); dir != "" {
@@ -202,6 +203,18 @@ func (b *Builder) Build(ctx context.Context) (Result, error) {
 		if err := copyFS(fsys, b.OutDir, &res, b.log); err != nil {
 			return res, err
 		}
+	}
+
+	// PWA surface — manifest, service worker, registration script, and
+	// offline fallback, mirroring the live WithPWA routes. Runs LAST so
+	// the full-site worker can precache the complete export (pages,
+	// runtime assets, AND the static dir copied above) and fingerprint
+	// its content. The uihost generators take BasePath directly
+	// (manifest start_url/scope/id, worker precache list, and
+	// registration target must all resolve under the mount path), so
+	// none of these go through rewriteJSAsset.
+	if err := b.dumpPWAAssets(&res, frameworkAssetCount); err != nil {
+		return res, err
 	}
 
 	return res, nil
@@ -386,7 +399,7 @@ func (b *Builder) rewriteBaseURLs(page string) string {
 // the runtime fetches their chrome from cfg.chromePath on open — which 404s
 // on a serverless host. Dumping the same bytes as files lets openWidget
 // resolve against the static tree, so every data-fui-open overlay works.
-func (b *Builder) dumpWidgetAssets() error {
+func (b *Builder) dumpWidgetAssets(res *Result) error {
 	defs := widget.AllForSSR()
 	if len(defs) == 0 {
 		return nil
@@ -403,6 +416,7 @@ func (b *Builder) dumpWidgetAssets() error {
 	if err := b.writeRawAsset("/__gofastr/widgets.json", []byte(cat)); err != nil {
 		return err
 	}
+	res.Assets = append(res.Assets, "/__gofastr/widgets.json")
 	b.log("wrote %s", "/__gofastr/widgets.json")
 	for _, d := range defs {
 		// Chrome HTML may carry root-absolute nav links (/docs/…); rewrite
@@ -411,9 +425,11 @@ func (b *Builder) dumpWidgetAssets() error {
 		if err := b.writeRawAsset("/core-ui/widget/"+d.Name+"/chrome", []byte(chrome)); err != nil {
 			return err
 		}
+		res.Assets = append(res.Assets, "/core-ui/widget/"+d.Name+"/chrome")
 		if err := b.writeRawAsset("/core-ui/widget/"+d.Name+"/style.css", []byte(widget.RenderCSS(d))); err != nil {
 			return err
 		}
+		res.Assets = append(res.Assets, "/core-ui/widget/"+d.Name+"/style.css")
 		b.log("wrote widget %s (chrome + css)", d.Name)
 	}
 	return nil
@@ -424,7 +440,7 @@ func (b *Builder) dumpWidgetAssets() error {
 // the offline fallback page (as offline/index.html so a plain static
 // server resolves the extension-less precache URL). No-op when the host
 // did not opt into WithPWA.
-func (b *Builder) dumpPWAAssets(res *Result) error {
+func (b *Builder) dumpPWAAssets(res *Result, frameworkAssetCount int) error {
 	if !b.Host.PWAEnabled() {
 		return nil
 	}
@@ -432,7 +448,23 @@ func (b *Builder) dumpPWAAssets(res *Result) error {
 	if err != nil {
 		return fmt.Errorf("static: pwa manifest: %w", err)
 	}
-	sw, err := b.Host.PWAServiceWorkerJS(b.BasePath)
+	// Static exports get the full-site worker: the page set is closed and
+	// immutable, so every exported page and asset is precached at install
+	// and the whole site works offline. The tree hash makes a
+	// content-only redeploy rotate the cache version.
+	contentHash, err := hashExportTree(b.OutDir)
+	if err != nil {
+		return fmt.Errorf("static: fingerprint export: %w", err)
+	}
+	if frameworkAssetCount > len(res.Assets) {
+		frameworkAssetCount = len(res.Assets)
+	}
+	sw, err := b.Host.PWAStaticServiceWorkerJS(b.BasePath, uihost.PWAStaticExport{
+		Pages:          res.Pages,
+		Assets:         res.Assets[:frameworkAssetCount],
+		OptionalAssets: res.Assets[frameworkAssetCount:],
+		ContentHash:    contentHash,
+	})
 	if err != nil {
 		return fmt.Errorf("static: pwa service worker: %w", err)
 	}
@@ -453,6 +485,16 @@ func (b *Builder) dumpPWAAssets(res *Result) error {
 		{"/__gofastr/pwa/offline", filepath.Join("__gofastr", "pwa", "offline", "index.html"), []byte(offline)},
 	}
 	for _, f := range files {
+		// User-supplied files win: before this surface moved to the end of
+		// the build, a manifest/worker shipped in the app's static dir
+		// landed after (and therefore over) the generated one. Preserve
+		// that precedence by never clobbering a file the static SOURCE
+		// provides (the source, not OutDir — a previous build's leftovers
+		// in a reused OutDir must not suppress regeneration).
+		if b.staticSourceHas(f.relFile) {
+			b.log("kept user-supplied %s", f.urlPath)
+			continue
+		}
 		dst := filepath.Join(b.OutDir, f.relFile)
 		if err := b.ensureContained(dst); err != nil {
 			return err
@@ -464,6 +506,70 @@ func (b *Builder) dumpPWAAssets(res *Result) error {
 		b.log("wrote %s", f.urlPath)
 	}
 	return nil
+}
+
+// staticSourceHas reports whether the host's static asset source (dir or
+// embedded FS) provides rel — meaning the user shipped their own copy.
+func (b *Builder) staticSourceHas(rel string) bool {
+	if dir := b.Host.StaticDir(); dir != "" {
+		if _, err := os.Stat(filepath.Join(dir, rel)); err == nil {
+			return true
+		}
+		return false
+	}
+	if fsys := b.Host.StaticFS(); fsys != nil {
+		if f, err := fsys.Open(filepath.ToSlash(rel)); err == nil {
+			_ = f.Close()
+			return true
+		}
+	}
+	return false
+}
+
+// hashExportTree fingerprints every file already written to outDir
+// (deterministic sorted walk over relative path + streamed bytes). The
+// PWA outputs themselves are excluded — they are (re)generated after
+// this hash, and a reused OutDir still holds the PREVIOUS build's
+// copies; hashing those would make every rebuild byte-different even
+// with identical content. A content-only redeploy therefore changes
+// the hash → the worker bytes → the cache version, and installed
+// clients re-precache; an unchanged rebuild reproduces the same worker.
+func hashExportTree(outDir string) (string, error) {
+	skip := map[string]bool{
+		"manifest.webmanifest": true,
+		"service-worker.js":    true,
+	}
+	h := sha256.New()
+	err := filepath.WalkDir(outDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(outDir, path)
+		if err != nil {
+			return err
+		}
+		slashRel := filepath.ToSlash(rel)
+		if skip[slashRel] || strings.HasPrefix(slashRel, "__gofastr/pwa/") {
+			return nil
+		}
+		h.Write([]byte(slashRel))
+		h.Write([]byte{0})
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(h, f)
+		_ = f.Close()
+		if err != nil {
+			return err
+		}
+		h.Write([]byte{0})
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil))[:16], nil
 }
 
 // writeRawAsset writes body to the OutDir path derived from urlPath WITHOUT

--- a/framework/static/builder_test.go
+++ b/framework/static/builder_test.go
@@ -526,3 +526,109 @@ func TestBuildDumpsWidgetCatalogAndChrome(t *testing.T) {
 		}
 	}
 }
+
+type textScreen struct{ Text string }
+
+func (s *textScreen) ScreenTitle() string            { return "T" }
+func (s *textScreen) ScreenDescription() string      { return "" }
+func (s *textScreen) ScreenType() coreapp.ScreenType { return coreapp.ScreenPage }
+func (s *textScreen) Render() render.HTML {
+	return html.Heading(html.HeadingConfig{Level: 1}, render.Text(s.Text))
+}
+
+// A static export is a closed page set: the emitted service worker must
+// precache every exported page and asset so the installed PWA serves the
+// whole site offline, and a content-only redeploy must change the worker
+// bytes (or browsers would never rotate the stale cache).
+func TestBuildStaticWorkerPrecachesExportedSite(t *testing.T) {
+	build := func(text string) (Result, string) {
+		a := coreapp.NewApp("SSGPWA")
+		a.Register("/", &textScreen{Text: text}, nil)
+		a.Register("/products/:slug", &productScreen{}, nil)
+		host := uihost.New(a, uihost.WithPWA(uihost.PWAConfig{}))
+		out := t.TempDir()
+		res, err := (&Builder{Host: host, OutDir: out}).Build(context.Background())
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		sw, err := os.ReadFile(filepath.Join(out, "service-worker.js"))
+		if err != nil {
+			t.Fatalf("service-worker.js: %v", err)
+		}
+		return res, string(sw)
+	}
+	res, sw := build("one")
+	if len(res.Pages) != 3 {
+		t.Fatalf("expected 3 pages, got %v", res.Pages)
+	}
+	for _, p := range res.Pages {
+		if !strings.Contains(sw, `"`+p+`"`) {
+			t.Errorf("exported page %s missing from worker precache:\n%s", p, sw)
+		}
+	}
+	for _, a := range []string{"/__gofastr/runtime.js", "/__gofastr/color-scheme.js"} {
+		if !strings.Contains(sw, `"`+a+`"`) {
+			t.Errorf("exported asset %s missing from worker precache", a)
+		}
+	}
+	_, sw2 := build("two")
+	if sw == sw2 {
+		t.Error("content-only change must alter the worker bytes so the SW update cycle fires")
+	}
+}
+
+// Review-driven builder contracts: widget assets and llm.md reach the
+// precache, a reused OutDir stays deterministic, and a user-supplied
+// manifest wins over the generated one.
+func TestBuildStaticWorkerReviewContracts(t *testing.T) {
+	a := coreapp.NewApp("SSGPWA2")
+	a.Register("/", &homeScreen{}, nil)
+	host := uihost.New(a, uihost.WithPWA(uihost.PWAConfig{}))
+	out := t.TempDir()
+	if _, err := (&Builder{Host: host, OutDir: out}).Build(context.Background()); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	sw1, err := os.ReadFile(filepath.Join(out, "service-worker.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"/llm.md"`, `"/llm-pages.md"`, `.css?v=`} {
+		if !strings.Contains(string(sw1), want) {
+			t.Errorf("worker precache missing %s", want)
+		}
+	}
+	// Rebuild into the SAME OutDir with identical content: the worker must
+	// be byte-identical (a hash that eats the previous build's PWA output
+	// would rotate the cache on every no-op deploy).
+	if _, err := (&Builder{Host: host, OutDir: out}).Build(context.Background()); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	sw2, err := os.ReadFile(filepath.Join(out, "service-worker.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sw1) != string(sw2) {
+		t.Error("no-op rebuild into a reused OutDir must reproduce identical worker bytes")
+	}
+}
+
+func TestBuildKeepsUserSuppliedManifest(t *testing.T) {
+	staticDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(staticDir, "manifest.webmanifest"), []byte(`{"name":"user-owned"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := coreapp.NewApp("SSGPWA3")
+	a.Register("/", &homeScreen{}, nil)
+	host := uihost.New(a, uihost.WithPWA(uihost.PWAConfig{}), uihost.WithStaticDir(staticDir))
+	out := t.TempDir()
+	if _, err := (&Builder{Host: host, OutDir: out}).Build(context.Background()); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(out, "manifest.webmanifest"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "user-owned") {
+		t.Errorf("generated manifest clobbered the user-supplied one: %s", b)
+	}
+}

--- a/framework/static/pwa_static_chrome_e2e_test.go
+++ b/framework/static/pwa_static_chrome_e2e_test.go
@@ -1,0 +1,113 @@
+package static
+
+// Real-browser proof of "static site as an app": export a site with
+// WithPWA, serve the files, let the service worker install (precaching
+// the WHOLE export), then kill the server and navigate to a page the
+// browser has NEVER visited — its real content must render from cache,
+// not the offline screen. Mirrors framework/uihost's PWA Chrome e2e
+// (dead listener instead of CDP network emulation, which does not
+// reliably reach service-worker fetches). Gated by -short.
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+
+	coreapp "github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/framework/uihost"
+)
+
+func TestPWAStaticChromeE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("boots Chrome")
+	}
+
+	a := coreapp.NewApp("Static App")
+	a.Register("/", &homeScreen{}, nil)
+	a.Register("/products/:slug", &productScreen{}, nil)
+	host := uihost.New(a, uihost.WithPWA(uihost.PWAConfig{}))
+	out := t.TempDir()
+	if _, err := (&Builder{Host: host, OutDir: out}).Build(context.Background()); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := "http://" + ln.Addr().String()
+	srv := &http.Server{Handler: http.FileServer(http.Dir(out))}
+	go srv.Serve(ln)
+
+	allocOpts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.Flag("headless", true),
+		chromedp.Flag("disable-gpu", true),
+		chromedp.Flag("no-sandbox", true),
+		chromedp.WSURLReadTimeout(90*time.Second),
+	)
+	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), allocOpts...)
+	defer allocCancel()
+	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
+	defer browserCancel()
+	ctx, cancel := context.WithTimeout(browserCtx, 120*time.Second)
+	defer cancel()
+
+	poll := func(expr string, timeout time.Duration) error {
+		deadline := time.Now().Add(timeout)
+		for {
+			var ok bool
+			if err := chromedp.Run(ctx, chromedp.Evaluate(expr, &ok)); err != nil {
+				return err
+			}
+			if ok {
+				return nil
+			}
+			if time.Now().After(deadline) {
+				return fmt.Errorf("timeout waiting for %s", expr)
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+
+	// Land once on the home page; the worker installs and precaches the
+	// whole export. Never touch the product pages while online.
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(base+"/"),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+	if err := poll(`!!(navigator.serviceWorker && navigator.serviceWorker.controller)`, 30*time.Second); err != nil {
+		t.Fatalf("service worker never took control: %v", err)
+	}
+	// Install is atomic (addAll-equivalent): a controlling worker means
+	// the full precache — including never-visited pages — is in place.
+
+	if err := srv.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Offline navigation to a page this browser has NEVER loaded.
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(base+"/products/beta"),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("offline navigation: %v", err)
+	}
+	var body string
+	if err := chromedp.Run(ctx, chromedp.Evaluate(`document.body.innerText`, &body)); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(body, "product-beta") {
+		t.Errorf("never-visited page must serve its REAL content offline, got: %q", body)
+	}
+	if strings.Contains(body, "offline") && !strings.Contains(body, "product-beta") {
+		t.Errorf("offline screen shown instead of precached content: %q", body)
+	}
+}

--- a/framework/uihost/pwa.go
+++ b/framework/uihost/pwa.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DonaldMurillo/gofastr/core-ui/component"
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
+	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/runtime"
 	"github.com/DonaldMurillo/gofastr/core-ui/widget"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -466,15 +467,53 @@ func (ds *UIHost) PWAServiceWorkerJS(basePath string) (string, error) {
 	version := ds.pwaVersion(manifest, precache, offlineHTML)
 	prefix := "gofastr-pwa-" + pwaSlug(cfg.Name) + "-"
 
-	prefixed := make([]string, len(precache))
-	for i, p := range precache {
-		prefixed[i] = pwaPrefix(basePath, p)
-	}
-	precacheJSON, err := json.Marshal(prefixed)
+	precacheJSON, err := pwaMarshalPrefixed(basePath, precache)
 	if err != nil {
 		return "", err
 	}
-	deny := pwaDenyPaths(cfg)
+	shared, err := pwaSharedWorkerArgs(basePath, pwaDenyPaths(cfg))
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(pwaServiceWorkerTemplate,
+		prefix+version,
+		prefix,
+		shared.offlineURL,
+		precacheJSON,
+		shared.denyExactJSON,
+		shared.denyPreJSON,
+	), nil
+}
+
+// PWAStaticExport describes a completed static export to the full-site
+// worker generator.
+type PWAStaticExport struct {
+	// Pages are the exported route paths — precached atomically.
+	Pages []string
+	// Assets are framework-generated files (runtime, CSS, widget chrome,
+	// llm.md) — precached atomically with the pages.
+	Assets []string
+	// OptionalAssets are user static-dir files — precached best-effort:
+	// one un-servable file (a dotfile a host strips, say) must not brick
+	// the install and pin clients to a previous deployment forever.
+	OptionalAssets []string
+	// ContentHash fingerprints the exported tree's bytes: a redeploy
+	// that edits content without changing the path list must still
+	// produce a byte-different worker, or browsers would never rotate
+	// the stale cache.
+	ContentHash string
+}
+
+// pwaWorkerArgs is the marshaling shared by both worker generators:
+// deny lists, basePath prefixing, and JSON encoding.
+type pwaWorkerArgs struct {
+	offlineURL    string
+	denyExactJSON []byte
+	denyPreJSON   []byte
+}
+
+func pwaSharedWorkerArgs(basePath string, deny []string) (pwaWorkerArgs, error) {
 	denyExact := make([]string, len(deny))
 	denyPrefix := make([]string, len(deny))
 	for i, d := range deny {
@@ -483,20 +522,112 @@ func (ds *UIHost) PWAServiceWorkerJS(basePath string) (string, error) {
 	}
 	denyExactJSON, err := json.Marshal(denyExact)
 	if err != nil {
+		return pwaWorkerArgs{}, err
+	}
+	denyPreJSON, err := json.Marshal(denyPrefix)
+	if err != nil {
+		return pwaWorkerArgs{}, err
+	}
+	return pwaWorkerArgs{
+		offlineURL:    pwaPrefix(basePath, pwaOfflinePath),
+		denyExactJSON: denyExactJSON,
+		denyPreJSON:   denyPreJSON,
+	}, nil
+}
+
+func pwaMarshalPrefixed(basePath string, paths []string) ([]byte, error) {
+	prefixed := make([]string, len(paths))
+	for i, p := range paths {
+		prefixed[i] = pwaPrefix(basePath, p)
+	}
+	return json.Marshal(prefixed)
+}
+
+// PWAStaticServiceWorkerJS generates the service worker for a STATIC
+// export ("static site as an app"). A static export is a closed,
+// immutable page set, so the personalization concern that keeps the
+// live worker's navigations network-first does not exist: this worker
+// precaches the WHOLE exported site — app shell, every page, every
+// component stylesheet (under the versioned ?v= URLs pages actually
+// request), every asset (deny-filtered) — and serves navigations
+// cache-first, tolerating the trailing-slash redirects of static
+// hosts, so the installed PWA works fully offline from the first
+// install. Everything else mirrors PWAServiceWorkerJS: exact URL
+// matching, no skipWaiting, denied endpoints never intercepted. The
+// cache prefix carries a "static" + basePath discriminator so a live
+// deployment and static exports on the same origin never delete each
+// other's caches.
+func (ds *UIHost) PWAStaticServiceWorkerJS(basePath string, export PWAStaticExport) (string, error) {
+	if ds.pwaConfig == nil {
+		return "", fmt.Errorf("uihost: PWA not configured")
+	}
+	cfg := ds.resolvedPWA()
+	offlineHTML := ds.PWAOfflineHTML()
+	manifest, err := ds.PWAManifestJSON("")
+	if err != nil {
 		return "", err
 	}
-	denyPrefixJSON, err := json.Marshal(denyPrefix)
+	deny := pwaDenyPaths(cfg)
+	seen := map[string]bool{}
+	add := func(dst *[]string, paths ...string) {
+		for _, p := range paths {
+			if !seen[p] && pwaAllowedPrecache(p, deny) {
+				seen[p] = true
+				*dst = append(*dst, p)
+			}
+		}
+	}
+	var precache []string
+	add(&precache, ds.pwaPrecachePaths(cfg, offlineHTML)...)
+	add(&precache, export.Pages...)
+	add(&precache, export.Assets...)
+	// Component stylesheets are requested under content-addressed ?v=
+	// URLs (page <link> tags and the runtime's lazy loader both append
+	// the version). URL matching is exact, so the precache must hold the
+	// SAME versioned form for every registered component or never-visited
+	// pages render unstyled offline.
+	theme := ds.activeTheme()
+	for _, e := range registry.All() {
+		add(&precache, "/__gofastr/comp/"+e.Name+".css?v="+e.VersionFor(theme))
+	}
+	sort.Strings(precache)
+	var optional []string
+	add(&optional, export.OptionalAssets...)
+	sort.Strings(optional)
+
+	versionInputs := append(append([]string(nil), precache...), optional...)
+	versionInputs = append(versionInputs, "static-content:"+export.ContentHash)
+	version := ds.pwaVersion(manifest, versionInputs, offlineHTML)
+	// "static" + basePath discriminator: does NOT share a prefix with the
+	// live worker's "gofastr-pwa-<slug>-" caches, and two static exports
+	// at different subpaths of one origin stay isolated too.
+	pathSlug := "root"
+	if basePath != "" {
+		pathSlug = pwaSlug(basePath)
+	}
+	prefix := "gofastr-pwa-static-" + pwaSlug(cfg.Name) + "-" + pathSlug + "-"
+
+	precacheJSON, err := pwaMarshalPrefixed(basePath, precache)
+	if err != nil {
+		return "", err
+	}
+	optionalJSON, err := pwaMarshalPrefixed(basePath, optional)
+	if err != nil {
+		return "", err
+	}
+	shared, err := pwaSharedWorkerArgs(basePath, deny)
 	if err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf(pwaServiceWorkerTemplate,
+	return fmt.Sprintf(pwaStaticServiceWorkerTemplate,
 		prefix+version,
 		prefix,
-		pwaPrefix(basePath, pwaOfflinePath),
+		shared.offlineURL,
 		precacheJSON,
-		denyExactJSON,
-		denyPrefixJSON,
+		optionalJSON,
+		shared.denyExactJSON,
+		shared.denyPreJSON,
 	), nil
 }
 
@@ -575,6 +706,107 @@ self.addEventListener("fetch", function (event) {
       if (hit) return hit;
       throw err;
     });
+  }));
+});
+`
+
+// pwaStaticServiceWorkerTemplate is the full-site worker for static
+// exports. Install/activate/deny mirror the live template; the fetch
+// strategy differs: the exported site is immutable, so navigations are
+// cache-first (network fallback, then the offline screen) and every
+// precached asset answers from cache. ES5-safe, dependency-free.
+const pwaStaticServiceWorkerTemplate = `/* goFastr service worker (static full-site) — generated by uihost.WithPWA + static export. Do not edit. */
+var CACHE_NAME = %q;
+var CACHE_PREFIX = %q;
+var OFFLINE_URL = %q;
+var PRECACHE = %s;
+var PRECACHE_OPT = %s;
+var DENY_EXACT = %s;
+var DENY_PREFIX = %s;
+
+function precacheOne(cache, u) {
+  // Each response is re-wrapped into a fresh Response before caching:
+  // static hosts answer extension-less URLs with a 301 to index.html,
+  // and a cached redirected response is rejected when used to answer a
+  // navigation fetch (redirect mode "manual").
+  return fetch(u, { cache: "no-cache" }).then(function (r) {
+    if (!r.ok) throw new Error("precache " + u + ": " + r.status);
+    return r.blob().then(function (body) {
+      return cache.put(u, new Response(body, { status: 200, headers: r.headers }));
+    });
+  });
+}
+
+self.addEventListener("install", function (event) {
+  event.waitUntil(caches.open(CACHE_NAME).then(function (cache) {
+    // Pages and framework assets install atomically — the offline
+    // guarantee is all-or-nothing for them. User static-dir files are
+    // best-effort: one un-servable file must not fail the install and
+    // pin every client to the previous deployment.
+    return Promise.all(PRECACHE.map(function (u) {
+      return precacheOne(cache, u);
+    })).then(function () {
+      return Promise.all(PRECACHE_OPT.map(function (u) {
+        return precacheOne(cache, u).catch(function () {});
+      }));
+    });
+  }));
+});
+
+self.addEventListener("activate", function (event) {
+  event.waitUntil(caches.keys().then(function (names) {
+    return Promise.all(names.filter(function (n) {
+      return n.indexOf(CACHE_PREFIX) === 0 && n !== CACHE_NAME;
+    }).map(function (n) { return caches.delete(n); }));
+  }).then(function () { return self.clients.claim(); }));
+});
+
+function denied(pathname) {
+  if (DENY_EXACT.indexOf(pathname) !== -1) return true;
+  for (var i = 0; i < DENY_PREFIX.length; i++) {
+    if (pathname.indexOf(DENY_PREFIX[i]) === 0) return true;
+  }
+  return false;
+}
+
+// Static hosts 301 extension-less pages to their trailing-slash form,
+// so history/bookmark URLs may carry a slash the precache key lacks
+// (or vice versa). Try the exact pathname, then the toggled form.
+function matchPage(pathname) {
+  return caches.match(pathname, { cacheName: CACHE_NAME }).then(function (hit) {
+    if (hit) return hit;
+    var alt = pathname.length > 1 && pathname.charAt(pathname.length - 1) === "/"
+      ? pathname.slice(0, -1)
+      : pathname + "/";
+    return caches.match(alt, { cacheName: CACHE_NAME });
+  });
+}
+
+self.addEventListener("fetch", function (event) {
+  var req = event.request;
+  if (req.method !== "GET") return;
+  var url = new URL(req.url);
+  if (url.origin !== self.location.origin) return;
+  if (denied(url.pathname)) return;
+  if (req.mode === "navigate") {
+    // Navigations are cache-first: the exported page set is immutable,
+    // every page was precached at install, and a new deployment ships a
+    // byte-different worker whose install repopulates a fresh cache.
+    // Network is the fallback for anything outside the precache; the
+    // offline screen is the last resort.
+    event.respondWith(matchPage(url.pathname).then(function (hit) {
+      if (hit) return hit;
+      return fetch(req).catch(function () {
+        return caches.match(OFFLINE_URL, { cacheName: CACHE_NAME });
+      });
+    }));
+    return;
+  }
+  // Assets: cache-first with network fallback. URLs are matched
+  // exactly, query string included; content-addressed ?v= URLs from a
+  // new deployment miss the old cache and reach the network.
+  event.respondWith(caches.match(req, { cacheName: CACHE_NAME }).then(function (hit) {
+    return hit || fetch(req);
   }));
 });
 `

--- a/framework/uihost/pwa_test.go
+++ b/framework/uihost/pwa_test.go
@@ -575,3 +575,132 @@ func TestPWANoHeadTagsWithoutOption(t *testing.T) {
 		t.Errorf("no PWA markup should be emitted without WithPWA:\n%s", body)
 	}
 }
+
+// Static exports are a closed, immutable page set: the static worker
+// precaches the WHOLE site at install and serves navigations cache-first,
+// so an installed PWA works fully offline. The version must track exported
+// CONTENT (not just the path list) or a redeploy with edited pages would
+// never rotate the cache.
+func TestStaticServiceWorkerPrecachesWholeSite(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{}))
+	sw, err := ds.PWAStaticServiceWorkerJS("", PWAStaticExport{
+		Pages:          []string{"/", "/docs", "/api/tokens"},
+		Assets:         []string{"/static/hero.png"},
+		OptionalAssets: []string{"/media/big-video.mp4"},
+		ContentHash:    "content-hash-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"/"`, `"/docs"`, `"/static/hero.png"`, `"/__gofastr/runtime.js"`, "/__gofastr/pwa/offline"} {
+		if !strings.Contains(sw, want) {
+			t.Errorf("static worker missing %s:\n%s", want, sw)
+		}
+	}
+	if strings.Contains(sw, "/api/tokens") {
+		t.Errorf("denied path must never be precached:\n%s", sw)
+	}
+	if strings.Contains(sw, "skipWaiting") {
+		t.Errorf("static worker must not force skipWaiting:\n%s", sw)
+	}
+	if strings.Contains(sw, "ignoreSearch") {
+		t.Errorf("URL matching stays exact — no ignoreSearch:\n%s", sw)
+	}
+	// Same page set, different content → the cache version must rotate.
+	sw2, err := ds.PWAStaticServiceWorkerJS("", PWAStaticExport{
+		Pages:          []string{"/", "/docs", "/api/tokens"},
+		Assets:         []string{"/static/hero.png"},
+		OptionalAssets: []string{"/media/big-video.mp4"},
+		ContentHash:    "content-hash-2",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := func(s string) string {
+		i := strings.Index(s, "gofastr-pwa-")
+		j := i + strings.IndexAny(s[i:], `"`)
+		return s[i:j]
+	}
+	if name(sw) == name(sw2) {
+		t.Error("content change must rotate the cache version")
+	}
+}
+
+func TestStaticServiceWorkerHonorsBasePath(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{}))
+	sw, err := ds.PWAStaticServiceWorkerJS("/sub", PWAStaticExport{Pages: []string{"/docs"}, ContentHash: "h"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(sw, `"/sub/docs"`) {
+		t.Errorf("basePath not applied to precached pages:\n%s", sw)
+	}
+}
+
+func TestStaticServiceWorkerRequiresPWA(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	if _, err := New(a).PWAStaticServiceWorkerJS("", PWAStaticExport{ContentHash: "h"}); err == nil {
+		t.Fatal("expected error without WithPWA")
+	}
+}
+
+// Review-driven contracts for the static worker: versioned component CSS in
+// the precache (pages request ?v= URLs and matching is exact), best-effort
+// tier for user static-dir files, slash-tolerant navigation lookup, and a
+// cache prefix that can never collide with the live worker's.
+func TestStaticServiceWorkerReviewContracts(t *testing.T) {
+	a := app.NewApp("x")
+	a.Register("/", &plainComp{}, nil)
+	ds := New(a, WithPWA(PWAConfig{}))
+	sw, err := ds.PWAStaticServiceWorkerJS("", PWAStaticExport{
+		Pages:          []string{"/"},
+		OptionalAssets: []string{"/media/huge.mp4"},
+		ContentHash:    "h",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Component CSS must be precached under the SAME ?v= form pages request.
+	if !strings.Contains(sw, `/__gofastr/comp/`) || !strings.Contains(sw, `.css?v=`) {
+		t.Errorf("versioned component CSS missing from precache:\n%s", sw)
+	}
+	// Optional tier: present, and installed best-effort (failure swallowed).
+	if !strings.Contains(sw, `"/media/huge.mp4"`) || !strings.Contains(sw, "PRECACHE_OPT") {
+		t.Errorf("optional best-effort precache tier missing:\n%s", sw)
+	}
+	if !strings.Contains(sw, `.catch(function () {})`) {
+		t.Errorf("optional entries must not fail the install:\n%s", sw)
+	}
+	// Slash-tolerant navigation lookup.
+	if !strings.Contains(sw, "matchPage") || !strings.Contains(sw, `pathname + "/"`) {
+		t.Errorf("navigation lookup must tolerate trailing-slash redirects:\n%s", sw)
+	}
+	// Prefix isolation: the live worker cleans caches under
+	// "gofastr-pwa-<slug>-"; the static prefix must NOT fall under it.
+	liveSW, err := ds.PWAServiceWorkerJS("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	prefix := func(s string) string {
+		i := strings.Index(s, "var CACHE_PREFIX = \"")
+		rest := s[i+len("var CACHE_PREFIX = \""):]
+		return rest[:strings.Index(rest, `"`)]
+	}
+	livePrefix, staticPrefix := prefix(liveSW), prefix(sw)
+	if strings.HasPrefix(staticPrefix, livePrefix) || strings.HasPrefix(livePrefix, staticPrefix) {
+		t.Errorf("live (%q) and static (%q) cache prefixes overlap — activates would delete each other's caches", livePrefix, staticPrefix)
+	}
+	// Two static exports at different subpaths stay isolated too.
+	swSub, err := ds.PWAStaticServiceWorkerJS("/docs", PWAStaticExport{Pages: []string{"/"}, ContentHash: "h"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prefix(swSub) == staticPrefix {
+		t.Errorf("static exports at different basePaths must not share a cache prefix")
+	}
+}


### PR DESCRIPTION
## Summary

Four workstreams for v0.24.0:

1. **Hot reload reaches every HTML surface** — `LiveReloadHTMLInjector` (dev-only, auto-wired) covers static file serving, widget pages, and hand-rolled handlers; guidance funnels the dev loop to `gofastr dev` everywhere (docs, README, generate next-steps, generated AGENTS.md triggers).
2. **HMR-readiness evals** — deterministic (examples sweep, blueprint dev-loop e2e, docs tripwire) plus a non-deterministic funnel signal in the UI-quality harness (snapshot-pure `gofastr` CLI shim on the builder's PATH; records whether blind builders discover `gofastr dev` from generated guidance alone).
3. **Documentation-accuracy sweep** — 77 surfaces audited; 8 misrepresentations fixed, including `gofastr migrate` now honoring an exported `DATABASE_URL`.
4. **Static site as an app** — full-site offline PWA for static exports: whole site precached at install, cache-first navigations, best-effort tier for user assets, isolated cache prefixes, deterministic content-fingerprinted versions. Hardened through a 10-finding adversarial review; proven by a Chrome e2e (install → kill server → never-visited page serves its real content).

## Validation

- Full suites green: framework, framework/dev (-race), uihost, static (incl. offline Chrome e2e), docs, evals, cmd/gofastr, examples (HMR sweep + site + meridian).
- Each workstream went through an independent adversarial review round; all confirmed findings fixed with pinning tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)