### PR TITLE
docs(skill): a release requires a GitHub Release, not just a tag

### DIFF
--- a/.claude/skills/gofastr-docs/SKILL.md
+++ b/.claude/skills/gofastr-docs/SKILL.md
@@ -105,6 +105,15 @@ was needed.
   `.claude/skills/gofastr-host/SKILL.md` recipe table + trigger
   phrases, then copy to `cmd/gofastr/embedded/gofastr-host-skill.md`
   (`TestEmbeddedHostSkillMatchesRepo` pins the sync)
+- **Publish the GitHub Release — a pushed tag is NOT a release.** After
+  the PR merges, tag the merge commit AND run
+  `gh release create vX.Y.Z --title "…" --notes-file <the CHANGELOG
+  section>`. `git push origin vX.Y.Z` only creates a tag object; the
+  repo's Releases page (and anyone watching for releases) shows nothing
+  until the Release object exists. The release is not "done" at the tag
+  — it's done when `gh release view vX.Y.Z` succeeds and it reads
+  `Latest`. (v0.27.0 and v0.28.0 are tag-only for exactly this reason —
+  backfill them if the Releases page needs to be complete.)
 
 ## Hard rules
 


### PR DESCRIPTION
The `gofastr-docs` release checklist listed the changelog / `upgrades.yml` / SECURITY.md steps but not the final **publish** step. That's how v0.29.0 (and v0.27.0, v0.28.0 before it) shipped as tag-only — a pushed tag object is not a GitHub Release, so the Releases page stayed frozen at v0.26.1.

Adds the explicit step to the checklist: after merge, tag the merge commit **and** `gh release create vX.Y.Z --notes-file <changelog section>`; the release is done only when `gh release view` reads `Latest`. Also notes v0.27.0/v0.28.0 are tag-only and can be backfilled.

Docs-only, no embedded-copy sync needed (only the host skill is embedded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)