### PR TITLE
feat(island): opt-in presence topic authorization (#98 Workstream B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+
+- **Presence topic authorization** (#98). `island.Manager.AuthorizeTopic`, when
+  set, gates which `?presence=<topic>` topics a connection may join. The hook
+  runs once per requested topic at SSE-connect time with the request context
+  (carrying the server-derived user), **before** any subscription or roster
+  emission — so an unauthorized viewer never receives the roster (which can
+  contain emails) or join/leave events. Rejection is silent (the topic is
+  simply not joined), so the gate is not a private-topic existence oracle. A
+  nil hook (the default) authorizes every topic — presence stays public unless
+  an app opts in, so existing apps are unaffected. See [presence](presence.md)
+  → "Topic authorization".
+
 ### Changed
 
 - **BREAKING — strict filter parsing on the List endpoint** (#100). An

--- a/core-ui/island/manager.go
+++ b/core-ui/island/manager.go
@@ -1,6 +1,7 @@
 package island
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -50,6 +51,22 @@ type Manager struct {
 	presenceConns    map[uint64]*presenceConn
 	nextPresenceID   uint64
 	OnPresenceChange func(topic string)
+
+	// AuthorizeTopic, when set, gates which presence topics a connection may
+	// join. It is called once per requested topic at SSE-connect time with
+	// the request context (carrying the server-derived authenticated user);
+	// returning false drops that topic BEFORE any subscription or roster
+	// emission, so an unauthorized viewer never sees the roster (which can
+	// contain emails) and never receives join/leave events. A nil hook
+	// authorizes every topic — presence is public by default (opt-in
+	// gating), so existing apps are unaffected. Rejected topics are dropped
+	// silently: there is no error distinguishing an unauthorized topic from a
+	// nonexistent one, so the gate is not a private-topic existence oracle.
+	//
+	// Set once before serving traffic (like OnPresenceChange). It is read
+	// under mu so a set-once assignment races nothing; hot-swapping it on a
+	// live manager is not supported.
+	AuthorizeTopic func(ctx context.Context, topic string) bool
 
 	// dropped counts island updates discarded because a client's SSE buffer
 	// was full (slow/stalled consumer). Exposed via DroppedUpdates so the

--- a/core-ui/island/presence.go
+++ b/core-ui/island/presence.go
@@ -198,6 +198,38 @@ func anonIdentity(sessionID string) PresenceIdentity {
 	}
 }
 
+// filterAuthorizedTopics returns the subset of topics the AuthorizeTopic hook
+// permits for ctx. A nil hook (the default) authorizes everything — presence
+// is public unless an app opts into gating. Rejected topics are dropped
+// silently; no error distinguishes an unauthorized topic from a nonexistent
+// one, so the filter cannot be used as a private-topic existence oracle.
+// Called at SSE-connect time (ServeSSEWithPresence) BEFORE PresenceJoin, so an
+// unauthorized topic never produces a subscription or a roster entry.
+func (m *Manager) filterAuthorizedTopics(ctx context.Context, topics []string) []string {
+	if len(topics) == 0 {
+		return topics
+	}
+	// Read the hook under the lock — matching how PresenceJoin reads
+	// OnPresenceChange — then call it OUTSIDE the lock so an app hook may
+	// safely read the roster (PresenceRoster/PresenceSessions) without
+	// deadlocking. AuthorizeTopic is expected set-once before serving
+	// traffic (see the field doc); the locked read keeps a concurrent
+	// hot-swap from being a torn read.
+	m.mu.RLock()
+	auth := m.AuthorizeTopic
+	m.mu.RUnlock()
+	if auth == nil {
+		return topics
+	}
+	out := make([]string, 0, len(topics))
+	for _, t := range topics {
+		if auth(ctx, t) {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
 // PresenceJoin registers a connection on one or more topics and returns
 // a handle whose Leave must be called on disconnect (ServeSSEWithPresence
 // defers it). An empty identity (anonymous) is filled with a

--- a/core-ui/island/presence_authz_test.go
+++ b/core-ui/island/presence_authz_test.go
@@ -1,0 +1,161 @@
+package island
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// filterAuthorizedTopics drops topics the AuthorizeTopic hook rejects.
+
+// A nil AuthorizeTopic hook authorizes everything — presence stays public by
+// default (opt-in gating), so existing apps are unaffected.
+func TestAuthorizeTopic_NilHookAllowsAll(t *testing.T) {
+	m := NewManager()
+	got := m.filterAuthorizedTopics(context.Background(), []string{"a", "b"})
+	if len(got) != 2 {
+		t.Fatalf("nil hook must pass all topics, got %v", got)
+	}
+}
+
+// When set, the hook filters the topic list — only authorized topics survive
+// to be joined.
+func TestAuthorizeTopic_FiltersTopics(t *testing.T) {
+	m := NewManager()
+	m.AuthorizeTopic = func(_ context.Context, topic string) bool {
+		return topic == "room:public"
+	}
+	got := m.filterAuthorizedTopics(context.Background(), []string{"room:public", "room:secret"})
+	if len(got) != 1 || got[0] != "room:public" {
+		t.Fatalf("hook must drop unauthorized topics, got %v", got)
+	}
+}
+
+// Composition: an unauthorized topic never reaches the roster or the push-
+// target set — no subscription, no roster emission — while the authorized one
+// works normally. Proves the gate happens before roster registration.
+func TestAuthorizeTopic_UnauthorizedTopicHasNoRoster(t *testing.T) {
+	m := NewManager()
+	m.AuthorizeTopic = func(_ context.Context, topic string) bool {
+		return topic == "room:public"
+	}
+	topics := m.filterAuthorizedTopics(context.Background(), []string{"room:public", "room:secret"})
+	h := m.PresenceJoin("sess-1", PresenceIdentity{UserID: "u1", DisplayName: "alice@x.com"}, topics)
+	defer h.Leave()
+
+	if r := m.PresenceRoster("room:public"); len(r) != 1 {
+		t.Fatalf("authorized topic roster = %d, want 1", len(r))
+	}
+	// The private topic must expose nothing — neither roster (identity leak)
+	// nor push sessions (existence oracle).
+	if r := m.PresenceRoster("room:secret"); len(r) != 0 {
+		t.Fatalf("SECURITY: unauthorized topic leaked roster: %v", r)
+	}
+	if s := m.PresenceSessions("room:secret"); len(s) != 0 {
+		t.Fatalf("SECURITY: unauthorized topic leaked push sessions: %v", s)
+	}
+}
+
+// Rejecting every topic yields an empty join (a nil handle from PresenceJoin),
+// which is a safe no-op — Leave on it must not panic.
+func TestAuthorizeTopic_AllRejectedIsSafe(t *testing.T) {
+	m := NewManager()
+	m.AuthorizeTopic = func(_ context.Context, _ string) bool { return false }
+	topics := m.filterAuthorizedTopics(context.Background(), []string{"a", "b"})
+	if len(topics) != 0 {
+		t.Fatalf("all-reject must yield no topics, got %v", topics)
+	}
+	h := m.PresenceJoin("sess-1", PresenceIdentity{UserID: "u1"}, topics)
+	h.Leave() // nil handle Leave is a no-op; must not panic
+}
+
+// End-to-end through the real SSE entry point: ServeSSEWithPresence must apply
+// the gate BEFORE the join, so an unauthorized topic named via ?presence=
+// yields no roster and no push-target session. This covers the actual
+// production wiring (stream.go), not just the helper — a refactor that moved
+// or dropped the filter would fail here.
+func TestServeSSEWithPresence_AuthorizeTopicGate(t *testing.T) {
+	m := NewManager()
+	m.AuthorizeTopic = func(_ context.Context, topic string) bool {
+		return topic == "room:public"
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		topics := ParsePresenceTopics(r.URL.Query().Get("presence"))
+		m.ServeSSEWithPresence(w, r, PresenceIdentity{UserID: "u1", DisplayName: "alice@x.com"}, topics)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		server.URL+"?session=sess-1&presence=room:public,room:secret", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("connect SSE: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Wait for the join to register (headers flush only after PresenceJoin).
+	deadline := time.Now().Add(5 * time.Second)
+	for len(m.PresenceRoster("room:public")) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("authorized topic never joined")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// The unauthorized topic must expose nothing through the real handler.
+	if r := m.PresenceRoster("room:secret"); len(r) != 0 {
+		t.Fatalf("SECURITY: unauthorized topic leaked roster via ServeSSEWithPresence: %v", r)
+	}
+	if s := m.PresenceSessions("room:secret"); len(s) != 0 {
+		t.Fatalf("SECURITY: unauthorized topic leaked push sessions: %v", s)
+	}
+	// Sanity: the authorized topic is present with exactly this viewer.
+	if r := m.PresenceRoster("room:public"); len(r) != 1 || r[0].UserID != "u1" {
+		t.Fatalf("authorized roster = %v, want [u1]", r)
+	}
+	cancel()
+}
+
+// A panicking AuthorizeTopic hook must not leak a subscription. The hook runs
+// BEFORE ConnectSession, so a panic (net/http recovers it) leaves no stream
+// entry behind — no ghost session accumulating pushes. Regression for the
+// window where the hook ran after Subscribe but before the Unsubscribe defer.
+func TestServeSSEWithPresence_PanickingHookLeaksNoSubscription(t *testing.T) {
+	m := NewManager()
+	m.AuthorizeTopic = func(_ context.Context, _ string) bool { panic("boom") }
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		topics := ParsePresenceTopics(r.URL.Query().Get("presence"))
+		m.ServeSSEWithPresence(w, r, PresenceIdentity{UserID: "u1"}, topics)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// The panic aborts the request; the client gets a 500 or a reset — either
+	// way the handler goroutine unwinds.
+	if resp, err := http.Get(server.URL + "?session=leak-sess&presence=room:x"); err == nil {
+		resp.Body.Close()
+	}
+
+	// No ghost stream entry may remain for the session.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		m.mu.RLock()
+		_, leaked := m.streams["leak-sess"]
+		m.mu.RUnlock()
+		if !leaked {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("panicking AuthorizeTopic leaked a subscription (ghost stream entry)")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/core-ui/island/stream.go
+++ b/core-ui/island/stream.go
@@ -41,6 +41,15 @@ func (m *Manager) ServeSSEWithPresence(w http.ResponseWriter, r *http.Request, i
 
 	sse := stream.NewSSEWriter(w)
 
+	// Gate the requested topics through AuthorizeTopic (nil hook = all
+	// allowed) BEFORE anything is subscribed. Running the app-supplied hook
+	// here — before ConnectSession — means a panicking hook cannot leak a
+	// subscription (there is none yet); net/http recovers the request and
+	// nothing needs teardown. An unauthorized topic never yields a
+	// subscription or a roster entry. The request context carries the
+	// server-derived user the hook authorizes against.
+	topics = m.filterAuthorizedTopics(r.Context(), topics)
+
 	// Subscribe BEFORE flushing headers. Flushing headers (the "connected"
 	// comment below) unblocks the HTTP client — its Do() returns — so a
 	// client that pushes immediately on connect would otherwise win the

--- a/framework/docs/content/presence.md
+++ b/framework/docs/content/presence.md
@@ -72,6 +72,37 @@ The raw value is also length-capped (`maxPresenceParamLen`) before it
 enters the HTML `<meta>` tag, and `url.QueryEscape`d to prevent
 attribute injection.
 
+### Topic authorization (invariant #3)
+
+Bounding a topic string is not the same as *authorizing* it. A client may
+name **any** topic within the bounds — including one it should not see. Since
+a roster can contain emails (the display name), an ungated private topic
+(`org:42:admins`) is a roster-disclosure vector to anyone who can guess it.
+
+Set `Manager.AuthorizeTopic` to gate joins:
+
+```go
+mgr.AuthorizeTopic = func(ctx context.Context, topic string) bool {
+    // Public topics: always allow.
+    if strings.HasPrefix(topic, "public:") {
+        return true
+    }
+    // Private topics: check the request's authenticated user against the
+    // topic's ACL. ctx is the SSE request context — read the trusted user
+    // with island.PresenceIdentityFromContext(ctx) or handler.GetUser(ctx).
+    return userMayViewTopic(ctx, topic)
+}
+```
+
+The hook runs once per requested topic at SSE-connect time, **before** any
+subscription or roster emission — an unauthorized topic is dropped, so the
+viewer never receives the roster or join/leave events for it. Rejection is
+**silent** (the topic is simply not joined): there is no distinguishable
+error, so the gate is not a private-topic existence oracle. A **nil** hook
+(the default) authorizes every topic — presence stays public unless you opt
+in, so existing apps are unaffected. Keep an ergonomic public path (e.g. a
+`public:` prefix) so only genuinely private topics pay the check.
+
 ---
 
 ## API


### PR DESCRIPTION
## Issue #98 — Workstream B: presence-topic authorization

A presence roster can contain emails (the display name), yet **any client could name any `?presence=<topic>` and read its roster** — a private-topic disclosure vector for anyone who could guess the topic string.

> Scope: Workstream B only. The OAuth `email_verified` / durable-link-store work (Workstream A) is **not** in this PR.

### Behavior
- New `island.Manager.AuthorizeTopic(ctx, topic) bool` hook. Called once per requested topic at SSE-connect time with the request context (server-derived user), **before** any subscription or roster emission → an unauthorized viewer never receives the roster or join/leave events.
- **Silent rejection** (the topic is simply not joined) → not a private-topic existence oracle.
- **Opt-in**: a nil hook (the default) authorizes every topic, so existing apps are byte-identical. Keep an ergonomic public path (e.g. a `public:` prefix) so only private topics pay the check.

Apps wire it via `uihost.Islands.AuthorizeTopic = …` (consistent with the existing `OnPresenceChange` field).

### Multi-model review (Claude workflow + GLM) — all findings fixed
- **Panicking hook leak** (Claude caught, GLM missed): the hook now runs **before** `ConnectSession`, so a panicking app hook can't leak a subscription — regression test included.
- **Concurrency**: the hook field is read once under `mu` (matching `OnPresenceChange`) + documented set-once; `go test -race` is clean.
- **Coverage**: an end-to-end test drives `ServeSSEWithPresence`, so a refactor that drops the gate fails CI.

Sol (`gpt-5.6-sol`) review was skipped this round — blocked on github-copilot auth in the environment.

### Follow-up (not this PR)
The issue also asks for a **fail-closed default**; this ships opt-in to avoid breaking existing presence apps. Flipping the default is a separate BREAKING change.

### Tests
`core-ui/island/presence_authz_test.go` — nil-hook allows all, filters topics, unauthorized-topic-has-no-roster/sessions, all-rejected-is-safe, end-to-end `ServeSSEWithPresence` gate, panicking-hook-leaks-nothing. `-race` clean; docs (`presence.md`) + CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)