### PR TITLE
fix(filter): strict rejection of unknown list filters (#100 Workstream A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,15 +45,16 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 - **Hidden columns reachable via nested filters** (#100). A `Hidden` column
   on a relation's target entity could be probed through a nested predicate
   (`?author.password_hash_like=…`), resurrecting the same value-disclosure
-  oracle the flat-filter Hidden exclusion blocks. Nested filters now reject
-  a hidden target field with the identical error as a nonexistent field
-  (non-leaky).
+  oracle the flat-filter Hidden exclusion blocks. Both the HTTP nested path
+  and the in-process typed-repo path now reject a hidden target field with
+  the identical error as a nonexistent field (non-leaky).
 - **`?offset=` now honored on the List endpoint** (#100). The raw
   `?offset=` row-skip control was accepted but silently ignored (the paged
   query always derived its offset from `?page`), so a caller paginating by
   offset — notably the process-module broker, which sends `?offset=` without
   `?page` — silently received page 1. An explicit non-negative `?offset=`
-  now overrides the page-derived offset.
+  now overrides the page-derived offset on both the buffered and streaming
+  list paths.
 
 ## [0.34.0] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,56 @@ All notable changes to GoFastr. Follows
 calendar versions (`YYYY-MM-DD` per substantive release until the API
 stabilises). Breaking changes are clearly marked with **BREAKING**.
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING — strict filter parsing on the List endpoint** (#100). An
+  unknown top-level filter query param (a typo like `?stauts=open`, or a
+  suffixed op on a non-field like `?scor_gt=5`) now returns a **400**
+  naming the bad key — with a "did you mean" suggestion when a field is an
+  unambiguous near-match — instead of being silently dropped. Silently
+  dropping a filter returned an **unfiltered** result set: a broken client
+  read the whole table and an attacker's probe was indistinguishable from a
+  real query. This aligns flat filters with the existing fail-closed policy
+  for `?sort=` and `?where=`. Hidden columns are rejected with the identical
+  "unknown filter" wording as a nonexistent column, so the error is not a
+  hidden-vs-absent oracle. Reserved list controls (`sort`, `page`, `limit`,
+  `offset`, `cursor`, `direction`, `where`, `fields`, `include`, `trashed`,
+  `stream`, `q`) and nested relation filters (`?author.name=`) are never
+  treated as unknown filters.
+
+  A declared column whose name collides with a control word (a field named
+  `stream`, `q`, …) still filters — a known field wins over the reserved-word
+  skip, so it is never silently swallowed. `?per_page` is accepted as an
+  alias for `?limit` (a common REST convention) so it neither 400s nor
+  silently serves the default page size.
+
+  **Migration.** An endpoint that reads its own non-column query params (a
+  `BeforeList` hook scoping on `?region=`) declares them with
+  `EntityConfig.AllowedFilterParams: []string{"region"}` so strict parsing
+  skips them without disabling typo protection. To tolerate *arbitrary*
+  extra params, restore the old drop-silently behavior per entity with
+  `EntityConfig.LenientFilters: true`, or per call with
+  `filter.ParseFilters(r, fields, filter.Lenient())`. Prefer the narrow
+  options — a dropped filter is a data-exposure hazard. See
+  [entity declarations → Flat filters](entity-declarations.md).
+
+### Fixed
+
+- **Hidden columns reachable via nested filters** (#100). A `Hidden` column
+  on a relation's target entity could be probed through a nested predicate
+  (`?author.password_hash_like=…`), resurrecting the same value-disclosure
+  oracle the flat-filter Hidden exclusion blocks. Nested filters now reject
+  a hidden target field with the identical error as a nonexistent field
+  (non-leaky).
+- **`?offset=` now honored on the List endpoint** (#100). The raw
+  `?offset=` row-skip control was accepted but silently ignored (the paged
+  query always derived its offset from `?page`), so a caller paginating by
+  offset — notably the process-module broker, which sends `?offset=` without
+  `?page` — silently received page 1. An explicit non-negative `?offset=`
+  now overrides the page-derived offset.
+
 ## [0.34.0] - 2026-07-18
 
 Makes framework-owned SQL work with the bundled pure-Go SQLite adapter (#91),

--- a/cmd/gofastr/cov_main_test.go
+++ b/cmd/gofastr/cov_main_test.go
@@ -70,22 +70,13 @@ func TestInfoWarnPrint(t *testing.T) {
 	}
 }
 
-func TestLevenshteinAndMin(t *testing.T) {
-	cases := []struct {
-		a, b string
-		want int
-	}{
-		{"", "abc", 3},
-		{"abc", "", 3},
-		{"kitten", "sitting", 3},
-		{"same", "same", 0},
-	}
-	for _, c := range cases {
-		if got := levenshtein(c.a, c.b); got != c.want {
-			t.Errorf("levenshtein(%q,%q)=%d want %d", c.a, c.b, got, c.want)
-		}
-	}
+// Edit distance now lives in core/fuzzy (shared with framework/filter) and is
+// tested there; here we only cover the CLI-local variadic min helper.
+func TestMin(t *testing.T) {
 	if min(3, 1, 2) != 1 {
 		t.Fatalf("min broken")
+	}
+	if min(5) != 5 {
+		t.Fatalf("min single-arg broken")
 	}
 }

--- a/cmd/gofastr/main.go
+++ b/cmd/gofastr/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/DonaldMurillo/gofastr/core/fuzzy"
 )
 
 // Version info — overridden via -ldflags at build time.
@@ -259,42 +261,13 @@ func dispatch(args []string) {
 		// Fuzzy suggestion: check if it's close to a known command
 		suggestions := []string{"init", "generate", "pack", "validate", "build", "dev", "migrate", "test", "embed", "harness", "docs", "agents", "audit", "upgrade", "version"}
 		for _, s := range suggestions {
-			if strings.HasPrefix(s, cmd) || levenshtein(cmd, s) <= 2 {
+			if strings.HasPrefix(s, cmd) || fuzzy.Levenshtein(cmd, s) <= 2 {
 				fmt.Printf("  Did you mean: %s?\n", bold("gofastr "+s))
 			}
 		}
 		printHelp()
 		osExit(1)
 	}
-}
-
-// levenshtein returns the edit distance between two strings.
-func levenshtein(a, b string) int {
-	la, lb := len(a), len(b)
-	if la == 0 {
-		return lb
-	}
-	if lb == 0 {
-		return la
-	}
-	d := make([][]int, la+1)
-	for i := range d {
-		d[i] = make([]int, lb+1)
-		d[i][0] = i
-	}
-	for j := 0; j <= lb; j++ {
-		d[0][j] = j
-	}
-	for i := 1; i <= la; i++ {
-		for j := 1; j <= lb; j++ {
-			cost := 1
-			if a[i-1] == b[j-1] {
-				cost = 0
-			}
-			d[i][j] = min(d[i-1][j]+1, d[i][j-1]+1, d[i-1][j-1]+cost)
-		}
-	}
-	return d[la][lb]
 }
 
 func min(vals ...int) int {

--- a/core/fuzzy/fuzzy.go
+++ b/core/fuzzy/fuzzy.go
@@ -1,0 +1,50 @@
+// Package fuzzy holds small string-similarity helpers shared across the
+// codebase. It is dependency-free and low-level so both the framework and
+// the CLI (which cannot import each other) can reuse one implementation
+// instead of maintaining copies.
+package fuzzy
+
+// Levenshtein returns the edit distance between a and b — the minimum number
+// of single-character insertions, deletions, or substitutions to turn one
+// into the other. Inputs are compared bytewise; for ASCII identifiers
+// (command names, field names) that is equivalent to rune distance.
+//
+// It uses two rolling rows, so allocation and memory are O(len(b)); the
+// identifier lists it runs against are tiny.
+func Levenshtein(a, b string) int {
+	la, lb := len(a), len(b)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min3(prev[j]+1, curr[j-1]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[lb]
+}
+
+func min3(a, b, c int) int {
+	m := a
+	if b < m {
+		m = b
+	}
+	if c < m {
+		m = c
+	}
+	return m
+}

--- a/core/fuzzy/fuzzy_test.go
+++ b/core/fuzzy/fuzzy_test.go
@@ -1,0 +1,28 @@
+package fuzzy
+
+import "testing"
+
+func TestLevenshtein(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"", "abc", 3},
+		{"abc", "", 3},
+		{"abc", "abc", 0},
+		{"kitten", "sitting", 3},
+		{"status", "statuss", 1}, // insertion
+		{"status", "stauts", 2},  // transposition = 2 edits
+		{"score", "scor", 1},     // deletion
+	}
+	for _, c := range cases {
+		if got := Levenshtein(c.a, c.b); got != c.want {
+			t.Errorf("Levenshtein(%q,%q)=%d want %d", c.a, c.b, got, c.want)
+		}
+		// Symmetric.
+		if got := Levenshtein(c.b, c.a); got != c.want {
+			t.Errorf("Levenshtein(%q,%q)=%d want %d (asymmetric)", c.b, c.a, got, c.want)
+		}
+	}
+}

--- a/framework/crud/cov_lastmile_test.go
+++ b/framework/crud/cov_lastmile_test.go
@@ -28,15 +28,19 @@ func TestList_ScanErr(t *testing.T) {
 }
 
 // crud.go:336 — List filter parse error → 400.
-func TestList_IgnoresUnknownFilter(t *testing.T) {
+func TestList_RejectsUnknownFilter(t *testing.T) {
 	ch, _ := covFaultNotes(t)
-	// An unknown filter param (unrecognised field/suffix) is leniently
-	// ignored, not rejected — the list still succeeds.
+	// An unknown filter param (unrecognised field/suffix) is REJECTED, not
+	// silently dropped — silently dropping returns an unfiltered result set
+	// (#100A). The bad key is named in the body so a client can surface it.
 	req := withTestUser(httptest.NewRequest("GET", "/notes?title_zz=x", nil), "u1")
 	rec := httptest.NewRecorder()
 	ch.List()(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("unknown filter = %d, want 200 (lenient)", rec.Code)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("unknown filter = %d, want 400 (strict)", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "title_zz") {
+		t.Fatalf("400 body must name the bad key, got %s", rec.Body.String())
 	}
 }
 

--- a/framework/crud/cov_pure_test.go
+++ b/framework/crud/cov_pure_test.go
@@ -325,6 +325,36 @@ func TestParseNestedFilters_HiddenTargetFieldRejected(t *testing.T) {
 	}
 }
 
+// The in-process typed-repo nested path (resolveNestedFilters) must reject a
+// Hidden target column exactly like the HTTP path — its doc comment claims
+// parity, and a typed caller passing a partially user-influenced field name
+// would otherwise rebuild the value-disclosure oracle one hop away.
+func TestResolveNestedFilters_HiddenTargetFieldRejected(t *testing.T) {
+	ent := covRelEntity()
+	reg := stubRegistry{byName: map[string]*entity.Entity{
+		"users": entity.Define("users", entity.EntityConfig{
+			Name: "users", Table: "users",
+			Fields: []schema.Field{
+				{Name: "name", Type: schema.String},
+				{Name: "password_hash", Type: schema.String, Hidden: true},
+			},
+		}.WithTimestamps(false)),
+	}}
+
+	_, err := resolveNestedFilters(ent, reg, []NestedFilter{
+		{Relation: "author", Field: "password_hash", Op: filter.OpLike, Value: "x"},
+	})
+	if err == nil {
+		t.Fatal("SECURITY: in-process nested filter accepted a Hidden target column")
+	}
+	// A visible field still resolves.
+	if _, err := resolveNestedFilters(ent, reg, []NestedFilter{
+		{Relation: "author", Field: "name", Op: filter.OpEq, Value: "alice"},
+	}); err != nil {
+		t.Fatalf("visible nested field must resolve, got %v", err)
+	}
+}
+
 func TestAuditCtx_RoundTrip(t *testing.T) {
 	if AuditRequestFromContext(context.Background()) != nil {
 		t.Error("expected nil request when unset")

--- a/framework/crud/cov_pure_test.go
+++ b/framework/crud/cov_pure_test.go
@@ -291,6 +291,40 @@ func TestParseNestedFilters_Paths(t *testing.T) {
 	}
 }
 
+// A Hidden column on the TARGET entity must not be reachable as a nested
+// predicate — otherwise ?author.password_hash_like=… resurrects the
+// value-disclosure oracle the flat-filter Hidden exclusion blocks, one
+// relation hop away. The rejection must be non-leaky: identical wording to a
+// nonexistent field, so the error can't distinguish hidden from absent.
+func TestParseNestedFilters_HiddenTargetFieldRejected(t *testing.T) {
+	ent := covRelEntity()
+	reg := stubRegistry{byName: map[string]*entity.Entity{
+		"users": entity.Define("users", entity.EntityConfig{
+			Name: "users", Table: "users",
+			Fields: []schema.Field{
+				{Name: "name", Type: schema.String},
+				{Name: "password_hash", Type: schema.String, Hidden: true},
+			},
+		}.WithTimestamps(false)),
+	}}
+
+	r := httptest.NewRequest("GET", "/?author.password_hash_like=%242a%2410%24", nil)
+	_, hiddenErr := parseNestedFilters(r, ent, reg)
+	if hiddenErr == nil {
+		t.Fatal("SECURITY: hidden target field reachable as nested predicate")
+	}
+	// Non-leaky: a truly-absent field must produce the same error shape.
+	r2 := httptest.NewRequest("GET", "/?author.nonexistent_like=x", nil)
+	_, absentErr := parseNestedFilters(r2, ent, reg)
+	if absentErr == nil {
+		t.Fatal("nonexistent target field must also error")
+	}
+	norm := func(s, field string) string { return strings.ReplaceAll(s, field, "F") }
+	if norm(hiddenErr.Error(), "password_hash") != norm(absentErr.Error(), "nonexistent") {
+		t.Errorf("SECURITY: hidden vs absent nested errors differ — oracle:\n hidden: %v\n absent: %v", hiddenErr, absentErr)
+	}
+}
+
 func TestAuditCtx_RoundTrip(t *testing.T) {
 	if AuditRequestFromContext(context.Background()) != nil {
 		t.Error("expected nil request when unset")

--- a/framework/crud/cross_owner_read_test.go
+++ b/framework/crud/cross_owner_read_test.go
@@ -92,11 +92,15 @@ func reqWithRolesOnly(r *http.Request, uid string) *http.Request {
 
 // TestCrossOwnerReadHTTPCannotSpoof proves client-supplied headers/params
 // naming the permission never widen the scope without a server-side grant.
+// Two vectors: a spoof carried in trusted-looking HEADERS still runs but
+// stays owner-scoped; a spoof carried in QUERY PARAMS is rejected outright
+// by strict filter parsing (#100A). Neither can ever surface bob's row.
 func TestCrossOwnerReadHTTPCannotSpoof(t *testing.T) {
 	installOwnerExtractor(t)
 	ch, _ := setupCrossOwnerReadHandler(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/ctickets?cross_owner_read=tickets:read:all&role=staff", nil)
+	// Vector 1 — header spoof. The request runs; owner scope holds.
+	req := httptest.NewRequest(http.MethodGet, "/api/ctickets", nil)
 	req.Header.Set("X-Cross-Owner-Read", "tickets:read:all")
 	req.Header.Set("X-Role", "staff")
 	req = withTestUser(req, "alice") // no policy/roles in context
@@ -104,7 +108,7 @@ func TestCrossOwnerReadHTTPCannotSpoof(t *testing.T) {
 	ch.List()(rec, req)
 
 	if rec.Code != http.StatusOK {
-		t.Fatalf("List status=%d body=%s", rec.Code, rec.Body.String())
+		t.Fatalf("header-spoof List status=%d body=%s", rec.Code, rec.Body.String())
 	}
 	body := rec.Body.String()
 	if strings.Contains(body, "t-b") || strings.Contains(body, "Beta") {
@@ -112,6 +116,19 @@ func TestCrossOwnerReadHTTPCannotSpoof(t *testing.T) {
 	}
 	if !strings.Contains(body, "t-a") {
 		t.Fatalf("alice's own row missing: %s", body)
+	}
+
+	// Vector 2 — query-param spoof. Strict filter parsing fails closed with
+	// a 400; the response body can never contain bob's row.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/ctickets?cross_owner_read=tickets:read:all&role=staff", nil)
+	req2 = withTestUser(req2, "alice")
+	rec2 := httptest.NewRecorder()
+	ch.List()(rec2, req2)
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("query-param spoof want 400 (strict), got %d body=%s", rec2.Code, rec2.Body.String())
+	}
+	if b := rec2.Body.String(); strings.Contains(b, "t-b") || strings.Contains(b, "Beta") {
+		t.Fatalf("rejected request leaked bob's row: %s", b)
 	}
 }
 

--- a/framework/crud/cross_owner_test.go
+++ b/framework/crud/cross_owner_test.go
@@ -110,9 +110,10 @@ func TestCrossOwner_HTTPCannotBypass(t *testing.T) {
 	installOwnerExtractor(t)
 	ch, _ := setupOwnerReadInProcHandler(t)
 
-	// Attacker-controlled inputs: query params and headers that name the
-	// escape. None of them can flip the marker.
-	req := httptest.NewRequest(http.MethodGet, "/api/onotes?all_owners=true&cross_owner=1", nil)
+	// Attacker-controlled HEADERS that name the escape. The request runs;
+	// the marker (set only by an unexported Go context key) never flips, so
+	// the list stays owner-scoped.
+	req := httptest.NewRequest(http.MethodGet, "/api/onotes", nil)
 	req.Header.Set("X-Cross-Owner", "true")
 	req.Header.Set("X-All-Owners", "true")
 	req = withTestUser(req, "alice")
@@ -128,5 +129,19 @@ func TestCrossOwner_HTTPCannotBypass(t *testing.T) {
 	}
 	if !strings.Contains(body, "note-a") {
 		t.Fatalf("HTTP List() did not return alice's own row: %s", body)
+	}
+
+	// Attacker-controlled QUERY PARAMS that name the escape. Strict filter
+	// parsing rejects the unknown params with a 400 before any scan — the
+	// body can never contain bob's row.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/onotes?all_owners=true&cross_owner=1", nil)
+	req2 = withTestUser(req2, "alice")
+	rec2 := httptest.NewRecorder()
+	ch.List()(rec2, req2)
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("query-param escape want 400 (strict), got %d body=%s", rec2.Code, rec2.Body.String())
+	}
+	if b := rec2.Body.String(); strings.Contains(b, "note-b") || strings.Contains(b, "Beta") {
+		t.Fatalf("rejected request leaked bob's row: %s", b)
 	}
 }

--- a/framework/crud/crud.go
+++ b/framework/crud/crud.go
@@ -340,7 +340,14 @@ func (ch *CrudHandler) List() http.HandlerFunc {
 			return
 		}
 
-		filters, err := filter.ParseFilters(r, ch.Entity.GetFields())
+		var filterOpts []filter.FilterOption
+		if ch.Entity.Config.LenientFilters {
+			filterOpts = append(filterOpts, filter.Lenient())
+		}
+		if extra := ch.Entity.Config.AllowedFilterParams; len(extra) > 0 {
+			filterOpts = append(filterOpts, filter.Allow(extra...))
+		}
+		filters, err := filter.ParseFilters(r, ch.Entity.GetFields(), filterOpts...)
 		if err != nil {
 			writeJSONError(w, http.StatusBadRequest, "invalid filters: "+err.Error())
 			return
@@ -485,6 +492,14 @@ func (ch *CrudHandler) List() http.HandlerFunc {
 		filter.ApplySortToQuery(qb, sorts)
 
 		offset := (page - 1) * perPage
+		// An explicit ?offset= overrides the page-derived offset. The
+		// process-module broker paginates by raw offset (it sets ?offset=
+		// without ?page=), and it is a documented control param — honoring it
+		// here is what makes those requests return the intended window
+		// instead of silently serving page 1.
+		if o, ok := explicitOffset(r); ok {
+			offset = o
+		}
 		qb.Limit(perPage)
 		qb.Offset(offset)
 
@@ -944,8 +959,8 @@ func isUniqueViolation(err error) bool {
 	return false
 }
 
-// parsePagination extracts page and per_page from query params.
-// Defaults: page=1, per_page=20.
+// parsePagination extracts the page number (?page) and page size (?limit,
+// or its ?per_page alias) from query params. Defaults: page=1, perPage=20.
 //
 // The per_page cap is 100 by default. Entities can raise this via
 // EntityConfig.MaxListLimit. ?stream=true on its own does NOT raise
@@ -965,8 +980,15 @@ func parsePagination(r *http.Request, entityMax int) (page, perPage int) {
 
 	maxPerPage := listLimitCap(entityMax)
 
-	if v := r.URL.Query().Get("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+	// ?limit is the canonical page-size param; ?per_page is accepted as an
+	// alias (a common REST convention) so a client using it gets the size it
+	// asked for rather than a silent default. ?limit wins when both are sent.
+	sizeParam := r.URL.Query().Get("limit")
+	if sizeParam == "" {
+		sizeParam = r.URL.Query().Get("per_page")
+	}
+	if sizeParam != "" {
+		if n, err := strconv.Atoi(sizeParam); err == nil && n > 0 {
 			perPage = n
 		}
 	}
@@ -977,6 +999,23 @@ func parsePagination(r *http.Request, entityMax int) (page, perPage int) {
 		perPage = maxPerPage
 	}
 	return
+}
+
+// explicitOffset reads a raw ?offset= row skip. Returns (n, true) only for a
+// well-formed non-negative integer; a missing, malformed, or negative value
+// yields (0, false) so the caller keeps the page-derived offset. LIMIT still
+// caps the row count, so an oversized offset just returns an empty window —
+// no need to clamp it here.
+func explicitOffset(r *http.Request) (int, bool) {
+	v := r.URL.Query().Get("offset")
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
 }
 
 // listLimitCap is the effective per-request row cap for an entity:

--- a/framework/crud/crud_stream.go
+++ b/framework/crud/crud_stream.go
@@ -30,7 +30,8 @@ const streamListThreshold = 1000
 //
 // `page` is honoured the same way the non-stream List handler honours it:
 // OFFSET (page-1)*limit. Without this, ?page=2&stream=true would re-stream
-// page 1 while reporting page 1 — silently dropping the offset.
+// page 1 while reporting page 1 — silently dropping the offset. An explicit
+// ?offset= overrides the page-derived offset, matching the buffered path.
 func (ch *CrudHandler) ServeStreamingList(ctx context.Context, w http.ResponseWriter, r *http.Request, cols []string, filters []filter.ParsedFilter, nested []nestedFilter, sorts []filter.ParsedSort, page, limit int, extraWhere []hook.WhereClause) {
 	// Same owner+tenant gate the public List handler enforces. Direct
 	// callers (in-process or chained from List) must not bypass it —
@@ -75,7 +76,14 @@ func (ch *CrudHandler) ServeStreamingList(ctx context.Context, w http.ResponseWr
 	}
 	filter.ApplySortToQuery(qb, sorts)
 	qb.Limit(limit)
-	if page > 1 {
+	// An explicit ?offset= overrides the page-derived offset, matching the
+	// buffered List() path — otherwise ?offset=N&stream=true would silently
+	// serve page 1 (the process-module broker paginates by raw offset).
+	if o, ok := explicitOffset(r); ok {
+		if o > 0 {
+			qb.Offset(o)
+		}
+	} else if page > 1 {
 		qb.Offset((page - 1) * limit)
 	}
 

--- a/framework/crud/nested_filter.go
+++ b/framework/crud/nested_filter.go
@@ -176,7 +176,12 @@ func resolveNestedFilters(ent *entity.Entity, registry entity.Registry, specs []
 				known := false
 				for _, f := range target.GetFields() {
 					if f.Name == spec.Field {
-						known = true
+						// A Hidden target column is treated as not-declared —
+						// the same value-disclosure-oracle rejection the HTTP
+						// path applies in parseNestedFilters. Without this, a
+						// typed caller passing a partially user-influenced
+						// field name rebuilds the oracle one relation hop away.
+						known = !f.Hidden
 						break
 					}
 				}

--- a/framework/crud/nested_filter.go
+++ b/framework/crud/nested_filter.go
@@ -99,12 +99,18 @@ func parseNestedFilters(r *http.Request, ent *entity.Entity, registry entity.Reg
 
 		// Validate the field exists on the target entity (when the registry
 		// has it). Without the registry we trust the field name as-is.
+		//
+		// A Hidden column is treated as NOT declared — the identical error to
+		// a nonexistent field, so the response can't distinguish hidden from
+		// absent. Otherwise a nested predicate (?author.password_hash_like=…)
+		// would resurrect exactly the value-disclosure oracle the flat-filter
+		// Hidden exclusion blocks, just one relation hop away.
 		if registry != nil {
 			if target, err := registry.Get(rel.Entity); err == nil {
 				known := false
 				for _, f := range target.GetFields() {
 					if f.Name == fieldName {
-						known = true
+						known = !f.Hidden
 						break
 					}
 				}

--- a/framework/crud/softdelete_public_security_test.go
+++ b/framework/crud/softdelete_public_security_test.go
@@ -74,7 +74,7 @@ func TestSoftDelete_PublicStreamingListDoesNotExposeDeletedRecords(t *testing.T)
 
 	req := makeRequest(t, RequestOpts{
 		Method: http.MethodGet,
-		Path:   "/announcements?trashed=true&stream=true&per_page=100000",
+		Path:   "/announcements?trashed=true&stream=true&limit=100000",
 	})
 	rec := httptest.NewRecorder()
 	ch.List()(rec, req)

--- a/framework/crud/strict_filter_wiring_test.go
+++ b/framework/crud/strict_filter_wiring_test.go
@@ -1,0 +1,154 @@
+package crud
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+	"github.com/DonaldMurillo/gofastr/framework/hook"
+)
+
+// allowedFilterHandler builds a notes handler whose entity declares `region`
+// as an extra allowed query param (consumed by a BeforeList hook).
+func allowedFilterHandler(t *testing.T, allowed []string) (*CrudHandler, *sql.DB) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Skip("sqlite3 driver not available")
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec(`CREATE TABLE notes (id TEXT PRIMARY KEY, owner TEXT NOT NULL, body TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	ent := entity.Define("notes", entity.EntityConfig{
+		Fields: []schema.Field{
+			{Name: "owner", Type: schema.String, Required: true},
+			{Name: "body", Type: schema.String},
+		},
+		AllowedFilterParams: allowed,
+	}.WithTimestamps(false))
+	ent.SetDB(db)
+	ch := NewCrudHandler(ent, db).WithJSONCase(CaseSnake)
+	ch.Hooks = hook.NewHookRegistry()
+	return ch, db
+}
+
+// A custom query param the entity declares in AllowedFilterParams must reach
+// the BeforeList hook (200), not be rejected by strict filter parsing (400).
+// This is the escape hatch for host-consumed params that keeps typo
+// protection intact (regression: strict parsing ran before BeforeList and
+// 400ed the param before the hook could read it).
+func TestList_AllowedFilterParamReachesHook(t *testing.T) {
+	ch, _ := allowedFilterHandler(t, []string{"region"})
+
+	sawRegion := ""
+	ch.Hooks.RegisterHook(hook.BeforeList, func(ctx context.Context, data any) error {
+		p := data.(*hook.ListPayload)
+		sawRegion = p.Request.URL.Query().Get("region")
+		return nil
+	})
+
+	req := withTestUser(httptest.NewRequest(http.MethodGet, "/notes?region=eu", nil), "u1")
+	rec := httptest.NewRecorder()
+	ch.List()(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("declared param must not 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if sawRegion != "eu" {
+		t.Fatalf("BeforeList hook did not see ?region=eu, got %q", sawRegion)
+	}
+}
+
+// Without the declaration the same custom param still fails closed — the
+// escape hatch is opt-in and narrow, not a blanket relaxation.
+func TestList_UndeclaredCustomParamStillRejected(t *testing.T) {
+	ch, _ := allowedFilterHandler(t, nil)
+	req := withTestUser(httptest.NewRequest(http.MethodGet, "/notes?region=eu", nil), "u1")
+	rec := httptest.NewRecorder()
+	ch.List()(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("undeclared custom param want 400, got %d", rec.Code)
+	}
+}
+
+// ?per_page is accepted as an alias for ?limit — both to set the page size
+// and to survive strict filter parsing — so a client using the common
+// per_page convention gets the size it asked for instead of a 400 or a
+// silent default.
+func TestParsePagination_PerPageAlias(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/notes?per_page=7", nil)
+	_, perPage := parsePagination(req, 0)
+	if perPage != 7 {
+		t.Fatalf("per_page alias = %d, want 7", perPage)
+	}
+	// ?limit wins when both are present.
+	req = httptest.NewRequest(http.MethodGet, "/notes?limit=5&per_page=7", nil)
+	if _, pp := parsePagination(req, 0); pp != 5 {
+		t.Fatalf("limit should win over per_page, got %d, want 5", pp)
+	}
+}
+
+// End-to-end: a ?per_page= request no longer 400s under strict parsing.
+func TestList_PerPageDoesNotReject(t *testing.T) {
+	ch, _ := allowedFilterHandler(t, nil)
+	req := withTestUser(httptest.NewRequest(http.MethodGet, "/notes?per_page=10", nil), "u1")
+	rec := httptest.NewRecorder()
+	ch.List()(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("per_page must not 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// explicitOffset parses a raw ?offset= row skip; anything malformed keeps the
+// page-derived offset.
+func TestExplicitOffset(t *testing.T) {
+	cases := []struct {
+		query   string
+		want    int
+		present bool
+	}{
+		{"", 0, false},
+		{"?offset=0", 0, true},
+		{"?offset=25", 25, true},
+		{"?offset=-3", 0, false},
+		{"?offset=abc", 0, false},
+	}
+	for _, c := range cases {
+		r := httptest.NewRequest(http.MethodGet, "/notes"+c.query, nil)
+		got, ok := explicitOffset(r)
+		if got != c.want || ok != c.present {
+			t.Errorf("explicitOffset(%q) = (%d,%v), want (%d,%v)", c.query, got, ok, c.want, c.present)
+		}
+	}
+}
+
+// End-to-end: ?offset= is honored (a raw row skip, as the process-module
+// broker sends it) rather than silently ignored — the regression F6 flagged.
+func TestList_OffsetSkipsRows(t *testing.T) {
+	ch, db := allowedFilterHandler(t, nil)
+	if _, err := db.Exec(`INSERT INTO notes (id, owner, body) VALUES
+		('n1','u1','a'), ('n2','u1','b'), ('n3','u1','c')`); err != nil {
+		t.Fatal(err)
+	}
+	// owner scoping is off (no OwnerField), so all three rows are visible.
+	req := withTestUser(httptest.NewRequest(http.MethodGet, "/notes?sort=id&offset=2", nil), "u1")
+	rec := httptest.NewRecorder()
+	ch.List()(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	// Offset 2 with id-sorted rows skips n1,n2 → only n3 remains.
+	if strings.Contains(body, `"n1"`) || strings.Contains(body, `"n2"`) {
+		t.Fatalf("offset=2 did not skip rows: %s", body)
+	}
+	if !strings.Contains(body, `"n3"`) {
+		t.Fatalf("offset=2 dropped the wrong rows: %s", body)
+	}
+}

--- a/framework/crud/strict_filter_wiring_test.go
+++ b/framework/crud/strict_filter_wiring_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DonaldMurillo/gofastr/core/schema"
 	"github.com/DonaldMurillo/gofastr/framework/entity"
+	"github.com/DonaldMurillo/gofastr/framework/filter"
 	"github.com/DonaldMurillo/gofastr/framework/hook"
 )
 
@@ -150,5 +151,31 @@ func TestList_OffsetSkipsRows(t *testing.T) {
 	}
 	if !strings.Contains(body, `"n3"`) {
 		t.Fatalf("offset=2 dropped the wrong rows: %s", body)
+	}
+}
+
+// The STREAMING path must honor ?offset= too — otherwise ?offset=N&stream=true
+// silently serves page 1 (the buffered path honors it; divergence caught by
+// the GLM review).
+func TestServeStreamingList_OffsetSkipsRows(t *testing.T) {
+	ch, db := allowedFilterHandler(t, nil)
+	if _, err := db.Exec(`INSERT INTO notes (id, owner, body) VALUES
+		('n1','u1','a'), ('n2','u1','b'), ('n3','u1','c')`); err != nil {
+		t.Fatal(err)
+	}
+	req := withTestUser(httptest.NewRequest(http.MethodGet, "/notes?sort=id&stream=true&offset=2", nil), "u1")
+	rec := httptest.NewRecorder()
+	cols := []string{"id", "owner", "body"}
+	sorts := []filter.ParsedSort{{Field: "id"}}
+	ch.ServeStreamingList(req.Context(), rec, req, cols, nil, nil, sorts, 1, 20, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, `"n1"`) || strings.Contains(body, `"n2"`) {
+		t.Fatalf("stream offset=2 did not skip rows: %s", body)
+	}
+	if !strings.Contains(body, `"n3"`) {
+		t.Fatalf("stream offset=2 dropped the wrong rows: %s", body)
 	}
 }

--- a/framework/docs/content/entity-declarations.md
+++ b/framework/docs/content/entity-declarations.md
@@ -569,6 +569,62 @@ rows, err := handler.ListAll(ctx, crud.ListOptions{Search: "go concurrency"})
 Setting `Search` on an entity without `SearchFields` returns an error
 (fail loud, matching the unknown-sort policy).
 
+## Flat filters (`?field_op=value`)
+
+The List endpoint filters on any known, non-Hidden column via query
+params:
+
+```
+GET /api/tickets?status=open&priority_gte=2&assignee_in=me,you&sort=-created_at
+```
+
+| Suffix   | Operator                                   |
+| -------- | ------------------------------------------ |
+| _(none)_ | `=` (equals)                               |
+| `_gt`    | `>`                                        |
+| `_gte`   | `>=`                                       |
+| `_lt`    | `<`                                        |
+| `_lte`   | `<=`                                       |
+| `_like`  | literal `contains` (`LIKE '%value%'`)      |
+| `_in`    | `IN (…)` — comma-separated, capped at 1000 |
+
+**Unknown filters fail closed (strict).** A misspelled or unrecognized
+top-level filter — `?stauts=open`, or a suffixed op on a non-field like
+`?scor_gt=5` — returns a **400** naming the bad key (with a "did you
+mean" suggestion when a field is an unambiguous near-match), rather than
+being silently dropped. Silently dropping a filter returns an
+**unfiltered** result set: a broken client reads the whole table, and an
+attacker's probe is indistinguishable from a real query. This mirrors the
+existing fail-closed policy for `?sort=` and `?where=`.
+
+Hidden columns are rejected with the **same** "unknown filter" wording as
+a nonexistent column, so the error can't be used to distinguish
+hidden-from-absent (the value-disclosure-oracle rationale — this also
+holds for nested relation filters like `?author.password_hash_like=`).
+Reserved list controls (`sort`, `page`, `limit`, `per_page`, `offset`,
+`cursor`, `direction`, `where`, `fields`, `include`, `trashed`, `stream`,
+`q`) and nested relation filters (dotted keys like `?author.name=alice`)
+are never treated as unknown filters. A declared **column** whose name
+collides with a control word (say a field literally named `stream`) still
+filters — a known field always wins over the reserved-word skip, so it is
+never silently swallowed.
+
+**Custom params.** An endpoint that reads its own non-column query params
+(e.g. a `BeforeList` hook scoping on `?region=eu`) declares them so strict
+parsing skips them without disabling typo protection for real fields:
+
+```go
+app.Entity("things", entity.EntityConfig{
+    AllowedFilterParams: []string{"region"}, // consumed by a BeforeList hook
+})
+```
+
+**Escape hatch.** To tolerate *arbitrary* extra params (e.g. legacy
+tracking params) rather than an enumerated set, opt back into the old
+drop-silently behavior with `EntityConfig.LenientFilters: true`. Prefer
+`AllowedFilterParams` or fixing the caller — a dropped filter is a
+data-exposure hazard.
+
 ## Nested predicate filters (`?where=`)
 
 The flat `?field_op=value` params AND-compose. When you need **boolean

--- a/framework/entity/entity.go
+++ b/framework/entity/entity.go
@@ -117,6 +117,26 @@ type EntityConfig struct {
 	// Ignored when SeedFS is nil.
 	SeedPath string
 
+	// LenientFilters opts the entity's auto-CRUD List endpoint OUT of strict
+	// filter parsing. By default an unknown top-level filter key (a typo like
+	// ?stauts=active) is REJECTED with a 400 rather than silently dropped —
+	// silently dropping it returns an UNFILTERED result set, which is a
+	// data-exposure and broken-client hazard. Set true only as a migration
+	// escape hatch for an endpoint that must tolerate arbitrary extra query
+	// params (e.g. legacy tracking params); prefer fixing the caller.
+	// Default false (strict).
+	LenientFilters bool
+
+	// AllowedFilterParams declares extra query-param keys that are NOT entity
+	// columns but are legitimately consumed elsewhere on the List request —
+	// typically read by a BeforeList hook or custom middleware (e.g. a
+	// bespoke "?region=eu" scope param). Strict filter parsing skips these
+	// instead of rejecting them, so the endpoint keeps typo-protection for
+	// real fields without falling back to LenientFilters (which disables it
+	// entirely). Reserved list controls are always allowed and need not be
+	// listed here.
+	AllowedFilterParams []string
+
 	// timestampsSet tracks whether Timestamps was explicitly set.
 	// When false (zero value), Define defaults Timestamps to true.
 	timestampsSet bool

--- a/framework/filter/filter.go
+++ b/framework/filter/filter.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/DonaldMurillo/gofastr/core/fuzzy"
 	"github.com/DonaldMurillo/gofastr/core/query"
 	"github.com/DonaldMurillo/gofastr/core/schema"
 )
@@ -64,6 +65,51 @@ type ParsedSort struct {
 	Desc  bool
 }
 
+// reservedListParams are the list-endpoint control keys that are never
+// entity fields. Strict parsing skips them so a legitimate ?sort=/?page=/…
+// is not rejected as an unknown filter. Keep in sync with the params the
+// CRUD list handler actually reads (crud.go, pagination, projection,
+// include, search, where-tree, soft-delete, streaming).
+var reservedListParams = map[string]bool{
+	"sort": true, "page": true, "limit": true, "per_page": true,
+	"offset": true, "cursor": true, "direction": true, "where": true,
+	"fields": true, "include": true, "trashed": true, "stream": true,
+	"q": true,
+}
+
+// filterOpts holds the resolved options for a ParseFilters call.
+type filterOpts struct {
+	lenient bool
+	allowed map[string]bool
+}
+
+// FilterOption tunes ParseFilters behavior.
+type FilterOption func(*filterOpts)
+
+// Lenient restores the pre-strict behavior: an unknown top-level filter key
+// is silently dropped instead of returning an error. It exists as a
+// migration escape hatch for apps that historically relied on unrecognized
+// query params being ignored. Prefer the strict default — a dropped filter
+// returns an UNFILTERED result set, which is a data-exposure and
+// broken-client hazard.
+func Lenient() FilterOption { return func(o *filterOpts) { o.lenient = true } }
+
+// Allow declares extra query-param keys that are NOT entity fields but are
+// legitimately consumed elsewhere on the request (a BeforeList hook, custom
+// middleware). Strict parsing skips them instead of rejecting them, so a
+// host keeps typo-protection for real fields without falling back to
+// Lenient (which disables it entirely). Keys are matched exactly.
+func Allow(keys ...string) FilterOption {
+	return func(o *filterOpts) {
+		if o.allowed == nil {
+			o.allowed = make(map[string]bool, len(keys))
+		}
+		for _, k := range keys {
+			o.allowed[k] = true
+		}
+	}
+}
+
 // ParseFilters extracts filters from query parameters based on entity fields.
 // Supported patterns:
 //
@@ -82,13 +128,29 @@ type ParsedSort struct {
 // Hidden column (e.g. a password hash) via ?password_hash_like=… and
 // exfiltrate it prefix by prefix. A Hidden field name is treated as an
 // unknown filter param and never produces a ParsedFilter.
-func ParseFilters(r *http.Request, fields []schema.Field) ([]ParsedFilter, error) {
+//
+// STRICT by default: an unknown top-level filter key (a typo like
+// ?stauts=active, or a suffixed op on a non-field) returns a structured
+// error rather than being silently dropped. Dropping it would return an
+// UNFILTERED 200 — a broken client reads the whole table and an attacker's
+// probe looks identical to the real query. Reserved list controls (sort,
+// page, cursor, …) and nested relation filters (dotted keys like
+// author.name, validated separately by parseNestedFilters) are skipped, not
+// rejected. Pass [Lenient] to restore the old drop-silently behavior.
+func ParseFilters(r *http.Request, fields []schema.Field, opts ...FilterOption) ([]ParsedFilter, error) {
+	var o filterOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	fieldSet := make(map[string]bool, len(fields))
+	names := make([]string, 0, len(fields))
 	for _, f := range fields {
 		if f.Hidden {
 			continue
 		}
 		fieldSet[f.Name] = true
+		names = append(names, f.Name)
 	}
 
 	q := r.URL.Query()
@@ -110,11 +172,27 @@ func ParseFilters(r *http.Request, fields []schema.Field) ([]ParsedFilter, error
 	// doesn't also match a field that was handled by a suffix.
 	consumed := make(map[string]bool)
 
+	// unknown records the first rejected key when strict — surfaced as a
+	// single structured error after the loop (query-map iteration order is
+	// non-deterministic, so report deterministically: the lexically
+	// smallest bad key, with a suggestion).
+	unknown := ""
+
 	for key, values := range q {
-		if len(values) == 0 || key == "sort" || key == "page" || key == "limit" || key == "offset" || key == "cursor" || key == "where" {
+		if len(values) == 0 {
+			continue
+		}
+		// Nested relation filters (author.name=…) are parsed and validated
+		// separately by parseNestedFilters (which enforces the same
+		// schema/Hidden allow-list) — skip dotted keys entirely here.
+		if strings.Contains(key, ".") {
 			continue
 		}
 
+		// A KNOWN field is matched FIRST — before the reserved-control skip —
+		// so a column whose name collides with a control word (e.g. a field
+		// named "stream" or "q") is still filtered rather than silently
+		// swallowed, which would return an unfiltered result set.
 		matched := false
 		for _, s := range suffixes {
 			if strings.HasSuffix(key, s.suffix) {
@@ -148,13 +226,80 @@ func ParseFilters(r *http.Request, fields []schema.Field) ([]ParsedFilter, error
 			continue
 		}
 
-		// Plain field=value → equals
-		if fieldSet[key] && !consumed[key] {
-			filters = append(filters, ParsedFilter{Field: key, Op: OpEq, Value: values[0]})
+		// A plain known field name. When it was already consumed by a
+		// suffixed op on the same request, drop the redundant equals — but it
+		// is still a KNOWN field, so it must never be reported as unknown.
+		if fieldSet[key] {
+			if !consumed[key] {
+				filters = append(filters, ParsedFilter{Field: key, Op: OpEq, Value: values[0]})
+			}
+			continue
+		}
+
+		// Not a field. A reserved list control or a host-declared extra
+		// param is consumed elsewhere on the request — skip it silently.
+		if reservedListParams[key] || o.allowed[key] {
+			continue
+		}
+
+		// Truly unrecognized. Fail closed unless the caller opted into
+		// lenient mode. Record the lexically smallest so the error is
+		// deterministic under randomized map iteration.
+		if !o.lenient && (unknown == "" || key < unknown) {
+			unknown = key
 		}
 	}
 
+	if unknown != "" {
+		return nil, unknownFilterError(unknown, names)
+	}
+
 	return filters, nil
+}
+
+// unknownFilterError builds the structured 400-shaped error for an
+// unrecognized filter key, appending a "did you mean" suggestion when a
+// field name is an unambiguous near-match. The bad key is always named so a
+// generated client can surface it verbatim.
+func unknownFilterError(key string, fieldNames []string) error {
+	if suggestion := nearestField(key, fieldNames); suggestion != "" {
+		return fmt.Errorf("unknown filter %q (did you mean %q?)", key, suggestion)
+	}
+	return fmt.Errorf("unknown filter %q", key)
+}
+
+// nearestField returns the single closest field name to key within a small
+// edit distance, or "" when there is no close or unambiguous match. It also
+// strips a known operator suffix from key first, so ?scor_gt suggests
+// "score". Kept deliberately conservative — a wrong suggestion is worse than
+// none.
+func nearestField(key string, fieldNames []string) string {
+	base := key
+	for _, s := range []string{"_gte", "_lte", "_gt", "_lt", "_like", "_in"} {
+		if strings.HasSuffix(base, s) {
+			base = strings.TrimSuffix(base, s)
+			break
+		}
+	}
+	best, bestDist, ties := "", 1<<30, 0
+	// Allow more slack for longer names; a 1-char typo in "status" and a
+	// 2-char transposition should both resolve.
+	maxDist := 2
+	if len(base) <= 4 {
+		maxDist = 1
+	}
+	for _, name := range fieldNames {
+		d := fuzzy.Levenshtein(base, name)
+		if d < bestDist {
+			best, bestDist, ties = name, d, 1
+		} else if d == bestDist {
+			ties++
+		}
+	}
+	if best == "" || bestDist > maxDist || ties > 1 {
+		return ""
+	}
+	return best
 }
 
 // ParseSort extracts sort information from query parameters.

--- a/framework/filter/hidden_security_test.go
+++ b/framework/filter/hidden_security_test.go
@@ -3,29 +3,41 @@ package filter
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/DonaldMurillo/gofastr/core/schema"
 )
+
+// replaceField swaps a field name inside a raw query string so the "absent"
+// probe mirrors the hidden probe byte-for-byte apart from the field name.
+func replaceField(query, from, to string) string {
+	return strings.Replace(query, from, to, 1)
+}
+
+// sameErrorShape reports whether two error strings are identical once the
+// two field names are normalized away — i.e. they differ ONLY by the field
+// name substituted in. Divergence beyond the name would leak hidden-vs-absent.
+func sameErrorShape(hiddenMsg, absentMsg, hiddenName, absentName string) bool {
+	norm := func(s, name string) string { return strings.ReplaceAll(s, name, "FIELD") }
+	return norm(hiddenMsg, hiddenName) == norm(absentMsg, absentName)
+}
 
 // TestFilter_HiddenFieldNoPredicate verifies a Hidden field can never be
 // used as a WHERE predicate over the HTTP List surface. Otherwise an
 // attacker probes prefixes via ?password_hash_like=... and observes
 // row-count/result changes to exfiltrate a Hidden column — a value
 // oracle. Mirrors ParseSort's existing Hidden exclusion.
+//
+// Under strict parsing a hidden-field key is REJECTED (not silently
+// dropped), which strengthens the invariant — no predicate is built AND
+// the request fails closed. The rejection must be NON-LEAKY: a hidden field
+// and a truly-nonexistent field must produce the identical error shape, so
+// the error cannot be used to distinguish "hidden" from "absent".
 func TestFilter_HiddenFieldNoPredicate(t *testing.T) {
 	fields := []schema.Field{
 		{Name: "title", Type: schema.String},
 		{Name: "password_hash", Type: schema.String, Hidden: true},
-	}
-
-	hiddenUsed := func(filters []ParsedFilter) bool {
-		for _, f := range filters {
-			if f.Field == "password_hash" {
-				return true
-			}
-		}
-		return false
 	}
 
 	cases := []struct {
@@ -42,11 +54,22 @@ func TestFilter_HiddenFieldNoPredicate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/?"+tc.query, nil)
 			filters, err := ParseFilters(req, fields)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+			if err == nil {
+				t.Fatalf("SECURITY: Hidden field filter %q must fail closed, got no error (filters=%+v)", tc.query, filters)
 			}
-			if hiddenUsed(filters) {
-				t.Errorf("SECURITY: Hidden field password_hash became a filter predicate via %q — value-disclosure oracle", tc.query)
+			if len(filters) != 0 {
+				t.Errorf("SECURITY: Hidden field password_hash produced a predicate via %q — value-disclosure oracle", tc.query)
+			}
+			// Non-leaky: a nonexistent field of the same shape must give the
+			// same "unknown filter" wording. If the messages diverged, the
+			// error would itself be a hidden-column oracle.
+			absent := httptest.NewRequest(http.MethodGet, "/?"+replaceField(tc.query, "password_hash", "nonexistent"), nil)
+			_, absentErr := ParseFilters(absent, fields)
+			if absentErr == nil {
+				t.Fatalf("nonexistent field must also error")
+			}
+			if !sameErrorShape(err.Error(), absentErr.Error(), "password_hash", "nonexistent") {
+				t.Errorf("SECURITY: hidden vs absent errors differ — oracle:\n hidden: %v\n absent: %v", err, absentErr)
 			}
 		})
 	}

--- a/framework/filter/strict_test.go
+++ b/framework/filter/strict_test.go
@@ -1,0 +1,167 @@
+package filter
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+)
+
+func strictFields() []schema.Field {
+	return []schema.Field{
+		{Name: "status", Type: schema.String},
+		{Name: "priority", Type: schema.String},
+		{Name: "score", Type: schema.Int},
+		{Name: "secret", Type: schema.String, Hidden: true},
+	}
+}
+
+func parseQuery(t *testing.T, rawQuery string, opts ...FilterOption) ([]ParsedFilter, error) {
+	t.Helper()
+	r := httptest.NewRequest("GET", "/things?"+rawQuery, nil)
+	return ParseFilters(r, strictFields(), opts...)
+}
+
+// A misspelled top-level filter must NOT silently return unfiltered data —
+// it must be rejected so a broken client can't read the whole table. This is
+// the core #100A correctness contract.
+func TestStrictRejectsUnknownFilter(t *testing.T) {
+	_, err := parseQuery(t, "stauts=active")
+	if err == nil {
+		t.Fatal("unknown filter key must error, got nil (silent unfiltered result)")
+	}
+	if !strings.Contains(err.Error(), "stauts") {
+		t.Fatalf("error must name the bad key, got %q", err)
+	}
+}
+
+// A misspelled suffixed operator (?score_gt vs ?scor_gt) must also reject,
+// not fall through and drop silently.
+func TestStrictRejectsUnknownSuffixedFilter(t *testing.T) {
+	if _, err := parseQuery(t, "scor_gt=5"); err == nil {
+		t.Fatal("unknown suffixed filter base must error")
+	}
+}
+
+// Filtering on a hidden column must fail closed (mirrors ParseSort) without
+// leaking that the field exists-but-hidden vs does-not-exist.
+func TestStrictRejectsHiddenFilter(t *testing.T) {
+	if _, err := parseQuery(t, "secret=x"); err == nil {
+		t.Fatal("hidden field filter must error")
+	}
+}
+
+// Reserved list-control params are not entity fields and must never be
+// rejected as unknown filters.
+func TestStrictAllowsReservedControls(t *testing.T) {
+	reserved := "sort=-score&page=2&limit=10&offset=0&cursor=abc&direction=next" +
+		"&where=%7B%7D&fields=status&include=author&trashed=true&stream=true&q=hi"
+	if _, err := parseQuery(t, reserved); err != nil {
+		t.Fatalf("reserved controls must not be rejected, got %v", err)
+	}
+}
+
+// Nested relation filters (?author.name=alice) are validated elsewhere
+// (parseNestedFilters); ParseFilters must skip dotted keys, not reject them.
+func TestStrictSkipsNestedDottedKeys(t *testing.T) {
+	if _, err := parseQuery(t, "author.name=alice"); err != nil {
+		t.Fatalf("dotted nested key must be skipped, got %v", err)
+	}
+}
+
+// Known fields (plain and suffixed) still parse into filters.
+func TestStrictAllowsKnownFields(t *testing.T) {
+	filters, err := parseQuery(t, "status=open&score_gte=3")
+	if err != nil {
+		t.Fatalf("known fields must parse, got %v", err)
+	}
+	if len(filters) != 2 {
+		t.Fatalf("want 2 filters, got %d: %v", len(filters), filters)
+	}
+}
+
+// A close misspelling gets a "did you mean" suggestion when unambiguous.
+func TestStrictSuggestsNearestField(t *testing.T) {
+	_, err := parseQuery(t, "statuss=open")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "status") {
+		t.Fatalf("error should suggest nearest field 'status', got %q", err)
+	}
+}
+
+// Lenient() restores the pre-strict behavior: unknown keys are dropped and
+// the known ones still parse. This is the documented escape hatch.
+func TestLenientDropsUnknown(t *testing.T) {
+	filters, err := parseQuery(t, "stauts=active&status=open", Lenient())
+	if err != nil {
+		t.Fatalf("lenient must not error, got %v", err)
+	}
+	if len(filters) != 1 || filters[0].Field != "status" {
+		t.Fatalf("lenient should keep only the known filter, got %v", filters)
+	}
+}
+
+// A declared field whose name collides with a reserved control word must be
+// FILTERED, never swallowed by the reserved-skip — otherwise ?stream=true
+// returns the whole table (the exact #100A hazard). Field wins over reserved.
+func TestStrictFieldWinsOverReservedName(t *testing.T) {
+	fields := []schema.Field{
+		{Name: "stream", Type: schema.String},
+		{Name: "q", Type: schema.String},
+	}
+	r := httptest.NewRequest("GET", "/x?stream=live&q=hi", nil)
+	filters, err := ParseFilters(r, fields)
+	if err != nil {
+		t.Fatalf("field named like a reserved word must not error: %v", err)
+	}
+	got := map[string]string{}
+	for _, f := range filters {
+		got[f.Field] = f.Value
+	}
+	if got["stream"] != "live" || got["q"] != "hi" {
+		t.Fatalf("reserved-named fields must be filtered, got %v", filters)
+	}
+}
+
+// A field sent both plain and suffixed (?priority=high&priority_gte=2) must
+// never be misreported as an unknown filter regardless of map-iteration
+// order — the suffixed op is consumed and the plain key is a KNOWN field.
+func TestStrictConsumedFieldNotUnknown(t *testing.T) {
+	// Run many times: Go map iteration order is randomized, so a flaky
+	// misclassification would surface across iterations.
+	for i := 0; i < 50; i++ {
+		filters, err := parseQuery(t, "priority=high&priority_gte=2")
+		if err != nil {
+			t.Fatalf("known field sent plain+suffixed must not error, got %v", err)
+		}
+		hasGte := false
+		for _, f := range filters {
+			if f.Field == "priority" && f.Op == OpGte {
+				hasGte = true
+			}
+		}
+		if !hasGte {
+			t.Fatalf("expected priority_gte filter, got %v", filters)
+		}
+	}
+}
+
+// Allow() lets a host declare custom query params (consumed by a BeforeList
+// hook or middleware) so strict parsing skips them instead of 400ing —
+// without disabling strictness for genuine typos.
+func TestStrictAllowsDeclaredExtraParams(t *testing.T) {
+	filters, err := parseQuery(t, "region=eu&status=open", Allow("region"))
+	if err != nil {
+		t.Fatalf("declared extra param must not error, got %v", err)
+	}
+	if len(filters) != 1 || filters[0].Field != "status" {
+		t.Fatalf("extra param must be skipped, known field kept, got %v", filters)
+	}
+	// A typo that is NOT declared still fails closed.
+	if _, err := parseQuery(t, "regionn=eu", Allow("region")); err == nil {
+		t.Fatal("undeclared unknown param must still error")
+	}
+}


### PR DESCRIPTION
## Issue #100 — Workstream A: reject unknown filters

A misspelled top-level filter (`?stauts=active`) was **silently dropped**, so the List endpoint returned an **unfiltered 200** — a broken client read the whole table and an attacker's probe was indistinguishable from a real query. `ParseFilters` now fails closed like `?sort=` and `?where=` already did.

> Scope: Workstream A only (correctness contract). Workstream B (filtered-list perf profiling) is **not** in this PR.

### Behavior
- **Unknown top-level filter → structured 400** naming the bad key, with a Levenshtein "did you mean" suggestion on an unambiguous near-match.
- **Hidden columns** reject with the *identical* `"unknown filter"` wording as a nonexistent column → the error is not a hidden-vs-absent oracle.
- **Field wins over reserved word**: a column named like a control word (`stream`, `q`, …) still filters and is never silently swallowed.
- **`?per_page`** accepted as a `?limit` alias; **`?offset`** now honored (raw row-skip) instead of silently ignored.

### Escape hatches (strict by default)
- `EntityConfig.AllowedFilterParams` — declare host-consumed params (read by a `BeforeList` hook) so strict parsing skips them without disabling typo protection.
- `EntityConfig.LenientFilters` / `filter.Lenient()` — restore old drop-silently behavior wholesale.

### Commits (themed, each green)
1. `refactor(core)` — extract shared `fuzzy.Levenshtein` (dedupes the copy in `cmd/gofastr`).
2. `fix(crud)` — reject Hidden columns reached via nested filters (pre-existing value-disclosure oracle).
3. `feat(filter)` — strict rejection + `per_page`/`offset`/field-wins + escape hatches.

### Review
Hardened via a workflow-backed code review (18 agents, high effort) — 7 findings, all fixed (5 correctness/security regressions + the 2 cleanups). Security-test rewrites split header-vs-query-param spoof vectors and assert non-leakiness. Docs (`entity-declarations.md` → Flat filters) + CHANGELOG (BREAKING + migration) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)