### PR TITLE
docs(ui): add capability map and Claude Opus discovery eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,8 @@ shared across the whole `go test` invocation so cold-start is amortised.
 
 ### `core-ui/` — server-driven UI runtime
 
+Start from the [UI capability map](framework/docs/content/ui-capability-map.md) when the question is product-shaped — live dashboard, optimistic board, master/detail workspace, server-authoritative reactive state, static export, or deliberate SPA integration — rather than a package name.
+
 A separate, independently usable system for rendering interactive UIs from Go: signals, HTML primitives (`core-ui/html`), composed UI patterns (`core-ui/patterns`), server-side islands, dev server with SSE hot-reload, a static-site compiler, a linter, and a vanilla-JS runtime. Fresh `gofastr init` apps mount the adaptive `framework/ui/theme.Default()` palette, so light/dark behavior is complete from the first render. See `examples/site` for an app that exercises every feature — including the 90+ `framework/ui` primitives, compact operational composition (`RecordSummary` + `MetricBand`), modal/drawer/popover/toast widgets, and CRUD-by-island patterns. Each component has a live demo at `/components/<slug>` on that site; the one-page catalog is [`ui-new-components.md`](framework/docs/content/ui-new-components.md) (`gofastr docs ui-new-components`), and `go doc github.com/DonaldMurillo/gofastr/framework/ui` lists every constructor.
 
 ### `battery/` — pluggable infrastructure
@@ -483,6 +485,7 @@ connected to a running app.
 
 - [Blueprint tutorial](framework/docs/content/tutorial-blueprint-app.md) — **the thesis walkthrough**: blueprint → generated UI + API → auth + owner scoping + RBAC → customize in plain Go → deploy
 - [Kiln (experimental)](framework/docs/content/kiln.md) — agent-driven build mode
+- [UI capability map](framework/docs/content/ui-capability-map.md) — **start from the job**: architecture, state ownership, delivery/scaling semantics, runnable proof, and explicit non-goals
 - [UI getting started](framework/docs/content/ui-getting-started.md) — **the 15-minute path**: scaffold → design direction → theme → framework-native composition
 - [UI composition recipes](framework/docs/content/ui-composition-recipes.md) — product-shaped page structures built entirely from `framework/ui` primitives
 - [UI components index](framework/docs/content/ui-new-components.md) — **the catalog**: every component the framework ships, with its `go doc` path and live demo at `/components/<slug>` in `examples/site`

--- a/cmd/gofastr/docs_command_test.go
+++ b/cmd/gofastr/docs_command_test.go
@@ -12,7 +12,9 @@ func TestDocsCommandListsGrepsAndReads(t *testing.T) {
 	if !strings.Contains(list, "entity-declarations") {
 		t.Fatalf("docs list missing entity-declarations topic:\n%s", list)
 	}
-
+	if !strings.Contains(list, "ui-capability-map") {
+		t.Fatalf("docs list missing task-oriented UI capability map:\n%s", list)
+	}
 	grep := captureStdout(t, func() {
 		runDocs([]string{"--grep", "owner scoping"})
 	})
@@ -20,6 +22,21 @@ func TestDocsCommandListsGrepsAndReads(t *testing.T) {
 		t.Fatalf("docs grep did not find owner scoping:\n%s", grep)
 	}
 
+	for _, term := range []string{"optimistic", "realtime", "live dashboard", "reactive state", "rollback", "reconciliation"} {
+		result := captureStdout(t, func() { runDocs([]string{"--grep", term}) })
+		if !strings.Contains(result, "ui-capability-map") {
+			t.Fatalf("docs grep %q did not route to ui-capability-map:\n%s", term, result)
+		}
+	}
+
+	capabilityMap := captureStdout(t, func() {
+		runDocs([]string{"ui-capability-map"})
+	})
+	for _, want := range []string{"The state boundary", "Live dashboards", "Stateless and affinity-bound islands", "Common mistakes"} {
+		if !strings.Contains(capabilityMap, want) {
+			t.Fatalf("ui-capability-map doc missing %q:\n%s", want, capabilityMap)
+		}
+	}
 	body := captureStdout(t, func() {
 		runDocs([]string{"entity-declarations"})
 	})

--- a/evals/ui-capability-discovery/README.md
+++ b/evals/ui-capability-discovery/README.md
@@ -1,0 +1,90 @@
+# UI capability-discovery evaluation
+
+This suite measures whether a cold-start coding agent can begin with a product
+problem, discover GoFastr's UI architecture, and produce a working application.
+It dispatches fresh Claude Code Opus processes for the builder, holistic visual
+panel, and mobile visual panel.
+
+The evaluator does not tell the builder to use the capability map, name a
+component, choose an island/store/SSE architecture, or run a particular
+command. The candidate receives the snapshot's ordinary `gofastr init` output
+and a product brief. That keeps documentation discovery part of the treatment.
+
+## What it measures
+
+- whether the Claude Opus builder invoked `gofastr docs`;
+- the topics it opened and `--grep` queries it used;
+- whether it opened `ui-capability-map`;
+- whether the generated app tests, builds, starts, and serves every required
+  route;
+- desktop/mobile and light/dark capture gates, overflow, visible bounds, and
+  interactive-label contrast;
+- independent Claude Opus visual scores for hierarchy, composition,
+  typography, product specificity, density, component polish, responsive
+  intent, and theme coherence;
+- the existing dev-loop and MCP discovery signals.
+
+Runs are written under `dist/ui-capability-eval/<run-id>/`. Each candidate
+result records the docs evidence beside build and judge results; the
+leaderboard aggregates capability-map discovery and documentation-call rates
+per framework snapshot.
+
+## Validate without agents
+
+From the repository root:
+
+```powershell
+go run ./evals/ui-quality/cmd/gofastr-ui-eval `
+  --suite ./evals/ui-capability-discovery/suite.json `
+  --dry-run
+```
+
+## Smoke run
+
+The checked-in suite is a one-snapshot certification run:
+
+```powershell
+go run ./evals/ui-quality/cmd/gofastr-ui-eval `
+  --suite ./evals/ui-capability-discovery/suite.json `
+  --smoke
+```
+
+That dispatches one Claude Opus builder plus one holistic and one mobile Opus
+judge for the first scenario.
+
+## Compare before and after
+
+For causal evidence, create two clean framework worktrees at the commits being
+compared, copy `suite.json`, and replace `variants`:
+
+```json
+"variants": [
+  {"id": "before", "framework_root": "C:/worktrees/gofastr-before"},
+  {"id": "capability-map", "framework_root": "C:/worktrees/gofastr-after"}
+]
+```
+
+Then run the full matrix:
+
+```powershell
+go run ./evals/ui-quality/cmd/gofastr-ui-eval `
+  --suite C:/path/to/ui-capability-comparison.json `
+  --runs 2
+```
+
+Use the same suite, scenarios, Claude Opus versions, run counts, and evaluator
+source for both snapshots. A one-variant or smoke run is diagnostic and cannot
+name a competitive winner.
+
+## Interpreting discovery
+
+Opening `ui-capability-map` is useful funnel evidence, not a quality pass by
+itself. An agent can read the right guide and still build a weak product; it
+can also reach a sound result through another valid doc path. The outcome is
+therefore reported as three layers:
+
+1. discovery (`gofastr docs` calls, searches, and topics);
+2. technical product outcome (test/build/boot/routes/captures);
+3. visible product outcome (blind holistic and mobile panels).
+
+Do not promote a documentation change from discovery rate alone.

--- a/evals/ui-capability-discovery/suite.json
+++ b/evals/ui-capability-discovery/suite.json
@@ -1,0 +1,77 @@
+{
+  "name": "gofastr-ui-capability-discovery-v1",
+  "repo_root": "../..",
+  "artifact_dir": "../../dist/ui-capability-eval",
+  "agents": {
+    "builder": {
+      "backend": "claude",
+      "program": "claude",
+      "model": "opus",
+      "timeout_minutes": 30
+    },
+    "judge": {
+      "backend": "claude",
+      "program": "claude",
+      "model": "opus",
+      "timeout_minutes": 12
+    },
+    "mobile_judge": {
+      "backend": "claude",
+      "program": "claude",
+      "model": "opus",
+      "timeout_minutes": 12
+    }
+  },
+  "variants": [
+    {
+      "id": "working-tree",
+      "framework_root": "../.."
+    }
+  ],
+  "scenarios": [
+    {
+      "id": "live-operations-dashboard",
+      "title": "Live operations dashboard",
+      "brief": "Build an operations dashboard for a payments platform. It must show service health, request volume, latency, current incidents, recent changes, and the next operator decision. Background checks can change service status while the page is open. An operator must be able to understand the current state and open one service from a phone.",
+      "pages": [
+        {"name": "overview", "path": "/", "ready_selector": "main"},
+        {"name": "service", "path": "/services/payments-api", "ready_selector": "main"}
+      ]
+    },
+    {
+      "id": "dispatch-board",
+      "title": "Dispatch planning board",
+      "brief": "Build a dispatch board for a regional field-service team. Dispatchers need to review unassigned, scheduled, in-progress, and blocked visits; move a visit between stages; see when a move is rejected because someone else changed the schedule; and open the visit record. The board must remain usable on a phone for an on-call dispatcher.",
+      "pages": [
+        {"name": "board", "path": "/", "ready_selector": "main"},
+        {"name": "visit", "path": "/visits/visit-2048", "ready_selector": "main"}
+      ]
+    },
+    {
+      "id": "customer-workspace",
+      "title": "Customer operations workspace",
+      "brief": "Build a customer-operations workspace for a subscription company. The main view must support finding an account, reading the durable account and billing state, reviewing activity, editing a support note without losing context, and seeing an unread-notification count update when background work completes. On mobile, the account identity and next action must lead.",
+      "pages": [
+        {"name": "workspace", "path": "/", "ready_selector": "main"},
+        {"name": "account", "path": "/accounts/acme-labs", "ready_selector": "main"}
+      ]
+    }
+  ],
+  "viewports": [
+    {"id": "mobile-light", "width": 390, "height": 844, "scheme": "light"},
+    {"id": "mobile-dark", "width": 390, "height": 844, "scheme": "dark"},
+    {"id": "desktop-light", "width": 1440, "height": 1000, "scheme": "light"},
+    {"id": "desktop-dark", "width": 1440, "height": 1000, "scheme": "dark"}
+  ],
+  "judge": {
+    "rubric": "../ui-quality/rubric.md",
+    "schema": "../ui-quality/judge.schema.json",
+    "runs": 3,
+    "mobile_runs": 3,
+    "minimum_overall": 8.5,
+    "minimum_dimension": 7.5,
+    "minimum_mobile_overall": 8.5,
+    "minimum_mobile_dimension": 7.5,
+    "require_shadcn_consensus": true
+  }
+}

--- a/evals/ui-quality/internal/evalrunner/aggregate.go
+++ b/evals/ui-quality/internal/evalrunner/aggregate.go
@@ -120,6 +120,10 @@ func summarize(suite *Suite, runID string, candidates []CandidateResult, nonComp
 			if cell.MobileOverall < vs.WorstMobileOverall {
 				vs.WorstMobileOverall = cell.MobileOverall
 			}
+			vs.MeanDocsCalls += float64(cell.BuilderDocsCalls)
+			if cell.BuilderUsedCapabilityMap {
+				vs.CapabilityMapDiscoveryRate++
+			}
 			if cell.BuilderDuration > 0 || cell.BuilderTokens > 0 {
 				vs.MeanBuilderMinutes += cell.BuilderDuration / 60
 				vs.MeanBuilderTokens += cell.BuilderTokens
@@ -132,6 +136,8 @@ func summarize(suite *Suite, runID string, candidates []CandidateResult, nonComp
 		vs.MeanOverall /= n
 		vs.MeanMinimumDimension /= n
 		vs.MeanMobileOverall /= n
+		vs.MeanDocsCalls /= n
+		vs.CapabilityMapDiscoveryRate /= n
 		if metricCells > 0 {
 			vs.MeanBuilderMinutes /= float64(metricCells)
 			vs.MeanBuilderTokens /= metricCells
@@ -209,12 +215,12 @@ func leaderboardMarkdown(summary Summary) string {
 	if !summary.Competitive {
 		fmt.Fprintf(&b, "Noncompetitive run: %s. Scores are diagnostic only.\n\n", strings.Join(summary.NonCompetitiveReasons, "; "))
 	}
-	b.WriteString("| Rank | Variant | Eligible | Rank score | Holistic | Holistic worst | Mobile | Mobile worst | Mean min dimension | Build min | Build tokens | Technical pass | Quality pass |\n")
-	b.WriteString("|---:|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+	b.WriteString("| Rank | Variant | Eligible | Rank score | Holistic | Holistic worst | Mobile | Mobile worst | Mean min dimension | Build min | Build tokens | Capability map | Docs calls | Technical pass | Quality pass |\n")
+	b.WriteString("|---:|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
 	for i, v := range summary.Variants {
-		fmt.Fprintf(&b, "| %d | %s | %t | %.2f | %.2f | %.2f | %.2f | %.2f | %.2f | %.2f | %d | %.0f%% | %.0f%% |\n",
+		fmt.Fprintf(&b, "| %d | %s | %t | %.2f | %.2f | %.2f | %.2f | %.2f | %.2f | %.2f | %d | %.0f%% | %.1f | %.0f%% | %.0f%% |\n",
 			i+1, v.VariantID, v.PromotionEligible, v.RankScore, v.MeanOverall, v.WorstOverall, v.MeanMobileOverall, v.WorstMobileOverall, v.MeanMinimumDimension,
-			v.MeanBuilderMinutes, v.MeanBuilderTokens, v.TechnicalPassRate*100, v.QualityPassRate*100)
+			v.MeanBuilderMinutes, v.MeanBuilderTokens, v.CapabilityMapDiscoveryRate*100, v.MeanDocsCalls, v.TechnicalPassRate*100, v.QualityPassRate*100)
 	}
 	b.WriteString("\n")
 	if summary.WinnerMeetsBar {
@@ -243,6 +249,8 @@ func leaderboardMarkdown(summary Summary) string {
 			c.HolisticShadcnConsensus, c.MobileShadcnConsensus, c.TechnicalPassed, c.QualityPassed)
 		fmt.Fprintf(&b, "Dev-loop funnel (non-deterministic): builder invoked `gofastr dev` `%t`; %d gofastr CLI call(s) total.\n\n",
 			c.BuilderUsedDevServer, c.BuilderCLICalls)
+		fmt.Fprintf(&b, "Docs funnel (non-deterministic): %d `gofastr docs` call(s); capability map `%t`; topics `%s`; searches `%s`.\n\n",
+			c.BuilderDocsCalls, c.BuilderUsedCapabilityMap, strings.Join(c.BuilderDocsTopics, ", "), strings.Join(c.BuilderDocsSearches, ", "))
 		fmt.Fprintf(&b, "MCP funnel (non-deterministic): builder touched `/mcp` `%t`; served candidate exposes %d MCP tool(s), introspection `%t`, dev-only log tools leaked into prod boot `%t`.\n\n",
 			c.BuilderUsedMCP, c.CandidateMCPTools, c.CandidateMCPIntrospection, c.CandidateMCPLogToolsProd)
 		if len(c.Weakest) > 0 {

--- a/evals/ui-quality/internal/evalrunner/clishim.go
+++ b/evals/ui-quality/internal/evalrunner/clishim.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 )
 
@@ -60,4 +61,71 @@ func cliInvocationStats(logPath string) (calls int, usedDev bool) {
 			return calls, usedDev
 		}
 	}
+}
+
+type cliDocumentationStats struct {
+	Calls             int
+	Searches          []string
+	Topics            []string
+	UsedCapabilityMap bool
+}
+
+// cliDocsInvocationStats extracts documentation-discovery evidence from the
+// same PATH-shim log as cliInvocationStats. The builder prompt names no docs
+// command or topic, so these are behavioral funnel signals rather than prompt
+// compliance. Searches and topics are unique and sorted for stable artifacts.
+func cliDocsInvocationStats(logPath string) cliDocumentationStats {
+	f, err := os.Open(logPath)
+	if err != nil {
+		return cliDocumentationStats{}
+	}
+	defer f.Close()
+
+	stats := cliDocumentationStats{}
+	searches := map[string]bool{}
+	topics := map[string]bool{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		fields := strings.Fields(line)
+		if len(fields) == 0 || fields[0] != "docs" {
+			continue
+		}
+		stats.Calls++
+		rest := strings.TrimSpace(strings.TrimPrefix(line, "docs"))
+		switch {
+		case strings.HasPrefix(rest, "--grep="):
+			query := strings.Trim(strings.TrimSpace(strings.TrimPrefix(rest, "--grep=")), `"'`)
+			if query != "" {
+				searches[query] = true
+			}
+		case strings.HasPrefix(rest, "--grep"):
+			query := strings.Trim(strings.TrimSpace(strings.TrimPrefix(rest, "--grep")), `"'`)
+			if query != "" {
+				searches[query] = true
+			}
+		default:
+			args := strings.Fields(rest)
+			if len(args) == 0 {
+				continue
+			}
+			topic := strings.Trim(args[0], `"'`)
+			if topic == "" || strings.HasPrefix(topic, "-") {
+				continue
+			}
+			topics[topic] = true
+			if topic == "ui-capability-map" {
+				stats.UsedCapabilityMap = true
+			}
+		}
+	}
+	for query := range searches {
+		stats.Searches = append(stats.Searches, query)
+	}
+	for topic := range topics {
+		stats.Topics = append(stats.Topics, topic)
+	}
+	sort.Strings(stats.Searches)
+	sort.Strings(stats.Topics)
+	return stats
 }

--- a/evals/ui-quality/internal/evalrunner/clishim_test.go
+++ b/evals/ui-quality/internal/evalrunner/clishim_test.go
@@ -60,6 +60,57 @@ func TestCLIInvocationStatsDistinguishesDevFromOtherSubcommands(t *testing.T) {
 	}
 }
 
+func TestCLIDocsInvocationStats(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "cli.log")
+	log := "docs --grep live dashboard\n" +
+		"docs ui-capability-map\n" +
+		"docs --grep=reconciliation\n" +
+		"docs ui-capability-map\n" +
+		"dev\n"
+	if err := os.WriteFile(logPath, []byte(log), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stats := cliDocsInvocationStats(logPath)
+	if stats.Calls != 4 || !stats.UsedCapabilityMap {
+		t.Fatalf("docs stats = %+v, want four calls and capability-map discovery", stats)
+	}
+	if got := strings.Join(stats.Searches, "|"); got != "live dashboard|reconciliation" {
+		t.Fatalf("searches = %q", got)
+	}
+	if got := strings.Join(stats.Topics, "|"); got != "ui-capability-map" {
+		t.Fatalf("topics = %q", got)
+	}
+}
+
+func TestLeaderboardReportsDocsFunnel(t *testing.T) {
+	summary := Summary{Candidates: []CandidateResult{{
+		VariantID: "working-tree", ScenarioID: "s", Repetition: 1,
+		BuilderDocsCalls: 2, BuilderUsedCapabilityMap: true,
+		BuilderDocsTopics:   []string{"ui-capability-map"},
+		BuilderDocsSearches: []string{"live dashboard"},
+	}}}
+	md := leaderboardMarkdown(summary)
+	if !strings.Contains(md, "2 `gofastr docs` call(s); capability map `true`") ||
+		!strings.Contains(md, "topics `ui-capability-map`") ||
+		!strings.Contains(md, "searches `live dashboard`") {
+		t.Fatalf("leaderboard missing docs funnel line:\n%s", md)
+	}
+}
+
+func TestSummaryAggregatesDocsDiscovery(t *testing.T) {
+	summary := summarize(&Suite{Name: "docs", Variants: []Variant{{ID: "v"}}}, "run", []CandidateResult{
+		{VariantID: "v", BuilderDocsCalls: 2, BuilderUsedCapabilityMap: true},
+		{VariantID: "v"},
+	}, nil)
+	if len(summary.Variants) != 1 {
+		t.Fatalf("variants = %+v", summary.Variants)
+	}
+	got := summary.Variants[0]
+	if got.MeanDocsCalls != 1 || got.CapabilityMapDiscoveryRate != 0.5 {
+		t.Fatalf("docs aggregate = %+v", got)
+	}
+}
+
 // The funnel signal must reach the human-readable output, not just JSON.
 func TestLeaderboardReportsDevLoopFunnel(t *testing.T) {
 	summary := Summary{Candidates: []CandidateResult{{

--- a/evals/ui-quality/internal/evalrunner/runner.go
+++ b/evals/ui-quality/internal/evalrunner/runner.go
@@ -447,6 +447,13 @@ func executeCandidate(ctx context.Context, suite *Suite, opts Options, gofastrBi
 		result.WorkspaceFingerprint = prior.WorkspaceFingerprint
 		result.BuilderProvenance = prior.BuilderProvenance
 		result.GuidanceFingerprint = prior.GuidanceFingerprint
+		result.BuilderCLICalls = prior.BuilderCLICalls
+		result.BuilderUsedDevServer = prior.BuilderUsedDevServer
+		result.BuilderDocsCalls = prior.BuilderDocsCalls
+		result.BuilderDocsSearches = append([]string(nil), prior.BuilderDocsSearches...)
+		result.BuilderDocsTopics = append([]string(nil), prior.BuilderDocsTopics...)
+		result.BuilderUsedCapabilityMap = prior.BuilderUsedCapabilityMap
+		result.BuilderUsedMCP = prior.BuilderUsedMCP
 	} else {
 		prepCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 		err := runCommand(prepCtx, filepath.Dir(mapping.Workspace), filepath.Join(mapping.ResultDir, "scaffold.log"), nil,
@@ -510,6 +517,11 @@ func executeCandidate(ctx context.Context, suite *Suite, opts Options, gofastrBi
 		result.BuilderDuration = time.Since(builderStarted).Seconds()
 		_, result.BuilderTokens = builderMetricsFromArtifacts(mapping.ResultDir)
 		result.BuilderCLICalls, result.BuilderUsedDevServer = cliInvocationStats(cliLog)
+		docsStats := cliDocsInvocationStats(cliLog)
+		result.BuilderDocsCalls = docsStats.Calls
+		result.BuilderDocsSearches = docsStats.Searches
+		result.BuilderDocsTopics = docsStats.Topics
+		result.BuilderUsedCapabilityMap = docsStats.UsedCapabilityMap
 		result.BuilderUsedMCP = builderUsedMCP(inv.LogPath, buildOutput)
 		integrityErr := verifyFrameworkIntegrity(variant.FrameworkRoot, gofastrBin, mapping.FrameworkFingerprint)
 		if integrityErr != nil {

--- a/evals/ui-quality/internal/evalrunner/types.go
+++ b/evals/ui-quality/internal/evalrunner/types.go
@@ -94,6 +94,13 @@ type CandidateResult struct {
 	// discovered the hot-reload loop from the generated guidance alone.
 	BuilderCLICalls      int  `json:"builder_cli_calls"`
 	BuilderUsedDevServer bool `json:"builder_used_dev_server"`
+	// BuilderDocs* records actual `gofastr docs` invocations from the CLI
+	// shim. These are discovery signals; they do not affect technical or
+	// quality pass status.
+	BuilderDocsCalls         int      `json:"builder_docs_calls"`
+	BuilderDocsSearches      []string `json:"builder_docs_searches,omitempty"`
+	BuilderDocsTopics        []string `json:"builder_docs_topics,omitempty"`
+	BuilderUsedCapabilityMap bool     `json:"builder_used_capability_map"`
 	// BuilderUsedMCP greps the builder's transcript for /mcp traffic — a
 	// soft behavioral signal that the builder discovered the app's MCP
 	// debug loop (introspection/log tools) from guidance alone.
@@ -189,21 +196,23 @@ type Dimensions struct {
 }
 
 type VariantSummary struct {
-	VariantID            string  `json:"variant_id"`
-	PromotionEligible    bool    `json:"promotion_eligible"`
-	Candidates           int     `json:"candidates"`
-	MeanBuilderMinutes   float64 `json:"mean_builder_minutes,omitempty"`
-	MeanBuilderTokens    int64   `json:"mean_builder_tokens,omitempty"`
-	TechnicalPassRate    float64 `json:"technical_pass_rate"`
-	QualityPassRate      float64 `json:"quality_pass_rate"`
-	AllTechnicalPassed   bool    `json:"all_technical_passed"`
-	AllQualityPassed     bool    `json:"all_quality_passed"`
-	MeanOverall          float64 `json:"mean_overall"`
-	WorstOverall         float64 `json:"worst_overall"`
-	MeanMinimumDimension float64 `json:"mean_minimum_dimension"`
-	MeanMobileOverall    float64 `json:"mean_mobile_overall"`
-	WorstMobileOverall   float64 `json:"worst_mobile_overall"`
-	RankScore            float64 `json:"rank_score"`
+	VariantID                  string  `json:"variant_id"`
+	PromotionEligible          bool    `json:"promotion_eligible"`
+	Candidates                 int     `json:"candidates"`
+	MeanBuilderMinutes         float64 `json:"mean_builder_minutes,omitempty"`
+	MeanBuilderTokens          int64   `json:"mean_builder_tokens,omitempty"`
+	MeanDocsCalls              float64 `json:"mean_docs_calls"`
+	CapabilityMapDiscoveryRate float64 `json:"capability_map_discovery_rate"`
+	TechnicalPassRate          float64 `json:"technical_pass_rate"`
+	QualityPassRate            float64 `json:"quality_pass_rate"`
+	AllTechnicalPassed         bool    `json:"all_technical_passed"`
+	AllQualityPassed           bool    `json:"all_quality_passed"`
+	MeanOverall                float64 `json:"mean_overall"`
+	WorstOverall               float64 `json:"worst_overall"`
+	MeanMinimumDimension       float64 `json:"mean_minimum_dimension"`
+	MeanMobileOverall          float64 `json:"mean_mobile_overall"`
+	WorstMobileOverall         float64 `json:"worst_mobile_overall"`
+	RankScore                  float64 `json:"rank_score"`
 }
 
 type Summary struct {

--- a/examples/site/docs_catalog.go
+++ b/examples/site/docs_catalog.go
@@ -94,9 +94,10 @@ var docIntents = []docIntent{
 	},
 	{
 		Num: "03", Slug: "ui", Title: "Building UI",
-		Lede: "Server-rendered with islands. Signals, HTML primitives, composed patterns, the runtime, and theming.",
-		Path: []string{"Getting started (UI)", "New components", "Widget builder"},
+		Lede: "Start from a product job, then choose the state boundary, server-rendered islands, primitives, runtime, and theme.",
+		Path: []string{"UI capability map", "Getting started (UI)", "Composition recipes"},
 		Docs: []docEntry{
+			{"ui-capability-map", "UI capability map", "Live dashboards, optimistic boards, master/detail, reactive state, static export, and SPA integration — mapped to proof and delivery semantics."},
 			{"ui-getting-started", "Getting started (UI)", "The path: scaffold → theme → screen → custom component."},
 			{"ui-composition-recipes", "Composition recipes", "Choose a page shape before composing framework-owned primitives."},
 			{"ui-wiring", "Wiring UI into an app", "framework.App + core-ui app + uihost, end to end in one annotated main.go."},

--- a/framework/docs/content/README.md
+++ b/framework/docs/content/README.md
@@ -10,6 +10,10 @@ results, the harness contract) are exempt — the exemption list lives in
 
 ## Start here
 
+- [UI capability map](ui-capability-map.md) — start from a product job
+  such as a live dashboard, optimistic board, master/detail workspace,
+  or server-authoritative reactive SaaS; choose state and delivery
+  boundaries before package names.
 - [Blueprint tutorial](tutorial-blueprint-app.md) — the thesis
   walkthrough: blueprint → generated UI + API → auth + owner scoping
   + RBAC → customize in plain Go → deploy.
@@ -73,6 +77,9 @@ results, the harness contract) are exempt — the exemption list lives in
 
 ## Building UI
 
+- [UI capability map](ui-capability-map.md) — task-oriented architecture
+  map with runnable proofs, state ownership, replica semantics, and
+  explicit non-goals.
 - [UI getting started](ui-getting-started.md) — the 15-minute path:
   scaffold → design direction → theme → framework-native composition.
 - [UI composition recipes](ui-composition-recipes.md) — product-shaped

--- a/framework/docs/content/benchmarks.md
+++ b/framework/docs/content/benchmarks.md
@@ -352,6 +352,12 @@ benchstat dist/bench/before.txt dist/bench/all.txt
 `benchstat` (`go install golang.org/x/perf/cmd/benchstat@latest`) reports
 geometric mean + p-value so noise doesn't show up as a regression.
 
+## See also
+
+- [UI capability map](ui-capability-map.md) separates composed capability from packaged convenience and measured performance.
+- [Runtime contract](runtime-contract.md) defines the UI paths being measured.
+- [Events and SSE](events.md) documents delivery semantics behind drop-rate metrics.
+
 ## Common mistakes
 
 - **Not skipping Postgres when it's unavailable.** Use

--- a/framework/docs/content/events.md
+++ b/framework/docs/content/events.md
@@ -93,6 +93,13 @@ filter changes) must come back over the request that triggered them —
 never via SSE. The framework's island runtime enforces this rule on
 the UI side; the same rule applies to your own clients.
 
+## See also
+
+- [UI capability map](ui-capability-map.md) distinguishes realtime UI invalidation from durable workflow delivery.
+- [Presence](presence.md) uses the same push lane for self-healing rosters.
+- [Horizontal scaling](scaling.md) covers fanout and replica topology.
+- [Benchmarks](benchmarks.md) documents SSE delivery/drop measurements.
+
 ## Common mistakes
 
 - **Subscribing to SSE for confirmations.** SSE is fire-and-forget.

--- a/framework/docs/content/interactive-patterns.md
+++ b/framework/docs/content/interactive-patterns.md
@@ -628,6 +628,14 @@ search := interactive.LiveSearch(
 
 ---
 
+## See also
+
+- [UI capability map](ui-capability-map.md) starts from optimistic UI, live dashboard, mutation, rollback, and reconciliation jobs.
+- [`docs/ui-new-components.md`](ui-new-components.md) — full component catalog.
+- [`docs/widgets.md`](widgets.md) — widget framework (Modal, Drawer, Popover mounts).
+- [runtime-contract](runtime-contract.md) — the SSR/hydration/island/SSE model + `data-fui-*` attribute reference (embedded extract of `core-ui/ARCHITECTURE.md`).
+- [`docs/ui-getting-started.md`](ui-getting-started.md) — first-time UI setup.
+
 ## Common mistakes
 
 - **Assuming a hand-written `data-fui-rpc` route is auto-registered.**
@@ -659,12 +667,3 @@ search := interactive.LiveSearch(
   contract.** Every attribute the runtime reads must land in
   `core-ui/ARCHITECTURE.md` and the runtime test suite — undocumented
   attributes are drift the next author can't discover.
-
----
-
-## See also
-
-- [`docs/ui-new-components.md`](ui-new-components.md) — full component catalog.
-- [`docs/widgets.md`](widgets.md) — widget framework (Modal, Drawer, Popover mounts).
-- [runtime-contract](runtime-contract.md) — the SSR/hydration/island/SSE model + `data-fui-*` attribute reference (embedded extract of `core-ui/ARCHITECTURE.md`).
-- [`docs/ui-getting-started.md`](ui-getting-started.md) — first-time UI setup.

--- a/framework/docs/content/presence.md
+++ b/framework/docs/content/presence.md
@@ -196,6 +196,12 @@ goroutines, no remote state, and `PresenceRoster` returns the byte-identical
 single-replica result. Sticky-session deployments keep working exactly as
 before; non-sticky deployments now aggregate correctly too.
 
+## See also
+
+- [UI capability map](ui-capability-map.md) places collaborative awareness in the wider state and delivery model.
+- [Events and SSE](events.md) defines the shared best-effort push lane.
+- [Horizontal scaling](scaling.md) covers fanout and affinity implications.
+
 ## Common mistakes
 
 - **Trusting a client-supplied name.** Identity is server-derived from the

--- a/framework/docs/content/runtime-contract.md
+++ b/framework/docs/content/runtime-contract.md
@@ -338,6 +338,12 @@ those are documented by the owning plugin.
 
 ---
 
+## See also
+
+- [UI capability map](ui-capability-map.md) maps product architectures to this runtime boundary and its scaling semantics.
+- [UI composition recipes](ui-composition-recipes.md) turns that architecture into product-shaped page grammar.
+- [Events and SSE](events.md) defines best-effort push and durable alternatives.
+
 ## Common mistakes
 
 These are the misreadings of the model that have already cost rework

--- a/framework/docs/content/scaling.md
+++ b/framework/docs/content/scaling.md
@@ -132,6 +132,12 @@ the connection. Options, in order of preference:
 - [ ] `AuthConfig.AllowInMemoryStores` **removed** — the boot warning is
       your regression test for the first two items.
 
+## See also
+
+- [UI capability map](ui-capability-map.md) contrasts reconstructable and affinity-bound islands by product job.
+- [Events and SSE](events.md) defines cross-replica fanout semantics.
+- [Presence](presence.md) documents lossy, self-healing roster aggregation.
+
 ## Common mistakes
 
 - **Scaling to two replicas with default sessions.** Users get randomly

--- a/framework/docs/content/signal-store.md
+++ b/framework/docs/content/signal-store.md
@@ -106,6 +106,12 @@ ui.Counter(ui.CounterConfig{Slice: store.New("cart").Int("count", 0)})
 - URL-bearing attributes bound via `BindAttr` keep the runtime's
   `javascript:`/`data:` scheme guard.
 
+## See also
+
+- [UI capability map](ui-capability-map.md) shows when a local signal, typed store, server recomputation, or durable database state is the right boundary.
+- [Interactive patterns](interactive-patterns.md) covers RPC producers that publish authoritative values and fragments.
+- [Runtime contract](runtime-contract.md) defines seeding and SPA-navigation rules.
+
 ## Common mistakes
 
 - **Re-declaring a slice name with a different default.** Panics at

--- a/framework/docs/content/ui-capability-map.md
+++ b/framework/docs/content/ui-capability-map.md
@@ -1,0 +1,160 @@
+# UI capability map
+
+Start here when the question is about a product shape rather than a Go
+package: "Can I build a live dashboard?", "Where should optimistic state
+live?", or "Does this need a client framework?" The component catalog answers
+what symbols exist. This guide maps jobs to primitives, state ownership,
+delivery and scaling semantics, runnable proof, and the detailed API docs.
+
+## The state boundary
+
+Use this as the default architecture:
+
+```text
+database/server = durable business truth
+signals/store    = immediate UI projection
+RPC              = mutation and reconciliation
+SSE              = update/invalidation delivery
+HTML/data result = authoritative response
+```
+
+That boundary is more important than the individual component choice. A local
+signal can make a control feel immediate, but it does not become business
+truth. An optimistic projection can move first, but the RPC response commits
+or rolls it back. SSE tells connected views that server state changed; it does
+not confirm the user's own mutation.
+
+## What kind of UI are you building?
+
+Every row distinguishes a capability from a packaged convenience. "Proof"
+names a route in the runnable `examples/site` gallery (start it with
+`go run ./examples/site`) or a complete example program. "Primary docs" points
+to the public contract rather than repeating it here.
+
+| Job to be done | Compose | State, delivery, and scaling semantics | Runnable proof | Primary docs |
+|---|---|---|---|---|
+| CRUD/admin or form-heavy screens | `ui.DataTable`, `ui.Form`, `ui.FormField`, entity CRUD, `battery/admin` | The database is truth. Filters, validation, pagination, and writes run on the server. RPC or normal form responses return authoritative HTML/data. CRUD requests are stateless and replica-safe; sessions and live invalidation still need the shared backends described in scaling. | [`/components/datatable`](../../../examples/site/components.go), [`/components/form`](../../../examples/site/components.go), and [`examples/backoffice`](../../../examples/backoffice/main.go) | [Forms](form-module.md), [Admin](admin.md), [Interactive patterns](interactive-patterns.md) |
+| Optimistic mutations | `ui.OptimisticAction`, `ui.ToggleAction`, versioned `sortablelist` | A signal/DOM change is a temporary projection. The RPC owns validation and commit. Non-2xx rolls back; a versioned 409 refetches authoritative server HTML. Do not wait for SSE to confirm the initiating action. | [`/components/optimisticaction`](../../../examples/site/components.go), [`/components/toggleaction`](../../../examples/site/components.go) | [Interactive patterns](interactive-patterns.md), [Runtime contract](runtime-contract.md) |
+| Live dashboards and streamed status | SSR charts/status components, `store.Slice`, island signals, SSE | SSR supplies the first complete view. The server owns metrics; signals project the latest value. SSE is best-effort update/invalidation delivery and may drop old frames for slow consumers. Add `WithFanout` across replicas; use an outbox/queue for lossless work. | [`/components/rpc-signal`](../../../examples/site/components.go), [`/components/linechart`](../../../examples/site/components.go), [`/components/recordsummary`](../../../examples/site/components.go) | [Signal store](signal-store.md), [Events and SSE](events.md), [Scaling](scaling.md) |
+| Master/detail workspaces | `ui.PaneHost`, server-rendered detail fragments, routes for durable/deep-linkable identity | The route identifies the selected durable record. Opening/swapping a pane is in-page projection; RPC can return its detail HTML. `PaneHost` owns pane behavior, not data fetching. Reconstructable handlers are stateless; process-held pane/widget objects require affinity. | [`/examples/workspace`](../../../examples/site/screen_workspace.go), [`/components/panehost`](../../../examples/site/components.go) | [Pane host](pane-host.md), [UI composition recipes](ui-composition-recipes.md) |
+| Sortable lists and Kanban | `core-ui/patterns/sortablelist`, stable keys, optional group/container/version | The browser previews a reorder. RPC persists it. Non-2xx restores the prior DOM; versioned 409 responses refetch server-rendered column state for reconciliation. Durable order belongs in the database. | [`/components/sortablelist`](../../../examples/site/components.go) | [Interactive patterns](interactive-patterns.md), [Runtime contract](runtime-contract.md) |
+| Notifications, progress, and activity feeds | `ui.NotificationBell`, toast presets, `progress`, `ui.Timeline`, signals/SSE | A toast is ephemeral projection; durable notification/read state belongs in the database. Progress can be an RPC result for user work or an SSE update for background work. An activity feed that must not lose entries comes from durable rows/outbox, not the lossy SSE buffer. | [`/components/notificationbell`](../../../examples/site/components.go), [`/components/progress`](../../../examples/site/components.go), [`/components/timeline`](../../../examples/site/components.go) | [Widgets](widgets.md), [Events and SSE](events.md), [Notifications](notifications.md) |
+| Server-authoritative reactive SaaS | SSR screen + typed store + RPC signal/fragment swaps + SSE invalidation | The store is a typed client projection seeded from SSR. User mutations use RPC and receive authoritative HTML/data. Background/other-user changes arrive through SSE and trigger a signal update or refetch. Shared fanout makes the push lane replica-aware; durable side effects stay on outbox/queue consumers. | [`/components/signal-store`](../../../examples/site/components.go), [`/components/rpc-form-signal`](../../../examples/site/components.go) | [Signal store](signal-store.md), [Interactive patterns](interactive-patterns.md), [Events and SSE](events.md) |
+| Presence and collaborative awareness | `island.Manager` presence topics + `ui.AvatarGroup` | Identity is derived by the server. Rosters are live, lossy, self-healing state, not an audit record. With fanout they merge across replicas; without it they are local to one process. | [`/examples/presence?presence=presence-demo`](../../../examples/site/screen_presence.go), [`/components/avatargroup`](../../../examples/site/components.go) | [Presence](presence.md), [Scaling](scaling.md) |
+| Static/exportable UI | SSR screens + `App.ExportStatic`; client-only signals/theme/copy where useful | The export is build-time truth: HTML and assets run without a Go server. Server RPC, SSE, and server-backed widgets are deliberately disabled and must not be presented as live. | [`examples/static-site`](../../../examples/static-site/README.md) | [Static export](static-export.md), [Runtime contract](runtime-contract.md) |
+| SPA integration by deliberate choice | GoFastr HTTP/OpenAPI/MCP backend + Vue, React, Svelte, or another client | The client framework owns browser state and rendering. GoFastr still owns durable data, authorization, validation, and API responses. This is a separate architecture, not a way to mix a second renderer into a GoFastr-managed screen. | [`examples/spa`](../../../examples/spa/README.md) | [Entity declarations](entity-declarations.md), [Security](security.md), [SDKs](sdk.md) |
+
+## Decide where state lives
+
+| Decision | Prefer the first option when | Prefer the second option when |
+|---|---|---|
+| Local signal vs typed store | The value has one small producer/consumer scope and can reset with the page. | Many consumers share it, it needs SSR seeding, or app-global lifetime must be explicit. Use `core-ui/store`. |
+| Computed signal vs server recomputation | The derivation is cheap, synchronous, presentation-only, and can be expressed by a CSP-safe registered reducer. | The result depends on authorization, durable data, pagination/filter rules, expensive work, or business invariants. Return it from the server. |
+| RPC signal vs fragment swap | The authoritative response is one text/value/attribute shared by bound consumers. | The authoritative response is structured UI. Let Go render HTML and replace the island region. |
+| Optimistic update vs pending-only action | The action is reversible, the prior projection is known, and failure/409 reconciliation is designed. | The effect is destructive, expensive, security-sensitive, or cannot be undone honestly. Show pending state, then commit from the response. |
+| SSE latest-state/drop vs durable queue/outbox | A future update heals a missed one: badge counts, status, invalidation, presence, dashboard refresh. | Every event/side effect matters: billing, email, workflow transitions, audit, or ordered processing. Use `battery/queue` or the transactional outbox. |
+| Process-local island vs reconstructable state | You deploy one process or deliberately configure affinity, and losing ephemeral state on restart is acceptable. | You need stateless load balancing or restart survival. Reconstruct from URL/session/database on every RPC and use fanout only for push delivery. |
+| GoFastr UI vs Vue/React/Svelte | SSR-first screens, server-owned rules, small generic JS, and HTML fragment reconciliation fit the product. | The product fundamentally needs a client-owned render graph or an ecosystem-specific client library. Keep GoFastr as the API/backend boundary. |
+
+## Stateless and affinity-bound islands
+
+These terms describe server ownership, not visual appearance.
+
+- A **reconstructable island** reads route/query/session/database state for each
+  request and renders the next authoritative fragment. Any replica can handle
+  its RPC. This is the preferred shape.
+- An **affinity-bound island** holds mutable widget/island objects in one
+  process. `WithFanout` can deliver an update to the replica holding an SSE
+  connection, but it cannot recreate that object on another replica. Use
+  sticky sessions or redesign the handler around reconstructable state.
+- A client-only signal is neither durable nor affinity-bound server state. It
+  is a projection and may reset unless declared app-global and reseeded.
+
+Read [Horizontal scaling](scaling.md) before adding the second replica.
+
+## Delivery guarantees
+
+| Lane | Guarantee | Use it for | Do not use it for |
+|---|---|---|---|
+| RPC response | One request receives one status and authoritative HTML/data response | Mutations, validation, reconciliation, fragment swaps | Broadcast to other sessions |
+| SSE/event bus | Best effort; default slow-client mode drops the oldest queued frames | Latest status, invalidation, presence, live dashboard updates | Billing, audit, exactly-once workflows |
+| Fanout | Best-effort broadcast between replicas; handlers run on every replica | Making SSE/island push visible wherever the browser connected | Single-execution side effects |
+| Queue/outbox | Durable, at-least-once processing; consumers must be idempotent | Workflows, email, webhooks, audit-adjacent side effects | Immediate browser confirmation |
+
+Performance claims are bounded by what is measured. [Benchmarks](benchmarks.md)
+includes island RPC, SSE delivery/drop metrics, and full UI-host SSR. It does
+not measure browser hydration or promise that lossy delivery became durable.
+
+## Capability, convenience, and non-goals
+
+- **Capability** means the public primitives compose the architecture and a
+  runnable example proves the path.
+- **Packaged convenience** means GoFastr provides the product-shaped component
+  or battery directly, such as `DataTable`, `PaneHost`, `OptimisticAction`, or
+  `battery/admin`. A capability may exist without a one-call convenience.
+- **Proven performance** means a named benchmark exercises that exact lane.
+  Treat unmeasured browser/network behavior as unmeasured.
+- **Explicit non-goals:** GoFastr does not specialize in canvas/media editors,
+  timeline/video authoring, offline-first CRDT workspaces, or a client-owned
+  virtual DOM. Use a purpose-built client library and integrate it through the
+  API/plugin boundary when those are the center of the product.
+
+## Search vocabulary
+
+`gofastr docs --grep` is substring search over the same embedded corpus exposed
+by the framework docs MCP tools. Useful ecosystem terms for this guide include:
+
+```text
+reactive state
+client state
+optimistic UI
+rollback
+reconciliation
+live updates
+realtime
+event stream
+live dashboard
+mutation
+derived state
+cache invalidation
+server-driven UI
+```
+
+Examples:
+
+```bash
+gofastr docs ui-capability-map
+gofastr docs --grep "live dashboard"
+gofastr docs --grep reconciliation
+gofastr docs --grep "reactive state"
+```
+
+## See also
+
+- [UI composition recipes](ui-composition-recipes.md) for product-shaped page
+  grammar after the architecture is chosen.
+- [UI components index](ui-new-components.md) for constructors and exact live
+  gallery routes.
+- [Interactive patterns](interactive-patterns.md) for RPC, optimistic, signal,
+  rollback, and reconciliation wiring.
+- [Signal store](signal-store.md) for typed client projection and derived state.
+- [Runtime contract](runtime-contract.md) for the SSR/hydration/island/SSE
+  boundary.
+- [Events and SSE](events.md), [Presence](presence.md), and
+  [Scaling](scaling.md) for delivery and replica semantics.
+
+## Common mistakes
+
+- **Starting from a component name.** State the job, truth owner, mutation
+  path, and delivery guarantee first; then choose components.
+- **Calling a signal durable state.** It is a UI projection. Persist business
+  truth on the server.
+- **Using SSE as mutation acknowledgment.** The initiating RPC response is the
+  acknowledgment and reconciliation channel.
+- **Assuming fanout makes process-held widget state stateless.** It only bridges
+  the push lane; reconstruct state or configure affinity.
+- **Promising durable realtime from the default event stream.** Default SSE is
+  latest-state delivery and can drop frames. Use queue/outbox for durable work.
+- **Choosing a client framework by reflex.** Use one when the product needs a
+  client-owned renderer, not to recreate an island or fragment swap already
+  covered by the runtime.

--- a/framework/docs/content/ui-composition-recipes.md
+++ b/framework/docs/content/ui-composition-recipes.md
@@ -85,6 +85,8 @@ weight. Do not stack a narrow table down the left half of a desktop canvas and
 leave an accidental empty rail. Let the framework grid reflow the pair to a
 single readable column on phones.
 
+**Live proof:** [RecordSummary](/components/recordsummary), [MetricBand](/components/metricband), and [Timeline](/components/timeline) in the component gallery.
+
 ---
 
 ## 2. Investigation workspace
@@ -115,6 +117,8 @@ On a phone, render the reader first and make source/annotation access explicit
 with normal routes or framework drawers; do not serialize three desktop panes
 into one endless page.
 
+**Live proof:** the full [/examples/workspace](/examples/workspace) route and the [PaneHost](/components/panehost) gallery demonstration.
+
 ---
 
 ## 3. Split narrative
@@ -135,6 +139,8 @@ On mobile, put the explanatory copy before the artifact when it establishes
 context; put the artifact first when recognition is the primary task. Check
 long code lines and actions at 390px rather than assuming the two columns will
 collapse cleanly.
+
+**Live proof:** [HeroSplit](/components/herosplit), [CodeBlock](/components/codeblock), and [TerminalBlock](/components/terminalblock) in the component gallery.
 
 ---
 
@@ -157,6 +163,8 @@ Mobile detail should keep identity, price, availability, and the primary
 action close to the first useful image. Do not make the user traverse a full
 desktop gallery before reaching the action.
 
+**Live proof:** [Gallery](/components/gallery), [Lightbox](/components/lightbox), and [FilterToolbar](/components/filtertoolbar) in the component gallery.
+
 ---
 
 ## 5. Transactional field flow
@@ -178,6 +186,8 @@ Keep the first mobile viewport focused: route/job identity, state, required
 readings, issue capture, and completion. Secondary history can follow after the
 active controls.
 
+**Live proof:** [ProgressSteps](/components/progresssteps), [Form](/components/form), and [Sticky](/components/sticky) in the component gallery.
+
 ---
 
 ## Choosing without overfitting
@@ -195,6 +205,13 @@ If the recipe cannot be expressed without local structural markup or CSS,
 record the missing reusable capability and add it to the design system. The
 application is the completeness test; it is not an exception to the styling
 contract.
+
+## See also
+
+- [UI capability map](ui-capability-map.md) chooses the state, mutation, delivery, and scaling boundaries before a page recipe.
+- [UI components index](ui-new-components.md) lists every constructor and live gallery route.
+- [Runtime contract](runtime-contract.md) defines SSR, RPC islands, and SSE.
+- [Signal store](signal-store.md) covers typed client projection and derived state.
 
 ## Common mistakes
 

--- a/framework/docs/docs_test.go
+++ b/framework/docs/docs_test.go
@@ -1,6 +1,9 @@
 package docs
 
 import (
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -11,7 +14,7 @@ import (
 // doc enforces "every doc removal requires an explicit decision."
 //
 // Bump it up when adding docs. Be reluctant to decrement.
-const MinExpectedTopics = 64
+const MinExpectedTopics = 65
 
 func TestEmbedManifestFloor(t *testing.T) {
 	topics, err := List()
@@ -155,6 +158,95 @@ func TestGuideDocsEndWithCommonMistakes(t *testing.T) {
 	}
 }
 
+func TestUICapabilityMapSearchVocabulary(t *testing.T) {
+	terms := []string{
+		"optimistic", "realtime", "live dashboard", "reactive state",
+		"rollback", "reconciliation", "client state", "live updates",
+		"event stream", "mutation", "derived state", "cache invalidation",
+		"server-driven UI",
+	}
+	for _, term := range terms {
+		hits, err := Search(term)
+		if err != nil {
+			t.Fatalf("Search(%q): %v", term, err)
+		}
+		found := false
+		for _, hit := range hits {
+			if hit.Topic == "ui-capability-map" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Search(%q) did not route to ui-capability-map: %+v", term, hits)
+		}
+	}
+}
+
+func TestUICapabilityMapLinksResolve(t *testing.T) {
+	body, err := Get("ui-capability-map")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{
+		"CRUD/admin", "Optimistic mutations", "Live dashboards",
+		"Master/detail", "Sortable lists and Kanban",
+		"Notifications, progress, and activity feeds",
+		"Server-authoritative reactive SaaS", "Static/exportable UI",
+		"SPA integration", "canvas/media editors", "offline-first CRDT",
+	} {
+		if !strings.Contains(string(body), required) {
+			t.Errorf("ui-capability-map is missing required coverage %q", required)
+		}
+	}
+
+	linkRE := regexp.MustCompile(`\[[^\]]+\]\(([^)]+)\)`)
+	for _, match := range linkRE.FindAllStringSubmatch(string(body), -1) {
+		target := strings.Split(strings.Split(match[1], "#")[0], "?")[0]
+		switch {
+		case strings.HasSuffix(target, ".md") && !strings.HasPrefix(target, "../../../examples/"):
+			topic := strings.TrimSuffix(filepath.Base(target), ".md")
+			if _, err := Get(topic); err != nil {
+				t.Errorf("mapped primary doc %q does not resolve: %v", target, err)
+			}
+		case strings.HasPrefix(target, "../../../examples/"):
+			resolved := filepath.Clean(filepath.Join("content", filepath.FromSlash(target)))
+			if _, err := os.Stat(resolved); err != nil {
+				t.Errorf("mapped runnable example %q does not resolve: %v", target, err)
+			}
+		}
+	}
+}
+
+func TestUICompositionRecipeGalleryProofsResolve(t *testing.T) {
+	body, err := Get("ui-composition-recipes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(body), "**Live proof:**"); got != 5 {
+		t.Fatalf("composition recipes have %d live proofs, want one for each of 5 recipes", got)
+	}
+	components, err := os.ReadFile(filepath.Join("..", "..", "examples", "site", "components.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	componentRE := regexp.MustCompile(`\]\(/components/([a-z0-9-]+)\)`)
+	for _, match := range componentRE.FindAllStringSubmatch(string(body), -1) {
+		if !strings.Contains(string(components), `{"`+match[1]+`",`) {
+			t.Errorf("recipe gallery route /components/%s has no catalog entry", match[1])
+		}
+	}
+	mainBody, err := os.ReadFile(filepath.Join("..", "..", "examples", "site", "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	exampleRE := regexp.MustCompile(`\]\((/examples/[a-z0-9-]+)\)`)
+	for _, match := range exampleRE.FindAllStringSubmatch(string(body), -1) {
+		if !strings.Contains(string(mainBody), `"`+match[1]+`"`) {
+			t.Errorf("recipe example route %s is not registered", match[1])
+		}
+	}
+}
 func TestSearchEmptyTerm(t *testing.T) {
 	hits, _ := Search("")
 	if len(hits) != 0 {

--- a/framework/mcp_introspection_test.go
+++ b/framework/mcp_introspection_test.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -66,6 +67,40 @@ func TestMCPFrameworkDocsListReturnsTopics(t *testing.T) {
 	count := m["count"].(int)
 	if count == 0 {
 		t.Fatal("framework_docs_list returned 0 topics — embed broken?")
+	}
+}
+
+// TestMCPFrameworkDocsCapabilityMapDiscovery pins parity between the embedded
+// docs, task-oriented search, and the live app's MCP discovery surface.
+func TestMCPFrameworkDocsCapabilityMapDiscovery(t *testing.T) {
+	app := NewApp(WithMCPIntrospection())
+	if err := app.InitPlugins(); err != nil {
+		t.Fatalf("InitPlugins: %v", err)
+	}
+	result, err := app.MCP.CallTool(context.Background(), "framework_docs_get",
+		map[string]any{"topic": "ui-capability-map"})
+	if err != nil {
+		t.Fatalf("framework_docs_get ui-capability-map: %v", err)
+	}
+	if markdown, _ := result.(map[string]any)["markdown"].(string); !strings.Contains(markdown, "Live dashboards") {
+		t.Fatalf("MCP capability map is missing live-dashboard guidance")
+	}
+
+	result, err = app.MCP.CallTool(context.Background(), "framework_docs_search",
+		map[string]any{"term": "live dashboard"})
+	if err != nil {
+		t.Fatalf("framework_docs_search: %v", err)
+	}
+	hits := result.(map[string]any)["hits"].([]map[string]any)
+	found := false
+	for _, hit := range hits {
+		if hit["topic"] == "ui-capability-map" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("MCP search did not route live dashboard to ui-capability-map: %+v", hits)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a canonical UI capability map organized by job-to-be-done, with state-boundary, scaling, delivery, and non-goal guidance
- make the guide discoverable through the docs catalog, CLI search aliases, MCP search, README links, and exact runnable gallery examples
- add link, catalog, CLI, MCP, and recipe-proof regression coverage
- add a Claude Opus UI capability-discovery eval suite with three build scenarios and desktop/mobile light/dark viewports
- extend the UI eval harness to measure documentation calls, search terms, topics opened, and capability-map discovery rate

## Why

Issue #102 asks developers and agents to discover the supported UI architecture from the job they are trying to accomplish, rather than needing to know internal feature names. The new guide supplies that decision path, and the eval suite measures whether Claude Opus builders actually find and use it while producing working builds.

## Impact

Developers now have one entry point for CRUD/admin screens, optimistic mutations, live dashboards, master/detail layouts, Kanban boards, notification/progress surfaces, server-authoritative reactive SaaS, presence, static export, and deliberate SPA integration. Eval reports now expose the documentation funnel alongside build and visual-quality outcomes.

## Validation

- `go test ./framework/docs -count=1`
- `go test ./evals/ui-quality/internal/evalrunner -count=1`
- `go test ./examples/site -run 'TestDoc|TestDocs|TestCatalog|TestUICapability' -count=1`
- `go test ./cmd/gofastr -run '^TestDocsCommandListsGrepsAndReads$' -count=1`
- `go run ./evals/ui-quality/cmd/gofastr-ui-eval --suite ./evals/ui-capability-discovery/suite.json --dry-run`
- `git diff --cached --check`

A broader Windows test invocation remains blocked by pre-existing Unix-specific test code using `syscall.Kill` in `framework/app_lifecycle_test.go` and `framework/app_shutdown_test.go`. The full paid Claude Opus smoke run was not launched; suite parsing, dispatch configuration, and dry-run artifact generation were validated locally.

Closes #102