### PR TITLE
fix(test): pin isolation off in the bind-failure Start test

### DIFF
--- a/framework/start_bindfail_test.go
+++ b/framework/start_bindfail_test.go
@@ -15,6 +15,14 @@ import (
 // context — instead of returning early and leaking every worker, cron, and
 // queue an earlier start phase spawned.
 func TestStart_BindFailureRunsShutdown(t *testing.T) {
+	// This test pins the bind-FAILURE contract, so worktree isolation must
+	// not rescue the bind: in a linked git worktree (the default "worktree"
+	// isolation mode) Start remaps the occupied port to a free one, binds
+	// successfully, and serves forever — failing this test with a
+	// misleading "Start did not return" in any worktree checkout while
+	// passing on a plain clone.
+	t.Setenv("GOFASTR_ISOLATION", "off")
+
 	// Occupy a port so the app's bind fails deterministically.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {


### PR DESCRIPTION
TestStart_BindFailureRunsShutdown occupies a port and asserts `Start` returns an error. In a linked git worktree, the default `worktree` isolation mode remaps the occupied port to a free one — so `Start` binds successfully and serves forever, failing the test with a misleading "Start did not return" in **every worktree checkout** while passing on a plain clone (which is why CI never saw it).

The test pins the bind-failure contract, not isolation behavior, so it now sets `GOFASTR_ISOLATION=off` for its duration. Verified 3/3 green in a linked worktree where it previously failed 100%, and still green on a plain checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)