### PR TITLE
Restore Kiln blueprint parity and Windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+
+- **Kiln is current again.** OMP with GLM-5.2 is the turnkey and first-choice
+  live driver; the world/tool schemas now cover the current app, entity,
+  screen, navigation, and owned-Go scaffold surfaces; pages render through the
+  framework UI host and component registry; and `kiln freeze` deterministically
+  emits generator-ready `gofastr.yml` plus lossless `world.json`. The removed
+  `entities/*.json` graduation path is gone end to end.
+- **Blueprint layout blocks.** Screens now preserve and generate the current
+  `framework/ui` `stack`, `cluster`, `grid`, and `stat_grid` primitives, with
+  semantic spacing/alignment validation and generate→pack recovery. This keeps
+  Kiln's typed live composition intact across the owned-Go freeze boundary.
+- **Windows embed WAL snapshots.** Snapshot completion now resets the
+  append-mode WAL by closing and reopening it with truncation, avoiding the
+  Windows `Access is denied` failure from truncating the live append handle.
+- **Windows generator and dev-loop parity.** `gofastr dev` now builds a
+  per-process `.exe` on Windows, its end-to-end harness kills the watcher tree
+  before canceling the parent, codegen's symlink guard handles drive-qualified
+  paths, additive generation normalizes platform separators, and generated
+  app/extension tests execute platform-native binaries. Fresh-port allocation
+  prevents stale dev servers from contaminating later browser tests.
+- **Deterministic Meridian scheme captures.** The flagship visual gate now
+  waits for Chromium to commit the scheme repaint before taking a from-surface
+  screenshot and asserts that the dark marketing band keeps visible heading
+  and paragraph contrast in both schemes.
+- **`widget.Builder.SSERefresh`.** SSE-triggered screen changes now force the
+  normal SPA navigation pipeline for the current URL. The old `SSEReload` name
+  remains as a source-compatible alias but no longer performs a hard reload.
+
+### Changed
+
+- **Kiln defaults its live REST surface to `/api`.** Entity CRUD and HTML
+  screens can share a name (`/api/posts` and `/posts`), matching current
+  blueprints. Agent-authored page trees reject `class`, `style`, and `on*`
+  props and compose the shared design system instead. Previously advertised
+  native-agent meta tools (`set_theme`, reject, reset) are now actually
+  dispatchable, and the new `set_scaffold` tool authors nav/stubs.
+
 ## [0.26.1] - 2026-07-15
 
 Repo-hygiene patch: process ledgers become enforced gates, and the docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,13 +55,27 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   fallback carries a `<main>`, so the SSE-triggered SPA refresh swaps in its
   content instead of emptying (and caching) a blank content area.
 - **`gofastr dev` removes its temp server binary on shutdown**, instead of
-  accumulating one pid-suffixed binary per run in the temp dir.
+  accumulating one pid-suffixed binary per run in the temp dir; the e2e
+  harnesses remove it for the processes they SIGKILL.
+- **The Kiln landing follows the theme.** The host fallback page now styles
+  itself entirely from the `/__gofastr/app.css` tokens (`--color-*`,
+  `--font-*`, `--radius-*`) instead of a hardcoded always-dark palette, so it
+  honors `set_theme` overrides and the light/dark scheme like every other
+  surface; its styles ride inside `<main>` so an SPA-swapped fallback keeps
+  its layout. The landing visual gate now captures both schemes.
 - The kiln skill's `add_page` example is valid JSON again (gated by a test),
   and the hooks/routes/seeds tools, action kinds, and expression language it
   references are documented in the skill once more.
 
 ### Changed
 
+- **`gofastr dev` runs the server in the project directory.** The rebuilt
+  binary's working directory is now `--dir` — the same cwd it gets when run
+  by hand — so relative paths (sqlite `db_url`, static dir) resolve against
+  the project, and the app's worktree-isolation lookup keys off the
+  project's location instead of wherever `gofastr dev` was launched. If you
+  relied on launch-cwd-relative paths, your sqlite file now lives in the
+  project dir.
 - **Kiln defaults its live REST surface to `/api`.** Entity CRUD and HTML
   screens can share a name (`/api/posts` and `/posts`), matching current
   blueprints. Agent-authored page trees reject `class`, `style`, and `on*`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,30 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   normal SPA navigation pipeline for the current URL. The old `SSEReload` name
   remains as a source-compatible alias but no longer performs a hard reload.
 
+### Fixed
+
+- **Freeze fails loudly on YAML-unrepresentable worlds.** The blueprint
+  emitter quotes commas, quotes, and brackets wherever they appear (a seed
+  value like `"a, b"` no longer re-parses as two items), leads list-item maps
+  with an inline scalar list when no scalar key exists, and
+  `BlueprintYAML` now errors — naming the offending key — on seed rows or
+  props that `core/yaml` cannot round-trip (map-only rows, keys containing
+  colons) instead of writing a silently corrupt `gofastr.yml`.
+- **Typed kinds render at any depth.** A design-system kind (`card`,
+  `stack`, `stat_card`, …) nested inside a semantic leaf container (`div`,
+  `form`, table cells) now dispatches through its component instead of
+  falling through to core noderender's unknown-kind comment; the `class`
+  strip for legacy journals now applies at every depth.
+  (`core-ui/noderender` exports the shallow `RenderKind` seam this uses.)
+- **Deleting the page being viewed shows the Kiln fallback.** The host
+  fallback carries a `<main>`, so the SSE-triggered SPA refresh swaps in its
+  content instead of emptying (and caching) a blank content area.
+- **`gofastr dev` removes its temp server binary on shutdown**, instead of
+  accumulating one pid-suffixed binary per run in the temp dir.
+- The kiln skill's `add_page` example is valid JSON again (gated by a test),
+  and the hooks/routes/seeds tools, action kinds, and expression language it
+  references are documented in the skill once more.
+
 ### Changed
 
 - **Kiln defaults its live REST surface to `/api`.** Entity CRUD and HTML

--- a/README.md
+++ b/README.md
@@ -436,8 +436,9 @@ gofastr embed query "<text>"        Top-K semantic hits as JSON
 
 ### `kiln/` — agent-driven build mode (experimental)
 
-Kiln lets you build a GoFastr app live by chatting with a coding agent
-(Claude Code, pi, Codex, …): the agent mutates an in-memory world over
+Kiln lets you build a GoFastr app live by chatting with a coding agent.
+OMP with GLM-5.2 is the turnkey/default driver; Claude Code, Pi, Codex, and
+custom commands remain adapters. The agent mutates an in-memory world over
 HTTP, the running app re-renders, and the schema migrates in-process.
 Freeze the journal when done and graduate to a `gofastr.yml` blueprint
 you commit. It's an experiment and not part of the supported framework

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,9 +135,6 @@ of `gofastr.yml` was deliberately rejected in favor of explicit
 - **`public_openapi` blueprint key.** The raw `/openapi.json` is
   auth-gated by secure-by-default; `AppConfig.PublicOpenAPI` exists but
   the blueprint can't opt into it. Add the key.
-- **`kiln freeze` → blueprint.** Freeze writes `entities/*.json`
-  snapshots that no longer have a framework loader; emit a `gofastr.yml`
-  blueprint so the graduate-to-Go path is one `gofastr generate`.
 
 ---
 

--- a/battery/embed/persist.go
+++ b/battery/embed/persist.go
@@ -201,6 +201,9 @@ func openWAL(path string) (*wal, error) {
 func (w *wal) append(e walEntry) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.f == nil {
+		return errors.New("embed: WAL is closed")
+	}
 	if err := w.enc.Encode(e); err != nil {
 		return fmt.Errorf("embed: wal append: %w", err)
 	}
@@ -210,6 +213,9 @@ func (w *wal) append(e walEntry) error {
 func (w *wal) replay(apply func(walEntry) error) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.f == nil {
+		return errors.New("embed: WAL is closed")
+	}
 	if _, err := w.f.Seek(0, io.SeekStart); err != nil {
 		return fmt.Errorf("embed: wal seek: %w", err)
 	}
@@ -240,14 +246,32 @@ func (w *wal) replay(apply func(walEntry) error) error {
 func (w *wal) truncate() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if err := w.f.Truncate(0); err != nil {
-		return fmt.Errorf("embed: wal truncate: %w", err)
+	if w.f == nil {
+		return errors.New("embed: WAL is closed")
 	}
-	if _, err := w.f.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("embed: wal seek after truncate: %w", err)
+	// Windows refuses SetEndOfFile on a handle opened with append semantics.
+	// Close and reopen with O_TRUNC while holding the WAL lock; this is also a
+	// cleaner reset boundary for the gob encoder on every platform.
+	if err := w.f.Sync(); err != nil {
+		return fmt.Errorf("embed: wal sync before truncate: %w", err)
 	}
-	w.enc = gob.NewEncoder(w.f)
-	return w.f.Sync()
+	if err := w.f.Close(); err != nil {
+		return fmt.Errorf("embed: wal close before truncate: %w", err)
+	}
+	w.f = nil
+	f, err := os.OpenFile(w.path, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_APPEND, 0o644)
+	if err != nil {
+		// Best-effort recovery keeps the WAL object usable even though the
+		// snapshot caller still receives the reset failure.
+		w.f, _ = os.OpenFile(w.path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o644)
+		if w.f != nil {
+			w.enc = gob.NewEncoder(w.f)
+		}
+		return fmt.Errorf("embed: wal reopen after truncate: %w", err)
+	}
+	w.f = f
+	w.enc = gob.NewEncoder(f)
+	return f.Sync()
 }
 
 func (w *wal) close() error {

--- a/battery/embed/persist_test.go
+++ b/battery/embed/persist_test.go
@@ -43,6 +43,7 @@ func TestSnapshotRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
+	defer idx2.Close()
 	stats := idx2.Stats()
 	if stats.Docs != 3 {
 		t.Fatalf("after reopen Docs = %d, want 3", stats.Docs)
@@ -85,6 +86,7 @@ func TestWALReplayRecoversUnsnapshottedWrites(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
+	defer idx2.Close()
 	if got := idx2.Stats().Docs; got != 2 {
 		t.Fatalf("after reopen Docs = %d, want 2 (WAL replay)", got)
 	}
@@ -106,6 +108,7 @@ func TestAutoSnapshotTruncatesWAL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
+	defer idx.Close()
 	for _, id := range []string{"a", "b", "c", "d"} {
 		if err := idx.Add(ctx, Document{ID: id, Text: id}); err != nil {
 			t.Fatalf("Add %s: %v", id, err)

--- a/battery/embed/store_capability_test.go
+++ b/battery/embed/store_capability_test.go
@@ -67,11 +67,13 @@ func TestOpen_FailsClosedOnKeywordWithoutChunkLister(t *testing.T) {
 
 // TestOpen_FlatStoreSatisfiesAll confirms the default store works with both.
 func TestOpen_FlatStoreSatisfiesAll(t *testing.T) {
-	if _, err := Open(Options{
+	idx, err := Open(Options{
 		Embedder: NewStubEmbedder(8),
 		Path:     t.TempDir(),
 		Keyword:  fakeKeyword{},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("Open with default FlatStore + Path + Keyword: %v", err)
 	}
+	defer idx.Close()
 }

--- a/cmd/gofastr/blueprint.go
+++ b/cmd/gofastr/blueprint.go
@@ -1823,6 +1823,10 @@ func validateBlueprintBlock(screenName string, entities map[string]framework.Ent
 				return fmt.Errorf("blueprint: screen %q stat_card source entity %q must enable crud", screenName, srcEntity)
 			}
 		}
+	case "stack", "cluster", "grid", "stat_grid":
+		if err := validateBlueprintLayoutBlock(screenName, kind, block.Props); err != nil {
+			return err
+		}
 	case "page_header", "hero", "card", "stat_row",
 		"link_button", "callout",
 		"markdown", "pricing", "divider":
@@ -1833,6 +1837,67 @@ func validateBlueprintBlock(screenName string, entities map[string]framework.Ent
 	}
 	for _, child := range block.Children {
 		if err := validateBlueprintBlock(screenName, entities, child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateBlueprintLayoutBlock(screenName, kind string, props map[string]any) error {
+	allowed := func(value string, values ...string) bool {
+		if value == "" {
+			return true
+		}
+		for _, candidate := range values {
+			if value == candidate {
+				return true
+			}
+		}
+		return false
+	}
+	stringProp := func(name string) (string, error) {
+		value, ok := props[name]
+		if !ok {
+			return "", nil
+		}
+		text, ok := value.(string)
+		if !ok {
+			return "", fmt.Errorf("blueprint: screen %q %s prop %q must be a string", screenName, kind, name)
+		}
+		return strings.ToLower(strings.TrimSpace(text)), nil
+	}
+	gap, err := stringProp("gap")
+	if err != nil {
+		return err
+	}
+	if !allowed(gap, "none", "xs", "sm", "md", "lg", "xl", "2xl") {
+		return fmt.Errorf("blueprint: screen %q %s gap %q is not a design token", screenName, kind, gap)
+	}
+	if kind == "stack" || kind == "cluster" {
+		align, err := stringProp("align")
+		if err != nil {
+			return err
+		}
+		if !allowed(align, "start", "center", "end", "baseline", "stretch") {
+			return fmt.Errorf("blueprint: screen %q %s align %q is unsupported", screenName, kind, align)
+		}
+		justify, err := stringProp("justify")
+		if err != nil {
+			return err
+		}
+		if !allowed(justify, "start", "center", "end", "between", "around") {
+			return fmt.Errorf("blueprint: screen %q %s justify %q is unsupported", screenName, kind, justify)
+		}
+	}
+	if kind == "cluster" {
+		if value, ok := props["no_wrap"]; ok {
+			if _, ok := value.(bool); !ok {
+				return fmt.Errorf("blueprint: screen %q cluster prop %q must be a boolean", screenName, "no_wrap")
+			}
+		}
+	}
+	if kind == "grid" || kind == "stat_grid" {
+		if _, err := stringProp("min"); err != nil {
 			return err
 		}
 	}
@@ -4745,6 +4810,7 @@ type screenImportNeeds struct {
 func blueprintCatalogKind(kind string) bool {
 	switch strings.ToLower(strings.TrimSpace(kind)) {
 	case "page_header", "hero", "section", "card", "stat_row", "stat_card",
+		"stack", "cluster", "grid", "stat_grid",
 		"bar_chart", "pie_chart", "line_chart", "link_button", "callout", "divider",
 		"markdown", "pricing":
 		return true
@@ -4950,6 +5016,63 @@ func blueprintProp(b BlueprintBlock, key string) string {
 	return s
 }
 
+func blueprintBoolProp(b BlueprintBlock, key string) bool {
+	if b.Props == nil {
+		return false
+	}
+	value, _ := b.Props[key].(bool)
+	return value
+}
+
+func blueprintGapExpr(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "none":
+		return "ui.GapNone"
+	case "xs":
+		return "ui.GapXS"
+	case "sm":
+		return "ui.GapSM"
+	case "lg":
+		return "ui.GapLG"
+	case "xl":
+		return "ui.GapXL"
+	case "2xl":
+		return "ui.Gap2XL"
+	default:
+		return "ui.GapMD"
+	}
+}
+
+func blueprintAlignExpr(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "center":
+		return "ui.AlignCenter"
+	case "end":
+		return "ui.AlignEnd"
+	case "baseline":
+		return "ui.AlignBaseline"
+	case "stretch":
+		return "ui.AlignStretch"
+	default:
+		return "ui.AlignStart"
+	}
+}
+
+func blueprintJustifyExpr(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "center":
+		return "ui.JustifyCenter"
+	case "end":
+		return "ui.JustifyEnd"
+	case "between":
+		return "ui.JustifyBetween"
+	case "around":
+		return "ui.JustifyAround"
+	default:
+		return "ui.JustifyStart"
+	}
+}
+
 // blueprintSectionChildrenAreCards reports whether every child of a section is
 // a card/stat_card — the only kinds that belong in the responsive card grid.
 // Mixed or non-card children flow in a left-aligned stack instead so a single
@@ -4982,6 +5105,35 @@ func renderBlueprintCatalogBlock(screen BlueprintScreen, block BlueprintBlock, p
 		return strings.Join(parts, ", ")
 	}
 	switch kind {
+	case "stack":
+		cfg := fmt.Sprintf("ui.StackConfig{Gap: %s, Align: %s, Justify: %s}", blueprintGapExpr(blueprintProp(block, "gap")), blueprintAlignExpr(blueprintProp(block, "align")), blueprintJustifyExpr(blueprintProp(block, "justify")))
+		children := childExprs()
+		if children == "" {
+			return "ui.Stack(" + cfg + ")", true
+		}
+		return "ui.Stack(" + cfg + ", " + children + ")", true
+	case "cluster":
+		cfg := fmt.Sprintf("ui.ClusterConfig{Gap: %s, Align: %s, Justify: %s, NoWrap: %t}", blueprintGapExpr(blueprintProp(block, "gap")), blueprintAlignExpr(blueprintProp(block, "align")), blueprintJustifyExpr(blueprintProp(block, "justify")), blueprintBoolProp(block, "no_wrap"))
+		children := childExprs()
+		if children == "" {
+			return "ui.Cluster(" + cfg + ")", true
+		}
+		return "ui.Cluster(" + cfg + ", " + children + ")", true
+	case "grid", "stat_grid":
+		min := blueprintProp(block, "min")
+		if min == "" {
+			if kind == "stat_grid" {
+				min = "12rem"
+			} else {
+				min = "16rem"
+			}
+		}
+		cfg := fmt.Sprintf("ui.GridConfig{Min: %q, Gap: %s}", min, blueprintGapExpr(blueprintProp(block, "gap")))
+		children := childExprs()
+		if children == "" {
+			return "ui.Grid(" + cfg + ")", true
+		}
+		return "ui.Grid(" + cfg + ", " + children + ")", true
 	case "page_header":
 		cfg := fmt.Sprintf("ui.PageHeaderConfig{Title: %q, Subtitle: %q, Eyebrow: %q}", blueprintProp(block, "title"), blueprintProp(block, "subtitle"), blueprintProp(block, "eyebrow"))
 		return "ui.PageHeader(" + cfg + ")", true

--- a/cmd/gofastr/blueprint_layout_blocks_test.go
+++ b/cmd/gofastr/blueprint_layout_blocks_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestBlueprintLayoutBlocksRenderAndPack(t *testing.T) {
+	body := []BlueprintBlock{{
+		Kind: "stack", Props: map[string]any{"gap": "xl"}, Children: []BlueprintBlock{
+			{Kind: "cluster", Props: map[string]any{"gap": "sm", "align": "center", "justify": "between", "no_wrap": true}, Children: []BlueprintBlock{
+				{Kind: "link_button", Props: map[string]any{"label": "Docs", "href": "/docs", "variant": "primary"}},
+			}},
+			{Kind: "grid", Props: map[string]any{"min": "14rem", "gap": "lg"}, Children: []BlueprintBlock{
+				{Kind: "card", Props: map[string]any{"heading": "One"}},
+				{Kind: "card", Props: map[string]any{"heading": "Two"}},
+			}},
+		},
+	}}
+	bp := Blueprint{
+		App:     BlueprintApp{Name: "Layouts", Module: "example.com/layouts", DBDriver: "sqlite", DBURL: "layouts.db"},
+		Screens: []BlueprintScreen{{Name: "home", Route: "/", Title: "Layouts", Body: body}},
+	}
+	if err := validateBlueprint(bp); err != nil {
+		t.Fatalf("validate layout blocks: %v", err)
+	}
+	files, err := renderBlueprintFiles(bp)
+	if err != nil {
+		t.Fatalf("render layout blocks: %v", err)
+	}
+	generated := allScreenContent(files)
+	for _, want := range []string{
+		"ui.Stack(ui.StackConfig{Gap: ui.GapXL",
+		"ui.Cluster(ui.ClusterConfig{Gap: ui.GapSM, Align: ui.AlignCenter, Justify: ui.JustifyBetween, NoWrap: true}",
+		"ui.Grid(ui.GridConfig{Min: \"14rem\", Gap: ui.GapLG}",
+	} {
+		if !strings.Contains(generated, want) {
+			t.Fatalf("generated screen missing %q:\n%s", want, generated)
+		}
+	}
+
+	dir := materializeBlueprint(t, bp)
+	packed, err := packReadScreens(dir)
+	if err != nil {
+		t.Fatalf("pack screens: %v", err)
+	}
+	if len(packed) != 1 || !reflect.DeepEqual(packed[0].Body, body) {
+		t.Fatalf("layout blocks did not round-trip:\nwant=%#v\ngot=%#v", body, packed[0].Body)
+	}
+}
+
+func TestBlueprintLayoutBlocksRejectNonTokenGap(t *testing.T) {
+	bp := Blueprint{Screens: []BlueprintScreen{{Name: "home", Route: "/", Body: []BlueprintBlock{{
+		Kind: "stack", Props: map[string]any{"gap": "23px"},
+	}}}}}
+	err := validateBlueprint(bp)
+	if err == nil || !strings.Contains(err.Error(), "not a design token") {
+		t.Fatalf("bad layout gap error = %v", err)
+	}
+}

--- a/cmd/gofastr/blueprint_test.go
+++ b/cmd/gofastr/blueprint_test.go
@@ -1001,7 +1001,7 @@ func TestBlueprintCLIGeneratesEntireWorkingAppE2E(t *testing.T) {
 		t.Fatalf("generated app entrypoint missing: %v", err)
 	}
 
-	appBin := filepath.Join(dir, "generated-blueprint-app")
+	appBin := testExecutablePath(filepath.Join(dir, "generated-blueprint-app"))
 	buildCmd := exec.Command("go", "build", "-mod=mod", "-o", appBin, ".")
 	buildCmd.Dir = dir
 	buildCmd.Env = append(os.Environ(), "GOCACHE="+filepath.Join(t.TempDir(), "gocache"))
@@ -1412,17 +1412,20 @@ func assertContains(t *testing.T, haystack, needle string) {
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 	old := os.Stdout
-	r, w, err := os.Pipe()
+	f, err := os.CreateTemp(t.TempDir(), "stdout-*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	os.Stdout = w
+	os.Stdout = f
+	defer func() {
+		os.Stdout = old
+		_ = f.Close()
+	}()
 	fn()
-	if err := w.Close(); err != nil {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		t.Fatal(err)
 	}
-	os.Stdout = old
-	out, err := io.ReadAll(r)
+	out, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gofastr/cov_dev_test.go
+++ b/cmd/gofastr/cov_dev_test.go
@@ -81,6 +81,9 @@ func TestBuildAndServeBuildsAndStarts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("isolation.Resolve: %v", err)
 	}
+	// In-process call: dev's shutdown path never runs, so remove the
+	// compiled temp binary ourselves.
+	t.Cleanup(func() { _ = os.Remove(devServerBinaryPath(rt)) })
 	var mu sync.Mutex
 	var cmd *exec.Cmd
 	ok := covT_capStdout(t, func() {

--- a/cmd/gofastr/cov_embed_test.go
+++ b/cmd/gofastr/cov_embed_test.go
@@ -17,6 +17,13 @@ func covT_embedSandbox(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	// os.UserHomeDir reads USERPROFILE on Windows; HOME alone only isolates
+	// Unix. Keep both pointed at the test sandbox so snapshot/WAL files never
+	// touch the developer's real index (or collide with another process).
+	t.Setenv("USERPROFILE", home)
+	if got, err := os.UserHomeDir(); err != nil || filepath.Clean(got) != filepath.Clean(home) {
+		t.Fatalf("embed sandbox did not isolate user home: got=%q err=%v want=%q", got, err, home)
+	}
 	t.Setenv("GOFASTR_URL", "")
 	t.Setenv("EMBED_BACKEND", "")
 	work := t.TempDir()
@@ -47,7 +54,13 @@ func TestRunEmbedHelpAndUnknown(t *testing.T) {
 
 func TestEmbedIndexQueryStatsClear(t *testing.T) {
 	covT_embedSandbox(t)
-	covT_capStdout(t, func() { runEmbed([]string{"index", "."}) })
+	var indexOut string
+	code := covT_capExit(t, func() {
+		indexOut = covT_capStdout(t, func() { runEmbed([]string{"index", "."}) })
+	})
+	if code != -1 {
+		t.Fatalf("embed index exited %d: %s", code, indexOut)
+	}
 	out := covT_capStdout(t, func() { runEmbed([]string{"query", "authentication", "-k", "3", "--hybrid"}) })
 	if !strings.HasPrefix(strings.TrimSpace(out), "[") {
 		t.Fatalf("query should print JSON array: %s", out)

--- a/cmd/gofastr/cov_error_branches_test.go
+++ b/cmd/gofastr/cov_error_branches_test.go
@@ -17,6 +17,7 @@ func covT_unwritableHome(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("HOME", f)
+	t.Setenv("USERPROFILE", f)
 	t.Setenv("GOFASTR_URL", "")
 	t.Setenv("EMBED_BACKEND", "")
 }

--- a/cmd/gofastr/cov_generate_dispatch_test.go
+++ b/cmd/gofastr/cov_generate_dispatch_test.go
@@ -90,7 +90,8 @@ func TestProjectRelativePath(t *testing.T) {
 	if projectRelativePath(".", "x.json") != "x.json" {
 		t.Fatal("dot project dir passthrough")
 	}
-	if projectRelativePath("/abs", "/other") != "/other" {
+	abs := filepath.Join(t.TempDir(), "other")
+	if projectRelativePath(filepath.Join(t.TempDir(), "project"), abs) != abs {
 		t.Fatal("absolute path passthrough")
 	}
 	if projectRelativePath("proj", "x.json") != filepath.Join("proj", "x.json") {

--- a/cmd/gofastr/cov_generate_helpers_test.go
+++ b/cmd/gofastr/cov_generate_helpers_test.go
@@ -229,7 +229,7 @@ func TestRenderEntityModelRelations(t *testing.T) {
 }
 
 func TestValidateOutputDir(t *testing.T) {
-	bad := []string{"", " ", "/abs", ".", "..", "../b"}
+	bad := []string{"", " ", t.TempDir(), ".", "..", "../b"}
 	for _, d := range bad {
 		if err := validateOutputDir(d); err == nil {
 			t.Errorf("validateOutputDir(%q) = nil, want error", d)

--- a/cmd/gofastr/coverage_helpers_test.go
+++ b/cmd/gofastr/coverage_helpers_test.go
@@ -46,7 +46,10 @@ func covT_capStdout(t *testing.T, fn func()) string {
 		t.Fatal(err)
 	}
 	os.Stdout = f
-	defer func() { os.Stdout = old }()
+	defer func() {
+		os.Stdout = old
+		_ = f.Close()
+	}()
 	fn()
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		t.Fatal(err)
@@ -55,7 +58,6 @@ func covT_capStdout(t *testing.T, fn func()) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = f.Close()
 	return string(b)
 }
 

--- a/cmd/gofastr/dev.go
+++ b/cmd/gofastr/dev.go
@@ -181,6 +181,11 @@ func buildAndServe(dir, addr string, runtimeIsolation *isolation.Runtime, mu *sy
 	// GOFASTR_ENV=production is checked as a kill switch.
 	childEnv := buildDevChildEnv(runtimeIsolation.Env(os.Environ()))
 	runCmd := exec.Command(tmpBin, "--addr", addr)
+	// Run the server in the project dir — the same cwd it gets when run by
+	// hand — so relative paths (sqlite db_url, static dir) resolve against
+	// the project, and the app's own worktree-isolation lookup sees the
+	// project's location rather than wherever `gofastr dev` was launched.
+	runCmd.Dir = dir
 	runCmd.Stdout = os.Stdout
 	runCmd.Stderr = os.Stderr
 	runCmd.Env = childEnv

--- a/cmd/gofastr/dev.go
+++ b/cmd/gofastr/dev.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -142,9 +143,12 @@ func resolveDevIsolation(dir, addr string) (*isolation.Runtime, string, error) {
 // buildAndServe builds and starts the server process.
 func buildAndServe(dir, addr string, runtimeIsolation *isolation.Runtime, mu *sync.Mutex, cmd **exec.Cmd) bool {
 	// Build binary to temp file
-	tmpName := "gofastr-dev-server"
+	tmpName := fmt.Sprintf("gofastr-dev-server-%d", os.Getpid())
 	if runtimeIsolation.Active() {
 		tmpName += "-" + runtimeIsolation.ID()
+	}
+	if runtime.GOOS == "windows" {
+		tmpName += ".exe"
 	}
 	tmpBin := filepath.Join(os.TempDir(), tmpName)
 	buildCmd := exec.Command("go", "build", "-o", tmpBin, ".")

--- a/cmd/gofastr/dev.go
+++ b/cmd/gofastr/dev.go
@@ -112,6 +112,7 @@ func runDev(args []string) {
 			fmt.Println()
 			info("Shutting down...")
 			killServer(&mu, &server)
+			_ = os.Remove(devServerBinaryPath(runtimeIsolation))
 			close(stop)
 			return
 
@@ -140,9 +141,11 @@ func resolveDevIsolation(dir, addr string) (*isolation.Runtime, string, error) {
 	return runtimeIsolation, resolvedAddr, nil
 }
 
-// buildAndServe builds and starts the server process.
-func buildAndServe(dir, addr string, runtimeIsolation *isolation.Runtime, mu *sync.Mutex, cmd **exec.Cmd) bool {
-	// Build binary to temp file
+// devServerBinaryPath is the per-process temp path the rebuilt server is
+// compiled to. The pid suffix lets concurrent dev instances coexist; the
+// shutdown path removes the file so restarts don't accumulate binaries in
+// the temp dir.
+func devServerBinaryPath(runtimeIsolation *isolation.Runtime) string {
 	tmpName := fmt.Sprintf("gofastr-dev-server-%d", os.Getpid())
 	if runtimeIsolation.Active() {
 		tmpName += "-" + runtimeIsolation.ID()
@@ -150,7 +153,13 @@ func buildAndServe(dir, addr string, runtimeIsolation *isolation.Runtime, mu *sy
 	if runtime.GOOS == "windows" {
 		tmpName += ".exe"
 	}
-	tmpBin := filepath.Join(os.TempDir(), tmpName)
+	return filepath.Join(os.TempDir(), tmpName)
+}
+
+// buildAndServe builds and starts the server process.
+func buildAndServe(dir, addr string, runtimeIsolation *isolation.Runtime, mu *sync.Mutex, cmd **exec.Cmd) bool {
+	// Build binary to temp file
+	tmpBin := devServerBinaryPath(runtimeIsolation)
 	buildCmd := exec.Command("go", "build", "-o", tmpBin, ".")
 	buildCmd.Dir = dir // Run from the project dir so go build resolves the local module.
 	buildCmd.Stdout = os.Stdout

--- a/cmd/gofastr/dev_blueprint_e2e_test.go
+++ b/cmd/gofastr/dev_blueprint_e2e_test.go
@@ -76,6 +76,7 @@ func TestE2E_DevLoop_BlueprintApp(t *testing.T) {
 		_ = killTestProcessTree(dev)
 		cancel()
 		_ = dev.Wait()
+		removeDevServerBinary(dev)
 	})
 
 	base := "http://localhost:" + port

--- a/cmd/gofastr/dev_blueprint_e2e_test.go
+++ b/cmd/gofastr/dev_blueprint_e2e_test.go
@@ -61,6 +61,9 @@ func TestE2E_DevLoop_BlueprintApp(t *testing.T) {
 	dev.Env = append(os.Environ(),
 		"PORT=localhost:"+port,
 		"DATABASE_URL=file:"+filepath.Join(dir, "devloop.db"),
+		// The child app resolves worktree isolation from its cwd; a linked
+		// git worktree would silently remap the polled port.
+		"GOFASTR_ISOLATION=off",
 	)
 	var devOut syncBuffer
 	dev.Stdout = &devOut

--- a/cmd/gofastr/dev_blueprint_e2e_test.go
+++ b/cmd/gofastr/dev_blueprint_e2e_test.go
@@ -15,7 +15,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -56,9 +55,8 @@ func TestE2E_DevLoop_BlueprintApp(t *testing.T) {
 	// Boot the generated app under `gofastr dev` — the path the guidance
 	// funnels users to, and the only one that enables livereload.
 	bin := buildGofastrBinary(t)
-	port := nextE2EPort()
+	port := nextE2EPort(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	dev := exec.CommandContext(ctx, bin, "dev", "-p", port, "--dir", dir)
 	dev.Env = append(os.Environ(),
 		"PORT=localhost:"+port,
@@ -67,14 +65,13 @@ func TestE2E_DevLoop_BlueprintApp(t *testing.T) {
 	var devOut syncBuffer
 	dev.Stdout = &devOut
 	dev.Stderr = &devOut
-	dev.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	configureTestProcessGroup(dev)
 	if err := dev.Start(); err != nil {
 		t.Fatalf("start gofastr dev: %v", err)
 	}
-	pid := dev.Process.Pid
 	t.Cleanup(func() {
+		_ = killTestProcessTree(dev)
 		cancel()
-		_ = syscall.Kill(-pid, syscall.SIGKILL)
 		_ = dev.Wait()
 	})
 

--- a/cmd/gofastr/dev_e2e_test.go
+++ b/cmd/gofastr/dev_e2e_test.go
@@ -36,6 +36,17 @@ func nextE2EPort(t *testing.T) string {
 	return strconv.Itoa(port)
 }
 
+// removeDevServerBinary deletes the temp server binary a SIGKILLed
+// `gofastr dev` left behind. Mirrors devServerBinaryPath for the
+// no-isolation case (the harnesses set GOFASTR_ISOLATION=off).
+func removeDevServerBinary(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	name := fmt.Sprintf("gofastr-dev-server-%d", cmd.Process.Pid)
+	_ = os.Remove(testExecutablePath(filepath.Join(os.TempDir(), name)))
+}
+
 func buildGofastrBinary(t *testing.T) string {
 	t.Helper()
 	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
@@ -116,6 +127,9 @@ func (h *devHarness) start() {
 		_ = killTestProcessTree(cmd)
 		cancel()
 		_ = cmd.Wait()
+		// SIGKILL means dev's own shutdown cleanup never ran; remove its
+		// pid-suffixed temp binary from out here instead.
+		removeDevServerBinary(cmd)
 	})
 
 	h.waitForServer(60 * time.Second)

--- a/cmd/gofastr/dev_e2e_test.go
+++ b/cmd/gofastr/dev_e2e_test.go
@@ -9,25 +9,31 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
-	"syscall"
 	"testing"
 	"time"
 
 	"github.com/chromedp/chromedp"
 )
 
-// Global port counter so tests don't collide on the same port.
-var e2ePortCounter atomic.Int64
-
-func nextE2EPort() string {
-	return fmt.Sprintf("%d", 18083+e2ePortCounter.Add(1)-1)
+func nextE2EPort(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return strconv.Itoa(port)
 }
 
 func buildGofastrBinary(t *testing.T) string {
@@ -36,7 +42,7 @@ func buildGofastrBinary(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	bin := filepath.Join(t.TempDir(), "gofastr")
+	bin := testExecutablePath(filepath.Join(t.TempDir(), "gofastr"))
 	build := exec.Command("go", "build", "-o", bin, ".")
 	build.Dir = filepath.Join(repoRoot, "cmd", "gofastr")
 	if out, err := build.CombinedOutput(); err != nil {
@@ -82,7 +88,7 @@ func newDevHarness(t *testing.T) *devHarness {
 		t.Fatalf("go mod tidy: %v\n%s", err, out)
 	}
 
-	return &devHarness{t: t, bin: bin, dir: projDir, port: nextE2EPort()}
+	return &devHarness{t: t, bin: bin, dir: projDir, port: nextE2EPort(t)}
 }
 
 func (h *devHarness) start() {
@@ -96,18 +102,17 @@ func (h *devHarness) start() {
 	cmd.Stderr = &h.output
 	// Set process group so we can kill the entire tree (gofastr dev + child server).
 	// Without this, SIGKILL on gofastr dev leaves the child server as an orphan.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	configureTestProcessGroup(cmd)
 	h.cmd = cmd
 
 	if err := cmd.Start(); err != nil {
 		h.t.Fatalf("start gofastr dev: %v", err)
 	}
-	pid := cmd.Process.Pid
 	h.t.Cleanup(func() {
-		cancel()
 		// Kill the entire process group (gofastr dev + child server).
-		syscall.Kill(-pid, syscall.SIGKILL)
-		cmd.Wait()
+		_ = killTestProcessTree(cmd)
+		cancel()
+		_ = cmd.Wait()
 	})
 
 	h.waitForServer(60 * time.Second)

--- a/cmd/gofastr/dev_e2e_test.go
+++ b/cmd/gofastr/dev_e2e_test.go
@@ -97,7 +97,10 @@ func (h *devHarness) start() {
 	h.cancelFunc = cancel
 
 	cmd := exec.CommandContext(ctx, h.bin, "dev", "-p", h.port, "--dir", h.dir)
-	cmd.Env = append(os.Environ(), "PORT=localhost:"+h.port)
+	// GOFASTR_ISOLATION=off: the child app resolves worktree isolation from
+	// its cwd, so running this suite from a linked git worktree would
+	// silently remap the port the test polls.
+	cmd.Env = append(os.Environ(), "PORT=localhost:"+h.port, "GOFASTR_ISOLATION=off")
 	cmd.Stdout = &h.output
 	cmd.Stderr = &h.output
 	// Set process group so we can kill the entire tree (gofastr dev + child server).

--- a/cmd/gofastr/dev_test.go
+++ b/cmd/gofastr/dev_test.go
@@ -62,7 +62,7 @@ func TestInitDropsAIAgentFiles(t *testing.T) {
 	// then invoke it from the tempdir — `go run` from outside any
 	// module fails to resolve cmd/gofastr's imports.
 	binDir := t.TempDir()
-	binPath := filepath.Join(binDir, "gofastr")
+	binPath := testExecutablePath(filepath.Join(binDir, "gofastr"))
 	build := exec.Command("go", "build", "-o", binPath, "./cmd/gofastr")
 	build.Dir = repoRoot
 	if out, err := build.CombinedOutput(); err != nil {

--- a/cmd/gofastr/generate.go
+++ b/cmd/gofastr/generate.go
@@ -665,14 +665,15 @@ func generateBlueprint(bp Blueprint, options generateOptions) {
 		if !options.json {
 			hasNewEntities := false
 			for _, f := range written {
-				if strings.HasPrefix(f.name, "entities/") && f.name != "entities/register.go" && !strings.HasPrefix(f.name, "entities/client/") {
+				name := filepath.ToSlash(f.name)
+				if strings.HasPrefix(name, "entities/") && name != "entities/register.go" && !strings.HasPrefix(name, "entities/client/") {
 					hasNewEntities = true
 					break
 				}
 			}
 			if hasNewEntities {
 				for _, f := range skipped {
-					if f.name == "entities/client/client.go" {
+					if filepath.ToSlash(f.name) == "entities/client/client.go" {
 						warn("entities/client/client.go already exists and was not updated — it does not include the new entities. Regenerate it from a full blueprint with --force, or extend it by hand.")
 						break
 					}
@@ -685,7 +686,7 @@ func generateBlueprint(bp Blueprint, options generateOptions) {
 			// the new files compile and then silently never register/mount.
 			hasNewScreens := false
 			for _, f := range written {
-				if strings.HasPrefix(f.name, "screen_") {
+				if strings.HasPrefix(filepath.ToSlash(f.name), "screen_") {
 					hasNewScreens = true
 					break
 				}

--- a/cmd/gofastr/generate_test.go
+++ b/cmd/gofastr/generate_test.go
@@ -7,11 +7,44 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/DonaldMurillo/gofastr/framework"
 )
+
+func writeReportExtension(t *testing.T, dir, marker string) string {
+	t.Helper()
+	var command []string
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(dir, "report-extension.cmd")
+		body := "@echo off\r\nmore >nul\r\n"
+		if marker != "" {
+			body += "type nul > \"" + marker + "\"\r\n"
+		}
+		body += "echo {\"files\":[{\"path\":\"report.go\",\"content\":\"package reports\\n\"}]}\r\n"
+		writeTestFile(t, path, body)
+		command = []string{"cmd.exe", "/d", "/c", path}
+	} else {
+		path := filepath.Join(dir, "report-extension.sh")
+		body := "#!/bin/sh\ncat >/dev/null\n"
+		if marker != "" {
+			body += "touch \"" + marker + "\"\n"
+		}
+		body += "printf '%s' '{\"files\":[{\"path\":\"report.go\",\"content\":\"package reports\\n\"}]}'\n"
+		writeTestFile(t, path, body)
+		if err := os.Chmod(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		command = []string{path}
+	}
+	encoded, err := json.Marshal(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(encoded)
+}
 
 func TestRenderGeneratedProjectFromDeclarations(t *testing.T) {
 	crud := true
@@ -107,14 +140,7 @@ func TestGenerateTypeScriptCommandShowsMigrationError(t *testing.T) {
 
 func TestGenerateProjectWithExternalCodegenExtension(t *testing.T) {
 	dir := t.TempDir()
-	extPath := filepath.Join(dir, "report-extension.sh")
-	writeTestFile(t, extPath, `#!/bin/sh
-cat >/dev/null
-printf '%s' '{"files":[{"path":"report.go","content":"package reports\n"}]}'
-`)
-	if err := os.Chmod(extPath, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	extCommand := writeReportExtension(t, dir, "")
 	writeTestFile(t, filepath.Join(dir, "reports.codegen.json"), `{"name":"reports"}`)
 	writeTestFile(t, filepath.Join(dir, "gofastr.codegen.yml"), `
 version: 1
@@ -129,7 +155,7 @@ codegen:
       output: reports
   extensions:
     - name: report-generator
-      command: [`+extPath+`]
+      command: `+extCommand+`
 `)
 
 	oldWD, err := os.Getwd()
@@ -219,14 +245,7 @@ func TestGenerateProjectDryRunJSONValidatesOutputBeforeExtensions(t *testing.T) 
 	}
 	dir := t.TempDir()
 	marker := filepath.Join(dir, "extension-ran")
-	extPath := filepath.Join(dir, "report-extension.sh")
-	writeTestFile(t, extPath, `#!/bin/sh
-touch `+marker+`
-printf '%s' '{"files":[{"path":"report.go","content":"package reports\n"}]}'
-`)
-	if err := os.Chmod(extPath, 0o755); err != nil {
-		t.Fatal(err)
-	}
+	extCommand := writeReportExtension(t, dir, marker)
 	writeTestFile(t, filepath.Join(dir, "reports.codegen.json"), `{"name":"reports"}`)
 	writeTestFile(t, filepath.Join(dir, "gofastr.codegen.yml"), `
 version: 1
@@ -240,7 +259,7 @@ codegen:
         path: reports.codegen.json
   extensions:
     - name: report-generator
-      command: [`+extPath+`]
+      command: `+extCommand+`
 `)
 	cmd := exec.Command("go", "run", filepath.Join(repoRoot, "cmd", "gofastr"), "generate", "--config="+filepath.Join(dir, "gofastr.codegen.yml"), "--out=..", "--dry-run", "--json")
 	cmd.Dir = repoRoot

--- a/cmd/gofastr/kiln_freeze_parity_test.go
+++ b/cmd/gofastr/kiln_freeze_parity_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/kiln/freeze"
+	"github.com/DonaldMurillo/gofastr/kiln/world"
+)
+
+// This is the cross-package parity gate: Kiln's emitted YAML must decode and
+// validate through the exact current generator, not a second approximation of
+// the blueprint schema.
+func TestKilnFreezeBlueprintParsesAndValidates(t *testing.T) {
+	timestamps := false
+	crud := true
+	w := world.New()
+	w.App = world.AppConfig{
+		Name: "forge", Module: "example.com/forge", DBDriver: "sqlite",
+		DBURL: "forge.db", StaticDir: "static", APIPrefix: "api", LLMMD: true,
+		Theme:     map[string]string{"primary": "#4338ca"},
+		ThemeDark: map[string]string{"primary": "#a5b4fc"},
+		Auth:      world.AuthConfig{Enabled: true, DevMode: true, BasePath: "/auth"},
+		PWA:       world.PWAConfig{Enabled: true, Name: "Forge", StartURL: "/", Scope: "/", Display: "standalone"},
+	}
+	w.Entities["tasks"] = &world.Entity{
+		Name: "tasks", OwnerField: "user_id", CrossOwnerRead: "tasks:read:any",
+		SearchFields: []string{"title"}, Timestamps: &timestamps, CRUD: &crud, MCP: true,
+		Access:       &world.AccessDeclaration{Read: "tasks:read", Create: "tasks:write"},
+		CursorFields: []string{"created_at", "id"},
+		Indices:      []world.Index{{Name: "idx_tasks_status", Columns: []string{"status"}}},
+		Properties:   map[string]any{"label": "Tasks"},
+		Fields: []world.Field{
+			{Name: "title", Type: "string", Required: true},
+			{Name: "status", Type: "enum", Values: []string{"open", "done"}, Default: "open"},
+		},
+	}
+	w.Pages["/"] = &world.Page{
+		Path: "/", Name: "home", Title: "Forge", Description: "Task overview",
+		Layout: &world.Layout{Name: "app"}, Access: world.PageAccess{Auth: true},
+		Tree: world.Node{Kind: "stack", Props: map[string]any{"gap": "xl"}, Children: []world.Node{
+			{Kind: "page_header", Props: map[string]any{"title": "Forge"}},
+			{Kind: "grid", Props: map[string]any{"min": "14rem", "gap": "lg"}, Children: []world.Node{
+				{Kind: "card", Props: map[string]any{"heading": "Tasks"}},
+				{Kind: "card", Props: map[string]any{"heading": "Owners"}},
+			}},
+		}},
+	}
+	w.Nav = []world.NavItem{{Label: "Home", Href: "/"}}
+	w.Seeds = []*world.Seed{{Entity: "tasks", Rows: []map[string]any{{"title": "Ship", "status": "open"}}}}
+
+	buf, err := freeze.BlueprintYAML(w)
+	if err != nil {
+		t.Fatalf("BlueprintYAML: %v", err)
+	}
+	bp, err := decodeBlueprintString(string(buf))
+	if err != nil {
+		t.Fatalf("current decoder rejected Kiln output: %v\n%s", err, buf)
+	}
+	if err := validateBlueprint(bp); err != nil {
+		t.Fatalf("current validator rejected Kiln output: %v\n%s", err, buf)
+	}
+	files, err := renderBlueprintFiles(bp)
+	if err != nil {
+		t.Fatalf("current renderer rejected Kiln output: %v\n%s", err, buf)
+	}
+	screens := allScreenContent(files)
+	for _, want := range []string{"ui.Stack(", "ui.Grid(", "ui.Card("} {
+		if !strings.Contains(screens, want) {
+			t.Fatalf("frozen layout did not reach current generator %q:\n%s", want, screens)
+		}
+	}
+	if len(bp.Entities) != 1 || bp.Entities[0].OwnerField != "user_id" || len(bp.Entities[0].CursorFields) != 2 {
+		t.Fatalf("entity surface drifted during freeze: %+v", bp.Entities)
+	}
+	if len(bp.Screens) != 1 || bp.Screens[0].Layout != "app" || !bp.Screens[0].Access.Auth {
+		t.Fatalf("screen surface drifted during freeze: %+v", bp.Screens)
+	}
+	if bp.App.APIPrefix != "api" || !bp.App.PWA.Enabled || !bp.App.LLMMD {
+		t.Fatalf("app surface drifted during freeze: %+v", bp.App)
+	}
+}

--- a/cmd/gofastr/mcp_blueprint_e2e_test.go
+++ b/cmd/gofastr/mcp_blueprint_e2e_test.go
@@ -18,7 +18,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -53,16 +52,17 @@ func TestE2E_MCP_BlueprintApp(t *testing.T) {
 	if output, err := tidy.CombinedOutput(); err != nil {
 		t.Fatalf("go mod tidy: %v\n%s", err, output)
 	}
-	build := exec.Command("go", "build", "-o", "app", ".")
+	appBin := testExecutablePath(filepath.Join(dir, "app"))
+	build := exec.Command("go", "build", "-o", appBin, ".")
 	build.Dir = dir
 	if output, err := build.CombinedOutput(); err != nil {
 		t.Fatalf("go build: %v\n%s", err, output)
 	}
 
-	port := nextE2EPort()
+	port := nextE2EPort(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	app := exec.CommandContext(ctx, filepath.Join(dir, "app"))
+	app := exec.CommandContext(ctx, appBin)
 	app.Dir = dir
 	app.Env = append(os.Environ(),
 		"PORT=localhost:"+port,
@@ -74,14 +74,13 @@ func TestE2E_MCP_BlueprintApp(t *testing.T) {
 	var appOut syncBuffer
 	app.Stdout = &appOut
 	app.Stderr = &appOut
-	app.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	configureTestProcessGroup(app)
 	if err := app.Start(); err != nil {
 		t.Fatalf("start generated app: %v", err)
 	}
-	pid := app.Process.Pid
 	t.Cleanup(func() {
 		cancel()
-		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		_ = killTestProcessTree(app)
 		_ = app.Wait()
 	})
 
@@ -171,12 +170,12 @@ func TestE2E_MCP_BlueprintApp(t *testing.T) {
 	// register — access logs carry client IPs and paths, so an untrusted
 	// production /mcp never exposes them by default.
 	cancel()
-	_ = syscall.Kill(-pid, syscall.SIGKILL)
+	_ = killTestProcessTree(app)
 	_ = app.Wait()
-	prodPort := nextE2EPort()
+	prodPort := nextE2EPort(t)
 	prodCtx, prodCancel := context.WithCancel(context.Background())
 	defer prodCancel()
-	prod := exec.CommandContext(prodCtx, filepath.Join(dir, "app"))
+	prod := exec.CommandContext(prodCtx, appBin)
 	prod.Dir = dir
 	prod.Env = append(os.Environ(),
 		"PORT=localhost:"+prodPort,
@@ -185,14 +184,13 @@ func TestE2E_MCP_BlueprintApp(t *testing.T) {
 	var prodOut syncBuffer
 	prod.Stdout = &prodOut
 	prod.Stderr = &prodOut
-	prod.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	configureTestProcessGroup(prod)
 	if err := prod.Start(); err != nil {
 		t.Fatalf("start generated app (prod mode): %v", err)
 	}
-	prodPid := prod.Process.Pid
 	t.Cleanup(func() {
 		prodCancel()
-		_ = syscall.Kill(-prodPid, syscall.SIGKILL)
+		_ = killTestProcessTree(prod)
 		_ = prod.Wait()
 	})
 	prodBase := "http://localhost:" + prodPort

--- a/cmd/gofastr/new_production_test.go
+++ b/cmd/gofastr/new_production_test.go
@@ -95,7 +95,7 @@ func TestNewHandlerOverwrite(t *testing.T) {
 func buildGofastrBin(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	out := filepath.Join(dir, "gofastr")
+	out := testExecutablePath(filepath.Join(dir, "gofastr"))
 	cmd := exec.Command("go", "build", "-o", out, ".")
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/cmd/gofastr/pack.go
+++ b/cmd/gofastr/pack.go
@@ -2109,21 +2109,32 @@ func reverseBlock(e ast.Expr, helpers map[string]ast.Expr) (BlueprintBlock, bool
 	case "ui.LinkButton":
 		c := cfgOf(call, 0)
 		return block("link_button", props2("label", astString(c["Label"]), "href", astString(c["Href"]), "variant", buttonVariant(c["Variant"]))), true
+	case "ui.Stack":
+		return reverseLayoutBlock("stack", call, helpers), true
+	case "ui.Cluster":
+		return reverseLayoutBlock("cluster", call, helpers), true
 	case "ui.Grid":
 		// A grid of pricing cards is a `pricing` block; a grid of stat cards
-		// is a stat_row.
+		// is a stat_row. Every other grid preserves the explicit layout block.
 		if len(call.Args) > 1 {
 			if first, ok := call.Args[1].(*ast.CallExpr); ok && callSel(first) == "ui.PricingCard" {
 				return reversePricing(call), true
 			}
 		}
-		b := BlueprintBlock{Kind: "stat_row"}
+		allStats := len(call.Args) > 1
 		for _, arg := range call.Args[1:] {
-			if cb, ok := reverseBlock(arg, helpers); ok {
-				b.Children = append(b.Children, cb)
+			child, ok := arg.(*ast.CallExpr)
+			if !ok || callSel(child) != "ui.StatCard" {
+				allStats = false
+				break
 			}
 		}
-		return b, true
+		if allStats {
+			b := reverseLayoutBlock("stat_row", call, helpers)
+			b.Props = nil
+			return b, true
+		}
+		return reverseLayoutBlock("grid", call, helpers), true
 	case "ui.StatCard":
 		return reverseStatCard(call), true
 	case "ui.Markdown":
@@ -2141,6 +2152,58 @@ func reverseBlock(e ast.Expr, helpers map[string]ast.Expr) (BlueprintBlock, bool
 		return reverseRenderTag(call)
 	}
 	return BlueprintBlock{}, false
+}
+
+func reverseLayoutBlock(kind string, call *ast.CallExpr, helpers map[string]ast.Expr) BlueprintBlock {
+	b := BlueprintBlock{Kind: kind, Props: map[string]any{}}
+	cfg := cfgOf(call, 0)
+	if kind == "grid" {
+		putStr(b.Props, "min", astString(cfg["Min"]))
+	}
+	if gap := reverseGap(astSelName(cfg["Gap"])); gap != "" && gap != "md" {
+		b.Props["gap"] = gap
+	}
+	if kind == "stack" || kind == "cluster" {
+		if align := reverseAlign(astSelName(cfg["Align"])); align != "" && align != "start" {
+			b.Props["align"] = align
+		}
+		if justify := reverseJustify(astSelName(cfg["Justify"])); justify != "" && justify != "start" {
+			b.Props["justify"] = justify
+		}
+	}
+	if kind == "cluster" && astBool(cfg["NoWrap"]) {
+		b.Props["no_wrap"] = true
+	}
+	for _, arg := range call.Args[1:] {
+		if child, ok := reverseBlock(arg, helpers); ok {
+			b.Children = append(b.Children, child)
+		}
+	}
+	if len(b.Props) == 0 {
+		b.Props = nil
+	}
+	return b
+}
+
+func reverseGap(name string) string {
+	return map[string]string{
+		"GapNone": "none", "GapXS": "xs", "GapSM": "sm", "GapMD": "md",
+		"GapLG": "lg", "GapXL": "xl", "Gap2XL": "2xl",
+	}[name]
+}
+
+func reverseAlign(name string) string {
+	return map[string]string{
+		"AlignStart": "start", "AlignCenter": "center", "AlignEnd": "end",
+		"AlignBaseline": "baseline", "AlignStretch": "stretch",
+	}[name]
+}
+
+func reverseJustify(name string) string {
+	return map[string]string{
+		"JustifyStart": "start", "JustifyCenter": "center", "JustifyEnd": "end",
+		"JustifyBetween": "between", "JustifyAround": "around",
+	}[name]
 }
 
 func reverseEntityResource(call *ast.CallExpr, helpers map[string]ast.Expr) (BlueprintBlock, bool) {

--- a/cmd/gofastr/readme_quickstart_test.go
+++ b/cmd/gofastr/readme_quickstart_test.go
@@ -229,7 +229,7 @@ func TestReadmeQuickstartBlueprintRuns(t *testing.T) {
 		writeTestFile(t, full, file.content)
 	}
 
-	appBin := filepath.Join(dir, "readme-quickstart-app")
+	appBin := testExecutablePath(filepath.Join(dir, "readme-quickstart-app"))
 	buildCmd := exec.Command("go", "build", "-mod=mod", "-o", appBin, ".")
 	buildCmd.Dir = dir
 	if output, err := buildCmd.CombinedOutput(); err != nil {

--- a/cmd/gofastr/testproc_unix_test.go
+++ b/cmd/gofastr/testproc_unix_test.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureTestProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func testExecutablePath(path string) string { return path }
+
+func killTestProcessTree(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+}

--- a/cmd/gofastr/testproc_windows_test.go
+++ b/cmd/gofastr/testproc_windows_test.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func configureTestProcessGroup(_ *exec.Cmd) {}
+
+func testExecutablePath(path string) string { return path + ".exe" }
+
+func killTestProcessTree(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	// CommandContext only terminates the parent. taskkill /T closes the dev
+	// watcher and its compiled child server so E2E ports are not leaked.
+	return exec.Command("taskkill", "/T", "/F", "/PID", fmt.Sprint(cmd.Process.Pid)).Run()
+}

--- a/cmd/kiln/adapters.go
+++ b/cmd/kiln/adapters.go
@@ -94,6 +94,28 @@ type Adapter struct {
 // adapters is the built-in registry. Adding a new agent is a one-entry
 // change here.
 var adapters = map[string]Adapter{
+	"omp": {
+		Name:    "omp",
+		Display: "omp -p --model glm-5.2 --tools bash  (Oh My Pi with GLM-5.2; kiln contract + skill, isolated cwd)",
+		Dir:     filepath.Join(os.TempDir(), "kiln-omp"),
+		Detect:  func() bool { _, err := exec.LookPath("omp"); return err == nil },
+		BuildArgs: func(text string) []string {
+			// OMP is Kiln's primary live-build driver. --no-session keeps
+			// each panel turn bounded to the journal/world context Kiln
+			// injects, instead of letting OMP's own session state become a
+			// second source of truth. Bash is the only tool it needs: every
+			// mutation crosses the audited $KILN_URL HTTP boundary.
+			return []string{
+				"omp", "-p",
+				"--model", "glm-5.2",
+				"--tools", "bash",
+				"--append-system-prompt", kilnSystemPrompt(),
+				"--auto-approve",
+				"--no-session",
+				text,
+			}
+		},
+	},
 	"claude-code": {
 		Name:    "claude-code",
 		Display: "claude --print --allowedTools Bash --append-system-prompt <kiln contract>  (Claude Code, reads ~/.claude/.credentials.json)",
@@ -163,9 +185,9 @@ var adapters = map[string]Adapter{
 }
 
 // adapterAutoOrder is the priority list for `--agent auto` detection.
-// Claude Code first because its credentials path is the most stable;
-// pi second; codex last (less common locally).
-var adapterAutoOrder = []string{"claude-code", "pi", "codex"}
+// OMP/GLM-5.2 is the canonical Kiln driver; the others remain available
+// for users who already have those CLIs authenticated.
+var adapterAutoOrder = []string{"omp", "claude-code", "pi", "codex"}
 
 // resolveAdapter maps a --agent flag value to a concrete Adapter.
 //

--- a/cmd/kiln/adapters_test.go
+++ b/cmd/kiln/adapters_test.go
@@ -60,6 +60,32 @@ func TestResolveAdapterCustomBuildArgs(t *testing.T) {
 	}
 }
 
+func TestOMPAdapterPinsGLM52AndKilnBoundary(t *testing.T) {
+	a := adapters["omp"]
+	argv := a.BuildArgs("build the app")
+	joined := strings.Join(argv, " ")
+	for _, want := range []string{"omp", "--model glm-5.2", "--tools bash", "--append-system-prompt", "--auto-approve", "--no-session"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("OMP argv missing %q: %v", want, argv)
+		}
+	}
+	if argv[len(argv)-1] != "build the app" {
+		t.Errorf("last argv = %q, want user prompt", argv[len(argv)-1])
+	}
+	if !strings.Contains(joined, "$KILN_URL") {
+		t.Errorf("OMP system prompt does not enforce the Kiln HTTP boundary: %v", argv)
+	}
+	if a.Dir == "" {
+		t.Error("OMP adapter should isolate the spawned agent from Kiln's cwd")
+	}
+}
+
+func TestAdapterAutoOrderPrefersOMP(t *testing.T) {
+	if len(adapterAutoOrder) == 0 || adapterAutoOrder[0] != "omp" {
+		t.Fatalf("adapterAutoOrder = %v, want omp first", adapterAutoOrder)
+	}
+}
+
 // pi has no auto-discovery for ~/.claude/skills/ — its adapter must
 // inject --skill <path> when the kiln skill file exists. Without it
 // pi has no idea about the kiln tool API and just hallucinates Go

--- a/cmd/kiln/agent.go
+++ b/cmd/kiln/agent.go
@@ -16,11 +16,11 @@ import (
 //go:embed skill.md
 var kilnSkillContent string
 
-// runAgent is the turnkey "build with pi" subcommand. It starts a long-
+// runAgent is the turnkey "build with OMP/GLM-5.2" subcommand. It starts a long-
 // running `kiln serve` in the cwd, waits for the HTTP server to come
 // online, exports KILN_URL so the agent's skill can reach it, ensures
 // the Kiln skill is installed under ~/.claude/skills/kiln/, then execs
-// pi with whatever args followed. On pi exit we send the serve
+// OMP with whatever args followed. On OMP exit we send the serve
 // subprocess SIGTERM and wait briefly for cleanup.
 func runAgent(args []string) int {
 	cwd, err := os.Getwd()
@@ -32,12 +32,12 @@ func runAgent(args []string) int {
 	skillPath, err := installSkill()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[kiln] install skill: %v\n", err)
-		// non-fatal — pi still runs, just without the framework skill
+		// non-fatal — OMP still runs, just without the framework skill
 	}
 
-	piBin, err := exec.LookPath("pi")
+	ompBin, err := exec.LookPath("omp")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[kiln] pi not found in PATH. Install pi first: https://pi.dev\n")
+		fmt.Fprintf(os.Stderr, "[kiln] omp not found in PATH. Install Oh My Pi first, then run `omp models` to verify glm-5.2 is available.\n")
 		return 1
 	}
 
@@ -89,9 +89,16 @@ func runAgent(args []string) int {
 	if skillPath != "" {
 		fmt.Fprintf(os.Stderr, "[kiln] skill:      %s\n", skillPath)
 	}
-	fmt.Fprintf(os.Stderr, "[kiln] launching pi…\n\n")
+	fmt.Fprintf(os.Stderr, "[kiln] launching OMP with GLM-5.2…\n\n")
 
-	cmd := exec.Command(piBin, args...)
+	ompArgs := []string{
+		"--model", "glm-5.2",
+		"--tools", "bash",
+		"--append-system-prompt", kilnSystemPrompt(),
+		"--auto-approve",
+	}
+	ompArgs = append(ompArgs, args...)
+	cmd := exec.Command(ompBin, ompArgs...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -101,7 +108,7 @@ func runAgent(args []string) int {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return exitErr.ExitCode()
 		}
-		fmt.Fprintf(os.Stderr, "[kiln] pi: %v\n", err)
+		fmt.Fprintf(os.Stderr, "[kiln] omp: %v\n", err)
 		return 1
 	}
 	return 0
@@ -148,7 +155,7 @@ func waitReady(url string, timeout time.Duration) error {
 }
 
 // installSkill writes the Kiln skill into ~/.claude/skills/kiln/SKILL.md
-// so pi (and Claude Code) auto-loads framework knowledge on every run.
+// so every adapter can inject the same framework knowledge on every run.
 // Idempotent: overwrites only if the embedded version differs from disk.
 func installSkill() (string, error) {
 	home, err := os.UserHomeDir()

--- a/cmd/kiln/agent_http.go
+++ b/cmd/kiln/agent_http.go
@@ -14,7 +14,7 @@ import (
 //	POST /kiln/agent          → switch the active adapter at runtime
 //
 // Used by the panel's config modal so the user can pick a harness
-// (claude-code, pi, codex, custom) without restarting kiln serve. The
+// (omp, claude-code, pi, codex, custom) without restarting kiln serve. The
 // adapter watcher reads the store at turn-spawn time, so any switch
 // takes effect on the next chat_user event. An in-flight turn is
 // cancelled when its adapter is replaced.
@@ -27,7 +27,7 @@ func mountAgentRoutes(r *router.Router, store *AdapterStore, notify func(kind, s
 	}))
 	r.Post("/kiln/agent", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		var args struct {
-			Name   string `json:"name"`             // "claude-code" | "pi" | "codex" | "auto" | "none" | "custom"
+			Name   string `json:"name"`             // "omp" | "claude-code" | "pi" | "codex" | "auto" | "none" | "custom"
 			Custom string `json:"custom,omitempty"` // freeform command if name == "custom"
 		}
 		if err := json.NewDecoder(req.Body).Decode(&args); err != nil {

--- a/cmd/kiln/agent_watcher.go
+++ b/cmd/kiln/agent_watcher.go
@@ -154,7 +154,7 @@ func chatTextByEntryID(l *live.Live, id string) string {
 }
 
 // destructiveIntent runs a quick keyword scan on the user message
-// before pi sees it. If the user asked for something destructive
+// before the selected agent sees it. If the user asked for something destructive
 // (delete, drop, wipe, rebuild, reset) we prepend a directive forcing
 // the agent through propose_plan + user approval first. This is a
 // pre-flight classifier — cheap, deterministic, no extra LLM call.

--- a/cmd/kiln/freeze.go
+++ b/cmd/kiln/freeze.go
@@ -14,18 +14,18 @@ import (
 // runFreeze: kiln freeze --journal .kiln.session.jsonl --dir build/
 //
 // Reads the on-disk journal, replays it into a session, and either:
-//   - --dir <path>   (default): writes entities/*.json + world.json to disk
+//   - --dir <path>   (default): writes gofastr.yml + world.json to disk
 //   - --diff         : prints a human-readable summary of what the
 //     agent built (entities, pages, hooks, routes,
 //     seeds). No files written. Use this to review
 //     agent-driven changes before graduating to source.
 //
 // This is the "graduate from build mode" step. Once frozen, the
-// JSON files can be checked into a regular GoFastr project.
+// blueprint can be reviewed, validated, and generated into owned Go.
 func runFreeze(args []string) int {
 	fs := flag.NewFlagSet("kiln freeze", flag.ExitOnError)
 	journalPath := fs.String("journal", ".kiln.session.jsonl", "JSONL journal to read")
-	dir := fs.String("dir", "build", "target directory for entities/*.json + world.json")
+	dir := fs.String("dir", "build", "target directory for gofastr.yml + world.json")
 	diff := fs.Bool("diff", false, "Print a human-readable summary of cumulative world changes; do not write files")
 	_ = fs.Parse(args)
 
@@ -63,7 +63,7 @@ func runFreeze(args []string) int {
 	fmt.Fprintf(os.Stderr, "[kiln freeze] wrote to %s/\n", *dir)
 	fmt.Fprintf(os.Stderr, "  entities: %d  pages: %d  hooks: %d  routes: %d\n",
 		entCount, pageCount, hookCount, routeCount)
-	fmt.Fprintf(os.Stderr, "  next: review %s/entities/, then declare these entities in a gofastr.yml blueprint (or in Go) and run `gofastr generate`\n", *dir)
+	fmt.Fprintf(os.Stderr, "  next: `gofastr validate %s/gofastr.yml`, then `gofastr generate --from=%s/gofastr.yml --out=<app-dir>`\n", *dir, *dir)
 	return 0
 }
 

--- a/cmd/kiln/main.go
+++ b/cmd/kiln/main.go
@@ -64,12 +64,12 @@ func usage() {
 	fmt.Fprint(os.Stderr, `kiln — Kiln runtime
 
 Usage:
-  kiln agent [pi-args…]   Turnkey: start kiln serve, install skill, exec pi
+  kiln agent [omp-args…]  Turnkey: start kiln serve, install skill, exec OMP/GLM-5.2
   kiln serve [flags]      HTTP server with panel + MCP at /mcp
   kiln mcp   [flags]      HTTP + MCP over stdio
   kiln acp   [flags]      HTTP + ACP over stdio
-  kiln freeze [flags]     Read journal, emit entities/*.json + world.json
-                          to a target dir for "graduate to source" commits
+  kiln freeze [flags]     Read journal, emit gofastr.yml + world.json
+                          for one-shot owned-Go generation
                           --diff to print a review summary instead of writing
 
 Flags:
@@ -78,7 +78,7 @@ Flags:
                           pass 0.0.0.0:8765 to expose it deliberately)
   --journal path        Path to JSONL journal (default: .kiln.session.jsonl)
   --agent value         Spawn an agent per chat_user event:
-                          claude-code | pi | codex   built-in adapters (BYO auth)
+                          omp | claude-code | pi | codex  built-in adapters (BYO auth)
                           auto                       first installed of the above
                           none                       explicit no-agent (default)
                           "<freeform cmd>"           custom command, prompt appended
@@ -86,7 +86,8 @@ Flags:
   --keep-db             Don't delete the ephemeral SQLite on exit
 
 Examples:
-  kiln agent "build me a blog"           # turnkey pi launcher
+  kiln agent -p "build me a blog"        # turnkey OMP/GLM-5.2 launcher
+  kiln serve --agent omp                 # panel-driven OMP/GLM-5.2 turns
   kiln serve --agent claude-code         # use Claude Code (~/.claude auth)
   kiln serve --agent auto                # whichever CLI you have installed
   kiln serve --addr :7777
@@ -122,10 +123,10 @@ func parseFlags(args []string) runOptions {
 	noHTTP := fs.Bool("no-http", false, "Skip the HTTP server in stdio modes")
 	keepDB := fs.Bool("keep-db", false, "Don't delete the ephemeral SQLite on exit")
 	agentCmd := fs.String("agent", "", `Agent to spawn on each chat_user event. Accepts:
-  claude-code | pi | codex   — built-in adapter (uses your existing CLI auth)
+  omp | claude-code | pi | codex — built-in adapter (uses your existing CLI auth)
   auto                       — pick the first installed from the list above
   none                       — explicitly run no agent (default if unset)
-  "<freeform cmd>"           — custom: e.g. "pi -p --model glm-5.1"
+  "<freeform cmd>"           — custom: e.g. "omp -p --model glm-5.2"
 KILN_URL is injected into the env so the agent can drive the runtime.`)
 	_ = fs.Parse(args)
 	return runOptions{addr: *addr, journal: *journalPath, noHTTP: *noHTTP, keepDB: *keepDB, agentCmd: *agentCmd}
@@ -252,15 +253,15 @@ func run(args []string, mcpStdio, acpStdio bool) int {
 		switch opts.agentCmd {
 		case "":
 			logger.Printf("agent:     (none — pass --agent auto to pick an installed CLI,")
-			logger.Printf("            or --agent claude-code|pi|codex to be explicit)")
+			logger.Printf("            or --agent omp|claude-code|pi|codex to be explicit)")
 		case "auto":
-			logger.Printf("agent:     auto-detect found nothing on PATH (claude-code, pi, codex)")
+			logger.Printf("agent:     auto-detect found nothing on PATH (omp, claude-code, pi, codex)")
 			logger.Printf("           — install one or pass --agent \"<full cmd>\"")
 		case "none":
 			logger.Printf("agent:     (none — explicit)")
 		default:
 			logger.Printf("agent:     %q is not a known adapter and its binary isn't on PATH", opts.agentCmd)
-			logger.Printf("           — pass --agent claude-code|pi|codex|auto|none")
+			logger.Printf("           — pass --agent omp|claude-code|pi|codex|auto|none")
 		}
 	}
 

--- a/cmd/kiln/skill.md
+++ b/cmd/kiln/skill.md
@@ -3,341 +3,147 @@ name: kiln
 description: Build a GoFastr web app live by calling Kiln over HTTP. Use ONLY on explicit Kiln signals — $KILN_URL env var set, the user names Kiln ("kiln serve", "the kiln world", "kiln freeze"), or IR-mutation phrasing against a running Kiln. Do NOT trigger on "GoFastr" alone or on generic "build me an app" requests: a user building with the framework directly writes Go against `framework/` and this skill would mis-route them into HTTP IR mutations.
 ---
 
-# Kiln
+You are driving a live GoFastr Kiln server. Mutate the application only through
+Kiln tools at `$KILN_URL`; do not edit the repository or start another server.
 
-Kiln is the in-app build-mode runtime for GoFastr. You compose web apps by calling tools that mutate a single in-memory IR ("the world"). The runtime journals every edit, auto-migrates SQLite, re-renders the live preview, and broadcasts SSE so the panel updates in real time.
+## Workflow
 
-**You never write Go, JS, or SQL inside Kiln.** All behavior is expressed declaratively through the tool surface. Custom logic uses a tiny built-in expression language; the engine evaluates it.
+1. Call `world_get` before changing anything.
+2. Make the smallest coherent tool calls that satisfy the user's request.
+3. Read the returned structured result. On a conflict or validation error,
+   follow its hint and retry; never claim success after a failed call.
+4. Read `world_get` again and verify the exact entity/page/config state.
+5. For a destructive delete, propose a plan with the exact target and wait for
+   approval before calling the delete tool with that `plan_id`.
 
-The user is watching the app live at the page URL itself — typically `$KILN_URL/` for the home page, `$KILN_URL/about` for an about page, etc. The floating chat widget rides along on every page; there is **no separate `/kiln/chat` URL to point users at**. When you finish, just confirm what landed and they'll see it on the page they're already on.
-
-## How to call tools
-
-Kiln exposes its full tool surface as **HTTP REST** at `$KILN_URL/kiln/tool/{name}`. Use bash + curl. This is the canonical transport — preferred over MCP because it has no startup race and works in every harness.
-
-Every call follows the same shape:
+The HTTP form is:
 
 ```bash
-curl -s -X POST "$KILN_URL/kiln/tool/<tool_name>" \
+curl -sS -X POST "$KILN_URL/kiln/tool/add_entity" \
   -H 'Content-Type: application/json' \
-  -d '<json args>'
+  -d '{"entity":{"name":"notes","fields":[
+    {"name":"text","type":"string","required":true}
+  ]}}'
 ```
 
-Response is always:
+Prefer native tool calling when available; HTTP and MCP reach the same typed
+dispatcher.
+
+## Current routing contract
+
+Entity CRUD defaults to `/api/<entity>`; HTML screens use bare paths. An entity
+`posts` and a screen `/posts` intentionally coexist. Forms targeting the entity
+must post to `/api/posts`, not `/posts`.
+
+`set_app_config` replaces app config. Its HTTP payload must wrap every field
+under `config`; a flat payload is invalid:
+
+```bash
+curl -sS -X POST "$KILN_URL/kiln/tool/set_app_config" \
+  -H 'Content-Type: application/json' \
+  -d '{"config":{"name":"my-app","module":"example.com/my-app","db_driver":"sqlite","db_url":"app.db","api_prefix":"api"}}'
+```
+
+Include a name and module before freeze. An omitted or empty `api_prefix`
+inside `config` resolves to `api`.
+
+## Entities
+
+Use the current declaration fields: `fields`, `relations`, `endpoints`,
+`soft_delete`, `owner_field`, `cross_owner_read`, `search_fields`, `access`,
+`timestamps`, `crud`, `mcp`, `cursor_field`/`cursor_fields`, `indices`, and
+`properties`.
+
+For per-user data, set `owner_field` to the user foreign-key column. Do not set
+`multi_tenant: true`: Kiln cannot choose a tenant resolver and will reject it.
+That integration belongs in owned Go after freeze.
+
+## Screens
+
+Send a complete, non-empty tree in `add_page`. Use design-system kinds for
+layout and styling:
+
+- `page_header`, `hero`, `section`, `card`
+- `stack`, `cluster`, `grid`, `stat_row`, `stat_grid`, `stat_card`
+- `link_button`, `callout`, `divider`
+
+Use semantic leaf kinds only for their HTML meaning: `heading`, `paragraph`,
+`text`, `link`, `form`, `label`, `input`, `button`, list and table elements.
+Never send `class`, `style`, or `on*` props. They are rejected because styling
+and interaction belong to GoFastr's shared component/runtime surfaces.
+
+Example:
 
 ```json
-{ "ok": true,  "result": { ... } }
-{ "ok": false, "error": "...", "kind": "validation|conflict|not_found|needs_plan", "hint": "..." }
-```
-
-If `$KILN_URL` isn't set, default to `http://localhost:8765`. The first `kiln serve` started in cwd is what you're talking to.
-
-## Operating rules
-
-### YOUR FIRST ACTION, EVERY TURN
-
-```bash
-curl -s "$KILN_URL/kiln/world"
-```
-
-Do this **before** writing any text. The response is the ONLY truth about what exists. Whatever you "remember" about a dashboard, blog, entities, or pages — discard it. Read the response, then act based on what's actually there.
-
-If the world is empty (`"entities":{}` or absent), there is **no app**. Do not describe a dashboard, do not list entities, do not say "this is already implemented". The correct response in that case is: act on the user's intent (build it now) or ask a clarifying question via the `chat` tool.
-
-### Other rules
-
-- For small additive asks ("add a `priority` field"), call the right tool directly. Don't narrate.
-- For any destructive op (`delete_entity`, `delete_field`, `delete_page`, `delete_hook`, `delete_route`), you MUST:
-  1. Call `propose_plan` with `targets` listing every destructive op you intend to perform. Example: `targets: [{op:"delete_entity", name:"posts"}]`.
-  2. Wait for the user to click Approve in the panel (which calls `approve_plan`).
-  3. Call the destructive tool with `plan_id` set to your plan's id. The protocol enforces this — calling without an approved plan returns `{"ok":false,"kind":"needs_plan",...}`. Each (plan, target) is single-use; reuse requires a new plan.
-- For large additive asks (>3 tool calls), `propose_plan` is recommended for visibility but not required.
-- When `ok=false`, read `kind` and `hint` and self-correct. Don't repeat the same call.
-- When unsure of state, GET `$KILN_URL/kiln/world` (or call the `world_get` tool with a path) before acting.
-- **MANDATORY FIRST STEP: GET `$KILN_URL/kiln/world` before doing anything else.** This is the source of truth for what's live. Do NOT make ANY statement about existing entities, pages, hooks, routes, or "what's already implemented" without first calling `world_get` (or `curl $KILN_URL/kiln/world`). Saying "the dashboard is already implemented" or "this is already wired up" without verifying is hallucination — the user is watching the live world, and they will catch you. There is no codebase to inspect; the world IR is the only state.
-- **DO NOT read files in the working directory.** Any Go / JS / SQL / Markdown sitting in `./` (including `examples/`, `entities/`, `screen_*.go`) is unrelated to the live kiln world. It is leftover source from prior sessions or unrelated apps. Reading it and reporting on it as if it were the kiln state is the most common failure mode. The world is **only** what `$KILN_URL/kiln/world` returns. Stick to bash + curl.
-- **When the request is ambiguous or you'd be guessing — STOP and ask.** Call `chat(role:"assistant", text:"<one focused question>")` with the specific clarification you need, then exit. The user will reply and a new turn will run with the answer. Examples:
-  - "list all entities" against an empty world → ask: "The world has no entities yet — should I scaffold a starter set (notes, users) or wait for you to add them first?"
-  - "add a hook" with no entity context → ask: "Which entity should the hook fire on, and at which lifecycle stage (before_create, after_update, …)?"
-  - "build a blog" → ask: "Quick check before I start: posts + authors with a one-to-many relation, or richer (tags, comments)?"
-  Asking is **always** preferred over guessing or claiming work is already done.
-
-## Tool surface
-
-### World inspection
-- `world_get(path?)` — read the world IR. Path examples: `""` (full world), `entities.posts`, `pages./dashboard`, `_chat`, `_plans`.
-  - Or just: `curl -s $KILN_URL/kiln/world` for everything.
-
-### Entities (CRUD, OpenAPI, MCP all auto-generate from these)
-- `add_entity(entity)` — declare a new entity with fields/relations/CRUD/MCP/soft-delete/multi-tenant flags.
-- `update_entity(entity)` — replace an entity in full (prefer `add_field` for additive changes).
-- `delete_entity(name, plan_id)` — drop an entity. Destructive: requires approved plan with target `{op:"delete_entity",name}`.
-- `add_field(entity, field)` — append a field. Auto-runs ALTER TABLE ADD COLUMN.
-- `delete_field(entity, field, plan_id)` — remove a field. Destructive: target `{op:"delete_field",name:"<entity>.<field>"}`.
-
-### UI pages
-- `add_page(page)` — register a page. Pages are element trees (`{kind, props, children, bindings, actions}`). Every node is auto-assigned a stable `_id` and the page gets a `version` (starts at 1).
-- `update_page_element(path, element_id, patch, if_match?)` — **surgical edit; prefer this over delete-and-readd for any change to an existing page.** Address one node by its `_id` (read from `/kiln/world/pages.<path>`) and apply ONE atomic patch. Non-destructive, no plan needed. `patch.op` is one of:
-  - `set_props` — merge `set_props` into the element's props (most common — change href, text, class)
-  - `replace_props` — replace props entirely
-  - `replace_subtree` — replace this element + children with `element` (preserves the `_id`)
-  - `remove` — drop this element from its parent (root not allowed)
-  - `insert_before` / `insert_after` — add `element` as a sibling
-  - `append_child` — add `element` as the last child
-  - Pass `if_match: <page.version>` to detect drift; mismatch returns `kind:"conflict"`, refetch and retry.
-- `delete_page(path)` — remove an entire page. Destructive (URL stops responding). Use only when the user really wants the page gone; for any *edit*, use `update_page_element`.
-
-### Behavior
-- `add_hook(hook)` / `delete_hook(id)` — declarative entity lifecycle hooks.
-- `add_route(route)` / `delete_route(method, path)` — declarative HTTP routes (e.g. `respond_json`).
-- `add_seed(seed)` — insert seed rows.
-
-### Plans, history, app config
-- `propose_plan(plan_id, steps[], reason?, targets?)` — submit a plan for user approval. List destructive ops in `targets` (e.g. `[{op:"delete_entity",name:"posts"}]`) to authorize them.
-- `approve_plan(plan_id)` — usually invoked by the panel when the user clicks Approve.
-- `reject_plan(plan_id, reason?)` — invoked by the panel when the user clicks Reject. Rejected plans cannot later be approved.
-- `undo()` — truncate the journal by one entry, reverting the most recent change.
-- `set_app_config(config)` — name, json case (`camel`/`snake`), debug endpoints.
-- `chat(role, text)` — record a message in the session journal.
-
-## Field types
-
-`string`, `text`, `int`, `float`, `decimal`, `bool`, `enum` (with `values: [...]`), `uuid`, `timestamp`, `date`, `json`, `relation` (with `to: "<entity_name>"`), `image`, `file`.
-
-Each field also takes optional `required`, `unique`, `default`, `auto_generate` (`uuid`/`timestamp`/`increment`), `min`, `max`, `pattern`, `read_only`, `hidden`.
-
-## Hook events
-
-`before_create`, `after_create`, `before_update`, `after_update`, `before_delete`, `after_delete`, `before_list`, `after_list`.
-
-A hook has an `id`, an `entity`, a `when`, an optional `condition` (expression), and an `action`.
-
-## Action kinds
-
-Actions describe what a hook or route does. Params are action-specific.
-
-- `noop` — no params.
-- `validate` — `{ expression: "<expr>", message: "<text>" }`. If the expression is false, the hook errors with the message.
-- `set_field` — `{ field: "<name>", value: "<expr>" }` or `{ field, value_literal: <any> }`. Sets `entity[field]`.
-- `audit` — `{ channel: "<name>", message: "<expr or text>" }`. Emits an audit record.
-- `emit_event` — `{ topic: "<name>", data: "<expr>" }`. Emits a session event.
-- `respond_json` — for routes only. `{ status: 200, body: <any> }` or `{ status, body: "<expr>" }`.
-
-## Expression language
-
-Used in hook conditions and action params (`expression`, `value`, `message`, `body` when string-typed).
-
-- Literals: numbers, strings (`"x"` or `'x'`), `true`, `false`, `null`, lists.
-- Operators: `+ - * / %`, `== != < > <= >=`, `&& || !`.
-- Member access: `entity.title`, `ctx.user.role`, `result.id`.
-- Built-in functions: `len(x)`, `lower(s)`, `upper(s)`, `contains(s, sub)`, `starts_with(s, p)`, `ends_with(s, p)`, `abs(n)`, `min(a, b)`, `max(a, b)`, `now()`.
-- Scope at hook time: `entity` (the row), `ctx` (request — user, tenant), `result` (after_* hooks).
-
-## Worked example: a blog
-
-```bash
-# 1. Add the posts entity (string title, text body, enum status)
-curl -s -X POST "$KILN_URL/kiln/tool/add_entity" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "entity": {
-      "name": "posts",
-      "soft_delete": true,
-      "fields": [
-        { "name": "title",  "type": "string", "required": true, "max": 200 },
-        { "name": "body",   "type": "text" },
-        { "name": "status", "type": "enum",   "values": ["draft", "published"], "default": "draft" }
-      ],
-      "mcp": true
-    }
-  }'
-
-# 2. Auto-derive a slug from the title before insert
-curl -s -X POST "$KILN_URL/kiln/tool/add_field" \
-  -d '{"entity":"posts","field":{"name":"slug","type":"string","unique":true}}' \
-  -H 'Content-Type: application/json'
-
-curl -s -X POST "$KILN_URL/kiln/tool/add_hook" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "hook": {
-      "id": "posts_slug",
-      "entity": "posts",
-      "when": "before_create",
-      "action": { "kind": "set_field", "params": { "field": "slug", "value": "lower(entity.title)" } }
-    }
-  }'
-
-# 3. Add a custom health route
-curl -s -X POST "$KILN_URL/kiln/tool/add_route" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "route": {
-      "method": "GET",
-      "path": "/health",
-      "action": { "kind": "respond_json", "params": { "status": 200, "body": { "ok": true } } }
-    }
-  }'
-
-# 4. Verify
-curl -s "$KILN_URL/posts" | head
-curl -s "$KILN_URL/health"
-```
-
-## Styling — use Kiln theme classes, NEVER inline styles
-
-Kiln serves a strict CSP. Any element with a `style="…"` attribute is
-**dropped by the renderer** and the browser rejects inline styles
-anyway. Don't put `style` in `props`. Use `class` with the utility
-classes below — they reference theme tokens (`var(--kiln-…)`) so a
-single theme change re-skins the whole app.
-
-**Layout containers** — `kiln-container` (1200px), `kiln-container-md`
-(960px), `kiln-container-sm` (720px), `kiln-section` (vertical padding),
-`kiln-section-soft` (muted bg), `kiln-section-inverse` (dark bg + light fg).
-
-**Stacks & rows** — `kiln-stack` / `kiln-stack-sm` / `kiln-stack-lg`
-(vertical), `kiln-row` / `kiln-row-end` / `kiln-row-between` /
-`kiln-row-wrap` (horizontal).
-
-**Grids** — `kiln-grid-2`, `kiln-grid-3`, `kiln-grid-4`, `kiln-grid-auto`
-(responsive auto-fit columns).
-
-**Hero / typography** — `kiln-hero` (centered hero block; wrap with this
-on the section, then a single h1 + p inside), `kiln-display`,
-`kiln-title`, `kiln-h2`, `kiln-eyebrow` (uppercase label), `kiln-muted`,
-`kiln-subtle`, `kiln-center`.
-
-**Surfaces** — `kiln-card` (elevated), `kiln-card-soft` (muted bg).
-
-**Buttons / CTAs** — `kiln-button` (primary CTA), `kiln-button-secondary`
-(outlined), `kiln-button-ghost` (tertiary). Use on `<a>` or `<button>`.
-
-**Nav / footer** — `kiln-nav`, `kiln-nav-links`, `kiln-footer`.
-
-**Pills / badges** — `kiln-pill`, `kiln-badge-success`, `kiln-badge-warning`,
-`kiln-badge-danger`.
-
-**Quote** — `kiln-quote` (centered pullquote).
-
-Forms and tables already get default styling on `body.kiln-app` — you
-don't need to add classes to `<input>`, `<table>`, etc. Just use the
-right element kinds.
-
-Theme tokens (read-only in this version): `--kiln-bg`, `--kiln-surface`,
-`--kiln-surface-soft`, `--kiln-border`, `--kiln-fg`, `--kiln-fg-soft`,
-`--kiln-fg-muted`, `--kiln-fg-subtle`, `--kiln-primary`, `--kiln-primary-fg`,
-`--kiln-accent`, `--kiln-success`, `--kiln-warning`, `--kiln-danger`,
-plus `--kiln-r-{sm,md,lg}` (radii) and `--kiln-pad-{xs,sm,md,lg,xl}`
-(spacing). The theme is consistent across every page.
-
-## Element kinds (for pages)
-
-`text`, `raw`, `div`, `section`, `header`, `footer`, `main`, `nav`, `aside`, `article`, `heading` (with `level: 1-6`), `paragraph`, `span`, `strong`, `em`, `code`, `pre`, `button`, `link`, `image`, `input`, `label`, `form`, `list` (use `ordered: true` for `<ol>`), `table`, `thead`, `tbody`, `tr`, `th`, `td`.
-
-### Complete page-tree example (copy-paste shape)
-
-When the user asks for a multi-section page, send ONE `add_page` call with the full nested tree. Don't send `add_page` with a placeholder tree and then describe what you "would" build — the page only renders what's in the IR. Below is a working three-section landing page with a nav bar — adapt the strings, keep the structure:
-
-```bash
-curl -s -X POST "$KILN_URL/kiln/tool/add_page" \
-  -H 'Content-Type: application/json' \
-  -d '{
+{
   "page": {
     "path": "/",
+    "name": "home",
     "title": "Home",
+    "layout": {"name": "marketing"},
     "tree": {
-      "kind": "div",
-      "props": { "class": "landing" },
+      "kind": "stack",
+      "props": {"gap": "xl"},
       "children": [
-        {
-          "kind": "nav",
-          "props": { "class": "navbar", "aria-label": "Main" },
-          "children": [
-            { "kind": "heading", "props": { "level": 2, "text": "MyApp" } },
-            { "kind": "div", "props": { "class": "nav-links" }, "children": [
-              { "kind": "link", "props": { "href": "#about",   "text": "About" } },
-              { "kind": "link", "props": { "href": "#contact", "text": "Contact" } }
-            ]}
-          ]
-        },
-        {
-          "kind": "section",
-          "props": { "id": "hero" },
-          "children": [
-            { "kind": "heading",   "props": { "level": 1, "text": "Build apps by talking to agents" } },
-            { "kind": "paragraph", "children": [ { "kind": "text", "props": { "value": "Kiln journals every change live." } } ] },
-            { "kind": "button",    "props": { "label": "Get Started" } }
-          ]
-        },
-        {
-          "kind": "section",
-          "props": { "id": "about" },
-          "children": [
-            { "kind": "heading",   "props": { "level": 2, "text": "About" } },
-            { "kind": "paragraph", "children": [ { "kind": "text", "props": { "value": "Three quick wins." } } ] }
-          ]
-        },
-        {
-          "kind": "section",
-          "props": { "id": "contact" },
-          "children": [
-            { "kind": "heading",   "props": { "level": 2, "text": "Contact" } },
-            { "kind": "form",      "props": { "method": "POST", "action": "/messages" }, "children": [
-              { "kind": "label",   "props": { "for": "name", "text": "Name" } },
-              { "kind": "input",   "props": { "id": "name", "name": "name", "type": "text", "required": true } },
-              { "kind": "label",   "props": { "for": "msg",  "text": "Message" } },
-              { "kind": "input",   "props": { "id": "msg",  "name": "message", "type": "text", "required": true } },
-              { "kind": "button",  "props": { "type": "submit", "label": "Send" } }
-            ]}
-          ]
+        {"kind": "hero", "props": {
+          "eyebrow": "GoFastr",
+          "title": "Build the app you can own",
+          "subtitle": "Live first, plain Go when you freeze."
+        }},
+        {"kind": "section", "props": {
+          "heading": "What ships", "description": "One current blueprint"
+        }, "children": [
+          {"kind": "grid", "props": {"min": "16rem", "gap": "lg"},
+           "children": [
+            {"kind": "card", "props": {"heading": "REST + OpenAPI"}},
+            {"kind": "card", "props": {"heading": "SSR + hydration"}}
+          ]}
         }
       ]
     }
   }
-}'
+}
 ```
 
-**Critical rules learned the hard way:**
-- The `tree` value MUST have a non-empty `kind`. `{"kind": ""}` is rejected by the server.
-- Don't send `add_page` and then describe what you "would" build — the page only renders what's literally in the IR.
-- After every `add_page`, verify with `curl $KILN_URL/kiln/world` that your tree landed intact, then summarize for the user honestly. If the world doesn't match what you intended, fix it before saying "Done".
-- **Page paths must not collide with entity CRUD paths.** Each entity claims `GET /<entity_name>` automatically. If you add an entity called `posts`, do NOT add a page at `/posts` — pick `/posts/index`, `/blog`, or `/posts-page` instead. The server returns a `conflict` error if you try; read the hint and rename. Same the other way: if a page exists at `/foo`, don't add an entity called `foo`.
+Kiln assigns `_id` values and a page `version`. Use `update_page_element` for
+later surgical edits; pass the current version as `if_match` when possible.
 
-### How to put text content
+## Scaffold surfaces
 
-**Always include the actual text** — empty `{"kind":"text"}` nodes render nothing. Two equivalent shapes (use whichever feels cleaner):
-
-A) Inline `text` / `label` prop on the element itself (preferred for short labels):
+Use `set_scaffold` to replace navigation and owned-Go stubs:
 
 ```json
-{"kind":"heading","props":{"level":1,"text":"Welcome to Kiln"}}
-{"kind":"link","props":{"href":"#contact","text":"Contact"}}
-{"kind":"button","props":{"label":"Get Started","data-kiln-tool":"add_seed"}}
+{
+  "nav": [{"label":"Dashboard","href":"/dashboard"}],
+  "endpoints": [{"name":"health","method":"GET","path":"/healthz"}],
+  "middleware": [{"name":"request_logger"}],
+  "plugins": [{"name":"metrics"}],
+  "helpers": [{"name":"slug"}]
+}
 ```
 
-B) `text` child node with `props.value` set (for richer paragraph content):
+Navigation renders live. Endpoint/middleware/plugin/helper declarations become
+editable Go stubs in the generated scaffold.
 
-```json
-{"kind":"paragraph","children":[
-  {"kind":"text","props":{"value":"Build a working app by talking to the agent."}}
-]}
+## Theme
+
+`set_theme` accepts semantic light color tokens such as `primary`,
+`primary-fg`, `background`, `surface`, `surface-soft`, `text`, `text-muted`,
+`border`, `accent`, `success`, `warning`, `danger`, and `info`. Prefer the
+default adaptive theme unless the user requested a brand palette. Dark tokens
+are part of `set_app_config.config.theme_dark`.
+
+## Freeze boundary
+
+When the user wants source, tell them to run:
+
+```bash
+kiln freeze --diff
+kiln freeze --dir build
+gofastr validate build/gofastr.yml
+gofastr generate --from=build/gofastr.yml --out=app
 ```
 
-**WRONG** — `text` node without `value`, or any element with empty children:
-
-```json
-// produces <h1></h1>
-{"kind":"heading","props":{"level":1},"children":[{"kind":"text"}]}
-
-// produces <a href="#about"></a>
-{"kind":"link","props":{"href":"#about"},"children":[{"kind":"text"}]}
-```
-
-When in doubt, use the inline `props.text` form. It's harder to leave empty by accident.
-
-Every page rendered by Kiln automatically embeds the floating chat widget in the corner, so the user can talk to you from any page they're looking at. The widget posts the current page path back as `ctx.page` on each `chat` call — use that for in-page-context replies.
-
-## When to freeze
-
-If the user says "ship it" or wants real source files, suggest they run `kiln freeze` (out-of-band CLI) to emit `entities/*.json`. Kiln's HTTP API also exposes a snapshot at `GET $KILN_URL/kiln/world`.
+Freeze emits `gofastr.yml` and the lossless `world.json`; it does not emit the
+removed `entities/*.json` format. Declarative behaviors that need a Go function
+graduate as named owned-Go stubs, with the exact IR retained in `world.json`.

--- a/cmd/kiln/skill.md
+++ b/cmd/kiln/skill.md
@@ -98,7 +98,7 @@ Example:
             {"kind": "card", "props": {"heading": "REST + OpenAPI"}},
             {"kind": "card", "props": {"heading": "SSR + hydration"}}
           ]}
-        }
+        ]}
       ]
     }
   }
@@ -124,6 +124,39 @@ Use `set_scaffold` to replace navigation and owned-Go stubs:
 
 Navigation renders live. Endpoint/middleware/plugin/helper declarations become
 editable Go stubs in the generated scaffold.
+
+## Behavior: hooks, routes, seeds
+
+Declarative behavior uses these tools (same dispatcher as everything else):
+
+- `add_hook(hook)` / `delete_hook(id)` — entity lifecycle hooks. `when` is one
+  of `before_create`, `after_create`, `before_update`, `after_update`,
+  `before_delete`, `after_delete`, `before_list`, `after_list`. A hook has an
+  `id`, an `entity`, a `when`, an optional `condition` (expression), and an
+  `action`.
+- `add_route(route)` / `delete_route(method, path)` — declarative HTTP routes.
+- `add_seed(seed)` — insert seed rows: `{"entity":"posts","rows":[{...}]}`.
+- `undo` — revert the most recent journal entry.
+
+Action kinds (params are action-specific): `noop`; `validate`
+`{ expression, message }` — errors with the message when false; `set_field`
+`{ field, value }` (expression) or `{ field, value_literal }`; `audit`
+`{ channel, message }`; `emit_event` `{ topic, data }`; `respond_json`
+(routes only) `{ status, body }`.
+
+The expression language covers `condition`, `value`, `message`, and
+string-typed `body`: literals (numbers, strings, `true`/`false`/`null`,
+lists), operators `+ - * / %`, `== != < > <= >=`, `&& || !`, member access
+(`entity.title`, `ctx.user.role`, `result.id`), and built-ins `len`, `lower`,
+`upper`, `contains`, `starts_with`, `ends_with`, `abs`, `min`, `max`, `now()`.
+Hook scope: `entity` (the row), `ctx` (request), `result` (`after_*` only).
+
+```bash
+curl -sS -X POST "$KILN_URL/kiln/tool/add_hook" \
+  -H 'Content-Type: application/json' \
+  -d '{"hook":{"id":"posts-slug","entity":"posts","when":"before_create",
+    "action":{"kind":"set_field","params":{"field":"slug","value":"lower(entity.title)"}}}}'
+```
 
 ## Theme
 

--- a/cmd/kiln/skill_md_test.go
+++ b/cmd/kiln/skill_md_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The skill is injected into every agent turn; a malformed example teaches
+// agents to send invalid payloads. Gate every fenced json block.
+func TestSkillJSONExamplesParse(t *testing.T) {
+	blocks := strings.Split(kilnSkillContent, "```json")
+	if len(blocks) < 2 {
+		t.Fatal("skill.md lost its json examples")
+	}
+	for i, rest := range blocks[1:] {
+		body, _, ok := strings.Cut(rest, "```")
+		if !ok {
+			t.Fatalf("json block %d is unterminated", i+1)
+		}
+		var v any
+		if err := json.Unmarshal([]byte(body), &v); err != nil {
+			t.Errorf("json block %d does not parse: %v\n%s", i+1, err, body)
+		}
+	}
+}

--- a/codegen/config_test.go
+++ b/codegen/config_test.go
@@ -5,9 +5,49 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+func extensionTestSuffix() string {
+	if runtime.GOOS == "windows" {
+		return ".cmd"
+	}
+	return ".sh"
+}
+
+func extensionTestCommand(path string) []string {
+	if runtime.GOOS == "windows" {
+		return []string{"cmd.exe", "/d", "/c", path}
+	}
+	return []string{path}
+}
+
+func writeExtensionTestScript(t *testing.T, path, response, requestPath string) {
+	t.Helper()
+	var body string
+	if runtime.GOOS == "windows" {
+		body = "@echo off\r\n"
+		if requestPath == "" {
+			body += "more >nul\r\n"
+		} else {
+			body += "more > \"" + requestPath + "\"\r\n"
+		}
+		body += "echo " + response + "\r\n"
+	} else {
+		body = "#!/bin/sh\n"
+		if requestPath == "" {
+			body += "cat >/dev/null\n"
+		} else {
+			body += "cat >\"" + requestPath + "\"\n"
+		}
+		body += "printf '%s' '" + response + "'\n"
+	}
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestDecodeConfig(t *testing.T) {
 	dir := t.TempDir()
@@ -563,13 +603,9 @@ func TestRegistryRejectsExtensionDeleteOfOtherOwner(t *testing.T) {
 
 func TestRegistryRunsExternalExtension(t *testing.T) {
 	dir := t.TempDir()
-	extPath := filepath.Join(dir, "ext.sh")
-	if err := os.WriteFile(extPath, []byte(`#!/bin/sh
-cat >/tmp/gofastr-codegen-request.json
-printf '%s' '{"files":[{"path":"report.go","content":"package reports\\n"}]}'
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	requestPath := filepath.Join(dir, "gofastr-codegen-request.json")
+	extPath := filepath.Join(dir, "ext"+extensionTestSuffix())
+	writeExtensionTestScript(t, extPath, `{"files":[{"path":"report.go","content":"package reports\\n"}]}`, requestPath)
 	if err := os.WriteFile(filepath.Join(dir, "reports.codegen.json"), []byte(`{"name":"reports"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -581,7 +617,7 @@ printf '%s' '{"files":[{"path":"report.go","content":"package reports\\n"}]}'
 			Source:    SourceConfig{Type: "json_file", Path: "reports.codegen.json"},
 			Output:    "reports",
 		}},
-		Extensions: []ExtensionConfig{{Name: "report-generator", Command: []string{extPath}}},
+		Extensions: []ExtensionConfig{{Name: "report-generator", Command: extensionTestCommand(extPath)}},
 	}}
 	reg := NewRegistry()
 	if err := reg.RegisterCommandExtensions(cfg.Codegen, nil); err != nil {
@@ -595,7 +631,7 @@ printf '%s' '{"files":[{"path":"report.go","content":"package reports\\n"}]}'
 	if len(files) != 1 || files[0].Path != "reports/report.go" {
 		t.Fatalf("files = %#v", files)
 	}
-	data, err := os.ReadFile("/tmp/gofastr-codegen-request.json")
+	data, err := os.ReadFile(requestPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -621,13 +657,8 @@ printf '%s' '{"files":[{"path":"report.go","content":"package reports\\n"}]}'
 
 func TestRegistryRejectsUnknownExtensionResponseFields(t *testing.T) {
 	dir := t.TempDir()
-	extPath := filepath.Join(dir, "ext.sh")
-	if err := os.WriteFile(extPath, []byte(`#!/bin/sh
-cat >/dev/null
-printf '%s' '{"surprise":true}'
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	extPath := filepath.Join(dir, "ext"+extensionTestSuffix())
+	writeExtensionTestScript(t, extPath, `{"surprise":true}`, "")
 	if err := os.WriteFile(filepath.Join(dir, "input.json"), []byte(`{"ok":true}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -638,7 +669,7 @@ printf '%s' '{"surprise":true}'
 			Extension: "bad-extension",
 			Source:    SourceConfig{Type: "json_file", Path: "input.json"},
 		}},
-		Extensions: []ExtensionConfig{{Name: "bad-extension", Command: []string{extPath}}},
+		Extensions: []ExtensionConfig{{Name: "bad-extension", Command: extensionTestCommand(extPath)}},
 	}}
 	reg := NewRegistry()
 	if err := reg.RegisterCommandExtensions(cfg.Codegen, nil); err != nil {
@@ -656,13 +687,9 @@ func TestRegistryRunsRelativeExtensionCommandFromProjectDir(t *testing.T) {
 	if err := os.Mkdir(tools, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	extPath := filepath.Join(tools, "ext.sh")
-	if err := os.WriteFile(extPath, []byte(`#!/bin/sh
-cat >/dev/null
-printf '%s' '{"files":[{"path":"relative.go","content":"package relative\\n"}]}'
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	extRel := filepath.Join("tools", "ext"+extensionTestSuffix())
+	extPath := filepath.Join(tools, "ext"+extensionTestSuffix())
+	writeExtensionTestScript(t, extPath, `{"files":[{"path":"relative.go","content":"package relative\\n"}]}`, "")
 	if err := os.WriteFile(filepath.Join(dir, "input.json"), []byte(`{"ok":true}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -673,7 +700,7 @@ printf '%s' '{"files":[{"path":"relative.go","content":"package relative\\n"}]}'
 			Extension: "relative-extension",
 			Source:    SourceConfig{Type: "json_file", Path: "input.json"},
 		}},
-		Extensions: []ExtensionConfig{{Name: "relative-extension", Command: []string{"./tools/ext.sh"}}},
+		Extensions: []ExtensionConfig{{Name: "relative-extension", Command: extensionTestCommand(extRel)}},
 	}}
 	reg := NewRegistry()
 	if err := reg.RegisterCommandExtensions(cfg.Codegen, nil); err != nil {
@@ -695,13 +722,9 @@ func TestRegistryRunsRelativeExtensionCommandWithRelativeProjectDir(t *testing.T
 	if err := os.MkdirAll(tools, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	extPath := filepath.Join(tools, "ext.sh")
-	if err := os.WriteFile(extPath, []byte(`#!/bin/sh
-cat >/dev/null
-printf '%s' '{"files":[{"path":"relative.go","content":"package relative\\n"}]}'
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	extRel := filepath.Join("tools", "ext"+extensionTestSuffix())
+	extPath := filepath.Join(tools, "ext"+extensionTestSuffix())
+	writeExtensionTestScript(t, extPath, `{"files":[{"path":"relative.go","content":"package relative\\n"}]}`, "")
 	if err := os.WriteFile(filepath.Join(project, "input.json"), []byte(`{"ok":true}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -720,7 +743,7 @@ printf '%s' '{"files":[{"path":"relative.go","content":"package relative\\n"}]}'
 			Extension: "relative-extension",
 			Source:    SourceConfig{Type: "json_file", Path: "input.json"},
 		}},
-		Extensions: []ExtensionConfig{{Name: "relative-extension", Command: []string{"./tools/ext.sh"}}},
+		Extensions: []ExtensionConfig{{Name: "relative-extension", Command: extensionTestCommand(extRel)}},
 	}}
 	reg := NewRegistry()
 	if err := reg.RegisterCommandExtensions(cfg.Codegen, nil); err != nil {

--- a/codegen/conflict_test.go
+++ b/codegen/conflict_test.go
@@ -85,7 +85,14 @@ func TestWriteFiles_RootRejectedWhenCleaning(t *testing.T) {
 }
 
 func TestEnsureNoSymlinkPathAcceptsAbsoluteTempPath(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "nested", "output")
+	// Resolve the temp root first: on macOS t.TempDir() lives under
+	// /var/folders and /var is itself a symlink, which the check
+	// correctly refuses to traverse.
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "nested", "output")
 	if err := EnsureNoSymlinkPath(path); err != nil {
 		t.Fatalf("absolute path %q: %v", path, err)
 	}

--- a/codegen/conflict_test.go
+++ b/codegen/conflict_test.go
@@ -83,3 +83,10 @@ func TestWriteFiles_RootRejectedWhenCleaning(t *testing.T) {
 		t.Fatal("expected root + clean to be rejected")
 	}
 }
+
+func TestEnsureNoSymlinkPathAcceptsAbsoluteTempPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "output")
+	if err := EnsureNoSymlinkPath(path); err != nil {
+		t.Fatalf("absolute path %q: %v", path, err)
+	}
+}

--- a/codegen/fileset.go
+++ b/codegen/fileset.go
@@ -273,9 +273,17 @@ func cleanManifestFiles(root string) error {
 func EnsureNoSymlinkPath(path string) error {
 	clean := filepath.Clean(path)
 	current := ""
-	if filepath.IsAbs(clean) {
+	volume := filepath.VolumeName(clean)
+	if volume != "" {
+		current = volume
+		clean = strings.TrimPrefix(clean, volume)
+		if strings.HasPrefix(clean, string(filepath.Separator)) {
+			current += string(filepath.Separator)
+			clean = strings.TrimLeft(clean, `\/`)
+		}
+	} else if filepath.IsAbs(clean) {
 		current = string(filepath.Separator)
-		clean = strings.TrimPrefix(clean, current)
+		clean = strings.TrimLeft(clean, `\/`)
 	}
 	parts := strings.Split(filepath.ToSlash(clean), "/")
 	for _, part := range parts {

--- a/core-ui/noderender/node.go
+++ b/core-ui/noderender/node.go
@@ -24,6 +24,15 @@ func RenderNode(n node.Node) render.HTML {
 	return renderKind(n.Kind, n.Props, children)
 }
 
+// RenderKind renders a single node's own element from pre-rendered children,
+// without walking the subtree. Callers with a wider vocabulary (kiln/render's
+// typed design-system kinds) dispatch each child themselves and use this for
+// the one-to-one semantic HTML shell, so a typed kind nested inside a leaf
+// container still renders through its component.
+func RenderKind(kind string, props map[string]any, children []render.HTML) render.HTML {
+	return renderKind(kind, props, children)
+}
+
 // renderKind dispatches each known IR kind to the matching
 // core-ui/html builder. All ID/Class plumbing and the agent's
 // arbitrary attrs (data-kiln-tool, etc.) flow through Attrs.

--- a/core-ui/runtime/src/widgets.js
+++ b/core-ui/runtime/src/widgets.js
@@ -318,7 +318,10 @@
               if (String(payload[k]) !== String(b.match[k])) return;
             }
           }
-          setTimeout(() => location.reload(), 200);
+          setTimeout(() => {
+            const path = location.pathname + location.search + location.hash;
+            if (NS.navigate) NS.navigate(path, { force: true });
+          }, 200);
         });
         continue;
       }

--- a/core-ui/runtime/widget_refresh_test.go
+++ b/core-ui/runtime/widget_refresh_test.go
@@ -1,0 +1,21 @@
+package runtime
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestWidgetSSERefreshUsesSPANavigation(t *testing.T) {
+	src, err := os.ReadFile("src/widgets.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(src)
+	if strings.Contains(text, "location.reload()") {
+		t.Fatal("widget SSE refresh must not hard-reload the page")
+	}
+	if !strings.Contains(text, "NS.navigate(path, { force: true })") {
+		t.Fatal("widget SSE refresh must bypass the SPA screen cache")
+	}
+}

--- a/core-ui/widget/widget.go
+++ b/core-ui/widget/widget.go
@@ -372,12 +372,12 @@ func (b *Builder) SSERefetch(path, event, signal string) *Builder {
 	return b
 }
 
-// SSEReload triggers a full page reload on the SSE event. Use for events
-// that change what's rendered at the current URL (e.g. kiln's add_page /
-// delete_page / add_route — the page itself is now different). Pass
-// matchPairs as alternating key/value strings to filter on payload
-// fields (e.g. SSEReload(path, "world_edit", "op", "add_page")).
-func (b *Builder) SSEReload(path, event string, matchPairs ...string) *Builder {
+// SSERefresh triggers a cache-bypassing client navigation to the current URL
+// on the SSE event. The runtime swaps the rendered screen through the normal
+// SPA pipeline; it never performs a hard browser reload. Use for events that
+// change what is rendered at the current URL. Pass matchPairs as alternating
+// key/value strings to filter on payload fields.
+func (b *Builder) SSERefresh(path, event string, matchPairs ...string) *Builder {
 	binding := SSEBinding{Path: path, Event: event, Reload: true}
 	if len(matchPairs) >= 2 {
 		binding.Match = map[string]string{}
@@ -387,6 +387,13 @@ func (b *Builder) SSEReload(path, event string, matchPairs ...string) *Builder {
 	}
 	b.def.SSE = append(b.def.SSE, binding)
 	return b
+}
+
+// SSEReload is retained for source compatibility. It now performs the same
+// soft, cache-bypassing SPA refresh as SSERefresh; callers should migrate to
+// SSERefresh so the behavior is named accurately.
+func (b *Builder) SSEReload(path, event string, matchPairs ...string) *Builder {
+	return b.SSERefresh(path, event, matchPairs...)
 }
 
 // RPC registers a server-side handler the widget can invoke from

--- a/core-ui/widget/widget_test.go
+++ b/core-ui/widget/widget_test.go
@@ -83,6 +83,18 @@ func TestSSEBinding(t *testing.T) {
 	}
 }
 
+func TestSSERefreshRegistersFilteredSoftRefresh(t *testing.T) {
+	def := widget.New("demo").
+		SSERefresh("/.events", "world_edit", "op", "add_page").
+		Build()
+	if len(def.SSE) != 1 || !def.SSE[0].Reload {
+		t.Fatalf("SSERefresh binding missing: %+v", def.SSE)
+	}
+	if got := def.SSE[0].Match["op"]; got != "add_page" {
+		t.Fatalf("match op=%q, want add_page", got)
+	}
+}
+
 func TestRPCDefaultMethodIsPOST(t *testing.T) {
 	def := widget.New("demo").
 		RPC("", "/x", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).

--- a/examples/meridian/e2e_test.go
+++ b/examples/meridian/e2e_test.go
@@ -8,8 +8,6 @@ import (
 	"net/http/cookiejar"
 	"net/url"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -34,24 +32,7 @@ func TestE2E(t *testing.T) {
 		adminPass = "e2e-seed-admin-pw"
 		t.Setenv("ADMIN_SEED_PASSWORD", adminPass)
 	}
-	dir := t.TempDir()
-	bin := filepath.Join(dir, "app")
-	build := exec.Command("go", "build", "-o", bin, ".")
-	build.Stderr = os.Stderr
-	if err := build.Run(); err != nil {
-		t.Fatalf("build: %v", err)
-	}
-	addr := e2eFreeAddr(t)
-	srv := exec.Command(bin)
-	srv.Dir = dir
-	srv.Env = append(os.Environ(), "PORT="+addr, "DATABASE_URL=file:"+filepath.Join(dir, "e2e.db"))
-	srv.Stdout, srv.Stderr = io.Discard, io.Discard
-	if err := srv.Start(); err != nil {
-		t.Fatalf("start: %v", err)
-	}
-	t.Cleanup(func() { _ = srv.Process.Kill(); _, _ = srv.Process.Wait() })
-	base := "http://" + addr
-	e2eWaitReady(t, base)
+	base := e2eBootApp(t)
 
 	if code, body := e2eDo(t, http.DefaultClient, "GET", base+"/", ""); code != http.StatusOK || !strings.Contains(body, "Meridian") {
 		t.Errorf("home page = %d, missing brand? %v", code, !strings.Contains(body, "Meridian"))

--- a/examples/meridian/e2e_visual_test.go
+++ b/examples/meridian/e2e_visual_test.go
@@ -21,6 +21,12 @@ type visualViewportMetrics struct {
 	DocumentWidth float64 `json:"documentWidth"`
 }
 
+type visualInkBandMetrics struct {
+	Background string `json:"background"`
+	Heading    string `json:"heading"`
+	Paragraph  string `json:"paragraph"`
+}
+
 // TestE2EVisualSurfaces is the rendered flagship canary required for
 // framework/design-system changes. It covers one representative marketing,
 // auth, app, and admin surface at desktop and phone widths in both schemes.
@@ -73,6 +79,7 @@ func captureMeridianSurface(t *testing.T, browser context.Context, base, surface
 		for _, scheme := range axetest.Schemes {
 			t.Run(surface+"/"+viewport.name+"/"+scheme, func(t *testing.T) {
 				var metrics visualViewportMetrics
+				var inkBand visualInkBandMetrics
 				var shot []byte
 				var lastErr error
 				for attempt := 1; attempt <= 6; attempt++ {
@@ -83,9 +90,9 @@ func captureMeridianSurface(t *testing.T, browser context.Context, base, surface
 					// there burns every attempt and times the package out.
 					ctx, timeoutCancel := context.WithTimeout(tab, 30*time.Second)
 					shot = nil
-					lastErr = chromedp.Run(ctx,
+					actions := []chromedp.Action{
 						chromedp.EmulateViewport(viewport.width, viewport.height),
-						chromedp.Navigate(base+path),
+						chromedp.Navigate(base + path),
 						chromedp.WaitReady("body", chromedp.ByQuery),
 						// New-headless Chrome produces compositor frames only
 						// for the active target. A fresh tab opened while
@@ -97,8 +104,27 @@ func captureMeridianSurface(t *testing.T, browser context.Context, base, surface
 						chromedp.ActionFunc(func(ctx context.Context) error {
 							return page.BringToFront().Do(ctx)
 						}),
-						chromedp.Sleep(300*time.Millisecond),
 						axetest.Prepare(scheme),
+						// Prepare changes the scheme attribute. Let Chromium commit the
+						// resulting paint before CaptureScreenshot; otherwise a fromSurface
+						// capture can contain a transient black compositor tile even though
+						// the DOM and computed colors are already correct.
+						chromedp.Sleep(300 * time.Millisecond),
+					}
+					if surface == "marketing" {
+						actions = append(actions, chromedp.Evaluate(`(() => {
+							const heading = document.getElementById("ui-card-simple-honest-pricing");
+							const card = heading && heading.closest('[data-fui-comp="ui-card"]');
+							const paragraph = heading && heading.nextElementSibling;
+							if (!heading || !card || !paragraph) return {};
+							return {
+								background: getComputedStyle(card).backgroundColor,
+								heading: getComputedStyle(heading).color,
+								paragraph: getComputedStyle(paragraph).color,
+							};
+						})()`, &inkBand))
+					}
+					actions = append(actions,
 						chromedp.Evaluate(`({viewportWidth: innerWidth, documentWidth: document.documentElement.scrollWidth})`, &metrics),
 						// Viewport capture is deliberate: full-page capture can wait on
 						// Meridian's long-lived SSE document and never complete.
@@ -111,8 +137,13 @@ func captureMeridianSurface(t *testing.T, browser context.Context, base, surface
 							return err
 						}),
 					)
+					lastErr = chromedp.Run(ctx, actions...)
 					timeoutCancel()
 					tabCancel()
+					if lastErr == nil && surface == "marketing" &&
+						(inkBand.Background == "" || inkBand.Heading == inkBand.Background || inkBand.Paragraph == inkBand.Background) {
+						lastErr = fmt.Errorf("ink band lacks visible contrast: %#v", inkBand)
+					}
 					if lastErr == nil {
 						lastErr = screenshotHasVariation(shot)
 					}

--- a/framework/docs/content/blueprints.md
+++ b/framework/docs/content/blueprints.md
@@ -529,9 +529,16 @@ per-role `Grant`s in `RegisterGenerated` as you define more roles.
 Any screen body can compose the framework's UI components directly via block
 `kind`s — the generator emits the matching `ui.X(...)` call:
 
-`page_header` · `hero` · `section` (with child blocks) · `card` · `stat_row` ·
-`stat_card` · `bar_chart` · `pie_chart` · `line_chart` · `link_button` ·
-`callout` · `divider` · `markdown` · `pricing`.
+`page_header` · `hero` · `section` (with child blocks) · `card` · `stack` ·
+`cluster` · `grid` · `stat_row` · `stat_grid` · `stat_card` · `bar_chart` ·
+`pie_chart` · `line_chart` · `link_button` · `callout` · `divider` ·
+`markdown` · `pricing`.
+
+The layout blocks map directly to `framework/ui`: `stack` and `cluster` accept
+semantic `gap`, `align`, and `justify` props (`cluster` also accepts
+`no_wrap`); `grid` accepts `min` and `gap`; `stat_grid` is the dashboard grid
+variant with a `12rem` default minimum. Spacing must use the shared
+`none|xs|sm|md|lg|xl|2xl` tokens—blueprints do not create a second CSS surface.
 
 **Long-form content** — `markdown` renders rich prose (`ui.Markdown`) from a
 `text:` string (headings, **bold**, lists, etc.) at a readable measure; the plain

--- a/framework/docs/content/dev-livereload.md
+++ b/framework/docs/content/dev-livereload.md
@@ -5,6 +5,12 @@ livereload pair when the process is running under `gofastr dev`. Edit
 a `.go` file, the binary restarts, and every open browser tab refreshes
 on its own — no host-app code required.
 
+The rebuilt server runs with the project directory (`--dir`) as its
+working directory — the same cwd it gets when run by hand — so relative
+paths like a sqlite `db_url` or a static dir resolve against the
+project, and worktree isolation keys off the project's location rather
+than wherever `gofastr dev` was launched.
+
 ## How it turns on
 
 Three env vars decide. All defaults are dev-friendly; production is

--- a/framework/docs/content/kiln.md
+++ b/framework/docs/content/kiln.md
@@ -1,227 +1,228 @@
 # Kiln — agent-driven build mode
 
+> **Experimental.** Kiln is a separate binary for shaping a GoFastr app live.
+> Its durable graduation artifact is the same `gofastr.yml` blueprint consumed
+> by the current generator; generated Go remains the source of truth.
 
-> **Experimental.** Kiln is the framework's most provisional surface.
-> The in-memory IR, journal-freeze format, and blueprint graduation
-> flow may still change between releases. Build with it; don't pin a
-> production path on it yet.
+Kiln gives an agent a small, journaled application IR. Each accepted edit is
+replayed into a fresh framework app, SQLite is migrated, and the browser sees
+the result through GoFastr's normal SSR + hydration host. REST CRUD defaults to
+`/api/<entity>` so an HTML screen may safely use `/<entity>`.
 
-Kiln is a separate binary that lets an AI agent (Claude Code, pi,
-Codex, any CLI with `KILN_URL`) build a GoFastr app live by mutating
-an in-memory IR over HTTP. The world re-renders, the schema migrates,
-and a chat panel streams the conversation — all in-process. Freeze
-the journal when done to emit a canonical snapshot of the built world,
-then graduate to a `gofastr.yml` blueprint (or hand-written Go) that you
-commit and generate from.
-
-This page is an overview. Source of truth: read the package docs in
-`kiln/` and the CLI help (`kiln serve -h`).
-
-## Install
+## Start it
 
 ```bash
-go install ./cmd/kiln
+# Turnkey path: starts the server, installs the Kiln skill, and runs OMP/GLM-5.2.
+kiln agent -p "build a small issue tracker"
+
+# Panel-driven mode with the same built-in adapter.
+kiln serve --agent omp
+
+# Other installed adapters or a custom command remain available.
+kiln serve --agent claude-code
+kiln serve --agent pi
+kiln serve --agent codex
+kiln serve --agent auto
+kiln serve --agent "omp -p --model glm-5.2"
 ```
 
-The binary builds independently of the main `gofastr` CLI; install
-both if you use both.
+The `omp` adapter runs OMP in an isolated temporary working directory with
+`--model glm-5.2`, the Bash tool, auto-approval, no session persistence, and
+Kiln's system prompt. Authentication stays with the installed CLI; Kiln does
+not store provider credentials.
 
-## Subcommands
+The server binds to `127.0.0.1:8765` by default. Open any current screen or the
+empty-state host and use the floating panel. Important endpoints are:
 
-| Subcommand    | Effect                                                          |
-|---------------|-----------------------------------------------------------------|
-| `kiln serve`  | HTTP server only: panel + SSE + REST tool dispatch + MCP at `/mcp`. |
-| `kiln mcp`    | HTTP + MCP on stdio (for subprocess harnesses).                 |
-| `kiln acp`    | HTTP + ACP on stdio (for ACP-attached harnesses).               |
-| `kiln agent`  | Run an embedded agent loop against a remote Kiln instance.      |
-| `kiln freeze` | Read the journal and emit canonical `entities/*.json` + `world.json`. |
+| Endpoint | Purpose |
+|---|---|
+| `GET /kiln/world` | Current lossless world IR. |
+| `GET /kiln/status` | Runtime status. |
+| `POST /kiln/tool/<name>` | JSON tool dispatch. |
+| `POST/GET /mcp` | Kiln authoring tools over Streamable HTTP MCP. |
+| `POST/GET /mcp/app` | Rebuilt app's entity MCP tools. |
+| `GET /.kiln/events` | Journal/build SSE stream. |
 
-In stdio modes the HTTP panel keeps running so you can watch the world
-build live. Logging goes to stderr; stdout is reserved for JSON-RPC.
+`kiln mcp` and `kiln acp` expose the same tool surface over stdio. Pass
+`--no-http` when a parent process owns the UI.
 
-## Picking an agent
+## Agent adapters
 
-```bash
-kiln serve --agent claude-code   # uses ~/.claude/.credentials.json
-kiln serve --agent pi            # uses pi's installed config
-kiln serve --agent auto          # picks the first installed CLI on PATH
-kiln serve --agent "<freeform>"  # any command; the prompt is appended
-```
+Built-ins are `omp`, `claude-code`, `pi`, and `codex`. `auto` chooses the first
+installed adapter in that order. `none` keeps chat journaled without spawning
+an agent. A free-form command is parsed as an executable plus arguments and
+receives the prompt as its final argument.
 
-Kiln subscribes to its own SSE bus: every `chat_user` event spawns the
-configured CLI as a subprocess with `KILN_URL` injected. The CLI reads
-the `~/.claude/skills/kiln/SKILL.md` file (auto-installed) and drives
-the build with `curl` against HTTP. Stdout is journaled back as
-`chat_assistant` so the panel renders the reply.
-
-## Bring-your-own auth
-
-Kiln does **not** manage credentials. Each adapter spawns its CLI
-which manages its own login (`claude` reads `~/.claude/.credentials.json`,
-`pi` reads its own config, etc.). Adding a new agent is a one-entry
-change in `cmd/kiln/adapters.go`.
-
-## Mutation surface & loopback binding
-
-The tool API (`POST /kiln/tool/{name}`, `/kiln/agent`, `/mcp`) mutates the
-in-memory world **without authentication** — Kiln is local build-mode
-tooling. The primary control is the **loopback bind** (`--addr` defaults to
-`127.0.0.1:8765`); pass `--addr 0.0.0.0:8765` only when you deliberately
-want it reachable off-box, and put your own auth in front of it.
-
-As defense-in-depth, an **same-origin guard** rejects cross-origin
-browser-driven state changes (a malicious web page or DNS-rebinding POSTing
-to `localhost:8765`). Non-browser clients (the agent, `curl`, MCP/ACP) send
-no `Origin` and are unaffected.
-
-## Plan-gated destructive ops
-
-Destructive tools (`delete_entity`, `delete_field`, `delete_page`,
-`delete_hook`, `delete_route`) are enforced at the protocol layer:
-
-1. The agent calls `propose_plan` listing each destructive op in
-   `targets`:
-
-   ```json
-   { "plan_id": "p1", "steps": ["drop posts"], "targets": [{"op":"delete_entity","name":"posts"}] }
-   ```
-
-2. The panel renders a plan card with **Approve** / **Reject** buttons.
-3. After Approve, the agent retries the destructive call with `plan_id`
-   set.
-
-Without an approved plan whose `targets` list matches, `delete_*`
-returns `{"ok":false,"kind":"needs_plan"}`. Each `(plan, target)` is
-single-use; reuse needs a new plan.
+Kiln injects `KILN_URL`, installs the current embedded skill, and enforces an
+HTTP boundary for built-in adapters: they must mutate the app through the tool
+surface, not by editing the repository.
 
 ## Tool surface
 
-`world_get`, `set_app_config`, `add_entity`, `update_entity`,
-`delete_entity`, `add_field`, `delete_field`, `add_page`, `delete_page`,
-`add_hook`, `delete_hook`, `add_route`, `delete_route`, `add_seed`,
-`propose_plan`, `approve_plan`, `reject_plan`, `undo`, `chat`. See
-`kiln/protocol/descriptors.go` for the full JSON schemas. A tool call over
-HTTP is a plain POST against the loopback server:
+Read and configuration:
 
-```bash
-kiln serve --agent none &   # loopback 127.0.0.1:8765 by default; unauthenticated
-curl -X POST http://localhost:8765/kiln/tool/add_entity \
-  -H 'Content-Type: application/json' \
-  -d '{"entity":{"name":"posts","fields":[{"name":"title","type":"string","required":true}]}}'
-curl http://localhost:8765/posts          # CRUD live
-curl http://localhost:8765/kiln/world     # current IR
-```
+- `world_get`
+- `set_app_config` — current blueprint app config; HTTP calls use
+  `{"config":{...}}`, a non-empty `config.name` is required, and an
+  omitted/empty API prefix resolves to `api`
+- `set_theme` — semantic light theme token overrides
+- `set_scaffold` — navigation plus owned-Go endpoint, middleware, plugin, and
+  helper stubs
 
-## Wire into Claude Code as an MCP server
+Entities and data:
+
+- `add_entity`, `update_entity`, `delete_entity`
+- `add_field`, `delete_field`
+- `add_seed`
+
+Screens and behavior:
+
+- `add_page`, `update_page_element`, `delete_page`
+- `add_hook`, `delete_hook`
+- `add_route`, `delete_route`
+
+Safety and session:
+
+- `propose_plan`, `approve_plan`, `reject_plan`
+- `undo`, `reset_session`, `chat`
+
+Every transport uses the same typed dispatcher. Destructive deletes require an
+approved plan naming the exact operation and target. An approval is
+single-use. `undo` truncates one journal entry and deterministically rebuilds;
+`reset_session` clears the journal and ephemeral schema.
+
+## Current world contract
+
+The world mirrors the current blueprint where a live representation is safe:
+
+- app module/database/static/output/API prefix, auth/admin/PWA, light and dark
+  semantic theme tokens;
+- current entity fields, relations, indices, access, owner scoping, search,
+  cursor fields, properties, hooks, declarative routes, and seeds;
+- screen metadata, layouts, access declarations, node trees, and navigation;
+- owned-Go endpoint/middleware/plugin/helper stubs.
+
+`multi_tenant: true` is rejected by authoring and freeze because neither Kiln
+nor the generator can guess the app-specific tenant resolver. Use
+`owner_field` for per-user CRUD, or wire tenant middleware in owned Go after
+graduation. Auth/admin declarations are preserved into the scaffold; Kiln's
+live preview is not a production auth certification environment.
+
+## UI composition
+
+Kiln pages run through `framework/uihost`: full SSR on first load, hydration of
+the existing DOM, SPA navigation across screens, and component CSS from the
+registry. Live world edits refresh the current screen through a forced SPA
+navigation, never `location.reload()`.
+
+Prefer design-system kinds:
+
+- `page_header`, `hero`, `section`, `card`
+- `stack`, `cluster`, `grid`, `stat_row`, `stat_grid`, `stat_card`
+- `link_button`, `callout`, `divider`
+
+Semantic leaf kinds such as `heading`, `paragraph`, `text`, `link`, `form`,
+`input`, `button`, `list`, and table elements remain available. `class`,
+`style`, and `on*` props are rejected: pages compose the shared design system
+instead of inventing a second styling surface. Form actions that target CRUD
+must use the API prefix, for example `/api/notes`.
+
+Example:
 
 ```json
 {
-  "mcpServers": {
-    "kiln": { "command": "kiln", "args": ["mcp", "--no-http"] }
+  "page": {
+    "path": "/dashboard",
+    "name": "dashboard",
+    "title": "Dashboard",
+    "layout": {"name": "app"},
+    "tree": {
+      "kind": "stack",
+      "props": {"gap": "lg"},
+      "children": [
+        {"kind": "page_header", "props": {
+          "title": "Dashboard", "subtitle": "Current project health"
+        }},
+        {"kind": "stat_row", "children": [
+          {"kind": "stat_card", "props": {"label": "Open", "value": "12"}},
+          {"kind": "stat_card", "props": {"label": "Closed", "value": "48"}}
+        ]}
+      ]
+    }
   }
 }
 ```
 
-## Generated apps don't carry Kiln
+`add_page` assigns stable node `_id` values and version `1`.
+`update_page_element` performs optimistic, surgical tree edits using those IDs
+and an optional `if_match` version.
 
-`gofastr generate --from <blueprint>` emits a plain framework app. Node
-trees render through the leaf package **`kiln/noderender`** (which imports
-only `core-ui/html`, `core/render`, and the zero-dependency `kiln/world`
-IR) — **not** `kiln/render`, which pulls Kiln's authoring engine
-(`kiln/expr`, `kiln/effect`, `framework`). So a shipped, frozen app does
-not link the build-mode evaluator. A codegen build test asserts this:
-the generated screens package compiles and its dependency graph excludes
-`kiln/expr` / `kiln/effect` / `kiln/render`.
-
-## Freezing
-
-When the build is done:
+## Graduate to owned Go
 
 ```bash
-kiln freeze --dir build/
+kiln freeze --diff
+kiln freeze --dir build
+gofastr validate build/gofastr.yml
+gofastr generate --from=build/gofastr.yml --out=app
+cd app
+go test ./...
 ```
 
-This reads the journal and emits:
+Freeze writes exactly:
 
-- `build/entities/*.json` — one declaration per entity, as a readable
-  snapshot of the frozen world's entities.
-- `build/world.json` — the canonical world IR snapshot.
+- `build/gofastr.yml` — deterministic current blueprint, ready for the
+  one-shot generator;
+- `build/world.json` — lossless authoring snapshot.
 
-You commit these files; the running Kiln process is no longer needed.
-To graduate to a running framework app, declare the frozen entities in a
-`gofastr.yml` blueprint (the snapshot makes a faithful starting point — see
-[Blueprints](blueprints.md)) or write them in Go with `app.Entity(...)`, then
-run `gofastr generate --from=gofastr.yml`. There is no file-based runtime
-loader; the generated `entities.RegisterAll(app)` wires them in.
+Declarative Kiln hook/route actions remain exact in `world.json`. Where the
+current blueprint requires a Go function, freeze emits an owned-Go handler
+stub with a description naming the declarative action; implement that behavior
+after generation. The removed pre-v0.1 `entities/*.json` format is not emitted.
 
-## Free-order authoring & durability
+`FreezeAndGenerate` performs the freeze and invokes
+`gofastr generate --from=gofastr.yml` when `gofastr` is on `PATH`.
 
-Build mode is **free-order**: you can add `posts` (with a `BelongsTo users`
-relation) before `users` exists. The live rebuild defers a `BelongsTo`
-whose target entity isn't registered yet and re-derives it once the target
-is added — the durable world (and `kiln freeze`) always keep the full
-relation. The framework's strict `AutoMigrate` still rejects a dangling
-`BelongsTo` outside build mode; only the kiln live runtime defers.
+## Security boundary
 
-Every mutation is **validated by a trial rebuild before it is journaled**.
-An entry that can't be rebuilt is rejected and never written to the
-durable log — so a poison entry can't survive a restart and brick the
-session. On any failure the in-memory session is restored by replaying the
-journal.
+Kiln's mutation surface is intentionally unauthenticated and local-development
+only. The default loopback bind is the primary boundary. Unsafe cross-origin
+browser requests are rejected; non-browser clients without an `Origin` header
+and same-origin requests are allowed. Binding `--addr 0.0.0.0:8765` is an
+explicit decision to expose the tool surface and should only be done behind an
+appropriate network/auth boundary.
 
-## Architecture
+## Verification
 
-Kiln is bigger than a single doc page; the layout under `kiln/`:
+From the framework checkout on Windows, ensure an MSYS2 GCC is on `PATH` so
+`go-sqlite3` can run, then:
 
-- `kiln/world` — in-memory IR for entities, fields, relations, pages.
-- `kiln/journal` — append-only event log; the basis for replay and
-  freeze.
-- `kiln/effect` — typed effects the agent fires; the world applies them.
-- `kiln/expr` — small expression language for hooks/computed fields.
-- `kiln/freeze` — IR → canonical declarations.
-- `kiln/render` — live UI render of the current world.
-- `kiln/live` — SSE bus + state subscription.
-- `kiln/protocol` — wire formats for HTTP + MCP + ACP.
-- `kiln/agent/mcp` — MCP server exposing kiln tools.
-- `kiln/agent/acp` — ACP server exposing kiln tools.
-- `kiln/integration` — end-to-end tests against a real subprocess agent.
-
-## Forms in the kiln world
-
-Kiln-rendered `form` nodes default `enctype="application/json"`
-because they target the world's CRUD endpoints (which decode JSON, not
-urlencoded). This is the **opposite** of the framework default — bare
-`<form>` elements in hand-written HTML submit browser-native, kiln
-forms intercept.
-
-To opt out per-form via the world API, set `enctype` explicitly:
-
-```yaml
-- kind: form
-  props:
-    method: POST
-    action: /notes
-    enctype: application/x-www-form-urlencoded  # browser-native submit
+```bash
+go test ./cmd/kiln ./kiln/...
+go test ./cmd/gofastr -run TestKilnFreezeBlueprintParsesAndValidates
 ```
 
-For RPC-island form submission (no navigation, JSON response signal),
-use `data-fui-rpc` via `attrs`:
-
-```yaml
-- kind: form
-  props:
-    action: /api/notes
-    attrs:
-      data-fui-rpc: "/api/notes"
-      data-fui-rpc-signal: notes-state
-```
+The integration suite covers journal replay, live migrations, CRUD, hooks,
+browser form submission, UI hosting, and freeze artifacts. Live provider tests
+remain opt-in because they consume external model credentials.
 
 ## Common mistakes
 
-- **Treating Kiln as a runtime.** It's a build-time tool. Once you
-  freeze, the running Kiln binary is not part of your app.
-- **Editing `entities/*.json` and then re-running Kiln on top.**
-  Kiln expects to own the world while it's running. Hand-edits should
-  happen post-freeze, after Kiln has exited.
-- **Storing credentials in `cmd/kiln/adapters.go`.** Adapters spawn
-  CLIs; credentials live wherever those CLIs already keep them.
+- **Passing flat app fields.** `set_app_config` requires
+  `{"config":{"name":"My App",...}}`. A flat payload is rejected so it cannot
+  appear to succeed while silently discarding configuration.
+- **Using bare CRUD paths.** Entities mount below `app.api_prefix`, which
+  defaults to `/api`; point forms and clients at `/api/<entity>` unless the
+  world explicitly changes that prefix.
+- **Adding page-local classes or styles.** Kiln page nodes reject `class`,
+  `style`, and `on*` props. Compose an existing typed component, or add a
+  missing component/token to the design system before using it in Kiln.
+- **Treating `world.json` as generated application code.** It is the lossless
+  authoring snapshot. `gofastr.yml` is the generator input, and declarative
+  behaviors that require Go graduate as explicit owned stubs to implement.
+- **Exposing the mutation server.** Keep Kiln on loopback. Binding a public
+  interface without an external authentication/network boundary exposes every
+  world-editing tool.
+- **Calling a provider run verified without using it live.** The deterministic
+  suite validates adapters and protocol behavior; set `KILN_LIVE=1` and run a
+  named `TestLive_*` case to prove the selected external driver actually edits,
+  renders, freezes, and generates the current world.

--- a/framework/docs/content/kiln.md
+++ b/framework/docs/content/kiln.md
@@ -179,6 +179,12 @@ current blueprint requires a Go function, freeze emits an owned-Go handler
 stub with a description naming the declarative action; implement that behavior
 after generation. The removed pre-v0.1 `entities/*.json` format is not emitted.
 
+Freeze fails loudly, naming the offending key, when world data cannot
+round-trip through the blueprint's YAML subset — a seed row whose every value
+is a nested object, or a props/row key containing a colon, comment marker, or
+brackets. Reshape the data (or drop the row) and re-run; a freeze that
+succeeded is guaranteed to re-parse into the same values.
+
 `FreezeAndGenerate` performs the freeze and invokes
 `gofastr generate --from=gofastr.yml` when `gofastr` is on `PATH`.
 

--- a/framework/docs/content/widgets.md
+++ b/framework/docs/content/widgets.md
@@ -185,6 +185,18 @@ On every `world_edit` event from `/.kiln/events`, the bootstrap pushes
 the event's `data` (JSON-decoded if possible) into `world_summary`,
 and any `[data-fui-signal="world_summary"]` node re-renders.
 
+For a derived server-side signal, use `SSERefetch`: the event is only a
+trigger and the widget's state endpoint provides the fresh value. For an event
+that changes the screen rendered at the current URL, use `SSERefresh`. It runs
+the normal cache-bypassing SPA navigation pipeline, so the screen and layout
+update without a hard browser reload. `SSEReload` remains as a deprecated
+source-compatible alias with the same soft-refresh behavior.
+
+```go
+.SSERefetch("/.events", "count_changed", "count")
+.SSERefresh("/.events", "world_edit", "op", "add_page")
+```
+
 ### RPCs
 
 A button or form click can invoke a server handler:
@@ -330,9 +342,10 @@ default theme out of the box. Token overrides flow through:
 2. Or rely on the default — `widget.Mount` builds a stylesheet with
    `:root` CSS variables for every token.
 
-Kiln's `set_theme` tool (see `kiln/protocol`) is the canonical example:
-the agent (or a host) updates `world.App.Theme` and the next
-`/kiln/theme.css` request reflects the new palette.
+Kiln's `set_theme` tool (see `kiln/protocol`) is an example: the agent updates
+semantic theme tokens such as `primary`, `surface`, and `text`; its live pages
+use the same `framework/uihost` app stylesheet and component registry as a
+generated app.
 
 ## Strict CSP
 
@@ -345,11 +358,9 @@ The framework runtime is **strict-CSP safe**. The bootstrap never:
 `kiln/render` additionally drops dangerous attrs server-side
 (`style`, `srcdoc`, `on*=`) so a bad agent turn can't poison the page.
 
-Use class names that map to theme tokens. The page theme exposes
-ready-made utility classes (`kiln-section`, `kiln-card`, `kiln-grid-3`,
-`kiln-button`, `kiln-hero`, etc.) — `docs/widgets.md` is the canonical
-reference for what's available; `core-ui/widget/theme/page.go` is the
-source of truth.
+Compose typed `framework/ui` components, `core-ui/patterns`, or semantic
+`core-ui/html` primitives. App-local utility-class palettes are a second
+styling surface and are not part of the current contract.
 
 ## Testing
 

--- a/kiln/agent/agent_test.go
+++ b/kiln/agent/agent_test.go
@@ -205,3 +205,15 @@ func TestDispatchExposesShared(t *testing.T) {
 		t.Fatalf("expected OK, got %+v", res)
 	}
 }
+
+func TestDispatchCoversNativeMetaAndScaffoldTools(t *testing.T) {
+	tools, _ := setupAgent(t)
+	for _, tc := range []agent.ToolCall{
+		{Name: "set_scaffold", Args: map[string]any{"nav": []any{map[string]any{"label": "Home", "href": "/"}}}},
+		{Name: "set_theme", Args: map[string]any{"theme": map[string]any{"primary": "#3366ff"}}},
+	} {
+		if res := agent.Dispatch(context.Background(), tools, tc); !res.OK {
+			t.Errorf("dispatch %s: %+v", tc.Name, res)
+		}
+	}
+}

--- a/kiln/agent/loop.go
+++ b/kiln/agent/loop.go
@@ -125,6 +125,12 @@ func dispatch(ctx context.Context, t *protocol.Tools, call ToolCall) protocol.Re
 			return protocol.Result{OK: false, Error: err.Error(), Kind: "validation"}
 		}
 		return t.SetAppConfig(ctx, a)
+	case "set_scaffold":
+		var a protocol.SetScaffoldArgs
+		if err := dec(&a); err != nil {
+			return protocol.Result{OK: false, Error: err.Error(), Kind: "validation"}
+		}
+		return t.SetScaffold(ctx, a)
 	case "add_entity":
 		var a protocol.AddEntityArgs
 		if err := dec(&a); err != nil {
@@ -215,8 +221,22 @@ func dispatch(ctx context.Context, t *protocol.Tools, call ToolCall) protocol.Re
 			return protocol.Result{OK: false, Error: err.Error(), Kind: "validation"}
 		}
 		return t.ApprovePlan(ctx, a)
+	case "reject_plan":
+		var a protocol.RejectPlanArgs
+		if err := dec(&a); err != nil {
+			return protocol.Result{OK: false, Error: err.Error(), Kind: "validation"}
+		}
+		return t.RejectPlan(ctx, a)
 	case "undo":
 		return t.Undo(ctx, protocol.UndoArgs{})
+	case "reset_session":
+		return t.ResetSession(ctx, protocol.ResetSessionArgs{})
+	case "set_theme":
+		var a protocol.SetThemeArgs
+		if err := dec(&a); err != nil {
+			return protocol.Result{OK: false, Error: err.Error(), Kind: "validation"}
+		}
+		return t.SetTheme(ctx, a)
 	case "chat":
 		var a protocol.ChatArgs
 		if err := dec(&a); err != nil {

--- a/kiln/chat/assets/host.html
+++ b/kiln/chat/assets/host.html
@@ -52,6 +52,10 @@
 </style>
 </head>
 <body>
+<!-- <main> is load-bearing: the GoFastr SPA runtime swaps pages by extracting
+     the response's <main>, and this fallback is what a deleted or unknown
+     path serves. Without it the swap empties the content area. -->
+<main>
 <div class="kiln-host">
   <div class="kiln-mark">✶</div>
   <h1>Kiln</h1>
@@ -78,6 +82,7 @@
 
   <p class="hint">Open <code>/kiln/world</code> to see the current IR · agent shortcut <code>kiln agent -p "build me X"</code></p>
 </div>
+</main>
 <script src="/__gofastr/runtime.js"></script>
 </body>
 </html>

--- a/kiln/chat/assets/host.html
+++ b/kiln/chat/assets/host.html
@@ -4,58 +4,67 @@
 <meta charset="utf-8">
 <title>Kiln</title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" href="/__gofastr/app.css">
+</head>
+<body>
+<!-- <main> is load-bearing: the GoFastr SPA runtime swaps pages by extracting
+     the response's <main>, and this fallback is what a deleted or unknown
+     path serves. Without it the swap empties the content area. The <style>
+     rides inside <main> so a swapped-in fallback keeps its layout; every
+     color/font/radius comes from the app.css theme tokens, so the landing
+     follows the world's theme and the light/dark scheme like any other
+     surface. -->
+<main>
 <style>
-  :root { color-scheme: dark; }
-  html, body {
-    margin: 0; padding: 0; height: 100%;
-    background: radial-gradient(ellipse at top, #1d2230 0%, #0e0f12 60%);
-    color: #e6e8eb;
-    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  }
   .kiln-host {
-    min-height: 100%;
+    min-height: 100vh;
     display: flex; flex-direction: column; align-items: center; justify-content: center;
     padding: 48px 24px 360px; gap: 18px; text-align: center;
+    background: var(--color-background); color: var(--color-text);
+    font-family: var(--font-body);
   }
   .kiln-mark {
-    width: 48px; height: 48px; border-radius: 12px;
-    background: linear-gradient(135deg, #4f8cff 0%, #6f5cff 100%);
+    width: 48px; height: 48px; border-radius: var(--radius-lg);
+    background: var(--color-primary); color: var(--color-primary-fg);
     display: flex; align-items: center; justify-content: center;
-    font-size: 22px; font-weight: 600; color: white;
-    box-shadow: 0 12px 36px rgba(79, 140, 255, 0.35);
+    font-size: 22px; font-weight: 600;
+    box-shadow: var(--shadow-lg);
   }
-  .kiln-host h1 { margin: 0; font-weight: 600; font-size: 22px; letter-spacing: 0.2px; }
-  .kiln-host p.lead { margin: 0; color: #b3b9c4; max-width: 44ch; font-size: 14px; }
+  .kiln-host h1 {
+    margin: 0; font-weight: 600; font-size: 22px; letter-spacing: 0.2px;
+    font-family: var(--font-heading);
+  }
+  .kiln-host p.lead { margin: 0; color: var(--color-text-muted); max-width: 44ch; font-size: 14px; }
   .kiln-cards {
     display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 12px; width: min(720px, 100%); margin-top: 12px;
   }
   .kiln-card {
     text-align: left; padding: 16px;
-    background: rgba(255,255,255,0.03);
-    border: 1px solid rgba(255,255,255,0.08);
-    border-radius: 12px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
   }
-  .kiln-card h2 { margin: 0 0 6px 0; font-size: 12px; font-weight: 600; letter-spacing: 0.4px; text-transform: uppercase; color: #9aa0a6; }
-  .kiln-card p { margin: 0; color: #b3b9c4; font-size: 13px; }
+  .kiln-card h2 {
+    margin: 0 0 6px 0; font-size: 12px; font-weight: 600; letter-spacing: 0.4px;
+    text-transform: uppercase; color: var(--color-text-muted);
+  }
+  .kiln-card p { margin: 0; color: var(--color-text-muted); font-size: 13px; }
   .kiln-card code {
     display: block; margin-top: 8px; padding: 8px 10px;
-    background: rgba(0,0,0,0.4); border: 1px solid rgba(255,255,255,0.06);
-    border-radius: 6px; font: 11px/1.45 ui-monospace, monospace;
-    color: #c2cad9; white-space: pre-wrap; word-break: break-word;
+    background: var(--color-surface-soft); border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm); font: 11px/1.45 var(--font-mono);
+    color: var(--color-text); white-space: pre-wrap; word-break: break-word;
   }
-  .kiln-host .hint { color: #6b7280; font-size: 12px; margin-top: 8px; }
+  .kiln-card code.kiln-inline-code {
+    display: inline; padding: 2px 6px; margin-top: 0;
+  }
+  .kiln-host .hint { color: var(--color-text-subtle); font-size: 12px; margin-top: 8px; }
   .kiln-host .hint code {
-    background: rgba(0,0,0,0.3); padding: 2px 6px; border-radius: 4px;
-    font-family: ui-monospace, monospace;
+    background: var(--color-surface-soft); padding: 2px 6px;
+    border-radius: var(--radius-sm); font-family: var(--font-mono);
   }
 </style>
-</head>
-<body>
-<!-- <main> is load-bearing: the GoFastr SPA runtime swaps pages by extracting
-     the response's <main>, and this fallback is what a deleted or unknown
-     path serves. Without it the swap empties the content area. -->
-<main>
 <div class="kiln-host">
   <div class="kiln-mark">✶</div>
   <h1>Kiln</h1>
@@ -76,7 +85,7 @@
     </div>
     <div class="kiln-card">
       <h2>Watch live</h2>
-      <p>Every edit journals to <code style="display:inline">.kiln.session.jsonl</code>, migrates SQLite, and broadcasts SSE so the panel updates in real time.</p>
+      <p>Every edit journals to <code class="kiln-inline-code">.kiln.session.jsonl</code>, migrates SQLite, and broadcasts SSE so the panel updates in real time.</p>
     </div>
   </div>
 

--- a/kiln/chat/assets/widget.js
+++ b/kiln/chat/assets/widget.js
@@ -18,6 +18,19 @@
   // override per-embed; transient close stays per-page-load only.
   const START_OPEN = !(script && script.dataset.open === "false");
 
+  // Current GoFastr pages navigate through the shared SPA runtime. A forced
+  // navigation bypasses the page cache so freshly journaled world edits become
+  // visible without destroying in-page state or hard-reloading the document.
+  async function refreshPage(path) {
+    const runtime = window.__gofastr;
+    if (!runtime || typeof runtime.navigate !== "function") {
+      setStatus("page changed; SPA runtime is not available", "warn");
+      return false;
+    }
+    await runtime.navigate(path || (window.location.pathname + window.location.search), { force: true });
+    return true;
+  }
+
   // ---- Stylesheet -----------------------------------------------------
   function loadStyles() {
     if (document.getElementById("kiln-widget-style")) return;
@@ -423,7 +436,7 @@
     const customInput = el("input", {
       type: "text",
       class: "kiln-adapter-custom-input",
-      placeholder: `e.g. "pi -p --provider zai --model glm-5.1"`,
+      placeholder: `e.g. "omp -p --model glm-5.2"`,
       "aria-label": "Custom agent command",
     });
     customInputWrap.appendChild(customInput);
@@ -599,8 +612,9 @@
           if (!r.ok) {
             setStatus("reset failed: " + ((r && (r.error || r.kind)) || "unknown"), "error");
           } else {
-            // Force a full reload — the page itself may not exist anymore.
-            location.reload();
+            // The page itself may no longer exist, so force a cache-bypass SPA
+            // navigation and let the server select the current fallback.
+            await refreshPage();
           }
         } catch (err) {
           setStatus("network error: " + err.message, "error");
@@ -611,7 +625,7 @@
     }
 
     // Config gear: opens the agent-settings modal. The modal lists
-    // available adapters (claude-code, pi, codex), shows which are
+    // available adapters (omp, claude-code, pi, codex), shows which are
     // installed, lets the user switch + supply a custom command. The
     // current selection is highlighted; switching warns the user that
     // any in-flight agent turn will be cancelled.
@@ -727,8 +741,8 @@
         const r = await postJSON("/kiln/tool/" + tool, args);
         if (r && r.ok) {
           setStatus("ok: " + tool, "ok");
-          if (onSuccess === "reload") location.reload();
-          else if (onSuccess && onSuccess.startsWith("navigate:")) location.assign(onSuccess.slice("navigate:".length));
+          if (onSuccess === "reload") await refreshPage();
+          else if (onSuccess && onSuccess.startsWith("navigate:")) await refreshPage(onSuccess.slice("navigate:".length));
           else setTimeout(() => setStatus(""), 1500);
         } else {
           setStatus(tool + " failed: " + ((r && (r.error || r.kind)) || "unknown"), "error");
@@ -763,8 +777,8 @@
         const onSuccess = form.getAttribute("data-kiln-on-success") || "reload";
         if (r.ok) {
           setStatus("ok", "ok");
-          if (onSuccess === "reload") location.reload();
-          else if (onSuccess.startsWith("navigate:")) location.assign(onSuccess.slice("navigate:".length));
+          if (onSuccess === "reload") await refreshPage();
+          else if (onSuccess.startsWith("navigate:")) await refreshPage(onSuccess.slice("navigate:".length));
         } else {
           let txt = "";
           try { txt = await r.text(); } catch (_) {}
@@ -838,7 +852,7 @@
         flashBuildBanner(opName);
 
         // Page-affecting ops change what the current URL renders.
-        // Always reload on these regardless of whether we're currently
+        // Always refresh on these regardless of whether we're currently
         // on the host fallback — the host might be about to be
         // superseded by a real page, or the real page rewritten.
         const pageAffecting = (
@@ -851,8 +865,8 @@
         );
         if (pageAffecting) {
           // Tiny delay so the system row is visible briefly before the
-          // reload kicks in.
-          setTimeout(() => location.reload(), 350);
+          // cache-bypass SPA navigation kicks in.
+          setTimeout(() => { void refreshPage(); }, 350);
         }
       });
       es.addEventListener("open", () => {

--- a/kiln/chat/panel.go
+++ b/kiln/chat/panel.go
@@ -35,7 +35,7 @@ type AgentStateFn func() any
 //
 // agentState is read by the gear modal's agent_list_html signal at
 // mount time so the user sees the actual adapter list (claude-code,
-// pi, codex, ...) instead of a Loading… placeholder. nil → no list.
+// omp, claude-code, pi, codex, ...) instead of a Loading… placeholder. nil → no list.
 //
 // All bespoke kiln widget plumbing (vanilla JS DOM, hand-rolled CSS,
 // per-route HTTP handlers) is replaced by this single declaration.
@@ -84,13 +84,13 @@ func MountPanel(r *router.Router, l *live.Live, tools *protocol.Tools, agentStat
 		// Refresh on any world_edit so the pill keeps pace with the agent.
 		SSERefetch("/.kiln/events", "world_edit", "world_snapshot").
 		SSERefetch("/.kiln/events", "session_reset", "world_snapshot").
-		// Page-affecting world edits: full reload so the now-rendered
+		// Page-affecting world edits: forced SPA refresh so the now-rendered
 		// page reflects the new world. Filtered by op so add_entity
 		// (which doesn't change page rendering) doesn't trigger reloads.
-		SSEReload("/.kiln/events", "world_edit", "op", "add_page").
-		SSEReload("/.kiln/events", "world_edit", "op", "delete_page").
-		SSEReload("/.kiln/events", "world_edit", "op", "add_route").
-		SSEReload("/.kiln/events", "world_edit", "op", "delete_route").
+		SSERefresh("/.kiln/events", "world_edit", "op", "add_page").
+		SSERefresh("/.kiln/events", "world_edit", "op", "delete_page").
+		SSERefresh("/.kiln/events", "world_edit", "op", "add_route").
+		SSERefresh("/.kiln/events", "world_edit", "op", "delete_route").
 		// RPC: chat send, reset, approve/reject, undo.
 		// SSE refetch owns log updates; the synchronous RPC response is
 		// just an ack. Binding chat_html to the response was a footgun:
@@ -238,7 +238,7 @@ func (pe *panelEnv) agentListHTML() string {
 	}
 	if !anyInstalled && len(available) > 0 {
 		b.WriteString(`<p class="kiln-modal-tip">No agent CLIs detected on PATH. Install one to enable chat-driven builds — e.g. ` +
-			`<code>brew install pi</code>, ` +
+			`install <code>omp</code> (recommended for GLM-5.2), ` +
 			`<code>npm i -g @anthropic-ai/claude-code</code>, ` +
 			`or <code>npm i -g @openai/codex</code>.</p>`)
 	}
@@ -869,7 +869,7 @@ func toolIcon(name string) string {
 		return "❘" // plan-shape
 	case "world_get":
 		return "◈" // read-only
-	case "set_app_config", "set_theme":
+	case "set_app_config", "set_scaffold", "set_theme":
 		return "✦" // app-meta
 	case "undo", "reset_session":
 		return "↶" // history meta

--- a/kiln/chat/server.go
+++ b/kiln/chat/server.go
@@ -59,19 +59,22 @@ func New(l *live.Live, t *protocol.Tools) *Server {
 //     since wrapping them in a journal entry would be incoherent —
 //     the wrapping entry races with the truncate they perform.
 var journaledTools = map[string]bool{
-	"set_app_config": true,
-	"add_entity":     true,
-	"update_entity":  true,
-	"delete_entity":  true,
-	"add_field":      true,
-	"delete_field":   true,
-	"add_page":       true,
-	"delete_page":    true,
-	"add_hook":       true,
-	"delete_hook":    true,
-	"add_route":      true,
-	"delete_route":   true,
-	"add_seed":       true,
+	"set_app_config":      true,
+	"set_scaffold":        true,
+	"add_entity":          true,
+	"update_entity":       true,
+	"delete_entity":       true,
+	"add_field":           true,
+	"delete_field":        true,
+	"add_page":            true,
+	"delete_page":         true,
+	"update_page_element": true,
+	"add_hook":            true,
+	"delete_hook":         true,
+	"add_route":           true,
+	"delete_route":        true,
+	"add_seed":            true,
+	"set_theme":           true,
 }
 
 // Mount registers the panel routes onto r. The host fallback page is
@@ -484,6 +487,12 @@ func (s *Server) dispatch(ctx context.Context, name string, body interface {
 			return protocol.Result{}, err
 		}
 		return s.tools.SetAppConfig(ctx, args), nil
+	case "set_scaffold":
+		var args protocol.SetScaffoldArgs
+		if err := dec.Decode(&args); err != nil {
+			return protocol.Result{}, err
+		}
+		return s.tools.SetScaffold(ctx, args), nil
 	case "add_entity":
 		var args protocol.AddEntityArgs
 		if err := dec.Decode(&args); err != nil {

--- a/kiln/chat/theme.go
+++ b/kiln/chat/theme.go
@@ -6,16 +6,16 @@ import (
 	"github.com/DonaldMurillo/gofastr/kiln/world"
 )
 
-// pageCSS resolves the kiln page stylesheet through core-ui/widget/theme.
-// World.App.Theme overrides (e.g. set by a future set_theme tool) merge
-// on top of the framework default.
+// pageCSS resolves the compatibility host stylesheet through
+// core-ui/widget/theme. Current world pages are rendered by UIHost and use
+// /__gofastr/app.css; this remains for direct legacy widget embeds.
 func pageCSS() string {
 	return pageCSSFor(nil)
 }
 
 // pageCSSFor resolves the page CSS with optional world-level overrides.
-// Used by /kiln/theme.css when the kiln server has access to the live
-// session and can pull the current world.App.Theme.
+// Used by the compatibility /kiln/theme.css endpoint when the kiln server has
+// access to the live session and can pull the current world.App.Theme.
 func pageCSSFor(app *world.AppConfig) string {
 	t := theme.PageTheme()
 	applyAppOverrides(&t, app)

--- a/kiln/freeze/blueprint.go
+++ b/kiln/freeze/blueprint.go
@@ -1,0 +1,765 @@
+package freeze
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/DonaldMurillo/gofastr/kiln/world"
+)
+
+// BlueprintYAML converts a Kiln world into the current gofastr.yml scaffold
+// contract. world.json remains the lossless authoring snapshot; the blueprint
+// is the one-shot, generator-ready graduation artifact.
+func BlueprintYAML(w *world.World) ([]byte, error) {
+	if w == nil {
+		return nil, fmt.Errorf("freeze: nil world")
+	}
+	if err := validateGraduation(w); err != nil {
+		return nil, err
+	}
+	doc := normalizeYAMLValue(blueprintMap(w)).(map[string]any)
+	var out strings.Builder
+	writeYAMLMap(&out, doc, 0, topLevelOrder)
+	return []byte(out.String()), nil
+}
+
+func validateGraduation(w *world.World) error {
+	for _, e := range sortedEntities(w) {
+		if e.MultiTenant {
+			return fmt.Errorf("freeze: entity %q sets multi_tenant, but a blueprint cannot choose the app-specific tenant resolver; use owner_field for per-user scoping or wire tenant middleware in owned Go before freezing", e.Name)
+		}
+	}
+	for path, page := range w.Pages {
+		if page != nil {
+			if err := validateNodeGraduation(page.Tree); err != nil {
+				return fmt.Errorf("freeze: page %q: %w", path, err)
+			}
+		}
+	}
+	if w.App.Auth.Enabled && !w.App.Auth.DevMode && w.App.Auth.JWTSecret == "" {
+		return fmt.Errorf("freeze: production auth requires app.auth.jwt_secret; set it or keep auth.dev_mode true for local development")
+	}
+	if w.App.PWA.Enabled {
+		switch w.App.PWA.Display {
+		case "", "standalone", "fullscreen", "minimal-ui", "browser":
+		default:
+			return fmt.Errorf("freeze: unsupported PWA display %q", w.App.PWA.Display)
+		}
+		for label, value := range map[string]string{"start_url": w.App.PWA.StartURL, "scope": w.App.PWA.Scope} {
+			if value != "" && !strings.HasPrefix(value, "/") {
+				return fmt.Errorf("freeze: app.pwa.%s must start with /", label)
+			}
+		}
+	}
+	return nil
+}
+
+func validateNodeGraduation(n world.Node) error {
+	for key := range n.Props {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if normalized == "class" || normalized == "style" || strings.HasPrefix(normalized, "on") {
+			return fmt.Errorf("node kind %q uses forbidden app-local styling or handler prop %q; compose a design-system kind instead", n.Kind, key)
+		}
+	}
+	for _, child := range n.Children {
+		if err := validateNodeGraduation(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func blueprintMap(w *world.World) map[string]any {
+	doc := map[string]any{"app": appMap(w.App)}
+	if entities := entityMaps(w); len(entities) > 0 {
+		doc["entities"] = entities
+	}
+	if screens := screenMaps(w); len(screens) > 0 {
+		doc["screens"] = screens
+	}
+	if nav := navMaps(w.Nav); len(nav) > 0 {
+		doc["nav"] = nav
+	}
+	if seed := seedMaps(w.Seeds); len(seed) > 0 {
+		doc["seed"] = seed
+	}
+	if endpoints := endpointMaps(w); len(endpoints) > 0 {
+		doc["endpoints"] = endpoints
+	}
+	if middleware := middlewareMaps(w); len(middleware) > 0 {
+		doc["middleware"] = middleware
+	}
+	if plugins := namedStubMaps(w.Plugins); len(plugins) > 0 {
+		doc["plugins"] = plugins
+	}
+	if helpers := namedStubMaps(w.Helpers); len(helpers) > 0 {
+		doc["helpers"] = helpers
+	}
+	return doc
+}
+
+func appMap(a world.AppConfig) map[string]any {
+	m := map[string]any{}
+	putString(m, "name", a.Name)
+	putString(m, "module", a.Module)
+	if a.DBDriver != "" || a.DBURL != "" {
+		db := map[string]any{}
+		putString(db, "driver", a.DBDriver)
+		putString(db, "url", a.DBURL)
+		m["db"] = db
+	}
+	putString(m, "static_dir", a.StaticDir)
+	putString(m, "output_dir", a.OutputDir)
+	// Kiln stores the resolved value, so an empty prefix is a deliberate
+	// opt-out and must be emitted explicitly rather than re-defaulting to api.
+	m["api_prefix"] = strings.Trim(a.APIPrefix, "/")
+	if len(a.Theme) > 0 || len(a.ThemeDark) > 0 {
+		theme := map[string]any{}
+		for k, v := range a.Theme {
+			theme[k] = v
+		}
+		if len(a.ThemeDark) > 0 {
+			dark := map[string]any{}
+			for k, v := range a.ThemeDark {
+				dark[k] = v
+			}
+			theme["dark"] = dark
+		}
+		m["theme"] = theme
+	}
+	if a.Auth.Enabled || a.Auth.BasePath != "" || a.Auth.JWTSecret != "" || !a.Auth.DevMode {
+		m["auth"] = map[string]any{
+			"enabled": a.Auth.Enabled, "dev_mode": a.Auth.DevMode,
+			"base_path": a.Auth.BasePath, "jwt_secret": a.Auth.JWTSecret,
+		}
+	}
+	if a.Admin.Enabled || a.Admin.Path != "" || a.Admin.Role != "" || a.Admin.LoginPath != "" || a.Admin.SeedEmail != "" || a.Admin.SeedPassword != "" {
+		m["admin"] = compact(map[string]any{
+			"enabled": a.Admin.Enabled, "path": a.Admin.Path, "role": a.Admin.Role,
+			"login_path": a.Admin.LoginPath, "seed_email": a.Admin.SeedEmail,
+			"seed_password": a.Admin.SeedPassword,
+		})
+	}
+	if a.PWA.Enabled {
+		m["pwa"] = compact(map[string]any{
+			"enabled": true, "name": a.PWA.Name, "short_name": a.PWA.ShortName,
+			"description": a.PWA.Description, "start_url": a.PWA.StartURL,
+			"scope": a.PWA.Scope, "display": a.PWA.Display,
+			"theme_color": a.PWA.ThemeColor, "background_color": a.PWA.BackgroundColor,
+		})
+	}
+	if a.LLMMD {
+		m["llm_md"] = true
+	}
+	return m
+}
+
+func entityMaps(w *world.World) []any {
+	entities := sortedEntities(w)
+	out := make([]any, 0, len(entities))
+	for _, e := range entities {
+		m := compact(map[string]any{
+			"name": e.Name, "table": e.Table, "soft_delete": e.SoftDelete,
+			"multi_tenant": e.MultiTenant, "owner_field": e.OwnerField,
+			"cross_owner_read": e.CrossOwnerRead, "search_fields": stringSlice(e.SearchFields),
+			"mcp": e.MCP, "cursor_field": e.CursorField,
+			"cursor_fields": stringSlice(e.CursorFields), "properties": e.Properties,
+		})
+		if e.Timestamps != nil {
+			m["timestamps"] = *e.Timestamps
+		}
+		if e.CRUD != nil {
+			m["crud"] = *e.CRUD
+		}
+		if e.Access != nil {
+			m["access"] = compact(map[string]any{
+				"read": e.Access.Read, "create": e.Access.Create,
+				"update": e.Access.Update, "delete": e.Access.Delete,
+			})
+		}
+		if len(e.Indices) > 0 {
+			indices := make([]any, 0, len(e.Indices))
+			for _, ix := range e.Indices {
+				indices = append(indices, compact(map[string]any{
+					"name": ix.Name, "columns": stringSlice(ix.Columns), "unique": ix.Unique,
+				}))
+			}
+			m["indices"] = indices
+		}
+		if len(e.Fields) > 0 {
+			fields := make([]any, 0, len(e.Fields))
+			for _, f := range e.Fields {
+				fm := compact(map[string]any{
+					"name": f.Name, "type": f.Type, "required": f.Required,
+					"unique": f.Unique, "auto_generate": f.AutoGenerate,
+					"read_only": f.ReadOnly, "hidden": f.Hidden, "pattern": f.Pattern,
+					"values": stringSlice(f.Values), "to": f.To, "many": f.Many,
+				})
+				if f.Default != nil {
+					fm["default"] = f.Default
+				}
+				if f.Max != nil {
+					fm["max"] = *f.Max
+				}
+				if f.Min != nil {
+					fm["min"] = *f.Min
+				}
+				fields = append(fields, fm)
+			}
+			m["fields"] = fields
+		}
+		if len(e.Relations) > 0 {
+			relations := make([]any, 0, len(e.Relations))
+			for _, r := range e.Relations {
+				target := r.Entity
+				if target == "" {
+					target = r.To
+				}
+				relations = append(relations, compact(map[string]any{
+					"type": normalizedRelationType(r.Type), "name": r.Name,
+					"entity": target, "foreign_key": r.ForeignKey, "through": r.Through,
+					"local_key": r.LocalKey, "foreign_key_target": r.ForeignKeyTarget,
+				}))
+			}
+			m["relations"] = relations
+		}
+		if len(e.Endpoints) > 0 {
+			endpoints := make([]any, 0, len(e.Endpoints))
+			for i, ep := range e.Endpoints {
+				name := ep.Name
+				if name == "" {
+					name = endpointName(ep.Method, ep.Path, i)
+				}
+				endpoints = append(endpoints, compact(map[string]any{
+					"name": name, "method": strings.ToUpper(ep.Method), "path": ep.Path,
+					"description": ep.Description, "mcp": ep.MCP,
+					"handler": identifier(e.Name + "_" + name),
+				}))
+			}
+			m["endpoints"] = endpoints
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func screenMaps(w *world.World) []any {
+	paths := make([]string, 0, len(w.Pages))
+	for path := range w.Pages {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	out := make([]any, 0, len(paths))
+	for _, path := range paths {
+		p := w.Pages[path]
+		if p == nil {
+			continue
+		}
+		layout := ""
+		if p.Layout != nil {
+			layout = p.Layout.Name
+		}
+		name := p.Name
+		if name == "" {
+			name = identifier(strings.Trim(path, "/"))
+			if name == "" {
+				name = "home"
+			}
+		}
+		route := p.Path
+		if route == "" {
+			route = path
+		}
+		m := compact(map[string]any{
+			"name": name, "route": route, "title": p.Title,
+			"description": p.Description, "type": p.Type, "layout": layout,
+			"body": []any{nodeMap(p.Tree)},
+		})
+		if p.Access.Auth || p.Access.Role != "" {
+			m["access"] = compact(map[string]any{"auth": p.Access.Auth || p.Access.Role != "", "role": p.Access.Role})
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func nodeMap(n world.Node) map[string]any {
+	m := compact(map[string]any{"kind": n.Kind, "props": n.Props})
+	if len(n.Children) > 0 {
+		children := make([]any, 0, len(n.Children))
+		for _, child := range n.Children {
+			children = append(children, nodeMap(child))
+		}
+		m["children"] = children
+	}
+	return m
+}
+
+func navMaps(items []world.NavItem) []any {
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		m := compact(map[string]any{"label": item.Label, "href": item.Href, "icon": item.Icon, "role": item.Role})
+		if children := navMaps(item.Items); len(children) > 0 {
+			m["items"] = children
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func seedMaps(seeds []*world.Seed) []any {
+	out := make([]any, 0, len(seeds))
+	for _, seed := range seeds {
+		if seed == nil {
+			continue
+		}
+		m := compact(map[string]any{"entity": seed.Entity, "rows": seed.Rows, "count": seed.Count, "weights": seed.Weights})
+		out = append(out, m)
+	}
+	return out
+}
+
+func endpointMaps(w *world.World) []any {
+	out := make([]any, 0, len(w.Endpoints)+len(w.Routes))
+	for i, ep := range w.Endpoints {
+		if ep == nil {
+			continue
+		}
+		name := ep.Name
+		if name == "" {
+			name = endpointName(ep.Method, ep.Path, i)
+		}
+		handler := ep.Handler
+		if handler == "" {
+			handler = identifier(name)
+		}
+		out = append(out, compact(map[string]any{
+			"name": name, "method": strings.ToUpper(ep.Method), "path": ep.Path,
+			"entity": ep.Entity, "handler": handler,
+			"description": ep.Description, "mcp": ep.MCP,
+		}))
+	}
+	for i, route := range w.Routes {
+		if route == nil {
+			continue
+		}
+		name := endpointName(route.Method, route.Path, len(out)+i)
+		out = append(out, map[string]any{
+			"name": name, "method": strings.ToUpper(route.Method), "path": route.Path,
+			"handler":     identifier(name),
+			"description": "Kiln declarative action " + route.Action.Kind + "; implement the owned-Go handler after generation",
+		})
+	}
+	return out
+}
+
+func middlewareMaps(w *world.World) []any {
+	out := make([]any, 0, len(w.Middleware)+len(w.MiddlewareStubs))
+	for _, item := range w.Middleware {
+		if item != nil {
+			out = append(out, compact(map[string]any{"name": item.Name, "description": item.Description}))
+		}
+	}
+	for _, item := range w.MiddlewareStubs {
+		out = append(out, compact(map[string]any{"name": item.Name, "description": item.Description}))
+	}
+	return out
+}
+
+func namedStubMaps(items []world.NamedStub) []any {
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		out = append(out, compact(map[string]any{"name": item.Name, "description": item.Description}))
+	}
+	return out
+}
+
+func sortedEntities(w *world.World) []*world.Entity {
+	names := make([]string, 0, len(w.Entities))
+	for name := range w.Entities {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]*world.Entity, 0, len(names))
+	for _, name := range names {
+		if w.Entities[name] != nil {
+			out = append(out, w.Entities[name])
+		}
+	}
+	return out
+}
+
+func endpointName(method, path string, fallback int) string {
+	name := identifier(strings.ToLower(method) + "_" + strings.Trim(path, "/"))
+	if name == "" {
+		return fmt.Sprintf("endpoint_%d", fallback+1)
+	}
+	return name
+}
+
+func identifier(value string) string {
+	var b strings.Builder
+	underscore := false
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			if underscore && b.Len() > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(unicode.ToLower(r))
+			underscore = false
+		} else {
+			underscore = true
+		}
+	}
+	out := strings.Trim(b.String(), "_")
+	if out != "" && unicode.IsDigit(rune(out[0])) {
+		out = "x_" + out
+	}
+	return out
+}
+
+func normalizedRelationType(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "has_one", "has_many", "many_to_many":
+		return strings.ToLower(strings.TrimSpace(value))
+	default:
+		return "belongs_to"
+	}
+}
+
+func stringSlice(values []string) any {
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}
+
+func putString(m map[string]any, key, value string) {
+	if value != "" {
+		m[key] = value
+	}
+}
+
+func compact(m map[string]any) map[string]any {
+	for key, value := range m {
+		switch v := value.(type) {
+		case nil:
+			delete(m, key)
+		case string:
+			if v == "" {
+				delete(m, key)
+			}
+		case bool:
+			if !v {
+				delete(m, key)
+			}
+		case int:
+			if v == 0 {
+				delete(m, key)
+			}
+		case []string:
+			if len(v) == 0 {
+				delete(m, key)
+			}
+		case []map[string]any:
+			if len(v) == 0 {
+				delete(m, key)
+			}
+		case map[string]any:
+			if len(v) == 0 {
+				delete(m, key)
+			}
+		default:
+			rv := reflect.ValueOf(value)
+			if (rv.Kind() == reflect.Map || rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array) && rv.Len() == 0 {
+				delete(m, key)
+			}
+		}
+	}
+	return m
+}
+
+// normalizeYAMLValue turns arbitrary JSON-clean maps/slices in props,
+// properties, seed rows, and defaults into the two container types the
+// deterministic writer understands.
+func normalizeYAMLValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Map:
+		out := map[string]any{}
+		iter := rv.MapRange()
+		for iter.Next() {
+			if iter.Key().Kind() != reflect.String {
+				continue
+			}
+			out[iter.Key().String()] = normalizeYAMLValue(iter.Value().Interface())
+		}
+		return out
+	case reflect.Slice, reflect.Array:
+		out := make([]any, rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			out[i] = normalizeYAMLValue(rv.Index(i).Interface())
+		}
+		return out
+	case reflect.Pointer:
+		if rv.IsNil() {
+			return nil
+		}
+		return normalizeYAMLValue(rv.Elem().Interface())
+	default:
+		return value
+	}
+}
+
+func writeYAMLMap(sb *strings.Builder, m map[string]any, indent int, order []string) {
+	for _, key := range orderedKeys(m, order) {
+		writeYAMLEntry(sb, key, m[key], indent)
+	}
+}
+
+func writeYAMLEntry(sb *strings.Builder, key string, value any, indent int) {
+	pad := strings.Repeat(" ", indent)
+	switch v := value.(type) {
+	case map[string]any:
+		if len(v) == 0 {
+			sb.WriteString(pad + key + ": {}\n")
+			return
+		}
+		sb.WriteString(pad + key + ":\n")
+		writeYAMLMap(sb, v, indent+2, orderFor(key))
+	case []any:
+		if len(v) == 0 {
+			sb.WriteString(pad + key + ": []\n")
+			return
+		}
+		if allScalars(v) {
+			sb.WriteString(pad + key + ": ")
+			writeFlowList(sb, v)
+			sb.WriteByte('\n')
+			return
+		}
+		sb.WriteString(pad + key + ":\n")
+		for _, item := range v {
+			writeYAMLListItem(sb, item, indent+2, orderFor(key))
+		}
+	default:
+		sb.WriteString(pad + key + ": ")
+		writeScalarInline(sb, value)
+		sb.WriteByte('\n')
+	}
+}
+
+func writeYAMLListItem(sb *strings.Builder, item any, indent int, order []string) {
+	if m, ok := item.(map[string]any); ok && len(m) > 0 {
+		keys := orderedKeys(m, order)
+		// core/yaml expects the first list-map key to have a scalar value.
+		// Prefer one even for arbitrary seed-row maps.
+		for i, key := range keys {
+			if isScalar(m[key]) {
+				keys[0], keys[i] = keys[i], keys[0]
+				break
+			}
+		}
+		first := keys[0]
+		sb.WriteString(strings.Repeat(" ", indent) + "- " + first + ":")
+		if isScalar(m[first]) {
+			sb.WriteByte(' ')
+			writeScalarInline(sb, m[first])
+			sb.WriteByte('\n')
+		} else {
+			sb.WriteByte('\n')
+			writeNestedValue(sb, m[first], indent+4, orderFor(first))
+		}
+		for _, key := range keys[1:] {
+			writeYAMLEntry(sb, key, m[key], indent+2)
+		}
+		return
+	}
+	sb.WriteString(strings.Repeat(" ", indent) + "- ")
+	writeScalarInline(sb, item)
+	sb.WriteByte('\n')
+}
+
+func writeNestedValue(sb *strings.Builder, value any, indent int, order []string) {
+	switch v := value.(type) {
+	case map[string]any:
+		writeYAMLMap(sb, v, indent, order)
+	case []any:
+		for _, item := range v {
+			writeYAMLListItem(sb, item, indent, order)
+		}
+	}
+}
+
+func writeFlowList(sb *strings.Builder, list []any) {
+	sb.WriteByte('[')
+	for i, value := range list {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		writeScalarInline(sb, value)
+	}
+	sb.WriteByte(']')
+}
+
+func writeScalarInline(sb *strings.Builder, value any) {
+	switch v := value.(type) {
+	case nil:
+		sb.WriteString("null")
+	case bool:
+		sb.WriteString(strconv.FormatBool(v))
+	case int:
+		sb.WriteString(strconv.Itoa(v))
+	case int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		sb.WriteString(fmt.Sprint(v))
+	case float32:
+		sb.WriteString(formatYAMLFloat(float64(v)))
+	case float64:
+		sb.WriteString(formatYAMLFloat(v))
+	case string:
+		sb.WriteString(quoteYAMLString(v))
+	default:
+		sb.WriteString(quoteYAMLString(fmt.Sprint(v)))
+	}
+}
+
+func formatYAMLFloat(value float64) string {
+	out := strconv.FormatFloat(value, 'g', -1, 64)
+	if !strings.ContainsAny(out, ".eE") {
+		out += ".0"
+	}
+	return out
+}
+
+func allScalars(values []any) bool {
+	for _, value := range values {
+		if !isScalar(value) {
+			return false
+		}
+	}
+	return true
+}
+
+func isScalar(value any) bool {
+	switch value.(type) {
+	case map[string]any, []any:
+		return false
+	default:
+		return true
+	}
+}
+
+func quoteYAMLString(value string) string {
+	if !needsQuote(value) {
+		return value
+	}
+	return strconv.Quote(value)
+}
+
+func needsQuote(value string) bool {
+	if value == "" {
+		return true
+	}
+	switch strings.ToLower(value) {
+	case "true", "false", "null", "~":
+		return true
+	}
+	if _, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return true
+	}
+	if _, err := strconv.ParseFloat(value, 64); err == nil && strings.ContainsAny(value, ".eE") {
+		return true
+	}
+	if strings.ContainsAny(value[:1], "[]{}&*!|>'\"%@`#,?: -") ||
+		strings.Contains(value, ": ") || strings.Contains(value, " #") ||
+		strings.ContainsAny(value, "\n\t") || value != strings.TrimSpace(value) ||
+		strings.HasSuffix(value, ":") {
+		return true
+	}
+	return false
+}
+
+func orderedKeys(m map[string]any, order []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(m))
+	for _, key := range order {
+		if _, ok := m[key]; ok {
+			out = append(out, key)
+			seen[key] = true
+		}
+	}
+	rest := make([]string, 0, len(m))
+	for key := range m {
+		if !seen[key] {
+			rest = append(rest, key)
+		}
+	}
+	sort.Strings(rest)
+	return append(out, rest...)
+}
+
+var (
+	topLevelOrder = []string{"app", "entities", "screens", "nav", "seed", "endpoints", "middleware", "plugins", "helpers"}
+	appOrder      = []string{"name", "module", "db", "static_dir", "output_dir", "api_prefix", "theme", "auth", "admin", "pwa", "llm_md"}
+	entityOrder   = []string{"name", "table", "crud", "mcp", "soft_delete", "multi_tenant", "owner_field", "cross_owner_read", "search_fields", "timestamps", "cursor_field", "cursor_fields", "properties", "access", "indices", "fields", "relations", "endpoints"}
+	fieldOrder    = []string{"name", "type", "required", "unique", "default", "max", "min", "pattern", "values", "to", "many", "auto_generate", "read_only", "hidden"}
+	screenOrder   = []string{"name", "route", "title", "description", "type", "layout", "access", "body"}
+	blockOrder    = []string{"kind", "props", "children"}
+	relationOrder = []string{"type", "name", "entity", "foreign_key", "through", "local_key", "foreign_key_target"}
+	indexOrder    = []string{"name", "columns", "unique"}
+	navOrder      = []string{"label", "href", "icon", "role", "items"}
+	accessOrder   = []string{"auth", "role", "read", "create", "update", "delete"}
+	endpointOrder = []string{"name", "method", "path", "entity", "handler", "description", "mcp"}
+	stubOrder     = []string{"name", "description"}
+	seedOrder     = []string{"entity", "rows", "count", "weights"}
+	dbOrder       = []string{"driver", "url"}
+	authOrder     = []string{"enabled", "dev_mode", "base_path", "jwt_secret"}
+	adminOrder    = []string{"enabled", "path", "role", "login_path", "seed_email", "seed_password"}
+	pwaOrder      = []string{"enabled", "name", "short_name", "description", "start_url", "scope", "display", "theme_color", "background_color"}
+)
+
+func orderFor(key string) []string {
+	switch key {
+	case "app":
+		return appOrder
+	case "entities":
+		return entityOrder
+	case "fields":
+		return fieldOrder
+	case "screens":
+		return screenOrder
+	case "body", "children":
+		return blockOrder
+	case "relations":
+		return relationOrder
+	case "indices":
+		return indexOrder
+	case "nav", "items":
+		return navOrder
+	case "access":
+		return accessOrder
+	case "endpoints":
+		return endpointOrder
+	case "middleware", "plugins", "helpers":
+		return stubOrder
+	case "seed":
+		return seedOrder
+	case "db":
+		return dbOrder
+	case "auth":
+		return authOrder
+	case "admin":
+		return adminOrder
+	case "pwa":
+		return pwaOrder
+	default:
+		return nil
+	}
+}

--- a/kiln/freeze/blueprint.go
+++ b/kiln/freeze/blueprint.go
@@ -22,6 +22,9 @@ func BlueprintYAML(w *world.World) ([]byte, error) {
 		return nil, err
 	}
 	doc := normalizeYAMLValue(blueprintMap(w)).(map[string]any)
+	if err := validateYAMLRepresentable(doc, ""); err != nil {
+		return nil, err
+	}
 	var out strings.Builder
 	writeYAMLMap(&out, doc, 0, topLevelOrder)
 	return []byte(out.String()), nil
@@ -557,34 +560,56 @@ func writeYAMLEntry(sb *strings.Builder, key string, value any, indent int) {
 }
 
 func writeYAMLListItem(sb *strings.Builder, item any, indent int, order []string) {
-	if m, ok := item.(map[string]any); ok && len(m) > 0 {
+	if m, ok := item.(map[string]any); ok {
+		if len(m) == 0 {
+			sb.WriteString(strings.Repeat(" ", indent) + "-\n")
+			return
+		}
 		keys := orderedKeys(m, order)
-		// core/yaml expects the first list-map key to have a scalar value.
-		// Prefer one even for arbitrary seed-row maps.
-		for i, key := range keys {
-			if isScalar(m[key]) {
-				keys[0], keys[i] = keys[i], keys[0]
-				break
-			}
+		// core/yaml expects the first list-map key to carry an inline value:
+		// a scalar, or a flow list of scalars. validateYAMLRepresentable
+		// guarantees one exists.
+		if i := inlineLeadKey(keys, m); i > 0 {
+			keys[0], keys[i] = keys[i], keys[0]
 		}
 		first := keys[0]
-		sb.WriteString(strings.Repeat(" ", indent) + "- " + first + ":")
-		if isScalar(m[first]) {
-			sb.WriteByte(' ')
-			writeScalarInline(sb, m[first])
-			sb.WriteByte('\n')
+		sb.WriteString(strings.Repeat(" ", indent) + "- " + first + ": ")
+		if lst, ok := m[first].([]any); ok {
+			writeFlowList(sb, lst)
 		} else {
-			sb.WriteByte('\n')
-			writeNestedValue(sb, m[first], indent+4, orderFor(first))
+			writeScalarInline(sb, m[first])
 		}
+		sb.WriteByte('\n')
 		for _, key := range keys[1:] {
 			writeYAMLEntry(sb, key, m[key], indent+2)
 		}
 		return
 	}
+	if lst, ok := item.([]any); ok && allScalars(lst) {
+		sb.WriteString(strings.Repeat(" ", indent) + "- ")
+		writeFlowList(sb, lst)
+		sb.WriteByte('\n')
+		return
+	}
 	sb.WriteString(strings.Repeat(" ", indent) + "- ")
 	writeScalarInline(sb, item)
 	sb.WriteByte('\n')
+}
+
+// inlineLeadKey returns the index of the first key whose value can head a
+// list item inline: a scalar, or a list of scalars. Returns -1 if none.
+func inlineLeadKey(keys []string, m map[string]any) int {
+	for i, key := range keys {
+		if isScalar(m[key]) {
+			return i
+		}
+	}
+	for i, key := range keys {
+		if lst, ok := m[key].([]any); ok && allScalars(lst) {
+			return i
+		}
+	}
+	return -1
 }
 
 func writeNestedValue(sb *strings.Builder, value any, indent int, order []string) {
@@ -679,11 +704,83 @@ func needsQuote(value string) bool {
 	}
 	if strings.ContainsAny(value[:1], "[]{}&*!|>'\"%@`#,?: -") ||
 		strings.Contains(value, ": ") || strings.Contains(value, " #") ||
+		// Commas split core/yaml flow lists; quotes and brackets anywhere
+		// confuse its quote/flow scanning; a colon in a block list item
+		// re-parses as `- key: value`. Quote them wherever they appear —
+		// over-quoting is harmless, under-quoting corrupts silently.
+		strings.ContainsAny(value, `,'"[]{}:`) ||
 		strings.ContainsAny(value, "\n\t") || value != strings.TrimSpace(value) ||
 		strings.HasSuffix(value, ":") {
 		return true
 	}
 	return false
+}
+
+// validateYAMLRepresentable rejects values the core/yaml emitter cannot
+// round-trip, so freeze fails loudly instead of writing a gofastr.yml that
+// silently re-parses into different data. Kiln worlds carry arbitrary JSON
+// (seed rows, props), so this is reachable, not theoretical.
+func validateYAMLRepresentable(value any, path string) error {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, child := range v {
+			if err := validateYAMLKey(key, path); err != nil {
+				return err
+			}
+			if err := validateYAMLRepresentable(child, joinPath(path, key)); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for i, item := range v {
+			itemPath := fmt.Sprintf("%s[%d]", path, i)
+			switch entry := item.(type) {
+			case map[string]any:
+				if len(entry) > 0 && inlineLeadKey(orderedKeys(entry, nil), entry) == -1 {
+					return fmt.Errorf("freeze: %s: core/yaml cannot represent a list item whose every value is nested (keys: %s); flatten one value to a scalar or scalar list", itemPath, strings.Join(sortedKeys(entry), ", "))
+				}
+			case []any:
+				if !allScalars(entry) {
+					return fmt.Errorf("freeze: %s: core/yaml cannot represent a list nested inside a list unless all its values are scalars", itemPath)
+				}
+			}
+			if err := validateYAMLRepresentable(item, itemPath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// validateYAMLKey rejects map keys core/yaml cannot parse back: it cuts each
+// line at the first colon and has no quoted-key syntax, comments start at
+// "#", and "[]{}" is rejected key syntax.
+func validateYAMLKey(key, path string) error {
+	if key == "" {
+		return fmt.Errorf("freeze: %s: empty map key cannot be represented in gofastr.yml", joinPath(path, key))
+	}
+	if strings.ContainsAny(key, ":#[]{}\n\t") ||
+		key != strings.TrimSpace(key) ||
+		strings.ContainsAny(key[:1], "-'\"") {
+		return fmt.Errorf("freeze: %s: map key %q cannot be represented in gofastr.yml (no colons, comments, brackets, quotes, or surrounding whitespace)", joinPath(path, key), key)
+	}
+	return nil
+}
+
+func joinPath(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
+}
+
+func sortedKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for key := range m {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func orderedKeys(m map[string]any, order []string) []string {

--- a/kiln/freeze/blueprint_yaml_test.go
+++ b/kiln/freeze/blueprint_yaml_test.go
@@ -1,0 +1,145 @@
+package freeze_test
+
+import (
+	"strings"
+	"testing"
+
+	coreyaml "github.com/DonaldMurillo/gofastr/core/yaml"
+	"github.com/DonaldMurillo/gofastr/kiln/freeze"
+	"github.com/DonaldMurillo/gofastr/kiln/world"
+)
+
+func seedWorld(rows ...map[string]any) *world.World {
+	w := world.New()
+	w.Entities["posts"] = &world.Entity{
+		Name: "posts",
+		Fields: []world.Field{
+			{Name: "title", Type: "string"},
+			{Name: "settings", Type: "json"},
+			{Name: "tags", Type: "json"},
+		},
+	}
+	w.Seeds = []*world.Seed{{Entity: "posts", Rows: rows}}
+	return w
+}
+
+func parseSeedRow(t *testing.T, buf []byte) *coreyaml.Node {
+	t.Helper()
+	doc, err := coreyaml.Parse(string(buf))
+	if err != nil {
+		t.Fatalf("core/yaml rejected freeze output: %v\n%s", err, buf)
+	}
+	seed := doc.Map["seed"]
+	if seed == nil || seed.Kind != coreyaml.List || len(seed.List) == 0 {
+		t.Fatalf("no seed list in blueprint:\n%s", buf)
+	}
+	rows := seed.List[0].Map["rows"]
+	if rows == nil || rows.Kind != coreyaml.List || len(rows.List) == 0 {
+		t.Fatalf("no seed rows in blueprint:\n%s", buf)
+	}
+	return rows.List[0]
+}
+
+func TestBlueprintQuotesCommaInList(t *testing.T) {
+	w := seedWorld(map[string]any{
+		"title": "Ship",
+		"tags":  []any{"Unlimited users, unlimited projects", "SSO"},
+	})
+	buf, err := freeze.BlueprintYAML(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := parseSeedRow(t, buf)
+	tags := row.Map["tags"]
+	if tags == nil || tags.Kind != coreyaml.List {
+		t.Fatalf("tags did not round-trip as a list:\n%s", buf)
+	}
+	if len(tags.List) != 2 {
+		t.Fatalf("comma split the list: got %d items, want 2\n%s", len(tags.List), buf)
+	}
+	if got := tags.List[0].Value; got != "Unlimited users, unlimited projects" {
+		t.Fatalf("first tag = %q", got)
+	}
+}
+
+func TestBlueprintQuotesApostropheInList(t *testing.T) {
+	w := seedWorld(map[string]any{
+		"title": "Ship",
+		"tags":  []any{"it's live", "done"},
+	})
+	buf, err := freeze.BlueprintYAML(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := parseSeedRow(t, buf)
+	tags := row.Map["tags"]
+	if tags == nil || tags.Kind != coreyaml.List || len(tags.List) != 2 {
+		t.Fatalf("apostrophe list did not round-trip:\n%s", buf)
+	}
+	if got := tags.List[0].Value; got != "it's live" {
+		t.Fatalf("first tag = %q", got)
+	}
+}
+
+func TestBlueprintSeedRowScalarListOnly(t *testing.T) {
+	// A row whose only values are scalar lists must still round-trip:
+	// the emitter leads the list item with an inline [a, b] key.
+	w := seedWorld(map[string]any{"tags": []any{"a", "b"}})
+	buf, err := freeze.BlueprintYAML(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := parseSeedRow(t, buf)
+	tags := row.Map["tags"]
+	if tags == nil || tags.Kind != coreyaml.List || len(tags.List) != 2 {
+		t.Fatalf("scalar-list row did not round-trip:\n%s", buf)
+	}
+	if len(row.Map) != 1 {
+		t.Fatalf("row grew phantom keys: %d keys, want 1\n%s", len(row.Map), buf)
+	}
+}
+
+func TestBlueprintRejectsMapOnlySeedRow(t *testing.T) {
+	// core/yaml cannot represent a list item whose every value is a nested
+	// map; freeze must fail loudly instead of emitting a corrupt blueprint.
+	w := seedWorld(map[string]any{"settings": map[string]any{"a": 1}})
+	_, err := freeze.BlueprintYAML(w)
+	if err == nil {
+		t.Fatal("expected loud error for map-only seed row, got nil")
+	}
+	if !strings.Contains(err.Error(), "settings") {
+		t.Fatalf("error should name the offending key: %v", err)
+	}
+}
+
+func TestBlueprintRejectsUnsafeSeedKey(t *testing.T) {
+	w := seedWorld(map[string]any{"aria: label": "v"})
+	_, err := freeze.BlueprintYAML(w)
+	if err == nil {
+		t.Fatal("expected loud error for key containing a colon, got nil")
+	}
+	if !strings.Contains(err.Error(), "aria: label") {
+		t.Fatalf("error should name the offending key: %v", err)
+	}
+}
+
+func TestBlueprintQuotesBareColonScalar(t *testing.T) {
+	// A mixed list forces block style; an unquoted "09:30" line would
+	// re-parse as the map {09: 30}.
+	w := seedWorld(map[string]any{
+		"title": "Ship",
+		"tags":  []any{"09:30", []any{"a"}},
+	})
+	buf, err := freeze.BlueprintYAML(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := parseSeedRow(t, buf)
+	tags := row.Map["tags"]
+	if tags == nil || tags.Kind != coreyaml.List || len(tags.List) != 2 {
+		t.Fatalf("mixed list did not round-trip:\n%s", buf)
+	}
+	if got := tags.List[0].Value; got != "09:30" {
+		t.Fatalf("colon scalar corrupted: got %v (kind %v)\n%s", got, tags.List[0].Kind, buf)
+	}
+}

--- a/kiln/freeze/codegen.go
+++ b/kiln/freeze/codegen.go
@@ -2,40 +2,40 @@ package freeze
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 
 	"github.com/DonaldMurillo/gofastr/kiln/world"
 )
 
-// ErrGenerateViaBlueprint signals that automated codegen from a frozen Kiln
-// world is temporarily unavailable. The legacy entities/*.json → gen/ codegen
-// path was removed in favour of the gofastr.yml blueprint; emitting a blueprint
-// from a Kiln world is a tracked follow-up (ROADMAP.md, "kiln freeze
-// → blueprint").
-var ErrGenerateViaBlueprint = errors.New(
-	"kiln freeze: automated codegen is pending blueprint support — the snapshot " +
-		"under <dir>/ is written; declare the frozen entities in a gofastr.yml " +
-		"blueprint and run `gofastr generate --from=gofastr.yml` to produce Go")
+// ErrGenerateViaBlueprint remains as a source-compatible sentinel for callers
+// compiled against the old deferred pipeline. FreezeAndGenerate no longer
+// returns it: Kiln now emits and invokes the blueprint directly.
+var ErrGenerateViaBlueprint = errors.New("kiln freeze: generate via blueprint")
 
-// FreezeAndGenerate writes the world's snapshot to dir (entities/*.json +
-// world.json) and previously also invoked `gofastr generate` to produce the
-// typed package alongside. The pkgPath argument named the relative output
-// directory for that generated Go code.
-//
-// The generate step is currently unavailable: it depended on the removed
-// entities/*.json → gen/ codegen path. The snapshot is still written; the
-// function then returns ErrGenerateViaBlueprint so callers can graduate the
-// frozen world manually via a gofastr.yml blueprint.
-func FreezeAndGenerate(w *world.World, dir, _ string) error {
+// FreezeAndGenerate writes gofastr.yml + world.json, then invokes the current
+// one-shot generator. pkgPath is an optional relative --out directory.
+func FreezeAndGenerate(w *world.World, dir, pkgPath string) error {
 	if err := Freeze(w, dir); err != nil {
 		return err
 	}
-	return ErrGenerateViaBlueprint
+	bin, err := exec.LookPath("gofastr")
+	if err != nil {
+		return fmt.Errorf("freeze: generate: %w", LookForGofastr())
+	}
+	args := []string{"generate", "--from=gofastr.yml"}
+	if pkgPath != "" {
+		args = append(args, "--out="+pkgPath)
+	}
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("freeze: gofastr generate: %w\n%s", err, output)
+	}
+	return nil
 }
 
 // LookForGofastr reports whether the gofastr binary is reachable on PATH.
-// Useful for callers that want to soft-detect codegen capability before
-// invoking FreezeAndGenerate.
 func LookForGofastr() error {
 	if _, err := exec.LookPath("gofastr"); err != nil {
 		return errors.New("gofastr binary not on PATH; run `go install ./cmd/gofastr` from the framework root")

--- a/kiln/freeze/codegen_test.go
+++ b/kiln/freeze/codegen_test.go
@@ -1,7 +1,6 @@
 package freeze
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,48 +9,29 @@ import (
 	"github.com/DonaldMurillo/gofastr/kiln/world"
 )
 
-// TestLookForGofastr_AbsentReturnsError confirms the soft-detect helper
-// returns a useful error when the binary isn't on PATH. We can't reliably
-// fake "not on PATH" at process scope; instead, this test just asserts
-// LookForGofastr's error wording when gofastr happens to be missing in the
-// CI sandbox. When it's present, we exercise the success path instead.
-func TestLookForGofastr_Reports(t *testing.T) {
+func TestLookForGofastrReports(t *testing.T) {
 	err := LookForGofastr()
-	if err != nil {
-		// gofastr not installed — verify the message is informative.
-		if !strings.Contains(err.Error(), "gofastr") {
-			t.Fatalf("expected error to mention gofastr binary, got %v", err)
-		}
+	if err != nil && !strings.Contains(err.Error(), "gofastr") {
+		t.Fatalf("expected error to mention gofastr binary, got %v", err)
 	}
-	// When gofastr IS on PATH, err is nil — nothing to assert beyond that.
 }
 
-// TestFreezeAndGenerate_WritesSnapshotDefersCodegen verifies the snapshot is
-// written and that automated codegen is deferred to the blueprint flow. The
-// legacy entities/*.json → gen/ codegen path was removed; FreezeAndGenerate
-// now returns ErrGenerateViaBlueprint after writing the snapshot.
-func TestFreezeAndGenerate_WritesSnapshotDefersCodegen(t *testing.T) {
+func TestFreezeAndGenerateAlwaysWritesBlueprintBeforeCommand(t *testing.T) {
 	w := world.New()
-	w.Entities["posts"] = &world.Entity{
-		Name:  "posts",
-		Table: "posts",
-		Fields: []world.Field{
-			{Name: "title", Type: "string", Required: true},
-			{Name: "body", Type: "text"},
-		},
-	}
+	w.App.Name = "demo"
+	w.Entities["posts"] = &world.Entity{Name: "posts", Fields: []world.Field{{Name: "title", Type: "string"}}}
 	dir := t.TempDir()
-	err := FreezeAndGenerate(w, dir, "gen")
-	if !errors.Is(err, ErrGenerateViaBlueprint) {
-		t.Fatalf("want ErrGenerateViaBlueprint, got %v", err)
+
+	// An empty PATH makes the command phase deterministic while still
+	// proving the new graduation artifact is written first.
+	t.Setenv("PATH", "")
+	err := FreezeAndGenerate(w, dir, "")
+	if err == nil || !strings.Contains(err.Error(), "gofastr") {
+		t.Fatalf("want missing gofastr error, got %v", err)
 	}
-	// The snapshot artifacts are still written.
-	for _, want := range []string{
-		filepath.Join(dir, "entities", "posts.json"),
-		filepath.Join(dir, "world.json"),
-	} {
-		if _, err := os.Stat(want); err != nil {
-			t.Errorf("missing snapshot file %s: %v", want, err)
+	for _, want := range []string{"gofastr.yml", "world.json"} {
+		if _, statErr := os.Stat(filepath.Join(dir, want)); statErr != nil {
+			t.Errorf("missing %s after command lookup failure: %v", want, statErr)
 		}
 	}
 }

--- a/kiln/freeze/freeze.go
+++ b/kiln/freeze/freeze.go
@@ -1,16 +1,11 @@
 // Package freeze emits canonical source artifacts from a Kiln world so
 // the in-memory build-mode app can graduate to a regular GoFastr project.
 //
-// v1 emits two artifacts:
+// Freeze emits two artifacts:
 //
-//	<dir>/entities/<name>.json — one file per entity in the readable JSON
-//	                             entity shape (mirrors EntityDeclaration).
-//	<dir>/world.json           — full world snapshot (entities + pages +
-//	                             hooks + routes + seeds + middleware).
-//
-// Pages, hooks, routes, and seeds aren't yet emittable as Go source. The
-// snapshot lets a Kiln session restart from where it left off; further
-// codegen lands in later phases.
+//	<dir>/gofastr.yml — current one-shot blueprint for owned-Go generation.
+//	<dir>/world.json  — lossless authoring snapshot, including declarative
+//	                    actions that graduate as owned-Go handler stubs.
 package freeze
 
 import (
@@ -35,8 +30,8 @@ func Freeze(w *world.World, dir string) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("freeze: mkdir: %w", err)
 	}
-	if err := writeEntities(w, dir); err != nil {
-		return fmt.Errorf("freeze: entities: %w", err)
+	if err := writeBlueprint(w, dir); err != nil {
+		return fmt.Errorf("freeze: blueprint: %w", err)
 	}
 	if err := writeWorldSnapshot(w, dir); err != nil {
 		return fmt.Errorf("freeze: world snapshot: %w", err)
@@ -44,28 +39,12 @@ func Freeze(w *world.World, dir string) error {
 	return nil
 }
 
-func writeEntities(w *world.World, dir string) error {
-	if len(w.Entities) == 0 {
-		return nil
-	}
-	entDir := filepath.Join(dir, "entities")
-	if err := os.MkdirAll(entDir, 0o755); err != nil {
+func writeBlueprint(w *world.World, dir string) error {
+	buf, err := BlueprintYAML(w)
+	if err != nil {
 		return err
 	}
-	for _, ent := range w.Entities {
-		if ent == nil {
-			continue
-		}
-		buf, err := json.MarshalIndent(ent, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal %s: %w", ent.Name, err)
-		}
-		path := filepath.Join(entDir, ent.Name+".json")
-		if err := os.WriteFile(path, append(buf, '\n'), 0o644); err != nil {
-			return fmt.Errorf("write %s: %w", path, err)
-		}
-	}
-	return nil
+	return os.WriteFile(filepath.Join(dir, "gofastr.yml"), buf, 0o644)
 }
 
 func writeWorldSnapshot(w *world.World, dir string) error {

--- a/kiln/freeze/freeze_test.go
+++ b/kiln/freeze/freeze_test.go
@@ -4,107 +4,82 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/DonaldMurillo/gofastr/kiln/freeze"
 	"github.com/DonaldMurillo/gofastr/kiln/world"
 )
 
-func TestFreezeWritesEntities(t *testing.T) {
+func TestFreezeWritesBlueprintAndWorldSnapshot(t *testing.T) {
 	w := world.New()
 	w.App.Name = "blog"
+	w.App.Module = "example.com/blog"
 	w.Entities["posts"] = &world.Entity{
-		Name: "posts",
+		Name: "posts", OwnerField: "user_id", SearchFields: []string{"title", "body"},
 		Fields: []world.Field{
 			{Name: "title", Type: "string", Required: true},
 			{Name: "body", Type: "text"},
 		},
 	}
-	w.Entities["users"] = &world.Entity{
-		Name: "users",
-		Fields: []world.Field{
-			{Name: "email", Type: "string", Required: true, Unique: true},
-		},
+	w.Pages["/posts"] = &world.Page{
+		Path: "/posts", Name: "posts", Title: "Posts",
+		Tree: world.Node{Kind: "page_header", Props: map[string]any{"title": "Posts"}},
 	}
+	w.Nav = []world.NavItem{{Label: "Posts", Href: "/posts"}}
 
 	dir := t.TempDir()
 	if err := freeze.Freeze(w, dir); err != nil {
 		t.Fatalf("Freeze: %v", err)
 	}
 
-	// entities/<name>.json files should exist and be valid JSON
-	// declarations with the expected name and fields.
-	for _, name := range []string{"posts", "users"} {
-		path := filepath.Join(dir, "entities", name+".json")
-		buf, err := os.ReadFile(path)
-		if err != nil {
-			t.Errorf("read %s: %v", name, err)
-			continue
-		}
-		var decl map[string]any
-		if err := json.Unmarshal(buf, &decl); err != nil {
-			t.Errorf("unmarshal %s: %v", name, err)
-			continue
-		}
-		if decl["name"] != name {
-			t.Errorf("frozen entity name = %v, want %q", decl["name"], name)
-		}
-		if fields, ok := decl["fields"].([]any); !ok || len(fields) == 0 {
-			t.Errorf("frozen entity %s missing fields: %#v", name, decl["fields"])
+	buf, err := os.ReadFile(filepath.Join(dir, "gofastr.yml"))
+	if err != nil {
+		t.Fatalf("read gofastr.yml: %v", err)
+	}
+	yml := string(buf)
+	for _, want := range []string{
+		"name: blog", "module: example.com/blog", "api_prefix: api",
+		"owner_field: user_id", "search_fields:", "route: /posts", "nav:",
+	} {
+		if !strings.Contains(yml, want) {
+			t.Errorf("gofastr.yml missing %q:\n%s", want, yml)
 		}
 	}
-}
-
-func TestFreezeWorldSnapshot(t *testing.T) {
-	w := world.New()
-	w.App.Name = "demo"
-	w.Pages["/dashboard"] = &world.Page{
-		Path: "/dashboard",
-		Tree: world.Node{Kind: "div", Children: []world.Node{{Kind: "heading", Props: map[string]any{"level": float64(1), "text": "Hi"}}}},
-	}
-	w.Hooks = append(w.Hooks, &world.Hook{ID: "h1", Entity: "posts", When: "before_create", Action: world.Action{Kind: world.ActionNoop}})
-
-	dir := t.TempDir()
-	if err := freeze.Freeze(w, dir); err != nil {
-		t.Fatalf("Freeze: %v", err)
+	if _, err := os.Stat(filepath.Join(dir, "entities")); !os.IsNotExist(err) {
+		t.Errorf("legacy entities/ output should be gone; stat err=%v", err)
 	}
 
-	buf, err := os.ReadFile(filepath.Join(dir, "world.json"))
+	snapshot, err := os.ReadFile(filepath.Join(dir, "world.json"))
 	if err != nil {
 		t.Fatalf("read world.json: %v", err)
 	}
 	var got world.World
-	if err := json.Unmarshal(buf, &got); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	if err := json.Unmarshal(snapshot, &got); err != nil {
+		t.Fatalf("unmarshal world snapshot: %v", err)
 	}
-	if got.App.Name != "demo" {
-		t.Errorf("App.Name = %q", got.App.Name)
-	}
-	if _, ok := got.Pages["/dashboard"]; !ok {
-		t.Error("page lost in snapshot")
-	}
-	if len(got.Hooks) != 1 {
-		t.Errorf("hooks = %d", len(got.Hooks))
+	if got.App.Name != "blog" || got.Entities["posts"].OwnerField != "user_id" {
+		t.Fatalf("snapshot lost current world fields: %+v", got)
 	}
 }
 
 func TestFreezeIdempotent(t *testing.T) {
 	w := world.New()
-	w.Entities["posts"] = &world.Entity{
-		Name:   "posts",
-		Fields: []world.Field{{Name: "title", Type: "string"}},
-	}
+	w.Entities["posts"] = &world.Entity{Name: "posts", Fields: []world.Field{{Name: "title", Type: "string"}}}
 	dir := t.TempDir()
 	if err := freeze.Freeze(w, dir); err != nil {
 		t.Fatalf("first: %v", err)
 	}
+	first, err := os.ReadFile(filepath.Join(dir, "gofastr.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := freeze.Freeze(w, dir); err != nil {
 		t.Fatalf("second: %v", err)
 	}
-	// Same content both times.
-	first, _ := os.ReadFile(filepath.Join(dir, "entities", "posts.json"))
-	if len(first) == 0 {
-		t.Fatal("entity file empty")
+	second, _ := os.ReadFile(filepath.Join(dir, "gofastr.yml"))
+	if string(first) != string(second) {
+		t.Fatalf("freeze output changed across identical runs:\n--- first ---\n%s\n--- second ---\n%s", first, second)
 	}
 }
 
@@ -114,39 +89,26 @@ func TestFreezeRejectsNilWorld(t *testing.T) {
 	}
 }
 
-func TestFrozenEntitiesLoadIntoFreshApp(t *testing.T) {
+func TestFreezeRejectsBlueprintThatCannotGraduate(t *testing.T) {
+	w := world.New()
+	w.Entities["records"] = &world.Entity{Name: "records", MultiTenant: true}
+	if err := freeze.Freeze(w, t.TempDir()); err == nil || !strings.Contains(err.Error(), "tenant resolver") {
+		t.Fatalf("expected actionable multi-tenant graduation error, got %v", err)
+	}
+}
+
+func TestBlueprintKeepsLegacyRelationTarget(t *testing.T) {
 	w := world.New()
 	w.Entities["posts"] = &world.Entity{
-		Name: "posts",
-		Fields: []world.Field{
-			{Name: "title", Type: "string", Required: true},
-			{Name: "body", Type: "text"},
-		},
-		MCP: true,
+		Name:      "posts",
+		Relations: []world.Relation{{Name: "author", To: "users", Type: "belongs_to", ForeignKey: "user_id"}},
 	}
-	dir := t.TempDir()
-	if err := freeze.Freeze(w, dir); err != nil {
-		t.Fatalf("Freeze: %v", err)
-	}
-
-	// The frozen entities/ drops straight into a regular GoFastr
-	// project. Validate the emitted declaration round-trips as JSON
-	// carrying the entity's name, fields, and config flags.
-	buf, err := os.ReadFile(filepath.Join(dir, "entities", "posts.json"))
+	buf, err := freeze.BlueprintYAML(w)
 	if err != nil {
-		t.Fatalf("read posts.json: %v", err)
+		t.Fatal(err)
 	}
-	var decl map[string]any
-	if err := json.Unmarshal(buf, &decl); err != nil {
-		t.Fatalf("unmarshal posts.json: %v", err)
-	}
-	if decl["name"] != "posts" {
-		t.Errorf("frozen entity name = %v", decl["name"])
-	}
-	if fields, ok := decl["fields"].([]any); !ok || len(fields) != 2 {
-		t.Errorf("frozen fields = %#v", decl["fields"])
-	}
-	if decl["mcp"] != true {
-		t.Errorf("frozen mcp flag = %#v", decl["mcp"])
+	yml := string(buf)
+	if !strings.Contains(yml, "entity: users") || strings.Contains(yml, "to: users") {
+		t.Fatalf("legacy relation target did not normalize to current blueprint shape:\n%s", yml)
 	}
 }

--- a/kiln/integration/browser_test.go
+++ b/kiln/integration/browser_test.go
@@ -299,6 +299,68 @@ func TestBrowser_AgentAddedPageRenders(t *testing.T) {
 	}
 }
 
+// A browser that opens after an agent turn receives an empty-world widget
+// skeleton inline, then hydrates the current chat/world signals. That panel
+// hydration must not erase or replace the already-rendered application screen.
+func TestBrowser_PrepopulatedWorldHydratesWithoutErasingScreen(t *testing.T) {
+	urlBase, tools := startKiln(t)
+	ctx, cancel := newChrome(t)
+	defer cancel()
+
+	if res := tools.SetAppConfig(t.Context(), protocol.SetAppConfigArgs{Config: world.AppConfig{
+		Name: "Live Forge", Module: "example.com/live-forge", APIPrefix: "api",
+	}}); !res.OK {
+		t.Fatal(res)
+	}
+	for _, entity := range []*world.Entity{
+		{Name: "posts", Fields: []world.Field{{Name: "title", Type: "string"}}},
+		{Name: "categories", Fields: []world.Field{{Name: "slug", Type: "string"}}},
+	} {
+		if res := tools.AddEntity(t.Context(), protocol.AddEntityArgs{Entity: entity}); !res.OK {
+			t.Fatal(res)
+		}
+	}
+	if res := tools.AddPage(t.Context(), protocol.AddPageArgs{Page: &world.Page{
+		Path: "/", Name: "home", Title: "Live Forge", Layout: &world.Layout{Name: "marketing"},
+		Tree: world.Node{Kind: "stack", Props: map[string]any{"gap": "xl"}, Children: []world.Node{
+			{Kind: "hero", Props: map[string]any{"eyebrow": "Kiln + OMP", "title": "Live Forge", "subtitle": "Owned Go."}},
+			{Kind: "section", Props: map[string]any{"heading": "What was built"}, Children: []world.Node{
+				{Kind: "grid", Props: map[string]any{"min": "16rem"}, Children: []world.Node{
+					{Kind: "card", Props: map[string]any{"heading": "Posts API"}},
+					{Kind: "card", Props: map[string]any{"heading": "Owned-Go freeze"}},
+				}},
+			}},
+		}},
+	}}); !res.OK {
+		t.Fatal(res)
+	}
+	if res := tools.Chat(t.Context(), protocol.ChatArgs{Role: "user", Text: "build the forge"}); !res.OK {
+		t.Fatal(res)
+	}
+
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(urlBase+"/"),
+		chromedp.WaitVisible(`h1`, chromedp.ByQuery),
+		chromedp.WaitVisible(`.kiln-msg-user`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.kiln-panel-snapshot')?.textContent.includes('2 entities')`, nil,
+			chromedp.WithPollingInterval(100*time.Millisecond)),
+	); err != nil {
+		t.Fatalf("hydrate populated world: %v", err)
+	}
+	var heading, body string
+	var scrollY float64
+	if err := chromedp.Run(ctx,
+		chromedp.Text(`h1`, &heading, chromedp.ByQuery),
+		chromedp.Text(`body`, &body, chromedp.ByQuery),
+		chromedp.Evaluate(`window.scrollY`, &scrollY),
+	); err != nil {
+		t.Fatalf("read hydrated screen: %v", err)
+	}
+	if heading != "Live Forge" || !strings.Contains(body, "Posts API") {
+		t.Fatalf("panel hydration erased the screen: h1=%q scrollY=%v body=%.500q", heading, scrollY, body)
+	}
+}
+
 // --- (5) data-kiln-tool button fires the tool ----------------------
 
 func TestBrowser_ButtonToolCallFires(t *testing.T) {
@@ -368,7 +430,7 @@ func TestBrowser_FormSubmitCreatesRow(t *testing.T) {
 		Path: "/new-note",
 		Tree: world.Node{Kind: "div", Children: []world.Node{
 			{Kind: "heading", Props: map[string]any{"level": float64(1), "text": "New Note"}},
-			{Kind: "form", Props: map[string]any{"id": "f", "method": "POST", "action": "/notes"}, Children: []world.Node{
+			{Kind: "form", Props: map[string]any{"id": "f", "method": "POST", "action": "/api/notes"}, Children: []world.Node{
 				{Kind: "input", Props: map[string]any{"id": "txt", "name": "text", "type": "text"}},
 				{Kind: "button", Props: map[string]any{"id": "submit", "type": "submit", "label": "Save"}},
 			}},
@@ -386,18 +448,18 @@ func TestBrowser_FormSubmitCreatesRow(t *testing.T) {
 		t.Fatalf("submit: %v", err)
 	}
 
-	// The widget's submit handler posts JSON to /notes then reloads.
+	// The runtime's submit handler posts JSON to /api/notes.
 	// Verify the row landed by polling the CRUD listing directly with
 	// the test's HTTP client — no need to fight the reload race.
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		body, err := httpGet(t, urlBase+"/notes")
+		body, err := httpGet(t, urlBase+"/api/notes")
 		if err == nil && strings.Contains(body, "a brand new note") {
 			return
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	t.Fatalf("note never landed in /notes")
+	t.Fatalf("note never landed in /api/notes")
 }
 
 // httpGet is a tiny helper for tests that want to bypass chromedp.
@@ -478,10 +540,10 @@ func TestBrowser_SeedRowsVisibleAfterAddSeed(t *testing.T) {
 
 	var listing string
 	if err := chromedp.Run(ctx,
-		chromedp.Navigate(urlBase+"/tasks"),
+		chromedp.Navigate(urlBase+"/api/tasks"),
 		chromedp.Text(`body`, &listing, chromedp.ByQuery),
 	); err != nil {
-		t.Fatalf("navigate /tasks: %v", err)
+		t.Fatalf("navigate /api/tasks: %v", err)
 	}
 	for _, want := range []string{"buy milk", "write more tests"} {
 		if !strings.Contains(listing, want) {

--- a/kiln/integration/integration_test.go
+++ b/kiln/integration/integration_test.go
@@ -86,7 +86,7 @@ func TestAllFieldTypesFunctional(t *testing.T) {
 	body := bytes.NewBufferString(`{
 		"s":"hello","t":"world","i":42,"f":3.14,"b":true,"e":"b","j":"{\"k\":1}"
 	}`)
-	req := httptest.NewRequest(http.MethodPost, "/kitchen_sink", body)
+	req := httptest.NewRequest(http.MethodPost, "/api/kitchen_sink", body)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	h.live.ServeHTTP(rec, req)
@@ -96,7 +96,7 @@ func TestAllFieldTypesFunctional(t *testing.T) {
 
 	// GET back and verify s/i/e survived round-trip.
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodGet, "/kitchen_sink", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/kitchen_sink", nil)
 	h.live.ServeHTTP(rec, req)
 	if rec.Code != 200 {
 		t.Fatalf("GET status=%d", rec.Code)
@@ -161,7 +161,7 @@ func TestBeforeCreateHookRejectsRow(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"name":"spam"}`)
-	req := httptest.NewRequest("POST", "/items", body)
+	req := httptest.NewRequest("POST", "/api/items", body)
 	req.Header.Set("Content-Type", "application/json")
 	h.live.ServeHTTP(rec, req)
 	if rec.Code < 400 {
@@ -297,26 +297,20 @@ func TestFreezeRoundTripWithRichWorld(t *testing.T) {
 		t.Fatalf("freeze: %v", err)
 	}
 
-	// Frozen JSON should drop into a vanilla project cleanly: each
-	// entities/<name>.json is a valid declaration carrying its name
-	// and fields.
-	for _, n := range []string{"posts", "users"} {
-		buf, err := os.ReadFile(filepath.Join(dir, "entities", n+".json"))
-		if err != nil {
-			t.Errorf("%s missing after freeze: %v", n, err)
-			continue
+	// Current graduation emits a generator-ready gofastr.yml plus the
+	// lossless world.json snapshot; the pre-v0.1 entities/*.json path is gone.
+	blueprint, err := os.ReadFile(filepath.Join(dir, "gofastr.yml"))
+	if err != nil {
+		t.Fatalf("gofastr.yml missing after freeze: %v", err)
+	}
+	text := string(blueprint)
+	for _, want := range []string{"name: posts", "name: users", "name: title", "name: email"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("blueprint missing %q:\n%s", want, text)
 		}
-		var decl map[string]any
-		if err := json.Unmarshal(buf, &decl); err != nil {
-			t.Errorf("%s invalid JSON: %v", n, err)
-			continue
-		}
-		if decl["name"] != n {
-			t.Errorf("%s frozen name = %v", n, decl["name"])
-		}
-		if fields, ok := decl["fields"].([]any); !ok || len(fields) == 0 {
-			t.Errorf("%s frozen fields = %#v", n, decl["fields"])
-		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "world.json")); err != nil {
+		t.Fatalf("world.json missing after freeze: %v", err)
 	}
 }
 
@@ -591,14 +585,14 @@ func TestFullBlogScenario(t *testing.T) {
 	// CRUD endpoint exists and posts derive slug via hook.
 	rec = httptest.NewRecorder()
 	body := bytes.NewBufferString(`{"title":"Hello World","body":"first post","status":"published"}`)
-	req := httptest.NewRequest("POST", "/posts", body)
+	req := httptest.NewRequest("POST", "/api/posts", body)
 	req.Header.Set("Content-Type", "application/json")
 	h.live.ServeHTTP(rec, req)
 	if rec.Code >= 400 {
-		t.Fatalf("POST /posts: %d body=%s", rec.Code, rec.Body.String())
+		t.Fatalf("POST /api/posts: %d body=%s", rec.Code, rec.Body.String())
 	}
 	rec = httptest.NewRecorder()
-	h.live.ServeHTTP(rec, httptest.NewRequest("GET", "/posts", nil))
+	h.live.ServeHTTP(rec, httptest.NewRequest("GET", "/api/posts", nil))
 	out := rec.Body.String()
 	if !strings.Contains(out, "hello world") {
 		t.Errorf("slug not derived to lowercase: %s", out)

--- a/kiln/integration/live_agent_test.go
+++ b/kiln/integration/live_agent_test.go
@@ -1,7 +1,7 @@
-// Live agent tests: spawn a real `kiln serve --agent "pi -p ..."`
+// Live agent tests: spawn a real `kiln serve --agent omp`
 // subprocess and drive build prompts end-to-end. These tests verify
 // "the agent can actually build X" — not "the IR shape works in
-// isolation". They burn pi API credits (~$0.001-0.01 per scenario)
+// isolation". They use OMP with GLM-5.2 and consume provider credits,
 // and are SLOW (30-180s per prompt), so they're gated by KILN_LIVE=1
 // and skip otherwise.
 //
@@ -26,16 +26,18 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/chromedp/chromedp"
 )
 
-// liveCheck skips the test if KILN_LIVE != 1 or pi isn't in PATH.
+// liveCheck skips the test if KILN_LIVE != 1 or OMP isn't in PATH.
 func liveCheck(t *testing.T) {
 	t.Helper()
 	if os.Getenv("KILN_LIVE") != "1" {
-		t.Skip("set KILN_LIVE=1 to run live agent tests (uses real pi + API credits)")
+		t.Skip("set KILN_LIVE=1 to run live agent tests (uses real OMP/GLM-5.2 + provider credits)")
 	}
-	if _, err := exec.LookPath("pi"); err != nil {
-		t.Skipf("pi not in PATH: %v", err)
+	if _, err := exec.LookPath("omp"); err != nil {
+		t.Skipf("omp not in PATH: %v", err)
 	}
 	if _, err := exec.LookPath("kiln"); err != nil {
 		// fall back to ~/go/bin/kiln
@@ -75,7 +77,7 @@ type liveServer struct {
 	t   *testing.T
 }
 
-// startLiveKiln spawns `kiln serve --agent "pi -p ..."` in a temp dir
+// startLiveKiln spawns `kiln serve --agent omp` in a temp dir
 // and waits for it to be ready. Returns a wrapper with cleanup.
 func startLiveKiln(t *testing.T) *liveServer {
 	t.Helper()
@@ -83,18 +85,9 @@ func startLiveKiln(t *testing.T) *liveServer {
 	port := freePort(t)
 	url := fmt.Sprintf("http://127.0.0.1:%d", port)
 
-	model := os.Getenv("KILN_LIVE_MODEL")
-	if model == "" {
-		model = "glm-5.1"
-	}
-	provider := os.Getenv("KILN_LIVE_PROVIDER")
-	if provider == "" {
-		provider = "zai"
-	}
-
 	cmd := exec.Command(kilnBin(t), "serve",
 		"--addr", fmt.Sprintf(":%d", port),
-		"--agent", fmt.Sprintf("pi -p --provider %s --model %s", provider, model),
+		"--agent", "omp",
 	)
 	cmd.Dir = dir
 	cmd.Stdout = newLogPipe(t, "kiln")
@@ -135,9 +128,9 @@ func (s *liveServer) Stop() {
 }
 
 // chatRetry runs a chat prompt and retries with a correction when the
-// supplied check fails. Pi is non-deterministic — sometimes it
+// supplied check fails. A live model is non-deterministic — sometimes it
 // describes the change in prose without actually making the tool
-// call. The corrective second prompt feeds the failure back so pi
+// call. The corrective second prompt feeds the failure back so the agent
 // can self-fix rather than blindly retrying.
 func (s *liveServer) chatRetry(prompt string, timeout time.Duration, attempts int, check func() bool) {
 	s.t.Helper()
@@ -351,22 +344,22 @@ func TestLive_BuildEntityWithFieldTypes(t *testing.T) {
 	)
 
 	// Hit the auto-generated CRUD endpoint.
-	body, err := httpGet(t, srv.URL+"/tasks")
+	body, err := httpGet(t, srv.URL+"/api/tasks")
 	if err != nil {
-		t.Fatalf("GET /tasks: %v", err)
+		t.Fatalf("GET /api/tasks: %v", err)
 	}
 	if !strings.Contains(body, "data") {
-		t.Errorf("/tasks doesn't look like a CRUD list: %.500s", body)
+		t.Errorf("/api/tasks doesn't look like a CRUD list: %.500s", body)
 	}
 
 	// Insert a row and re-fetch.
 	row, _ := json.Marshal(map[string]any{
 		"title": "first task", "done": false, "priority": 1, "notes": "live",
 	})
-	if _, err := httpPost(t, srv.URL+"/tasks", row); err != nil {
-		t.Fatalf("POST /tasks: %v", err)
+	if _, err := httpPost(t, srv.URL+"/api/tasks", row); err != nil {
+		t.Fatalf("POST /api/tasks: %v", err)
 	}
-	body, _ = httpGet(t, srv.URL+"/tasks")
+	body, _ = httpGet(t, srv.URL+"/api/tasks")
 	if !strings.Contains(body, "first task") {
 		t.Errorf("inserted row not visible after GET: %.500s", body)
 	}
@@ -401,12 +394,12 @@ func TestLive_BuildHookFires(t *testing.T) {
 
 	// Allowed insert.
 	good, _ := json.Marshal(map[string]any{"title": "hello", "body": ""})
-	if _, err := httpPost(t, srv.URL+"/posts", good); err != nil {
+	if _, err := httpPost(t, srv.URL+"/api/posts", good); err != nil {
 		t.Fatalf("good post: %v", err)
 	}
 	// Spam should be rejected by the hook.
 	bad, _ := json.Marshal(map[string]any{"title": "spam", "body": ""})
-	resp, _ := httpPost(t, srv.URL+"/posts", bad)
+	resp, _ := httpPost(t, srv.URL+"/api/posts", bad)
 	if !strings.Contains(resp, "no spam allowed") {
 		t.Errorf("hook didn't fire / didn't include the message: %.500s", resp)
 	}
@@ -449,7 +442,7 @@ func TestLive_PageWithForm(t *testing.T) {
 
 	srv.chatRetry(
 		`Step 1: add an entity "notes" with field text (string, required). `+
-			`Step 2: add a page at "/new" containing a form with method POST action /notes, `+
+			`Step 2: add a page at "/new" containing a form with method POST action /api/notes, `+
 			`a label "Note" with for="t", an input id="t" name="text" type="text", and a submit button labeled "Save". `+
 			`Use add_entity then add_page.`,
 		liveTimeout(),
@@ -469,7 +462,7 @@ func TestLive_PageWithForm(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /new: %v", err)
 	}
-	if !strings.Contains(body, `action="/notes"`) {
+	if !strings.Contains(body, `action="/api/notes"`) {
 		t.Errorf("form action missing: %.800s", body)
 	}
 	if !strings.Contains(body, `name="text"`) {
@@ -584,10 +577,10 @@ func TestLive_AllFieldTypes(t *testing.T) {
 		"i": 42, "f": 3.14, "d": "10.50",
 		"b": true, "e": "b", "j": `{"k":1}`,
 	})
-	if _, err := httpPost(t, srv.URL+"/kitchen_sink", row); err != nil {
-		t.Fatalf("POST /kitchen_sink: %v", err)
+	if _, err := httpPost(t, srv.URL+"/api/kitchen_sink", row); err != nil {
+		t.Fatalf("POST /api/kitchen_sink: %v", err)
 	}
-	got, _ := httpGet(t, srv.URL+"/kitchen_sink")
+	got, _ := httpGet(t, srv.URL+"/api/kitchen_sink")
 	for _, want := range []string{`"s":"hello"`, `"i":42`} {
 		if !strings.Contains(got, want) {
 			t.Errorf("response missing %s: %.500s", want, got)
@@ -628,14 +621,14 @@ Do exactly these three calls and stop.`,
 
 	// Validate hook should reject empty title.
 	bad, _ := json.Marshal(map[string]any{"title": ""})
-	resp, _ := httpPost(t, srv.URL+"/posts", bad)
+	resp, _ := httpPost(t, srv.URL+"/api/posts", bad)
 	if !strings.Contains(resp, "title required") {
 		t.Errorf("validate hook didn't fire; got: %.300s", resp)
 	}
 
 	// set_field hook should derive slug from title.
 	good, _ := json.Marshal(map[string]any{"title": "Hello World"})
-	resp, err := httpPost(t, srv.URL+"/posts", good)
+	resp, err := httpPost(t, srv.URL+"/api/posts", good)
 	if err != nil {
 		t.Fatalf("good post: %v", err)
 	}
@@ -645,7 +638,7 @@ Do exactly these three calls and stop.`,
 }
 
 // TestLive_OpenAPIFromAgent: agent registers entities; openapi.json
-// auto-served by Live includes them. Distinguishes "pi didn't follow"
+// auto-served by Live includes them. Distinguishes "the agent didn't follow"
 // from "openapi mount broken" so failures point at the right thing.
 func TestLive_OpenAPIFromAgent(t *testing.T) {
 	liveCheck(t)
@@ -657,7 +650,7 @@ func TestLive_OpenAPIFromAgent(t *testing.T) {
 2) add_entity for "authors" with fields name (string, required) and bio (text)
 Make EXACTLY these two add_entity calls. Stop after the second.`,
 		liveTimeout(),
-		3, // pi is non-deterministic; allow one retry
+		3, // a live model is non-deterministic; allow retries
 		func() bool {
 			w := srv.world()
 			_, hasBooks := w.Entities["books"]
@@ -668,10 +661,10 @@ Make EXACTLY these two add_entity calls. Stop after the second.`,
 
 	world := srv.world()
 	if _, ok := world.Entities["books"]; !ok {
-		t.Fatalf("pi didn't add books entity even after retry; world=%+v", world.Entities)
+		t.Fatalf("agent didn't add books entity even after retry; world=%+v", world.Entities)
 	}
 	if _, ok := world.Entities["authors"]; !ok {
-		t.Fatalf("pi didn't add authors entity even after retry; world=%+v", world.Entities)
+		t.Fatalf("agent didn't add authors entity even after retry; world=%+v", world.Entities)
 	}
 
 	spec, err := httpGet(t, srv.URL+"/openapi.json")
@@ -712,10 +705,10 @@ Use add_entity exactly once with mcp:true set. Stop after.`,
 	world := srv.world()
 	ent, ok := world.Entities["products"]
 	if !ok {
-		t.Fatalf("pi didn't add products entity even after retry")
+		t.Fatalf("agent didn't add products entity even after retry")
 	}
 	if ent["mcp"] != true {
-		t.Fatalf("pi added products but without mcp:true; got %v", ent["mcp"])
+		t.Fatalf("agent added products but without mcp:true; got %v", ent["mcp"])
 	}
 
 	body, _ := json.Marshal(map[string]any{
@@ -856,7 +849,7 @@ func TestLive_MultiTurnConversation(t *testing.T) {
 	)
 	w := srv.world()
 	if _, ok := w.Entities["posts"]; !ok {
-		t.Fatalf("turn 1 — pi never added posts entity. world=%+v", w.Entities)
+		t.Fatalf("turn 1 — agent never added posts entity. world=%+v", w.Entities)
 	}
 	t.Logf("turn 1 ok: posts entity present")
 
@@ -878,15 +871,14 @@ func TestLive_MultiTurnConversation(t *testing.T) {
 		t.Fatalf("turn 2 — comments missing. world=%+v", w.Entities)
 	}
 	if _, ok := w.Entities["posts"]; !ok {
-		t.Fatalf("turn 2 — pi destroyed the posts entity. world=%+v", w.Entities)
+		t.Fatalf("turn 2 — agent destroyed the posts entity. world=%+v", w.Entities)
 	}
 	t.Logf("turn 2 ok: posts + comments coexist")
 
 	// --- Turn 3: add a page; entities stay intact -------------------
-	// Avoid colliding with the posts entity's CRUD list endpoint at
-	// GET /posts. Use /blog as the page path.
+	// CRUD lives under /api, so /blog is an ordinary UI route.
 	srv.chatRetry(
-		`Add a page at path "/blog" (NOT "/posts" — that path is taken by the posts entity's auto-CRUD). `+
+		`Add a page at path "/blog". `+
 			`The page should have a heading level 1 with text "Blog" and a paragraph saying "All recent posts." `+
 			`Make EXACTLY one add_page call. Don't touch entities.`,
 		liveTimeout(),
@@ -925,13 +917,13 @@ func TestLive_MultiTurnConversation(t *testing.T) {
 	)
 	// Try to insert a row with empty title — hook should reject.
 	bad, _ := json.Marshal(map[string]any{"title": "", "body": "x"})
-	resp, _ := httpPost(t, srv.URL+"/posts", bad)
+	resp, _ := httpPost(t, srv.URL+"/api/posts", bad)
 	if !strings.Contains(resp, "title required") {
 		t.Errorf("turn 4 — hook didn't fire on empty title. got: %.300s", resp)
 	}
 	// Good insert should still succeed.
 	good, _ := json.Marshal(map[string]any{"title": "Hi", "body": "first"})
-	if _, err := httpPost(t, srv.URL+"/posts", good); err != nil {
+	if _, err := httpPost(t, srv.URL+"/api/posts", good); err != nil {
 		t.Errorf("turn 4 — good insert failed: %v", err)
 	}
 	t.Logf("turn 4 ok: hook rejects empty, allows valid")
@@ -962,7 +954,7 @@ func TestLive_MultiTurnConversation(t *testing.T) {
 		t.Errorf("turn 5 — /blog page got dropped")
 	}
 	// Hook still fires.
-	resp, _ = httpPost(t, srv.URL+"/posts", bad)
+	resp, _ = httpPost(t, srv.URL+"/api/posts", bad)
 	if !strings.Contains(resp, "title required") {
 		t.Errorf("turn 5 — hook stopped firing after route add. got: %.300s", resp)
 	}
@@ -1002,15 +994,15 @@ func TestLive_SeedRowsVisible(t *testing.T) {
 		liveTimeout(),
 		3,
 		func() bool {
-			body, _ := httpGet(t, srv.URL+"/tasks")
+			body, _ := httpGet(t, srv.URL+"/api/tasks")
 			return strings.Contains(body, "buy milk") && strings.Contains(body, "ship feature")
 		},
 	)
 
-	body, _ := httpGet(t, srv.URL+"/tasks")
+	body, _ := httpGet(t, srv.URL+"/api/tasks")
 	for _, want := range []string{"buy milk", "ship feature"} {
 		if !strings.Contains(body, want) {
-			t.Errorf("seed row %q not visible at GET /tasks: %.500s", want, body)
+			t.Errorf("seed row %q not visible at GET /api/tasks: %.500s", want, body)
 		}
 	}
 }
@@ -1039,7 +1031,7 @@ func TestLive_AfterCreateAuditFires(t *testing.T) {
 	)
 
 	row, _ := json.Marshal(map[string]any{"name": "first", "detail": "trigger the hook"})
-	resp, err := httpPost(t, srv.URL+"/events", row)
+	resp, err := httpPost(t, srv.URL+"/api/events", row)
 	if err != nil {
 		t.Fatalf("POST /events: %v", err)
 	}
@@ -1074,7 +1066,7 @@ func TestLive_RelationField(t *testing.T) {
 
 	// Insert an author then a book referencing them.
 	a, _ := json.Marshal(map[string]any{"name": "Octavia Butler"})
-	respA, err := httpPost(t, srv.URL+"/authors", a)
+	respA, err := httpPost(t, srv.URL+"/api/authors", a)
 	if err != nil {
 		t.Fatalf("post author: %v", err)
 	}
@@ -1094,10 +1086,10 @@ func TestLive_RelationField(t *testing.T) {
 	}
 
 	b, _ := json.Marshal(map[string]any{"title": "Kindred", "author_id": id})
-	if _, err := httpPost(t, srv.URL+"/books", b); err != nil {
+	if _, err := httpPost(t, srv.URL+"/api/books", b); err != nil {
 		t.Fatalf("post book: %v", err)
 	}
-	books, _ := httpGet(t, srv.URL+"/books")
+	books, _ := httpGet(t, srv.URL+"/api/books")
 	if !strings.Contains(books, "Kindred") {
 		t.Errorf("book with relation not visible: %.500s", books)
 	}
@@ -1140,7 +1132,7 @@ func TestLive_PageElementsVariety(t *testing.T) {
 	}
 	for snippet, label := range checks {
 		if !strings.Contains(body, snippet) {
-			t.Errorf("%s missing (looking for %q) — pi may have used wrong IR shape: %.800s", label, snippet, body)
+			t.Errorf("%s missing (looking for %q) — agent may have used wrong IR shape: %.800s", label, snippet, body)
 		}
 	}
 }
@@ -1184,167 +1176,169 @@ func TestLive_ButtonToolDispatch(t *testing.T) {
 	}
 }
 
-// TestLive_FreezeAndGenerateGo: the actual ship-it pipeline.
-//
-//  1. Live kiln, agent builds an app (entities, hook, route, page).
-//  2. kiln freeze --dir build/ reads the journal and writes
-//     entities/*.json + world.json.
-//  3. cmd/gofastr generate reads build/entities/*.json and writes
-//     gen/entities/{models.go, register.go} alongside it.
-//  4. We check that the produced Go files compile (via `go build`
-//     against a tiny synthetic main.go that imports them).
-//
-// If any step blows up, "the agent can build a real app you can
-// commit" is a lie. This test is the contract.
+// TestLive_FreezeAndGenerateGo is the ship-it contract:
+// OMP/GLM-5.2 edits a live world, `kiln freeze` emits the current blueprint,
+// the current CLI validates and generates it, and the complete owned-Go app
+// compiles against this worktree.
 func TestLive_FreezeAndGenerateGo(t *testing.T) {
-	// The generate step (cmd/gofastr generate over build/entities/*.json) was
-	// removed with the legacy entities/*.json codegen path. Graduating a frozen
-	// Kiln world to Go now goes through a gofastr.yml blueprint — a tracked
-	// follow-up (ROADMAP.md, "kiln freeze → blueprint").
-	t.Skip("freeze→generate ship-it pipeline pending blueprint support")
 	liveCheck(t)
 	srv := startLiveKiln(t)
 
-	// 1) Agent scaffolds something with multiple field types and a hook.
 	srv.chatRetry(
-		`Make these calls in order:
-1) add_entity "posts" with fields title (string, required, unique), body (text), status (enum, values [draft, published], default draft).
-2) add_entity "users" with fields email (string, required, unique), name (string).
-Stop after the two add_entity calls.`,
+		`Use the Kiln tools now; do not merely describe the calls.
+1) Call set_app_config with this exact nested argument shape: {"config":{"name":"Live Forge","module":"example.com/kiln-live","db_driver":"sqlite","db_url":"live.db","api_prefix":"api","llm_md":true}}.
+2) add_entity "posts" with title (string, required, unique), body (text), and status (enum values draft and published, default draft).
+3) add_entity "categories" with slug (string, required, unique) and description (text).
+4) Call add_page with this exact current design-system page: {"page":{"path":"/","name":"home","title":"Live Forge","layout":{"name":"marketing"},"tree":{"kind":"stack","props":{"gap":"xl"},"children":[{"kind":"hero","props":{"eyebrow":"Kiln + OMP","title":"Live Forge","subtitle":"A live world that graduates to owned Go."}},{"kind":"section","props":{"heading":"What was built","description":"Current GoFastr surfaces, driven live."},"children":[{"kind":"grid","props":{"min":"16rem","gap":"lg"},"children":[{"kind":"card","props":{"heading":"Posts API"}},{"kind":"card","props":{"heading":"Owned-Go freeze"}}]}]}]}}}.
+5) Call set_scaffold with {"nav":[{"label":"Home","href":"/"}],"endpoints":[{"name":"health","method":"GET","path":"/healthz","handler":"HealthHandler","description":"Health check"}],"middleware":[{"name":"request_logger","description":"Request logging"}],"plugins":[{"name":"metrics","description":"Metrics integration"}],"helpers":[{"name":"slug","description":"Slug helper"}]}.
+Stop after world_get confirms the app config, both entities, the home page, and navigation.`,
 		liveTimeout(),
 		3,
 		func() bool {
 			w := srv.world()
 			_, hasPosts := w.Entities["posts"]
-			_, hasUsers := w.Entities["users"]
-			return hasPosts && hasUsers
+			_, hasCategories := w.Entities["categories"]
+			_, hasHome := w.Pages["/"]
+			return hasPosts && hasCategories && hasHome && len(w.Nav) == 1 && w.App["name"] == "Live Forge"
 		},
 	)
 	w := srv.world()
 	if _, ok := w.Entities["posts"]; !ok {
 		t.Fatalf("agent never built posts; world=%+v", w.Entities)
 	}
-	if _, ok := w.Entities["users"]; !ok {
-		t.Fatalf("agent never built users; world=%+v", w.Entities)
+	if _, ok := w.Entities["categories"]; !ok {
+		t.Fatalf("agent never built categories; world=%+v", w.Entities)
+	}
+	if w.App["name"] != "Live Forge" {
+		t.Fatalf("agent never configured the app; app=%+v", w.App)
+	}
+	if _, ok := w.Pages["/"]; !ok || len(w.Nav) != 1 {
+		t.Fatalf("agent never built the live home/navigation surface; pages=%+v nav=%+v", w.Pages, w.Nav)
 	}
 
-	// 2) kiln freeze: invoke the CLI directly so the test exercises the
-	//    user-visible command, not just the library.
-	freezeDir := filepath.Join(srv.Dir, "build")
+	// Read pixels from the actual OMP-built world before graduation. The
+	// screenshot is intentionally retained under testdata for human review.
+	ctx, cancel := newChrome(t)
+	defer cancel()
+	var shot []byte
+	var renderedBody string
+	if err := chromedp.Run(ctx,
+		chromedp.EmulateViewport(1280, 900),
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`h1`, chromedp.ByQuery),
+		// Widget chrome is SSR-inlined from the server's initial empty world;
+		// hydration must replace it with the current journal/snapshot state.
+		chromedp.WaitVisible(`.kiln-msg-user`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.kiln-panel-snapshot')?.textContent.includes('2 entities')`, nil,
+			chromedp.WithPollingInterval(100*time.Millisecond)),
+		chromedp.Text(`body`, &renderedBody, chromedp.ByQuery),
+		chromedp.Evaluate(`window.scrollTo(0, 0)`, nil),
+		chromedp.FullScreenshot(&shot, 90),
+	); err != nil {
+		t.Fatalf("render OMP-built page: %v", err)
+	}
+	if !strings.Contains(renderedBody, "Live Forge") || !strings.Contains(renderedBody, "Owned-Go freeze") {
+		t.Fatalf("hydrated OMP-built page lost its screen content: %.800s", renderedBody)
+	}
+	saveShot(t, "09_live_omp_forge_desktop", shot)
+
+	// Freeze into the future app root. A go.mod beside the blueprint lets both
+	// validate and generation prove module-path consistency.
+	appDir := filepath.Join(srv.Dir, "app")
 	freezeCmd := exec.Command(kilnBin(t), "freeze",
 		"--journal", filepath.Join(srv.Dir, ".kiln.session.jsonl"),
-		"--dir", freezeDir)
+		"--dir", appDir)
 	freezeCmd.Stdout = newLogPipe(t, "freeze")
 	freezeCmd.Stderr = newLogPipe(t, "freeze")
 	if err := freezeCmd.Run(); err != nil {
 		t.Fatalf("kiln freeze failed: %v", err)
 	}
-	for _, ent := range []string{"posts", "users"} {
-		path := filepath.Join(freezeDir, "entities", ent+".json")
-		if _, err := os.Stat(path); err != nil {
-			t.Fatalf("freeze missing %s: %v", path, err)
+	for _, name := range []string{"gofastr.yml", "world.json"} {
+		if _, err := os.Stat(filepath.Join(appDir, name)); err != nil {
+			t.Fatalf("freeze missing %s: %v", name, err)
 		}
 	}
-	t.Logf("freeze ok: %s/entities/{posts,users}.json", freezeDir)
 
-	// 3) cmd/gofastr generate: emits Go from the JSON declarations.
-	gofastrPath, err := exec.LookPath("gofastr")
-	if err != nil {
-		// fall back to ~/go/bin/gofastr if not in PATH
-		home, _ := os.UserHomeDir()
-		alt := filepath.Join(home, "go/bin/gofastr")
-		if _, e := os.Stat(alt); e == nil {
-			gofastrPath = alt
-		} else {
-			// Build it in-place into the test's temp space.
-			gofastrPath = filepath.Join(srv.Dir, "gofastr")
-			build := exec.Command("go", "build", "-o", gofastrPath,
-				"github.com/DonaldMurillo/gofastr/cmd/gofastr")
-			build.Stdout = newLogPipe(t, "go-build")
-			build.Stderr = newLogPipe(t, "go-build")
-			if err := build.Run(); err != nil {
-				t.Fatalf("build gofastr: %v", err)
-			}
-		}
-	}
-	genCmd := exec.Command(gofastrPath, "generate")
-	genCmd.Dir = freezeDir
-	genCmd.Stdout = newLogPipe(t, "generate")
-	genCmd.Stderr = newLogPipe(t, "generate")
-	if err := genCmd.Run(); err != nil {
-		t.Fatalf("gofastr generate failed: %v", err)
-	}
-
-	for _, want := range []string{
-		filepath.Join(freezeDir, "gen/entities/models.go"),
-		filepath.Join(freezeDir, "gen/entities/register.go"),
-	} {
-		if _, err := os.Stat(want); err != nil {
-			t.Errorf("expected generated file missing: %s (%v)", want, err)
-		}
-	}
-	t.Logf("gofastr generate ok: produced gen/entities/*.go")
-
-	// 4) Inspect a generated file for entity-specific markers — proves
-	//    the IR actually drove codegen, not a static stub.
-	body, err := os.ReadFile(filepath.Join(freezeDir, "gen/entities/models.go"))
-	if err != nil {
-		t.Fatalf("read generated models.go: %v", err)
-	}
-	src := string(body)
-	for _, want := range []string{"posts", "users", "Title", "Email"} {
-		// Some fields may end up Title-cased in struct names, hence
-		// the mixed list. Either form indicates the entity-specific
-		// content rendered.
-		if !strings.Contains(strings.ToLower(src), strings.ToLower(want)) {
-			t.Errorf("models.go missing %q (entity-specific content didn't generate): %.500s",
-				want, src)
-		}
-	}
-	t.Logf("generated Go references entity-specific content (posts, users, Title, Email)")
-
-	// 5) Real commit-flow check: the generated code must actually COMPILE.
-	//    Inspecting strings is not enough — a typo in the generator could
-	//    produce text that "looks right" but won't build. Wire up a
-	//    throwaway go module that depends on the local worktree, then
-	//    `go build ./...`.
 	repoRoot, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
 	if err != nil {
 		t.Fatalf("git rev-parse: %v", err)
 	}
 	repoRootStr := strings.TrimSpace(string(repoRoot))
-
-	goMod := "module compile-check\n\n" +
-		"go 1.26\n\n" +
+	goMod := "module example.com/kiln-live\n\ngo 1.26\n\n" +
 		"require github.com/DonaldMurillo/gofastr v0.0.0-00010101000000-000000000000\n\n" +
-		"replace github.com/DonaldMurillo/gofastr => " + repoRootStr + "\n"
-	if err := os.WriteFile(filepath.Join(freezeDir, "go.mod"), []byte(goMod), 0o644); err != nil {
-		t.Fatalf("write go.mod: %v", err)
-	}
-	// Mirror the worktree's go.sum so transitive deps are already pinned
-	// and we don't need network during the test.
-	if existing, err := os.ReadFile(filepath.Join(repoRootStr, "go.sum")); err == nil {
-		_ = os.WriteFile(filepath.Join(freezeDir, "go.sum"), existing, 0o644)
+		"replace github.com/DonaldMurillo/gofastr => " + filepath.ToSlash(repoRootStr) + "\n"
+	if err := os.WriteFile(filepath.Join(appDir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatalf("write generated-app go.mod: %v", err)
 	}
 
-	// Generated package lives at gen/entities — Go's `./...` skips
-	// dot-prefixed directories, so target it explicitly.
-	build := exec.Command("go", "build", "./gen/entities")
-	build.Dir = freezeDir
-	build.Env = append(os.Environ(), "GOFLAGS=-mod=mod")
-	build.Stdout = newLogPipe(t, "go-build-gen")
-	build.Stderr = newLogPipe(t, "go-build-gen")
-	if err := build.Run(); err != nil {
-		t.Fatalf("generated code did not compile: %v", err)
+	// Always build the CLI from this worktree; an installed older gofastr must
+	// never make a parity test pass or fail for the wrong version.
+	gofastrPath := filepath.Join(srv.Dir, "gofastr")
+	if os.PathSeparator == '\\' {
+		gofastrPath += ".exe"
 	}
-	t.Logf("generated code compiles cleanly — commit-flow round-trip is real")
+	cliBuild := exec.Command("go", "build", "-o", gofastrPath,
+		"github.com/DonaldMurillo/gofastr/cmd/gofastr")
+	cliBuild.Stdout = newLogPipe(t, "go-build-gofastr")
+	cliBuild.Stderr = newLogPipe(t, "go-build-gofastr")
+	if err := cliBuild.Run(); err != nil {
+		t.Fatalf("build current gofastr: %v", err)
+	}
+
+	blueprint := filepath.Join(appDir, "gofastr.yml")
+	validateCmd := exec.Command(gofastrPath, "validate", blueprint)
+	validateCmd.Dir = appDir
+	validateCmd.Stdout = newLogPipe(t, "validate")
+	validateCmd.Stderr = newLogPipe(t, "validate")
+	if err := validateCmd.Run(); err != nil {
+		t.Fatalf("frozen blueprint did not validate: %v", err)
+	}
+
+	genCmd := exec.Command(gofastrPath, "generate", "--from=gofastr.yml")
+	genCmd.Dir = appDir
+	genCmd.Stdout = newLogPipe(t, "generate")
+	genCmd.Stderr = newLogPipe(t, "generate")
+	if err := genCmd.Run(); err != nil {
+		t.Fatalf("gofastr generate failed: %v", err)
+	}
+	for _, want := range []string{
+		"main.go", "app.go", "stubs.go", filepath.Join("entities", "posts.go"),
+		filepath.Join("entities", "categories.go"), filepath.Join("entities", "register.go"),
+		"screen_home.go",
+	} {
+		if _, err := os.Stat(filepath.Join(appDir, want)); err != nil {
+			t.Errorf("expected generated file missing: %s (%v)", want, err)
+		}
+	}
+
+	postsBody, err := os.ReadFile(filepath.Join(appDir, "entities", "posts.go"))
+	if err != nil {
+		t.Fatalf("read generated posts.go: %v", err)
+	}
+	for _, want := range []string{"Title", "Body", "Status", "published"} {
+		if !strings.Contains(string(postsBody), want) {
+			t.Errorf("posts.go missing %q: %.800s", want, postsBody)
+		}
+	}
+
+	build := exec.Command("go", "build", "./...")
+	build.Dir = appDir
+	build.Env = append(os.Environ(), "GOFLAGS=-mod=mod")
+	build.Stdout = newLogPipe(t, "go-build-generated")
+	build.Stderr = newLogPipe(t, "go-build-generated")
+	if err := build.Run(); err != nil {
+		t.Fatalf("generated app did not compile: %v", err)
+	}
+	t.Logf("OMP/GLM-5.2 world froze, validated, generated, and compiled at %s", appDir)
 }
 
 // --- world dump helper ----------------------------------------------
 
 type worldDump struct {
+	App      map[string]any
 	Entities map[string]map[string]any
 	Pages    map[string]map[string]any
+	Nav      []map[string]any
 	Routes   []map[string]any
 	Hooks    []map[string]any
 }
@@ -1357,8 +1351,10 @@ func (s *liveServer) world() worldDump {
 	}
 	var resp struct {
 		World struct {
+			App      map[string]any            `json:"app"`
 			Entities map[string]map[string]any `json:"entities"`
 			Pages    map[string]map[string]any `json:"pages"`
+			Nav      []map[string]any          `json:"nav"`
 			Routes   []map[string]any          `json:"routes"`
 			Hooks    []map[string]any          `json:"hooks"`
 		} `json:"world"`
@@ -1367,8 +1363,10 @@ func (s *liveServer) world() worldDump {
 		s.t.Fatalf("decode world: %v body=%.300s", err, body)
 	}
 	return worldDump{
+		App:      resp.World.App,
 		Entities: resp.World.Entities,
 		Pages:    resp.World.Pages,
+		Nav:      resp.World.Nav,
 		Routes:   resp.World.Routes,
 		Hooks:    resp.World.Hooks,
 	}

--- a/kiln/integration/visual_test.go
+++ b/kiln/integration/visual_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"github.com/DonaldMurillo/gofastr/internal/axetest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,19 +46,28 @@ func TestVisual_HostEmptyState(t *testing.T) {
 	ctx, cancel := newChrome(t)
 	defer cancel()
 
-	var shot []byte
 	if err := chromedp.Run(ctx,
 		chromedp.EmulateViewport(1280, 800),
 		chromedp.Navigate(urlBase+"/"),
 		chromedp.WaitVisible(`.kiln-panel.kiln-open`, chromedp.ByQuery),
 		chromedp.WaitVisible(`.kiln-quickstart`, chromedp.ByQuery),
 		chromedp.WaitVisible(`.kiln-input`, chromedp.ByQuery),
-		chromedp.FullScreenshot(&shot, 90),
 	); err != nil {
 		t.Fatalf("navigate: %v", err)
 	}
-	path := saveShot(t, "01_host_empty", shot)
-	t.Logf("saved: %s", path)
+	// The landing is themed by app.css tokens; capture it in both schemes.
+	for _, scheme := range axetest.Schemes {
+		var shot []byte
+		if err := chromedp.Run(ctx,
+			axetest.Prepare(scheme),
+			chromedp.Sleep(300*time.Millisecond),
+			chromedp.FullScreenshot(&shot, 90),
+		); err != nil {
+			t.Fatalf("capture %s: %v", scheme, err)
+		}
+		path := saveShot(t, "01_host_empty_"+scheme, shot)
+		t.Logf("saved: %s", path)
+	}
 }
 
 // (2) Agent-turn state is visibly delivered by the current SSE signal path.

--- a/kiln/integration/visual_test.go
+++ b/kiln/integration/visual_test.go
@@ -38,10 +38,9 @@ func saveShot(t *testing.T, name string, buf []byte) string {
 	return path
 }
 
-// (1) Empty state on host renders the welcome cards + the floating
-// expanded panel with empty message.
+// (1) Empty state on host renders the current framework floating panel and
+// its server-rendered quick-start tray.
 func TestVisual_HostEmptyState(t *testing.T) {
-	t.Skip("host empty-state DOM (.kiln-empty) was a legacy widget.js construct; new panel mounts immediately — needs visual test rewrite")
 	urlBase, _ := startKiln(t)
 	ctx, cancel := newChrome(t)
 	defer cancel()
@@ -50,7 +49,8 @@ func TestVisual_HostEmptyState(t *testing.T) {
 	if err := chromedp.Run(ctx,
 		chromedp.EmulateViewport(1280, 800),
 		chromedp.Navigate(urlBase+"/"),
-		chromedp.WaitVisible(`.kiln-empty`, chromedp.ByQuery),
+		chromedp.WaitVisible(`.kiln-panel.kiln-open`, chromedp.ByQuery),
+		chromedp.WaitVisible(`.kiln-quickstart`, chromedp.ByQuery),
 		chromedp.WaitVisible(`.kiln-input`, chromedp.ByQuery),
 		chromedp.FullScreenshot(&shot, 90),
 	); err != nil {
@@ -60,55 +60,50 @@ func TestVisual_HostEmptyState(t *testing.T) {
 	t.Logf("saved: %s", path)
 }
 
-// (2) Status text is visible mid-flight. We slow the network so the
-// pending state stays on screen long enough to capture.
-func TestVisual_StatusFeedbackOnSend(t *testing.T) {
-	t.Skip(".kiln-status was a legacy widget.js DOM node; status feedback in the new panel surfaces via signals — needs visual test rewrite")
-	urlBase, _ := startKiln(t)
+// (2) Agent-turn state is visibly delivered by the current SSE signal path.
+func TestVisual_StatusFeedbackDuringTurn(t *testing.T) {
+	urlBase, l, _ := startKilnExt(t)
 	ctx, cancel := newChrome(t)
 	defer cancel()
 
-	var statusVisibleText string
 	if err := chromedp.Run(ctx,
 		chromedp.EmulateViewport(1280, 800),
 		chromedp.Navigate(urlBase+"/"),
-		chromedp.WaitVisible(`.kiln-input`, chromedp.ByQuery),
-		// Stub fetch with a 400ms delay so the "sending…" / "sent" text
-		// is observable to a human eye AND to chromedp.
-		chromedp.Evaluate(`(function(){
-			const orig = window.fetch;
-			window.fetch = (u, o) => new Promise((res) => {
-				setTimeout(() => res(orig(u, o)), 400);
-			});
-		})()`, nil),
-		chromedp.SendKeys(`.kiln-input`, "watch the status"),
-		chromedp.Click(`.kiln-send`, chromedp.ByQuery),
+		chromedp.WaitVisible(`.kiln-panel-head`, chromedp.ByQuery),
 	); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
+	waitForSSE(t, ctx)
+	testInFlight.Store(true)
+	l.Notify("agent_turn_started", "omp")
 
-	// Capture the pending status while the request is in-flight.
+	var statusVisibleText string
 	var shotPending []byte
 	if err := chromedp.Run(ctx,
-		chromedp.WaitVisible(`.kiln-status`, chromedp.ByQuery),
-		chromedp.Text(`.kiln-status`, &statusVisibleText, chromedp.ByQuery),
+		chromedp.WaitVisible(`.kiln-msg-thinking`, chromedp.ByQuery),
+		chromedp.Text(`.kiln-msg-thinking`, &statusVisibleText, chromedp.ByQuery),
 		chromedp.FullScreenshot(&shotPending, 90),
 	); err != nil {
 		t.Fatalf("pending: %v", err)
 	}
 	saveShot(t, "02_status_pending", shotPending)
-
-	if !strings.Contains(statusVisibleText, "sending") &&
-		!strings.Contains(statusVisibleText, "ok") &&
-		!strings.Contains(statusVisibleText, "sent") {
-		t.Errorf("expected sending/ok/sent in status, got %q", statusVisibleText)
+	if !strings.Contains(statusVisibleText, "thinking") {
+		t.Errorf("expected thinking status, got %q", statusVisibleText)
 	}
 
-	// Capture the success status before it auto-clears.
-	if err := chromedp.Run(ctx,
-		chromedp.Sleep(600*time.Millisecond), // let the post resolve
-	); err != nil {
-		t.Fatal(err)
+	testInFlight.Store(false)
+	l.Notify("agent_turn_ended", "omp")
+	deadline := time.Now().Add(3 * time.Second)
+	present := true
+	for time.Now().Before(deadline) {
+		_ = chromedp.Run(ctx, chromedp.Evaluate(`!!document.querySelector('.kiln-msg-thinking')`, &present))
+		if !present {
+			break
+		}
+		time.Sleep(60 * time.Millisecond)
+	}
+	if present {
+		t.Error("thinking status remained after agent_turn_ended")
 	}
 	var shotOK []byte
 	if err := chromedp.Run(ctx, chromedp.FullScreenshot(&shotOK, 90)); err != nil {
@@ -227,7 +222,8 @@ func TestVisual_RapidEditsAccumulate(t *testing.T) {
 }
 
 // (5) THE CRITICAL ONE: user is sitting on a page, the agent updates
-// it, browser reloads automatically and the new content is visible.
+// it, a cache-bypass SPA navigation swaps in the new content without a
+// document reload.
 // This is the "live build" claim.
 func TestVisual_LivePageHotReload(t *testing.T) {
 	urlBase, tools := startKiln(t)
@@ -266,6 +262,11 @@ func TestVisual_LivePageHotReload(t *testing.T) {
 		t.Fatalf("v1 body wrong: %q", bodyV1)
 	}
 	waitForSSE(t, ctx)
+	if err := chromedp.Run(ctx,
+		chromedp.Evaluate(`window.__kilnDocumentSentinel = "same-document"`, nil),
+	); err != nil {
+		t.Fatalf("install document sentinel: %v", err)
+	}
 
 	// Agent rewrites the page in place: propose+approve a plan, delete, then add.
 	if r := tools.ProposePlan(t.Context(), protocol.ProposePlanArgs{
@@ -294,7 +295,7 @@ func TestVisual_LivePageHotReload(t *testing.T) {
 		t.Fatal(r)
 	}
 
-	// Browser should auto-reload via SSE → location.reload().
+	// Browser should refresh through the GoFastr SPA runtime after the SSE edit.
 	deadline := time.Now().Add(8 * time.Second)
 	for time.Now().Before(deadline) {
 		var body string
@@ -308,12 +309,14 @@ func TestVisual_LivePageHotReload(t *testing.T) {
 
 	var bodyV2 string
 	var shotV2 []byte
+	var sentinel string
 	if err := chromedp.Run(ctx,
 		chromedp.WaitVisible(`h1`, chromedp.ByQuery),
 		chromedp.Text(`body`, &bodyV2, chromedp.ByQuery),
+		chromedp.Evaluate(`window.__kilnDocumentSentinel || ""`, &sentinel),
 		chromedp.FullScreenshot(&shotV2, 90),
 	); err != nil {
-		t.Fatalf("post-reload: %v", err)
+		t.Fatalf("post-refresh: %v", err)
 	}
 	saveShot(t, "07_live_v2_after_hot_reload", shotV2)
 
@@ -322,6 +325,9 @@ func TestVisual_LivePageHotReload(t *testing.T) {
 	}
 	if !strings.Contains(bodyV2, "agent rewrote me hot") {
 		t.Errorf("body missing new paragraph: %q", bodyV2)
+	}
+	if sentinel != "same-document" {
+		t.Errorf("hot refresh replaced the browser document; want SPA navigation sentinel, got %q", sentinel)
 	}
 }
 

--- a/kiln/integration/visual_test.go
+++ b/kiln/integration/visual_test.go
@@ -374,3 +374,70 @@ func waitForSSE(t *testing.T, ctx context.Context) {
 	}
 	t.Fatal("SSE did not open within 8s")
 }
+
+// Deleting a page the user is viewing must degrade to the Kiln host fallback,
+// not a blank document: the SSE-triggered SPA refresh extracts <main> from the
+// fallback response, so host.html must carry one.
+func TestVisual_DeletePageShowsFallback(t *testing.T) {
+	urlBase, tools := startKiln(t)
+	ctx, cancel := newChrome(t)
+	defer cancel()
+
+	add := tools.AddPage(t.Context(), protocol.AddPageArgs{Page: &world.Page{
+		Path:  "/doomed",
+		Title: "Doomed",
+		Tree: world.Node{Kind: "div", Children: []world.Node{
+			{Kind: "heading", Props: map[string]any{"level": float64(1), "text": "Short lived"}},
+		}},
+	}})
+	if !add.OK {
+		t.Fatal(add)
+	}
+
+	var body string
+	if err := chromedp.Run(ctx,
+		chromedp.EmulateViewport(1280, 800),
+		chromedp.Navigate(urlBase+"/doomed"),
+		chromedp.WaitVisible(`h1`, chromedp.ByQuery),
+		chromedp.Text(`body`, &body, chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+	if !strings.Contains(body, "Short lived") {
+		t.Fatalf("page body wrong before delete: %q", body)
+	}
+	waitForSSE(t, ctx)
+
+	if r := tools.ProposePlan(t.Context(), protocol.ProposePlanArgs{
+		PlanID:  "kill-doomed",
+		Steps:   []string{"remove /doomed"},
+		Targets: []journal.PlanTarget{{Op: "delete_page", Name: "/doomed"}},
+	}); !r.OK {
+		t.Fatal(r)
+	}
+	if r := tools.ApprovePlan(t.Context(), protocol.ApprovePlanArgs{PlanID: "kill-doomed"}); !r.OK {
+		t.Fatal(r)
+	}
+	if r := tools.DeletePage(t.Context(), protocol.DeletePageArgs{Path: "/doomed", PlanID: "kill-doomed"}); !r.OK {
+		t.Fatal(r)
+	}
+
+	// The SSE edit forces an SPA refresh of /doomed, which now serves the
+	// host fallback. The swapped-in content must not be blank.
+	deadline := time.Now().Add(8 * time.Second)
+	var after string
+	for time.Now().Before(deadline) {
+		if err := chromedp.Run(ctx,
+			chromedp.Text(`body`, &after, chromedp.ByQuery),
+		); err == nil && !strings.Contains(after, "Short lived") {
+			break
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	if strings.Contains(after, "Short lived") {
+		t.Fatalf("refresh never happened; still showing deleted page: %q", after)
+	}
+	if !strings.Contains(after, "Talk to it") {
+		t.Fatalf("EMPTY MAIN: host fallback content did not arrive after delete_page (host.html needs a <main> for the SPA swap): %q", after)
+	}
+}

--- a/kiln/journal/entry.go
+++ b/kiln/journal/entry.go
@@ -41,6 +41,7 @@ const (
 	OpAddSeed           Op = "add_seed"
 	OpAddMiddleware     Op = "add_middleware"
 	OpSetAppConfig      Op = "set_app_config"
+	OpSetScaffold       Op = "set_scaffold"
 )
 
 // Entry is one record in the append-only log. Payload is held as raw JSON
@@ -163,6 +164,26 @@ type AddMiddlewarePayload struct {
 type SetAppConfigPayload struct {
 	Config world.AppConfig  `json:"config"`
 	Prev   *world.AppConfig `json:"prev,omitempty"`
+}
+
+// SetScaffoldPayload replaces the blueprint-only surfaces as one coherent
+// snapshot. Prev keeps undo/replay audit data even though undo is implemented
+// by journal truncation today.
+type SetScaffoldPayload struct {
+	Nav        []world.NavItem       `json:"nav,omitempty"`
+	Endpoints  []*world.EndpointStub `json:"endpoints,omitempty"`
+	Middleware []world.NamedStub     `json:"middleware,omitempty"`
+	Plugins    []world.NamedStub     `json:"plugins,omitempty"`
+	Helpers    []world.NamedStub     `json:"helpers,omitempty"`
+	Prev       *ScaffoldSnapshot     `json:"prev,omitempty"`
+}
+
+type ScaffoldSnapshot struct {
+	Nav        []world.NavItem       `json:"nav,omitempty"`
+	Endpoints  []*world.EndpointStub `json:"endpoints,omitempty"`
+	Middleware []world.NamedStub     `json:"middleware,omitempty"`
+	Plugins    []world.NamedStub     `json:"plugins,omitempty"`
+	Helpers    []world.NamedStub     `json:"helpers,omitempty"`
 }
 
 // --- Payload types for chat / plan kinds --------------------------------

--- a/kiln/journal/replay.go
+++ b/kiln/journal/replay.go
@@ -131,6 +131,18 @@ func applyWorldEdit(w *world.World, e Entry) error {
 		w.App = p.Config
 		return nil
 
+	case OpSetScaffold:
+		var p SetScaffoldPayload
+		if err := e.Decode(&p); err != nil {
+			return err
+		}
+		w.Nav = p.Nav
+		w.Endpoints = p.Endpoints
+		w.MiddlewareStubs = p.Middleware
+		w.Plugins = p.Plugins
+		w.Helpers = p.Helpers
+		return nil
+
 	case OpAddEntity:
 		var p AddEntityPayload
 		if err := e.Decode(&p); err != nil {

--- a/kiln/live/live_test.go
+++ b/kiln/live/live_test.go
@@ -84,11 +84,11 @@ func TestApplyAddEntityPersistsAndRebuilds(t *testing.T) {
 		t.Errorf("journal len = %d, want 1", n)
 	}
 	// New app handles the route.
-	req := httptest.NewRequest(http.MethodGet, "/posts", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/posts", nil)
 	rec := httptest.NewRecorder()
 	l.ServeHTTP(rec, req)
 	if rec.Code == http.StatusNotFound {
-		t.Errorf("/posts should be registered after Apply, got 404")
+		t.Errorf("/api/posts should be registered after Apply, got 404")
 	}
 }
 

--- a/kiln/live/migrate_test.go
+++ b/kiln/live/migrate_test.go
@@ -45,8 +45,8 @@ func TestLiveAutoMigratesOnEntityAdd(t *testing.T) {
 		t.Fatalf("Apply: %v", err)
 	}
 
-	// Table should exist; GET /posts should return 200 (empty list).
-	req := httptest.NewRequest(http.MethodGet, "/posts", nil)
+	// Table should exist; GET /api/posts should return 200 (empty list).
+	req := httptest.NewRequest(http.MethodGet, "/api/posts", nil)
 	rec := httptest.NewRecorder()
 	l.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {

--- a/kiln/noderender/noderender.go
+++ b/kiln/noderender/noderender.go
@@ -12,3 +12,7 @@ import corenoderender "github.com/DonaldMurillo/gofastr/core-ui/noderender"
 // core-ui/noderender.RenderNode. Accepts world.Node because world.Node is
 // a type alias for core-ui/node.Node.
 var RenderNode = corenoderender.RenderNode
+
+// RenderKind renders one node's own element from pre-rendered children. See
+// core-ui/noderender.RenderKind.
+var RenderKind = corenoderender.RenderKind

--- a/kiln/protocol/app_config_test.go
+++ b/kiln/protocol/app_config_test.go
@@ -1,0 +1,38 @@
+package protocol_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/kiln/protocol"
+	"github.com/DonaldMurillo/gofastr/kiln/world"
+)
+
+func TestSetAppConfigRejectsMissingNestedConfig(t *testing.T) {
+	tools := newTools(t)
+	res := tools.SetAppConfig(context.Background(), protocol.SetAppConfigArgs{})
+	if res.OK || res.Kind != "validation" {
+		t.Fatalf("empty app config = %+v, want validation failure", res)
+	}
+	if !strings.Contains(res.Hint, `{"config":`) {
+		t.Fatalf("hint must show the transport wrapper: %+v", res)
+	}
+	if got := tools.Live().Session().World.App.Name; got != "" {
+		t.Fatalf("invalid config mutated world name to %q", got)
+	}
+}
+
+func TestSetAppConfigAcceptsCurrentShapeAndDefaultsAPI(t *testing.T) {
+	tools := newTools(t)
+	res := tools.SetAppConfig(context.Background(), protocol.SetAppConfigArgs{Config: world.AppConfig{
+		Name: "forge", Module: "example.com/forge",
+	}})
+	if !res.OK {
+		t.Fatalf("SetAppConfig: %+v", res)
+	}
+	app := tools.Live().Session().World.App
+	if app.Name != "forge" || app.Module != "example.com/forge" || app.APIPrefix != "api" {
+		t.Fatalf("app config not preserved/defaulted: %+v", app)
+	}
+}

--- a/kiln/protocol/descriptors.go
+++ b/kiln/protocol/descriptors.go
@@ -1,5 +1,7 @@
 package protocol
 
+import "sort"
+
 // Descriptor is the public schema of one tool. Transports (MCP, ACP)
 // expose Descriptor.Schema as the tool's input schema and Description
 // as its description.
@@ -16,6 +18,7 @@ func (t *Tools) List() []Descriptor {
 	for _, d := range descriptors {
 		out = append(out, d)
 	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
 }
 
@@ -35,14 +38,51 @@ var descriptors = map[string]Descriptor{
 	},
 	"set_app_config": {
 		Name:        "set_app_config",
-		Description: "Replace the app-level configuration (name, json case, debug endpoints).",
+		Description: "Replace the app-level configuration. This is the same app surface accepted by the current gofastr.yml blueprint; include api_prefix (normally api) so UI and CRUD routes stay separate.",
 		Schema: object(map[string]any{
 			"config": object(map[string]any{
 				"name":            str(""),
+				"module":          str("Go module path for the frozen scaffold"),
 				"json_case":       enum("camel", "snake"),
 				"debug_endpoints": boolean(),
+				"db_driver":       str("database driver for the frozen scaffold"),
+				"db_url":          str("database URL for the frozen scaffold"),
+				"static_dir":      str("static asset directory"),
+				"output_dir":      str("optional scaffold output directory"),
+				"api_prefix":      str("CRUD prefix without leading slash; use api unless there is a deliberate reason not to"),
+				"llm_md":          boolean(),
+				"theme":           stringMap("light theme token overrides"),
+				"theme_dark":      stringMap("dark theme color overrides"),
+				"auth": object(map[string]any{
+					"enabled": boolean(), "dev_mode": boolean(), "base_path": str(""), "jwt_secret": str(""),
+				}, nil),
+				"admin": object(map[string]any{
+					"enabled": boolean(), "path": str(""), "role": str(""), "login_path": str(""), "seed_email": str(""), "seed_password": str(""),
+				}, nil),
+				"pwa": object(map[string]any{
+					"enabled": boolean(), "name": str(""), "short_name": str(""), "description": str(""),
+					"start_url": str(""), "scope": str(""), "display": enum("standalone", "fullscreen", "minimal-ui", "browser"),
+					"theme_color": str(""), "background_color": str(""),
+				}, nil),
 			}, []string{"name"}),
 		}, []string{"config"}),
+	},
+	"set_scaffold": {
+		Name:        "set_scaffold",
+		Description: "Replace navigation and the owned-Go endpoint, middleware, plugin, and helper stubs preserved by freeze into the current gofastr.yml blueprint. Navigation is rendered live; stubs become editable Go in the generated scaffold.",
+		Schema: object(map[string]any{
+			"nav": list(navItemSchema()),
+			"endpoints": list(object(map[string]any{
+				"name": str(""), "method": enum("GET", "POST", "PUT", "PATCH", "DELETE"),
+				"path": str(""), "entity": str(""), "handler": str("owned-Go handler name"),
+				"description": str(""), "mcp": boolean(),
+			}, []string{"method", "path"})),
+			"middleware": list(object(map[string]any{
+				"name": str(""), "description": str(""),
+			}, []string{"name"})),
+			"plugins": list(namedStubSchema()),
+			"helpers": list(namedStubSchema()),
+		}, nil),
 	},
 	"add_entity": {
 		Name:        "add_entity",
@@ -194,7 +234,7 @@ var descriptors = map[string]Descriptor{
 	},
 	"set_theme": {
 		Name:        "set_theme",
-		Description: "Replace the kiln page theme. Keys are core-ui/widget/theme token names (e.g. \"page-bg\", \"page-primary\", \"page-accent\"); values are CSS color literals. Empty `theme` clears overrides. The next /kiln/theme.css fetch reflects the change and every page re-skins on next load.",
+		Description: "Replace the kiln page theme. Keys are current semantic app-theme names (for example \"background\", \"primary\", \"accent\", \"text-muted\", \"font_body\", and \"font_heading\"); values are CSS literals. Empty `theme` clears overrides. Current pages consume the palette through UIHost's /__gofastr/app.css.",
 		Schema: object(map[string]any{
 			"theme": object(nil, nil),
 		}, []string{"theme"}),
@@ -246,14 +286,26 @@ func list(item map[string]any) map[string]any {
 
 func entitySchema() map[string]any {
 	return object(map[string]any{
-		"name":         str("entity name; lowercase, plural by convention"),
-		"table":        str("optional table name override"),
-		"fields":       list(fieldSchema()),
-		"soft_delete":  boolean(),
-		"multi_tenant": boolean(),
-		"timestamps":   boolean(),
-		"crud":         boolean(),
-		"mcp":          boolean(),
+		"name":             str("entity name; lowercase, plural by convention"),
+		"table":            str("optional table name override"),
+		"fields":           list(fieldSchema()),
+		"relations":        list(relationSchema()),
+		"endpoints":        list(entityEndpointSchema()),
+		"soft_delete":      boolean(),
+		"multi_tenant":     map[string]any{"type": "boolean", "description": "legacy journals only; Kiln rejects true because tenant resolution must be wired in owned Go"},
+		"owner_field":      str("row owner column, e.g. user_id; required for per-user auto-CRUD data"),
+		"cross_owner_read": str("optional permission that lifts owner scoping for reads"),
+		"search_fields":    list(str("searchable field")),
+		"access": object(map[string]any{
+			"read": str(""), "create": str(""), "update": str(""), "delete": str(""),
+		}, nil),
+		"timestamps":    boolean(),
+		"crud":          boolean(),
+		"mcp":           boolean(),
+		"cursor_field":  str("legacy single cursor field"),
+		"cursor_fields": list(str("ordered cursor field")),
+		"indices":       list(indexSchema()),
+		"properties":    map[string]any{"type": "object"},
 	}, []string{"name", "fields"})
 }
 
@@ -265,6 +317,8 @@ func fieldSchema() map[string]any {
 		"unique":        boolean(),
 		"default":       map[string]any{},
 		"auto_generate": enum("uuid", "timestamp", "increment"),
+		"read_only":     boolean(),
+		"hidden":        boolean(),
 		"max":           map[string]any{"type": "number"},
 		"min":           map[string]any{"type": "number"},
 		"pattern":       str(""),
@@ -274,12 +328,41 @@ func fieldSchema() map[string]any {
 	}, []string{"name", "type"})
 }
 
+func relationSchema() map[string]any {
+	return object(map[string]any{
+		"type":               enum("has_one", "has_many", "belongs_to", "many_to_many"),
+		"name":               str("logical relation name"),
+		"entity":             str("target entity"),
+		"foreign_key":        str("foreign-key column"),
+		"through":            str("many-to-many pivot table"),
+		"local_key":          str("many-to-many source key"),
+		"foreign_key_target": str("many-to-many target key"),
+	}, []string{"type", "name", "entity"})
+}
+
+func entityEndpointSchema() map[string]any {
+	return object(map[string]any{
+		"method": enum("GET", "POST", "PUT", "DELETE", "PATCH"),
+		"path":   str(""), "name": str(""), "description": str(""), "mcp": boolean(), "action": actionSchema(),
+	}, []string{"method", "path", "action"})
+}
+
+func indexSchema() map[string]any {
+	return object(map[string]any{
+		"name": str(""), "columns": list(str("indexed column")), "unique": boolean(),
+	}, nil)
+}
+
 func pageSchema() map[string]any {
 	return object(map[string]any{
-		"path":  str(""),
-		"title": str(""),
-		"type":  enum("page", "drawer", "sheet", "dialog"),
-		"tree":  nodeSchema(),
+		"path":        str(""),
+		"name":        str(""),
+		"title":       str(""),
+		"description": str(""),
+		"type":        enum("page", "drawer", "sheet", "dialog"),
+		"layout":      object(map[string]any{"name": str("")}, nil),
+		"access":      object(map[string]any{"auth": boolean(), "role": str("")}, nil),
+		"tree":        nodeSchema(),
 	}, []string{"path", "tree"})
 }
 
@@ -320,7 +403,28 @@ func actionSchema() map[string]any {
 
 func seedSchema() map[string]any {
 	return object(map[string]any{
-		"entity": str(""),
-		"rows":   list(map[string]any{"type": "object"}),
-	}, []string{"entity", "rows"})
+		"entity":  str(""),
+		"rows":    list(map[string]any{"type": "object"}),
+		"count":   map[string]any{"type": "integer", "minimum": 0},
+		"weights": map[string]any{"type": "object"},
+	}, []string{"entity"})
+}
+
+func stringMap(description string) map[string]any {
+	return map[string]any{"type": "object", "description": description, "additionalProperties": map[string]any{"type": "string"}}
+}
+
+func namedStubSchema() map[string]any {
+	return object(map[string]any{"name": str(""), "description": str("")}, []string{"name"})
+}
+
+func navItemSchema() map[string]any {
+	return object(map[string]any{
+		"label": str(""), "href": str(""), "icon": str(""), "role": str(""),
+		// Keep the recursive child shape intentionally shallow in JSON Schema;
+		// nested values use the same runtime world.NavItem validation.
+		"items": list(object(map[string]any{
+			"label": str(""), "href": str(""), "icon": str(""), "role": str(""),
+		}, []string{"label", "href"})),
+	}, []string{"label", "href"})
 }

--- a/kiln/protocol/protocol.go
+++ b/kiln/protocol/protocol.go
@@ -65,6 +65,17 @@ type SetAppConfigArgs struct {
 	Config world.AppConfig `json:"config"`
 }
 
+// SetScaffoldArgs replaces the current blueprint-owned navigation and Go-stub
+// declarations. These surfaces are preserved into gofastr.yml at freeze time;
+// only navigation has a live visual representation.
+type SetScaffoldArgs struct {
+	Nav        []world.NavItem       `json:"nav,omitempty"`
+	Endpoints  []*world.EndpointStub `json:"endpoints,omitempty"`
+	Middleware []world.NamedStub     `json:"middleware,omitempty"`
+	Plugins    []world.NamedStub     `json:"plugins,omitempty"`
+	Helpers    []world.NamedStub     `json:"helpers,omitempty"`
+}
+
 type AddEntityArgs struct {
 	Entity *world.Entity `json:"entity"`
 }
@@ -179,10 +190,9 @@ type UndoArgs struct{}
 
 type ResetSessionArgs struct{}
 
-// SetThemeArgs replaces world.App.Theme. Keys are token names from
-// core-ui/widget/theme (e.g. "page-bg", "page-primary", "page-accent");
-// values are CSS color literals. Empty Theme map clears overrides
-// (revert to framework defaults).
+// SetThemeArgs replaces world.App.Theme. Keys are current semantic app-theme
+// names such as "background", "primary", and "accent"; values are CSS color
+// literals. An empty Theme map clears overrides and restores defaults.
 type SetThemeArgs struct {
 	Theme map[string]string `json:"theme"`
 }
@@ -225,23 +235,82 @@ func (t *Tools) WorldGet(_ context.Context, args WorldGetArgs) Result {
 }
 
 func (t *Tools) SetAppConfig(_ context.Context, args SetAppConfigArgs) Result {
+	if strings.TrimSpace(args.Config.Name) == "" {
+		return invalid("app config requires a non-empty name").
+			withHint(`wrap the app fields under config, for example {"config":{"name":"my-app","module":"example.com/my-app","api_prefix":"api"}}`)
+	}
+	args.Config.APIPrefix = strings.Trim(args.Config.APIPrefix, "/")
+	if args.Config.APIPrefix == "" {
+		args.Config.APIPrefix = "api"
+	}
 	prev := t.live.Session().World.App
 	return t.applyEdit(journal.OpSetAppConfig, journal.SetAppConfigPayload{Config: args.Config, Prev: &prev})
+}
+
+func (t *Tools) SetScaffold(_ context.Context, args SetScaffoldArgs) Result {
+	if err := validateNavItems(args.Nav); err != nil {
+		return invalid("navigation: %v", err)
+	}
+	for _, endpoint := range args.Endpoints {
+		if endpoint == nil || endpoint.Method == "" || endpoint.Path == "" {
+			return invalid("every endpoint requires method and path")
+		}
+	}
+	for _, middleware := range args.Middleware {
+		if middleware.Name == "" {
+			return invalid("every middleware stub requires name")
+		}
+	}
+	for _, group := range [][]world.NamedStub{args.Plugins, args.Helpers} {
+		for _, stub := range group {
+			if stub.Name == "" {
+				return invalid("every plugin and helper stub requires name")
+			}
+		}
+	}
+	w := t.live.Session().World
+	prev := &journal.ScaffoldSnapshot{
+		Nav: w.Nav, Endpoints: w.Endpoints, Middleware: w.MiddlewareStubs,
+		Plugins: w.Plugins, Helpers: w.Helpers,
+	}
+	return t.applyEdit(journal.OpSetScaffold, journal.SetScaffoldPayload{
+		Nav: args.Nav, Endpoints: args.Endpoints, Middleware: args.Middleware,
+		Plugins: args.Plugins, Helpers: args.Helpers, Prev: prev,
+	})
+}
+
+func validateNavItems(items []world.NavItem) error {
+	for _, item := range items {
+		if item.Label == "" || item.Href == "" {
+			return fmt.Errorf("every item requires label and href")
+		}
+		if err := validateNavItems(item.Items); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (t *Tools) AddEntity(_ context.Context, args AddEntityArgs) Result {
 	if args.Entity == nil || args.Entity.Name == "" {
 		return invalid("missing entity or entity.name")
 	}
+	if args.Entity.MultiTenant {
+		return invalid("entity %q sets multi_tenant, but Kiln cannot choose the app-specific tenant resolver", args.Entity.Name).
+			withHint("use owner_field for per-user scoping, or add tenant middleware in owned Go after freeze")
+	}
 	if _, exists := t.live.Session().World.Entities[args.Entity.Name]; exists {
 		return conflict("entity %q already exists", args.Entity.Name).withHint("use update_entity to modify")
 	}
-	// Reject if a page already lives at /<entity>; both would register
-	// GET /<entity> on the router.
-	if _, hasPage := t.live.Session().World.Pages["/"+args.Entity.Name]; hasPage {
-		return conflict("entity %q would collide with existing page at /%s",
-			args.Entity.Name, args.Entity.Name).
-			withHint("rename the entity (e.g. add a suffix) or delete the page first")
+	// Bare CRUD routes can collide with a page. The current default API
+	// prefix is /api, so this guard is only needed when the app explicitly
+	// opts out of namespacing.
+	if t.live.Session().World.App.APIPrefix == "" {
+		if _, hasPage := t.live.Session().World.Pages["/"+args.Entity.Name]; hasPage {
+			return conflict("entity %q would collide with existing page at /%s",
+				args.Entity.Name, args.Entity.Name).
+				withHint("rename the entity (e.g. add a suffix) or delete the page first")
+		}
 	}
 	return t.applyEdit(journal.OpAddEntity, journal.AddEntityPayload{Entity: args.Entity})
 }
@@ -249,6 +318,10 @@ func (t *Tools) AddEntity(_ context.Context, args AddEntityArgs) Result {
 func (t *Tools) UpdateEntity(_ context.Context, args UpdateEntityArgs) Result {
 	if args.Entity == nil || args.Entity.Name == "" {
 		return invalid("missing entity or entity.name")
+	}
+	if args.Entity.MultiTenant {
+		return invalid("entity %q sets multi_tenant, but Kiln cannot choose the app-specific tenant resolver", args.Entity.Name).
+			withHint("use owner_field for per-user scoping, or add tenant middleware in owned Go after freeze")
 	}
 	prev, exists := t.live.Session().World.Entities[args.Entity.Name]
 	if !exists {
@@ -324,17 +397,21 @@ func (t *Tools) AddPage(_ context.Context, args AddPageArgs) Result {
 		return invalid("page.tree.kind must be set (e.g. \"div\") — the tree is the root element and nothing renders without a kind").
 			withHint(`minimal page: {"path":"/x","tree":{"kind":"div","children":[{"kind":"heading","props":{"level":1,"text":"Hello"}}]}}`)
 	}
+	if err := validatePageTree(args.Page.Tree); err != nil {
+		return invalid("page tree: %v", err).withHint("compose layout with page_header, section, card, stack, cluster, grid, and other design-system kinds; do not supply class or style props")
+	}
 	if _, exists := t.live.Session().World.Pages[args.Page.Path]; exists {
 		return conflict("page %q already exists", args.Page.Path)
 	}
-	// Reject paths that already belong to an entity's CRUD list endpoint.
-	// Both register `GET /<path>` so the underlying router would panic.
-	for _, ent := range t.live.Session().World.Entities {
-		if "/"+ent.Name == args.Page.Path {
-			return conflict("page path %q collides with entity %q's CRUD list endpoint at GET %q",
-				args.Page.Path, ent.Name, args.Page.Path).
-				withHint(fmt.Sprintf("pick a different path like %q, %q, or %q",
-					args.Page.Path+"/list", "/view"+args.Page.Path, args.Page.Path+"-page"))
+	// Bare CRUD is an explicit compatibility mode. With the current /api
+	// default, a page and an entity may intentionally share the same name.
+	if t.live.Session().World.App.APIPrefix == "" {
+		for _, ent := range t.live.Session().World.Entities {
+			if "/"+ent.Name == args.Page.Path {
+				return conflict("page path %q collides with entity %q's bare CRUD list endpoint at GET %q",
+					args.Page.Path, ent.Name, args.Page.Path).
+					withHint("set app.api_prefix to api (recommended), or choose a different page path")
+			}
 		}
 	}
 	// Assign a stable _id to every node lacking one, so update_page_element
@@ -383,6 +460,9 @@ func (t *Tools) UpdatePageElement(_ context.Context, args UpdatePageElementArgs)
 	if r := applyPageElementPatch(target, parent, idx, args.Patch); !r.OK {
 		return r
 	}
+	if err := validatePageTree(next.Tree); err != nil {
+		return invalid("page tree: %v", err).withHint("use a typed design-system node kind instead of app-local class/style props")
+	}
 	// Re-assign IDs in case the patch introduced fresh subtrees that
 	// lacked _id. Existing IDs are preserved by AssignNodeIDs.
 	world.AssignNodeIDs(&next.Tree, world.NewElementID)
@@ -392,6 +472,21 @@ func (t *Tools) UpdatePageElement(_ context.Context, args UpdatePageElementArgs)
 		New:  next,
 		Prev: current,
 	})
+}
+
+func validatePageTree(n world.Node) error {
+	for key := range n.Props {
+		normalized := strings.ToLower(strings.TrimSpace(key))
+		if normalized == "class" || normalized == "style" || strings.HasPrefix(normalized, "on") {
+			return fmt.Errorf("node kind %q uses forbidden styling or handler prop %q", n.Kind, key)
+		}
+	}
+	for _, child := range n.Children {
+		if err := validatePageTree(child); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // applyPageElementPatch mutates target/parent in-place per the op.
@@ -631,10 +726,9 @@ func (t *Tools) RejectPlan(_ context.Context, args RejectPlanArgs) Result {
 	})
 }
 
-// SetTheme writes world.App.Theme via a SetAppConfig journal entry.
-// Theme tokens flow into core-ui/widget/theme.PageCSS at render time;
-// the next /kiln/theme.css fetch reflects the new palette and every
-// page re-skins on the client's next stylesheet load.
+// SetTheme writes world.App.Theme via a SetAppConfig journal entry. Current
+// pages consume it through UIHost's /__gofastr/app.css; the compatibility
+// /kiln/theme.css endpoint consumes the same palette for legacy embeds.
 func (t *Tools) SetTheme(_ context.Context, args SetThemeArgs) Result {
 	prev := t.live.Session().World.App
 	next := prev

--- a/kiln/protocol/protocol_test.go
+++ b/kiln/protocol/protocol_test.go
@@ -42,6 +42,34 @@ func TestAddEntityHappyPath(t *testing.T) {
 	}
 }
 
+func TestSetScaffoldPreservesCurrentBlueprintSurfaces(t *testing.T) {
+	tools := newTools(t)
+	res := tools.SetScaffold(context.Background(), protocol.SetScaffoldArgs{
+		Nav:        []world.NavItem{{Label: "Home", Href: "/"}},
+		Endpoints:  []*world.EndpointStub{{Name: "health", Method: "GET", Path: "/healthz"}},
+		Middleware: []world.NamedStub{{Name: "request_logger"}},
+		Plugins:    []world.NamedStub{{Name: "metrics"}},
+		Helpers:    []world.NamedStub{{Name: "slug"}},
+	})
+	if !res.OK {
+		t.Fatalf("SetScaffold: %+v", res)
+	}
+	w := tools.Live().Session().World
+	if len(w.Nav) != 1 || len(w.Endpoints) != 1 || len(w.MiddlewareStubs) != 1 || len(w.Plugins) != 1 || len(w.Helpers) != 1 {
+		t.Fatalf("scaffold surface lost: %+v", w)
+	}
+}
+
+func TestAddPageRejectsSecondStylingSurface(t *testing.T) {
+	tools := newTools(t)
+	res := tools.AddPage(context.Background(), protocol.AddPageArgs{Page: &world.Page{
+		Path: "/bad", Tree: world.Node{Kind: "div", Props: map[string]any{"class": "app-local"}},
+	}})
+	if res.OK || res.Kind != "validation" {
+		t.Fatalf("app-local class should be rejected, got %+v", res)
+	}
+}
+
 func TestAddEntityDuplicate(t *testing.T) {
 	tools := newTools(t)
 	posts := &world.Entity{Name: "posts", Fields: []world.Field{{Name: "title", Type: "string"}}}

--- a/kiln/protocol/theme_test.go
+++ b/kiln/protocol/theme_test.go
@@ -12,14 +12,14 @@ import (
 // TestSetThemeUpdatesWorldAppTheme is the protocol-level guarantee:
 // SetTheme writes to world.App.Theme via a SetAppConfig journal entry,
 // so replay reproduces the override exactly. The renderer reads
-// world.App.Theme on each /kiln/theme.css fetch.
+// world.App.Theme while replay reproduces the semantic tokens exactly.
 func TestSetThemeUpdatesWorldAppTheme(t *testing.T) {
 	tools := newTools(t)
 
 	res := tools.SetTheme(context.Background(), protocol.SetThemeArgs{
 		Theme: map[string]string{
-			"page-bg":      "#0F172A",
-			"page-primary": "#22D3EE",
+			"background": "#0F172A",
+			"primary":    "#22D3EE",
 		},
 	})
 	if !res.OK {
@@ -27,11 +27,11 @@ func TestSetThemeUpdatesWorldAppTheme(t *testing.T) {
 	}
 
 	app := tools.Live().Session().World.App
-	if app.Theme["page-bg"] != "#0F172A" {
-		t.Errorf("page-bg = %q, want #0F172A", app.Theme["page-bg"])
+	if app.Theme["background"] != "#0F172A" {
+		t.Errorf("background = %q, want #0F172A", app.Theme["background"])
 	}
-	if app.Theme["page-primary"] != "#22D3EE" {
-		t.Errorf("page-primary = %q, want #22D3EE", app.Theme["page-primary"])
+	if app.Theme["primary"] != "#22D3EE" {
+		t.Errorf("primary = %q, want #22D3EE", app.Theme["primary"])
 	}
 
 	// Empty Theme clears overrides.

--- a/kiln/render/declarative_test.go
+++ b/kiln/render/declarative_test.go
@@ -80,14 +80,14 @@ func TestApplyHookValidatesOnCreate(t *testing.T) {
 
 	// Allowed post passes through.
 	good := bytes.NewBufferString(`{"title":"hello"}`)
-	res := postJSON(t, app.Router(), "/posts", good)
+	res := postJSON(t, app.Router(), "/api/posts", good)
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
 		t.Errorf("good post status = %d", res.StatusCode)
 	}
 
 	// Spam post is rejected by the declarative hook.
 	bad := bytes.NewBufferString(`{"title":"spam"}`)
-	res = postJSON(t, app.Router(), "/posts", bad)
+	res = postJSON(t, app.Router(), "/api/posts", bad)
 	if res.StatusCode < 400 {
 		t.Errorf("expected client error for spam, got %d", res.StatusCode)
 	}
@@ -126,14 +126,14 @@ func TestApplyHookConditionGate(t *testing.T) {
 
 	// status != draft → validation skipped.
 	body := bytes.NewBufferString(`{"title":"hi","status":"published"}`)
-	res := postJSON(t, app.Router(), "/posts", body)
+	res := postJSON(t, app.Router(), "/api/posts", body)
 	if res.StatusCode >= 400 {
 		t.Errorf("non-draft should pass, got %d", res.StatusCode)
 	}
 
 	// status == draft + short title → validation runs and fails.
 	body = bytes.NewBufferString(`{"title":"hi","status":"draft"}`)
-	res = postJSON(t, app.Router(), "/posts", body)
+	res = postJSON(t, app.Router(), "/api/posts", body)
 	if res.StatusCode < 400 {
 		t.Errorf("short draft should fail, got %d", res.StatusCode)
 	}
@@ -176,7 +176,7 @@ func TestHookRejectionIncludesMessage(t *testing.T) {
 	if err := framework.AutoMigrate(db, app.Registry); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	res := postJSON(t, app.Router(), "/posts", bytes.NewBufferString(`{"title":"x"}`))
+	res := postJSON(t, app.Router(), "/api/posts", bytes.NewBufferString(`{"title":"x"}`))
 	out, _ := io.ReadAll(res.Body)
 	if !strings.Contains(string(out), "always-block-message") {
 		t.Errorf("response missing message: %q", string(out))

--- a/kiln/render/node.go
+++ b/kiln/render/node.go
@@ -1,14 +1,280 @@
 package render
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/DonaldMurillo/gofastr/core/render"
+	"github.com/DonaldMurillo/gofastr/framework/ui"
 	"github.com/DonaldMurillo/gofastr/kiln/noderender"
 	"github.com/DonaldMurillo/gofastr/kiln/world"
 )
 
-// RenderNode walks a world.Node tree and emits HTML. The implementation lives
-// in the leaf package kiln/noderender (which imports only core-ui/html +
-// core/render + kiln/world) so that generated/frozen apps can render node trees
-// without dragging in Kiln's authoring engine (kiln/expr, kiln/effect,
-// framework). This thin re-export keeps the live build-mode render path here.
-func RenderNode(n world.Node) render.HTML { return noderender.RenderNode(n) }
+// RenderNode renders current design-system component kinds directly and falls
+// back to the leaf noderender package for one-to-one semantic HTML nodes. This
+// keeps Kiln's live preview on the same component/CSS surface as generated Go
+// without pulling the authoring engine into generated apps.
+func RenderNode(n world.Node) render.HTML {
+	children := renderChildren(n.Children)
+	switch strings.ToLower(strings.TrimSpace(n.Kind)) {
+	case "page_header":
+		title := propString(n.Props, "title", "text")
+		if title == "" {
+			return renderLeaf(n)
+		}
+		return ui.PageHeader(ui.PageHeaderConfig{
+			Title: title, Subtitle: propString(n.Props, "subtitle", "description"),
+			Eyebrow: propString(n.Props, "eyebrow"), Actions: render.Join(children...),
+			HeadingLevel: propInt(n.Props, "heading_level", "level"), ID: propString(n.Props, "id"),
+		})
+	case "hero":
+		return ui.Hero(ui.HeroConfig{
+			Title:    propString(n.Props, "title", "text"),
+			Subtitle: propString(n.Props, "subtitle", "description"),
+			Eyebrow:  propString(n.Props, "eyebrow"), Actions: children,
+		})
+	case "section":
+		return ui.Section(ui.SectionConfig{
+			Heading:     propString(n.Props, "heading", "title"),
+			Description: propString(n.Props, "description", "subtitle"),
+			Eyebrow:     propString(n.Props, "eyebrow"), Label: propString(n.Props, "label"),
+			ID: propString(n.Props, "id"),
+		}, children...)
+	case "card":
+		return ui.Card(ui.CardConfig{
+			Heading:      propString(n.Props, "heading", "title"),
+			Description:  propString(n.Props, "description", "subtitle"),
+			HeadingLevel: propInt(n.Props, "heading_level", "level"),
+			Href:         propString(n.Props, "href"), Variant: cardVariant(propString(n.Props, "variant")),
+			ID: propString(n.Props, "id"),
+		}, withTextFallback(children, propString(n.Props, "text"))...)
+	case "link_button":
+		label, href := propString(n.Props, "label", "text"), propString(n.Props, "href")
+		if label == "" || href == "" {
+			return renderLeaf(n)
+		}
+		return ui.LinkButton(ui.LinkButtonConfig{
+			Label: label, Href: href, Variant: buttonVariant(propString(n.Props, "variant")),
+			Size: buttonSize(propString(n.Props, "size")), External: propBool(n.Props, "external"),
+			ID: propString(n.Props, "id"),
+		})
+	case "callout":
+		return ui.Callout(ui.CalloutConfig{
+			Title: propString(n.Props, "title"), Variant: statusVariant(propString(n.Props, "variant", "status")),
+			ID: propString(n.Props, "id"),
+		}, withTextFallback(children, propString(n.Props, "text", "description"))...)
+	case "stat_card":
+		label, value := propString(n.Props, "label"), propString(n.Props, "value")
+		if label == "" || value == "" {
+			return renderLeaf(n)
+		}
+		return ui.StatCard(ui.StatCardConfig{
+			Label: label, Value: value, Trend: propString(n.Props, "trend"),
+			Direction: trendDirection(propString(n.Props, "direction")), ID: propString(n.Props, "id"),
+		})
+	case "stat_row", "stat_grid":
+		return ui.Grid(ui.GridConfig{Min: "12rem", Gap: gap(propString(n.Props, "gap")), ID: propString(n.Props, "id")}, children...)
+	case "stack":
+		return ui.Stack(ui.StackConfig{
+			Gap: gap(propString(n.Props, "gap")), Align: align(propString(n.Props, "align")),
+			Justify: justify(propString(n.Props, "justify")), ID: propString(n.Props, "id"),
+		}, children...)
+	case "cluster":
+		return ui.Cluster(ui.ClusterConfig{
+			Gap: gap(propString(n.Props, "gap")), Align: align(propString(n.Props, "align")),
+			Justify: justify(propString(n.Props, "justify")), NoWrap: propBool(n.Props, "no_wrap"),
+			ID: propString(n.Props, "id"),
+		}, children...)
+	case "grid":
+		return ui.Grid(ui.GridConfig{
+			Min: propString(n.Props, "min"), Gap: gap(propString(n.Props, "gap")), ID: propString(n.Props, "id"),
+		}, children...)
+	case "divider":
+		orientation := ui.DividerHorizontal
+		if propString(n.Props, "orientation") == "vertical" {
+			orientation = ui.DividerVertical
+		}
+		return ui.Divider(ui.DividerConfig{
+			Label: propString(n.Props, "label", "text"), Orientation: orientation, ID: propString(n.Props, "id"),
+		})
+	default:
+		return renderLeaf(n)
+	}
+}
+
+// renderLeaf keeps legacy journals renderable without letting them reintroduce
+// app-local styling. Structural classes belong to typed design-system
+// components; one-to-one semantic HTML nodes receive only their safe props.
+func renderLeaf(n world.Node) render.HTML {
+	if len(n.Props) > 0 {
+		props := make(map[string]any, len(n.Props))
+		for key, value := range n.Props {
+			if strings.EqualFold(key, "class") {
+				continue
+			}
+			props[key] = value
+		}
+		n.Props = props
+	}
+	return noderender.RenderNode(n)
+}
+
+func renderChildren(nodes []world.Node) []render.HTML {
+	out := make([]render.HTML, 0, len(nodes))
+	for _, child := range nodes {
+		out = append(out, RenderNode(child))
+	}
+	return out
+}
+
+func withTextFallback(children []render.HTML, text string) []render.HTML {
+	if len(children) == 0 && text != "" {
+		return []render.HTML{render.Text(text)}
+	}
+	return children
+}
+
+func propString(props map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := props[key]; ok && value != nil {
+			switch v := value.(type) {
+			case string:
+				if v != "" {
+					return v
+				}
+			default:
+				return fmt.Sprint(v)
+			}
+		}
+	}
+	return ""
+}
+
+func propInt(props map[string]any, keys ...string) int {
+	for _, key := range keys {
+		switch value := props[key].(type) {
+		case int:
+			return value
+		case int64:
+			return int(value)
+		case float64:
+			return int(value)
+		}
+	}
+	return 0
+}
+
+func propBool(props map[string]any, key string) bool {
+	value, _ := props[key].(bool)
+	return value
+}
+
+func buttonVariant(value string) ui.ButtonVariant {
+	switch value {
+	case "secondary":
+		return ui.ButtonSecondary
+	case "danger":
+		return ui.ButtonDanger
+	case "ghost":
+		return ui.ButtonGhost
+	default:
+		return ui.ButtonPrimary
+	}
+}
+
+func buttonSize(value string) ui.ButtonSize {
+	switch value {
+	case "small":
+		return ui.ButtonSizeSmall
+	case "large":
+		return ui.ButtonSizeLarge
+	default:
+		return ui.ButtonSizeDefault
+	}
+}
+
+func cardVariant(value string) ui.CardVariant {
+	switch value {
+	case "outlined":
+		return ui.CardOutlined
+	case "flat":
+		return ui.CardFlat
+	default:
+		return ui.CardElevated
+	}
+}
+
+func statusVariant(value string) ui.StatusVariant {
+	switch value {
+	case "success":
+		return ui.StatusSuccess
+	case "warning":
+		return ui.StatusWarning
+	case "danger":
+		return ui.StatusDanger
+	case "neutral":
+		return ui.StatusNeutral
+	default:
+		return ui.StatusInfo
+	}
+}
+
+func trendDirection(value string) ui.TrendDirection {
+	switch value {
+	case "up":
+		return ui.TrendUp
+	case "down":
+		return ui.TrendDown
+	default:
+		return ui.TrendFlat
+	}
+}
+
+func gap(value string) ui.Gap {
+	switch value {
+	case "none":
+		return ui.GapNone
+	case "xs":
+		return ui.GapXS
+	case "sm":
+		return ui.GapSM
+	case "lg":
+		return ui.GapLG
+	case "xl":
+		return ui.GapXL
+	case "2xl":
+		return ui.Gap2XL
+	default:
+		return ui.GapMD
+	}
+}
+
+func align(value string) ui.Align {
+	switch value {
+	case "start":
+		return ui.AlignStart
+	case "center":
+		return ui.AlignCenter
+	case "end":
+		return ui.AlignEnd
+	case "baseline":
+		return ui.AlignBaseline
+	default:
+		return ui.AlignStretch
+	}
+}
+
+func justify(value string) ui.Justify {
+	switch value {
+	case "center":
+		return ui.JustifyCenter
+	case "end":
+		return ui.JustifyEnd
+	case "between":
+		return ui.JustifyBetween
+	case "around":
+		return ui.JustifyAround
+	default:
+		return ui.JustifyStart
+	}
+}

--- a/kiln/render/node.go
+++ b/kiln/render/node.go
@@ -20,7 +20,7 @@ func RenderNode(n world.Node) render.HTML {
 	case "page_header":
 		title := propString(n.Props, "title", "text")
 		if title == "" {
-			return renderLeaf(n)
+			return renderLeaf(n, children)
 		}
 		return ui.PageHeader(ui.PageHeaderConfig{
 			Title: title, Subtitle: propString(n.Props, "subtitle", "description"),
@@ -51,7 +51,7 @@ func RenderNode(n world.Node) render.HTML {
 	case "link_button":
 		label, href := propString(n.Props, "label", "text"), propString(n.Props, "href")
 		if label == "" || href == "" {
-			return renderLeaf(n)
+			return renderLeaf(n, children)
 		}
 		return ui.LinkButton(ui.LinkButtonConfig{
 			Label: label, Href: href, Variant: buttonVariant(propString(n.Props, "variant")),
@@ -66,7 +66,7 @@ func RenderNode(n world.Node) render.HTML {
 	case "stat_card":
 		label, value := propString(n.Props, "label"), propString(n.Props, "value")
 		if label == "" || value == "" {
-			return renderLeaf(n)
+			return renderLeaf(n, children)
 		}
 		return ui.StatCard(ui.StatCardConfig{
 			Label: label, Value: value, Trend: propString(n.Props, "trend"),
@@ -98,25 +98,29 @@ func RenderNode(n world.Node) render.HTML {
 			Label: propString(n.Props, "label", "text"), Orientation: orientation, ID: propString(n.Props, "id"),
 		})
 	default:
-		return renderLeaf(n)
+		return renderLeaf(n, children)
 	}
 }
 
 // renderLeaf keeps legacy journals renderable without letting them reintroduce
 // app-local styling. Structural classes belong to typed design-system
 // components; one-to-one semantic HTML nodes receive only their safe props.
-func renderLeaf(n world.Node) render.HTML {
-	if len(n.Props) > 0 {
-		props := make(map[string]any, len(n.Props))
+// It renders just this node's element around the already-kiln-rendered
+// children, so typed design-system kinds nested inside a semantic container
+// still dispatch through their components (and the class strip applies at
+// every depth, since every node passes through here).
+func renderLeaf(n world.Node, children []render.HTML) render.HTML {
+	props := n.Props
+	if len(props) > 0 {
+		props = make(map[string]any, len(n.Props))
 		for key, value := range n.Props {
 			if strings.EqualFold(key, "class") {
 				continue
 			}
 			props[key] = value
 		}
-		n.Props = props
 	}
-	return noderender.RenderNode(n)
+	return noderender.RenderKind(n.Kind, props, children)
 }
 
 func renderChildren(nodes []world.Node) []render.HTML {

--- a/kiln/render/node_test.go
+++ b/kiln/render/node_test.go
@@ -208,3 +208,46 @@ func TestRawNodeDoesNotEmitUnescapedHTML(t *testing.T) {
 		t.Errorf("raw node leaked unescaped HTML: %q", got)
 	}
 }
+
+// Design-system kinds must render wherever they appear, including inside
+// semantic leaf containers — the leaf branch must not hand the whole subtree
+// to core noderender, whose vocabulary has no typed kinds.
+func TestRenderNodeCardInsideDiv(t *testing.T) {
+	got := render.RenderNode(world.Node{
+		Kind: "div",
+		Children: []world.Node{
+			{Kind: "card", Props: map[string]any{"heading": "Revenue"}},
+		},
+	})
+	s := string(got)
+	if !strings.Contains(s, `data-fui-comp="ui-card"`) || !strings.Contains(s, "Revenue") {
+		t.Fatalf("card inside div vanished: %q", s)
+	}
+	if strings.Contains(s, "unknown kind") {
+		t.Fatalf("leaf subtree fell through to core noderender: %q", s)
+	}
+}
+
+func TestRenderNodeLeafChildrenRenderOnce(t *testing.T) {
+	got := render.RenderNode(world.Node{
+		Kind: "div",
+		Children: []world.Node{
+			{Kind: "paragraph", Props: map[string]any{"text": "once"}},
+		},
+	})
+	if n := strings.Count(string(got), "once"); n != 1 {
+		t.Fatalf("leaf children rendered %d times, want 1: %q", n, got)
+	}
+}
+
+func TestRenderNodeDropsNestedClassProp(t *testing.T) {
+	got := render.RenderNode(world.Node{
+		Kind: "div",
+		Children: []world.Node{
+			{Kind: "div", Props: map[string]any{"class": "kiln-rogue"}},
+		},
+	})
+	if strings.Contains(string(got), "kiln-rogue") {
+		t.Errorf("nested leaf kept agent-authored class: %q", got)
+	}
+}

--- a/kiln/render/node_test.go
+++ b/kiln/render/node_test.go
@@ -13,7 +13,7 @@ func TestRenderNodeDiv(t *testing.T) {
 		Kind:  "div",
 		Props: map[string]any{"id": "main", "class": "container"},
 	})
-	want := `<div class="container" id="main"></div>`
+	want := `<div id="main"></div>`
 	if string(got) != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -139,9 +139,8 @@ func TestRenderNodeAttrsEscape(t *testing.T) {
 }
 
 // Strict CSP rejects inline style="…" and on*="…" handlers. The
-// renderer drops those props server-side so a single bad agent turn
-// can't poison the page. The kiln-* utility classes from theme.css
-// are the supported alternative.
+// renderer drops those props server-side so a legacy journal cannot
+// poison the page. Typed design-system kinds own styling.
 func TestRenderNodeDropsDangerousAttrs(t *testing.T) {
 	cases := []struct {
 		name string
@@ -172,14 +171,26 @@ func TestRenderNodeDropsDangerousAttrs(t *testing.T) {
 	}
 }
 
-// Class-based styling is the supported path. Verify class survives.
-func TestRenderNodeKeepsClassProp(t *testing.T) {
+// Agent-authored class names would create a second styling surface. Kiln
+// strips them from legacy worlds; current protocol calls reject them.
+func TestRenderNodeDropsClassProp(t *testing.T) {
 	got := render.RenderNode(world.Node{
 		Kind:  "section",
 		Props: map[string]any{"class": "kiln-section kiln-section-soft"},
 	})
-	if !strings.Contains(string(got), `class="kiln-section kiln-section-soft"`) {
-		t.Errorf("class prop should pass through: %q", got)
+	if strings.Contains(string(got), `kiln-section`) {
+		t.Errorf("class prop should be design-system-owned: %q", got)
+	}
+}
+
+func TestRenderNodeUsesDesignSystemCard(t *testing.T) {
+	got := render.RenderNode(world.Node{
+		Kind: "card", Props: map[string]any{"heading": "Current", "variant": "outlined"},
+		Children: []world.Node{{Kind: "paragraph", Props: map[string]any{"text": "Built from framework/ui"}}},
+	})
+	s := string(got)
+	if !strings.Contains(s, `data-fui-comp="ui-card"`) || !strings.Contains(s, "Built from framework/ui") {
+		t.Fatalf("card did not use current design-system component: %q", s)
 	}
 }
 

--- a/kiln/render/render.go
+++ b/kiln/render/render.go
@@ -3,13 +3,11 @@ package render
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"sort"
+	"strings"
 
-	"github.com/DonaldMurillo/gofastr/core-ui/widget"
 	"github.com/DonaldMurillo/gofastr/framework"
 	"github.com/DonaldMurillo/gofastr/kiln/effect"
 	"github.com/DonaldMurillo/gofastr/kiln/world"
@@ -44,9 +42,6 @@ func ApplyDetailed(app *framework.App, w *world.World) (Deferred, error) {
 	if err := applyEntities(app, w); err != nil {
 		return Deferred{}, fmt.Errorf("kiln/render: entities: %w", err)
 	}
-	if err := applyPages(app, w); err != nil {
-		return Deferred{}, fmt.Errorf("kiln/render: pages: %w", err)
-	}
 	if err := applyMiddleware(app, w); err != nil {
 		return Deferred{}, fmt.Errorf("kiln/render: middleware: %w", err)
 	}
@@ -55,6 +50,9 @@ func ApplyDetailed(app *framework.App, w *world.World) (Deferred, error) {
 	}
 	if err := applyRoutes(app, w); err != nil {
 		return Deferred{}, fmt.Errorf("kiln/render: routes: %w", err)
+	}
+	if err := applyUIHostPages(app, w); err != nil {
+		return Deferred{}, fmt.Errorf("kiln/render: pages: %w", err)
 	}
 	return Deferred{}, nil
 }
@@ -130,6 +128,8 @@ func applyRoutes(app *framework.App, w *world.World) error {
 func applyAppConfig(app *framework.App, c world.AppConfig) error {
 	app.Config.Name = c.Name
 	app.Config.DebugEndpoints = c.DebugEndpoints
+	app.Config.APIPrefix = strings.Trim(c.APIPrefix, "/")
+	app.Config.NoLLMMD = !c.LLMMD
 	switch c.JSONCase {
 	case "", "camel", "camelCase":
 		app.Config.JSONCase = framework.CaseCamel
@@ -168,126 +168,77 @@ func applyEntities(app *framework.App, w *world.World) error {
 	return nil
 }
 
-// entityConfig converts a world.Entity to a framework.EntityConfig by
-// round-tripping through framework.EntityDeclaration. The two declarative
-// shapes share the same JSON tags by design, so this is lossless for
-// every field declared in v1.
+// entityConfig converts the JSON-only world shape into the framework's
+// current declaration contract. It is intentionally explicit: relation
+// types are strings in the authoring IR and enums in framework code, so a
+// JSON round-trip silently drifted as the framework surface evolved.
 func entityConfig(e *world.Entity) (framework.EntityConfig, error) {
-	buf, err := json.Marshal(e)
-	if err != nil {
-		return framework.EntityConfig{}, fmt.Errorf("marshal: %w", err)
+	decl := framework.EntityDeclaration{
+		Name:           e.Name,
+		Table:          e.Table,
+		SoftDelete:     e.SoftDelete,
+		MultiTenant:    e.MultiTenant,
+		OwnerField:     e.OwnerField,
+		CrossOwnerRead: e.CrossOwnerRead,
+		SearchFields:   append([]string(nil), e.SearchFields...),
+		Timestamps:     e.Timestamps,
+		CRUD:           e.CRUD,
+		MCP:            e.MCP,
+		CursorField:    e.CursorField,
+		CursorFields:   append([]string(nil), e.CursorFields...),
+		Properties:     e.Properties,
 	}
-	var decl framework.EntityDeclaration
-	if err := json.Unmarshal(buf, &decl); err != nil {
-		return framework.EntityConfig{}, fmt.Errorf("unmarshal as declaration: %w", err)
+	for _, f := range e.Fields {
+		decl.Fields = append(decl.Fields, framework.FieldDeclaration{
+			Name: f.Name, Type: f.Type, Required: f.Required, Unique: f.Unique,
+			Default: f.Default, AutoGenerate: f.AutoGenerate, ReadOnly: f.ReadOnly,
+			Hidden: f.Hidden, Max: f.Max, Min: f.Min, Pattern: f.Pattern,
+			Values: append([]string(nil), f.Values...), To: f.To, Many: f.Many,
+		})
+	}
+	for _, r := range e.Relations {
+		relationType, err := relationType(r.Type)
+		if err != nil {
+			return framework.EntityConfig{}, err
+		}
+		target := r.Entity
+		if target == "" {
+			target = r.To // pre-parity journal compatibility
+		}
+		decl.Relations = append(decl.Relations, framework.Relation{
+			Type: relationType, Name: r.Name, Entity: target,
+			ForeignKey: r.ForeignKey, Through: r.Through, LocalKey: r.LocalKey,
+			ForeignKeyTarget: r.ForeignKeyTarget,
+		})
+	}
+	for _, ix := range e.Indices {
+		decl.Indices = append(decl.Indices, framework.Index{
+			Name: ix.Name, Columns: append([]string(nil), ix.Columns...),
+			Unique: ix.Unique,
+		})
+	}
+	if e.Access != nil {
+		decl.Access = &framework.AccessDeclaration{
+			Read: e.Access.Read, Create: e.Access.Create,
+			Update: e.Access.Update, Delete: e.Access.Delete,
+		}
 	}
 	return decl.Config()
 }
 
-// widgetTag returns the script tag auto-injected into every Kiln-rendered
-// page. Delegates to widget.RuntimeTag for content-hash cache-busting
-// so a fresh build invalidates any stale runtime in the browser.
-func widgetTag() string { return widget.RuntimeTag() }
-
-func applyPages(app *framework.App, w *world.World) error {
-	// Build a set of paths the entity CRUD layer has already registered
-	// so we can skip a page that would collide. The framework's
-	// auto-CRUD assumes it owns "/<table>" — if the agent declares a
-	// page at the same URL, ServeMux panics. Pages take precedence
-	// for HTML; the entity's CRUD remains reachable as JSON via its
-	// other verbs (POST/PUT/DELETE) and via the framework's auto-MCP
-	// surface.
-	entityRoots := map[string]bool{}
-	for _, ent := range app.Registry.All() {
-		entityRoots["/"+ent.GetTable()] = true
+func relationType(value string) (framework.RelationType, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "has_one":
+		return framework.RelHasOne, nil
+	case "has_many":
+		return framework.RelHasMany, nil
+	case "", "belongs_to", "many_to_one":
+		return framework.RelManyToOne, nil
+	case "many_to_many":
+		return framework.RelManyToMany, nil
+	default:
+		return 0, fmt.Errorf("unknown relation type %q", value)
 	}
-
-	paths := make([]string, 0, len(w.Pages))
-	for p := range w.Pages {
-		paths = append(paths, p)
-	}
-	sort.Strings(paths)
-	for _, path := range paths {
-		page := w.Pages[path]
-		if page == nil {
-			continue
-		}
-		// Conflict guard: if the path was already claimed by a CRUD list
-		// route, register the page on a content-negotiated wrapper that
-		// only renders HTML for browser GETs and falls through to the
-		// CRUD handler for JSON requests. We replace the existing route
-		// since router.Handle would panic otherwise — but Router has no
-		// "replace" API, so the practical fix is: SKIP when there's a
-		// CRUD entity at the same root, and emit a warning. Agents
-		// should namespace pages (e.g., /posts/list) — the skill flags
-		// this collision so they self-correct.
-		if entityRoots[path] {
-			fmt.Fprintf(os.Stderr, "[kiln/render] page %q skipped: collides with entity CRUD list endpoint. "+
-				"Use a different page path (e.g. %q) or remove the entity.\n", path, path+"/list")
-			continue
-		}
-		p := page
-		// Recover from any other ServeMux registration panic (e.g. two
-		// pages claim the same path, or a custom route does). Live's
-		// rebuild logs and continues — a partial app is better than a
-		// dead one for build-mode iteration.
-		func() {
-			defer func() {
-				if rec := recover(); rec != nil {
-					fmt.Fprintf(os.Stderr, "[kiln/render] page %q registration panic: %v\n", path, rec)
-				}
-			}()
-			app.Router().Get(path, http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
-				rw.Header().Set("Content-Type", "text/html; charset=utf-8")
-				fmt.Fprint(rw, renderFullPage(p))
-			}))
-		}()
-	}
-	return nil
-}
-
-// renderFullPage wraps the page tree in a full HTML document and injects
-// the floating chat widget so every Kiln-served page surfaces the
-// agent in its corner.
-func renderFullPage(p *world.Page) string {
-	title := p.Title
-	if title == "" {
-		title = p.Path
-	}
-	return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>` + escapeText(title) + `</title>
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<link rel="stylesheet" href="/kiln/theme.css">
-</head>
-<body class="kiln-app">
-<main class="kiln-page">
-` + string(RenderNode(p.Tree)) + `
-</main>
-` + widgetTag() + `
-</body>
-</html>`
-}
-
-func escapeText(s string) string {
-	out := make([]byte, 0, len(s))
-	for _, r := range s {
-		switch r {
-		case '<':
-			out = append(out, []byte("&lt;")...)
-		case '>':
-			out = append(out, []byte("&gt;")...)
-		case '&':
-			out = append(out, []byte("&amp;")...)
-		case '"':
-			out = append(out, []byte("&quot;")...)
-		default:
-			out = append(out, []byte(string(r))...)
-		}
-	}
-	return string(out)
 }
 
 // ApplySeeds inserts the world's seed rows into db. It's a separate call

--- a/kiln/render/render_test.go
+++ b/kiln/render/render_test.go
@@ -81,9 +81,9 @@ func TestApplyEntityRegistersCRUDRoutes(t *testing.T) {
 		t.Fatalf("migrate: %v", err)
 	}
 
-	res, body := get(t, app.Router(), "/posts")
+	res, body := get(t, app.Router(), "/api/posts")
 	if res.StatusCode != http.StatusOK {
-		t.Fatalf("GET /posts status = %d, body = %q", res.StatusCode, body)
+		t.Fatalf("GET /api/posts status = %d, body = %q", res.StatusCode, body)
 	}
 	if !strings.Contains(body, "data") && !strings.HasPrefix(strings.TrimSpace(body), "[") {
 		t.Errorf("GET /posts body unexpected: %q", body)
@@ -113,9 +113,9 @@ func TestApplyEntityWithSeed(t *testing.T) {
 		t.Fatalf("ApplySeeds: %v", err)
 	}
 
-	res, body := get(t, app.Router(), "/posts")
+	res, body := get(t, app.Router(), "/api/posts")
 	if res.StatusCode != http.StatusOK {
-		t.Fatalf("GET /posts status = %d, body = %q", res.StatusCode, body)
+		t.Fatalf("GET /api/posts status = %d, body = %q", res.StatusCode, body)
 	}
 	if !strings.Contains(body, "hello") || !strings.Contains(body, "world") {
 		t.Errorf("seeded rows missing: %q", body)
@@ -158,8 +158,34 @@ func TestApplyPageRendersHTML(t *testing.T) {
 	if !strings.Contains(body, "/__gofastr/runtime.js") {
 		t.Errorf("page should auto-inject the widget bootstrap script: %q", body)
 	}
+	if !strings.Contains(body, "/__gofastr/app.css") {
+		t.Errorf("page should use the current UI host stylesheet: %q", body)
+	}
+	if strings.Contains(body, "/kiln/theme.css") || strings.Contains(body, "kiln-page") {
+		t.Errorf("page should not use the removed bespoke Kiln page surface: %q", body)
+	}
 	if !strings.Contains(body, "Dashboard") {
 		t.Errorf("page <title> should reflect page.Title: %q", body)
+	}
+}
+
+func TestApplyPageAndEntityMayShareNameUnderAPIPrefix(t *testing.T) {
+	app, _ := newTestApp(t)
+	w := world.New()
+	w.Entities["posts"] = &world.Entity{Name: "posts", Fields: []world.Field{{Name: "title", Type: "string"}}}
+	w.Pages["/posts"] = &world.Page{Path: "/posts", Title: "Posts", Tree: world.Node{
+		Kind: "page_header", Props: map[string]any{"title": "Posts"},
+	}}
+	if err := render.Apply(app, w); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	res, body := get(t, app.Router(), "/posts")
+	if res.StatusCode != http.StatusOK || !strings.Contains(body, "Posts") {
+		t.Fatalf("GET /posts status=%d body=%q", res.StatusCode, body)
+	}
+	res, _ = get(t, app.Router(), "/api/posts")
+	if res.StatusCode == http.StatusNotFound {
+		t.Fatal("entity CRUD route was not registered under /api")
 	}
 }
 

--- a/kiln/render/uihost.go
+++ b/kiln/render/uihost.go
@@ -1,0 +1,187 @@
+package render
+
+import (
+	"sort"
+	"strings"
+
+	coreapp "github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/core-ui/style"
+	"github.com/DonaldMurillo/gofastr/core-ui/widget"
+	corerender "github.com/DonaldMurillo/gofastr/core/render"
+	corerouter "github.com/DonaldMurillo/gofastr/core/router"
+	"github.com/DonaldMurillo/gofastr/framework"
+	"github.com/DonaldMurillo/gofastr/framework/ui"
+	uitheme "github.com/DonaldMurillo/gofastr/framework/ui/theme"
+	"github.com/DonaldMurillo/gofastr/framework/uihost"
+	"github.com/DonaldMurillo/gofastr/kiln/world"
+)
+
+// applyUIHostPages mounts the same SSR + hydration host used by current
+// generated apps. It must run after CRUD, middleware, hooks, and explicit
+// routes because UIHost is the router fallback.
+func applyUIHostPages(fwApp *framework.App, w *world.World) error {
+	name := w.App.Name
+	if name == "" {
+		name = "Kiln"
+	}
+	site := coreapp.NewApp(name).WithTheme(worldTheme(w.App))
+	site.NoLLMMD = !w.App.LLMMD
+
+	layouts := map[string]*coreapp.Layout{}
+	defaultLayout := coreapp.NewLayout("app").WithContainer()
+	if len(w.Nav) > 0 {
+		sidebarCfg := ui.SidebarConfig{Title: name, Items: sidebarItems(w.Nav)}
+		defaultLayout = coreapp.NewLayout("app").WithSidebar(ui.Sidebar(sidebarCfg))
+		ui.MountSidebar(routerMounter{fwApp.Router()}, sidebarCfg)
+	}
+	layouts["app"] = defaultLayout
+	layouts["marketing"] = coreapp.NewLayout("marketing").WithContainer()
+	site.SetDefaultLayout(defaultLayout)
+
+	paths := make([]string, 0, len(w.Pages))
+	for path := range w.Pages {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		page := w.Pages[path]
+		if page == nil {
+			continue
+		}
+		layout := defaultLayout
+		if page.Layout != nil && page.Layout.Name != "" {
+			var ok bool
+			layout, ok = layouts[page.Layout.Name]
+			if !ok {
+				layout = coreapp.NewLayout(page.Layout.Name).WithContainer()
+				layouts[page.Layout.Name] = layout
+			}
+		}
+		site.RegisterScreen(&coreapp.Screen{
+			Path: path, Name: page.Name, Title: page.Title,
+			Description: page.Description, Type: screenType(page.Type),
+			Component: &worldScreen{page: page}, Layout: layout,
+		}, layout)
+	}
+
+	opts := []uihost.Option{}
+	if w.App.StaticDir != "" {
+		opts = append(opts, uihost.WithStaticDir(w.App.StaticDir))
+	}
+	if w.App.LLMMD {
+		opts = append(opts, uihost.WithPublicLLMMD())
+	}
+	if w.App.PWA.Enabled {
+		deny := []string{"/kiln", "/mcp"}
+		if prefix := strings.Trim(w.App.APIPrefix, "/"); prefix != "" && prefix != "api" {
+			deny = append(deny, "/"+prefix)
+		}
+		if authPath := strings.TrimSpace(w.App.Auth.BasePath); authPath != "" && authPath != "/auth" {
+			deny = append(deny, authPath)
+		}
+		opts = append(opts, uihost.WithPWA(uihost.PWAConfig{
+			Name: w.App.PWA.Name, ShortName: w.App.PWA.ShortName,
+			Description: w.App.PWA.Description, StartURL: w.App.PWA.StartURL,
+			Scope: w.App.PWA.Scope, Display: uihost.PWADisplay(w.App.PWA.Display),
+			ThemeColor: w.App.PWA.ThemeColor, BackgroundColor: w.App.PWA.BackgroundColor,
+			DenyPaths: deny,
+		}))
+	}
+	fwApp.Mount(uihost.New(site, opts...))
+	return nil
+}
+
+type worldScreen struct{ page *world.Page }
+
+func (s worldScreen) Render() corerender.HTML {
+	// Kiln's build-mode node renderer is the sole trusted source for these
+	// attributes; it allow-lists props and strips inline handlers/raw HTML.
+	// The marker keeps the legacy data-kiln-tool delegation scoped to this
+	// rendered world instead of trusting the entire uihost document.
+	return corerender.Tag("div", map[string]string{"data-fui-trusted": ""}, RenderNode(s.page.Tree))
+}
+
+func screenType(value string) coreapp.ScreenType {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "drawer":
+		return coreapp.ScreenDrawer
+	case "sheet":
+		return coreapp.ScreenSheet
+	case "dialog":
+		return coreapp.ScreenDialog
+	default:
+		return coreapp.ScreenPage
+	}
+}
+
+func sidebarItems(items []world.NavItem) []ui.SidebarItem {
+	out := make([]ui.SidebarItem, 0, len(items))
+	for _, item := range items {
+		var roles []string
+		if item.Role != "" {
+			roles = []string{item.Role}
+		}
+		out = append(out, ui.SidebarItem{
+			Label: item.Label, Href: item.Href, Roles: roles,
+			Children: sidebarItems(item.Items),
+		})
+	}
+	return out
+}
+
+type routerMounter struct{ r *corerouter.Router }
+
+func (m routerMounter) MountWidget(def *widget.Definition) { widget.Mount(m.r, def) }
+
+func worldTheme(c world.AppConfig) style.Theme {
+	t := uitheme.Default()
+	for key, value := range c.Theme {
+		if value == "" {
+			continue
+		}
+		switch key {
+		case "primary":
+			t.Colors.Primary.Value = value
+		case "primary-fg":
+			t.Colors.PrimaryFg.Value = value
+		case "secondary":
+			t.Colors.Secondary.Value = value
+		case "background":
+			t.Colors.Background.Value = value
+		case "surface":
+			t.Colors.Surface.Value = value
+		case "surface-soft":
+			t.Colors.SurfaceSoft.Value = value
+		case "text":
+			t.Colors.Text.Value = value
+		case "text-muted":
+			t.Colors.TextMuted.Value = value
+		case "text-subtle":
+			t.Colors.TextSubtle.Value = value
+		case "border":
+			t.Colors.Border.Value = value
+		case "border-strong":
+			t.Colors.BorderStrong.Value = value
+		case "accent":
+			t.Colors.Accent.Value = value
+		case "success":
+			t.Colors.Success.Value = value
+		case "warning":
+			t.Colors.Warning.Value = value
+		case "danger":
+			t.Colors.Danger.Value = value
+		case "info":
+			t.Colors.Info.Value = value
+		case "font_body":
+			t.Fonts.Body.Value = value
+		case "font_heading", "font_display":
+			t.Fonts.Heading.Value = value
+		}
+	}
+	for key, value := range c.ThemeDark {
+		if value != "" {
+			t.DarkColors[key] = value
+		}
+	}
+	return t
+}

--- a/kiln/world/world.go
+++ b/kiln/world/world.go
@@ -40,20 +40,26 @@ const SchemaVersion = 1
 
 // World is the canonical, JSON-clean representation of a Kiln application.
 type World struct {
-	SchemaVersion int                `json:"schema_version"`
-	App           AppConfig          `json:"app"`
-	Entities      map[string]*Entity `json:"entities,omitempty"`
-	Pages         map[string]*Page   `json:"pages,omitempty"`
-	Hooks         []*Hook            `json:"hooks,omitempty"`
-	Routes        []*Route           `json:"routes,omitempty"`
-	Seeds         []*Seed            `json:"seeds,omitempty"`
-	Middleware    []*Middleware      `json:"middleware,omitempty"`
+	SchemaVersion   int                `json:"schema_version"`
+	App             AppConfig          `json:"app"`
+	Entities        map[string]*Entity `json:"entities,omitempty"`
+	Pages           map[string]*Page   `json:"pages,omitempty"`
+	Nav             []NavItem          `json:"nav,omitempty"`
+	Hooks           []*Hook            `json:"hooks,omitempty"`
+	Routes          []*Route           `json:"routes,omitempty"`
+	Endpoints       []*EndpointStub    `json:"endpoints,omitempty"`
+	Seeds           []*Seed            `json:"seeds,omitempty"`
+	Middleware      []*Middleware      `json:"middleware,omitempty"`
+	MiddlewareStubs []NamedStub        `json:"middleware_stubs,omitempty"`
+	Plugins         []NamedStub        `json:"plugins,omitempty"`
+	Helpers         []NamedStub        `json:"helpers,omitempty"`
 }
 
 // New returns an empty World at the current SchemaVersion.
 func New() *World {
 	return &World{
 		SchemaVersion: SchemaVersion,
+		App:           AppConfig{APIPrefix: "api", Auth: AuthConfig{DevMode: true}},
 		Entities:      map[string]*Entity{},
 		Pages:         map[string]*Page{},
 	}
@@ -63,32 +69,93 @@ func New() *World {
 // kiln-specific UI configuration (theme overrides) that the agent or
 // a host tool may override at runtime.
 type AppConfig struct {
-	Name           string `json:"name,omitempty"`
-	JSONCase       string `json:"json_case,omitempty"` // "camel" | "snake"
-	DebugEndpoints bool   `json:"debug_endpoints,omitempty"`
+	Name           string      `json:"name,omitempty"`
+	Module         string      `json:"module,omitempty"`
+	JSONCase       string      `json:"json_case,omitempty"` // "camel" | "snake"
+	DebugEndpoints bool        `json:"debug_endpoints,omitempty"`
+	DBDriver       string      `json:"db_driver,omitempty"`
+	DBURL          string      `json:"db_url,omitempty"`
+	StaticDir      string      `json:"static_dir,omitempty"`
+	OutputDir      string      `json:"output_dir,omitempty"`
+	APIPrefix      string      `json:"api_prefix,omitempty"`
+	LLMMD          bool        `json:"llm_md,omitempty"`
+	Auth           AuthConfig  `json:"auth,omitempty"`
+	Admin          AdminConfig `json:"admin,omitempty"`
+	PWA            PWAConfig   `json:"pwa,omitempty"`
 
-	// Theme is an optional set of token overrides applied to the
-	// framework's default page theme. Keys are token names (e.g.
-	// "page-bg", "page-primary", "page-fg-soft"); values are CSS
-	// color literals. The renderer merges these on top of
-	// core-ui/widget/theme.PageTheme(), so a single set_theme call
-	// re-skins every page.
-	Theme map[string]string `json:"theme,omitempty"`
+	// Theme and ThemeDark are optional semantic token overrides applied to
+	// the framework theme. Light keys include colors such as "background",
+	// "primary", and "text-muted", plus "font_body" and "font_heading";
+	// dark overrides accept the semantic color keys. Values are CSS literals.
+	Theme     map[string]string `json:"theme,omitempty"`
+	ThemeDark map[string]string `json:"theme_dark,omitempty"`
+}
+
+// AuthConfig, AdminConfig, and PWAConfig mirror the corresponding current
+// gofastr.yml app sections. Kiln previews the surfaces it can render safely;
+// freeze preserves the full declaration for the owned-Go scaffold.
+type AuthConfig struct {
+	Enabled   bool   `json:"enabled,omitempty"`
+	DevMode   bool   `json:"dev_mode,omitempty"`
+	BasePath  string `json:"base_path,omitempty"`
+	JWTSecret string `json:"jwt_secret,omitempty"`
+}
+
+type AdminConfig struct {
+	Enabled      bool   `json:"enabled,omitempty"`
+	Path         string `json:"path,omitempty"`
+	Role         string `json:"role,omitempty"`
+	LoginPath    string `json:"login_path,omitempty"`
+	SeedEmail    string `json:"seed_email,omitempty"`
+	SeedPassword string `json:"seed_password,omitempty"`
+}
+
+type PWAConfig struct {
+	Enabled         bool   `json:"enabled,omitempty"`
+	Name            string `json:"name,omitempty"`
+	ShortName       string `json:"short_name,omitempty"`
+	Description     string `json:"description,omitempty"`
+	StartURL        string `json:"start_url,omitempty"`
+	Scope           string `json:"scope,omitempty"`
+	Display         string `json:"display,omitempty"`
+	ThemeColor      string `json:"theme_color,omitempty"`
+	BackgroundColor string `json:"background_color,omitempty"`
 }
 
 // Entity is the JSON-clean entity declaration. It tracks framework
 // EntityDeclaration plus declarative hooks and endpoints.
 type Entity struct {
-	Name        string           `json:"name"`
-	Table       string           `json:"table,omitempty"`
-	Fields      []Field          `json:"fields"`
-	Relations   []Relation       `json:"relations,omitempty"`
-	Endpoints   []EntityEndpoint `json:"endpoints,omitempty"`
-	SoftDelete  bool             `json:"soft_delete,omitempty"`
-	MultiTenant bool             `json:"multi_tenant,omitempty"`
-	Timestamps  *bool            `json:"timestamps,omitempty"`
-	CRUD        *bool            `json:"crud,omitempty"`
-	MCP         bool             `json:"mcp,omitempty"`
+	Name           string             `json:"name"`
+	Table          string             `json:"table,omitempty"`
+	Fields         []Field            `json:"fields"`
+	Relations      []Relation         `json:"relations,omitempty"`
+	Endpoints      []EntityEndpoint   `json:"endpoints,omitempty"`
+	SoftDelete     bool               `json:"soft_delete,omitempty"`
+	MultiTenant    bool               `json:"multi_tenant,omitempty"`
+	OwnerField     string             `json:"owner_field,omitempty"`
+	CrossOwnerRead string             `json:"cross_owner_read,omitempty"`
+	SearchFields   []string           `json:"search_fields,omitempty"`
+	Access         *AccessDeclaration `json:"access,omitempty"`
+	Timestamps     *bool              `json:"timestamps,omitempty"`
+	CRUD           *bool              `json:"crud,omitempty"`
+	MCP            bool               `json:"mcp,omitempty"`
+	CursorField    string             `json:"cursor_field,omitempty"`
+	CursorFields   []string           `json:"cursor_fields,omitempty"`
+	Indices        []Index            `json:"indices,omitempty"`
+	Properties     map[string]any     `json:"properties,omitempty"`
+}
+
+type AccessDeclaration struct {
+	Read   string `json:"read,omitempty"`
+	Create string `json:"create,omitempty"`
+	Update string `json:"update,omitempty"`
+	Delete string `json:"delete,omitempty"`
+}
+
+type Index struct {
+	Name    string   `json:"name,omitempty"`
+	Columns []string `json:"columns,omitempty"`
+	Unique  bool     `json:"unique,omitempty"`
 }
 
 // Field mirrors framework.FieldDeclaration verbatim.
@@ -111,9 +178,16 @@ type Field struct {
 
 // Relation matches the framework's relation shape.
 type Relation struct {
-	Name string `json:"name"`
-	To   string `json:"to"`
-	Type string `json:"type,omitempty"` // "belongs_to" | "has_many" | "many_to_many"
+	Type             string `json:"type,omitempty"` // "has_one" | "has_many" | "belongs_to" | "many_to_many"
+	Name             string `json:"name"`
+	Entity           string `json:"entity,omitempty"`
+	ForeignKey       string `json:"foreign_key,omitempty"`
+	Through          string `json:"through,omitempty"`
+	LocalKey         string `json:"local_key,omitempty"`
+	ForeignKeyTarget string `json:"foreign_key_target,omitempty"`
+	// To is the pre-parity target key. It remains readable so existing
+	// journals replay; new clients should use Entity.
+	To string `json:"to,omitempty"`
 }
 
 // EntityEndpoint is a custom HTTP endpoint attached to an entity. Unlike
@@ -146,16 +220,45 @@ type Route struct {
 
 // Seed is initial data for an entity, applied after migrations.
 type Seed struct {
-	Entity string           `json:"entity"`
-	Rows   []map[string]any `json:"rows"`
+	Entity  string                    `json:"entity"`
+	Rows    []map[string]any          `json:"rows,omitempty"`
+	Count   int                       `json:"count,omitempty"`
+	Weights map[string]map[string]int `json:"weights,omitempty"`
 }
 
 // Middleware selects from a built-in catalog by name and supplies optional
 // declarative configuration. The catalog is closed; the agent cannot author
 // new middleware without escalating beyond Kiln's declarative surface.
 type Middleware struct {
-	Name string         `json:"name"`
-	Cfg  map[string]any `json:"cfg,omitempty"`
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Cfg         map[string]any `json:"cfg,omitempty"`
+}
+
+// EndpointStub, NamedStub, and NavItem are the scaffold-only surfaces from
+// the current blueprint contract. They do not invent live handler bodies;
+// freeze emits owned-Go stubs while world.json retains the exact live IR.
+type EndpointStub struct {
+	Name        string `json:"name,omitempty"`
+	Method      string `json:"method"`
+	Path        string `json:"path"`
+	Entity      string `json:"entity,omitempty"`
+	Handler     string `json:"handler,omitempty"`
+	Description string `json:"description,omitempty"`
+	MCP         bool   `json:"mcp,omitempty"`
+}
+
+type NamedStub struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+type NavItem struct {
+	Label string    `json:"label"`
+	Href  string    `json:"href"`
+	Icon  string    `json:"icon,omitempty"`
+	Role  string    `json:"role,omitempty"`
+	Items []NavItem `json:"items,omitempty"`
 }
 
 // Page is a UI screen described as an element tree.
@@ -166,14 +269,20 @@ type Middleware struct {
 // IfMatch so an agent can verify the page hasn't shifted under it
 // between fetch and patch.
 type Page struct {
-	Path        string  `json:"path"`
-	Name        string  `json:"name,omitempty"`
-	Title       string  `json:"title,omitempty"`
-	Description string  `json:"description,omitempty"`
-	Type        string  `json:"type,omitempty"` // "page" | "drawer" | "sheet" | "dialog"
-	Version     int     `json:"version,omitempty"`
-	Layout      *Layout `json:"layout,omitempty"`
-	Tree        Node    `json:"tree"`
+	Path        string     `json:"path"`
+	Name        string     `json:"name,omitempty"`
+	Title       string     `json:"title,omitempty"`
+	Description string     `json:"description,omitempty"`
+	Type        string     `json:"type,omitempty"` // "page" | "drawer" | "sheet" | "dialog"
+	Version     int        `json:"version,omitempty"`
+	Layout      *Layout    `json:"layout,omitempty"`
+	Access      PageAccess `json:"access,omitempty"`
+	Tree        Node       `json:"tree"`
+}
+
+type PageAccess struct {
+	Auth bool   `json:"auth,omitempty"`
+	Role string `json:"role,omitempty"`
 }
 
 // Layout is a placeholder mirroring core-ui/app.Layout. v1 stores the layout


### PR DESCRIPTION
## Summary

- bring Kiln's live authoring world, tools, routes, and agent workflow back to the current GoFastr blueprint contract
- freeze deterministic `gofastr.yml` plus lossless `world.json`, then validate/generate a complete owned-Go app
- preserve current layout primitives across generate/pack and render live pages through the shared UI host/design system
- harden Windows WAL snapshots, generator/dev-loop process handling, executable paths, and symlink checks
- make SSE-triggered widget refreshes use the SPA navigation pipeline and strengthen Meridian visual timing/contrast assertions

## Why

Kiln had drifted behind the framework: it still graduated through the removed `entities/*.json` path, used bare CRUD routes and a parallel renderer, and advertised tools the native agent dispatcher could not execute. Windows also exposed append-handle, process-tree, executable-path, and path-normalization assumptions that the Unix test path did not catch.

## Impact

Kiln can now author against the same typed app/entity/screen/navigation surface that GoFastr generates, coexist with HTML screens under the `/api` CRUD boundary, and graduate a live world into inspectable Go that validates and compiles. The CLI and E2E harnesses now behave consistently across Windows and Unix.

## Validation

- `./scripts/test-all.sh` — build, vet, and uncached full repository suite passed with the PR code
- `go test ./cmd/kiln ./kiln/freeze ./kiln/integration ./cmd/gofastr ./cmd/repolint ./framework/docs ./core-ui/runtime -count=1 -timeout 20m`
- `go test ./battery/email ./battery/embed ./core/schema ./framework -count=1 -timeout 20m`
- upgrade registry/changelog contract tests
- `git diff --check` and conflict-marker audit

## Note

The executable repo-lint command reports checkout-wide CRLF on this Windows worktree, including untouched files; the repolint package tests pass and the staged diff is whitespace-clean. CI's LF checkout will exercise the canonical gate.
