### PR TITLE
chore(release): v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,23 @@ All notable changes to GoFastr. Follows
 calendar versions (`YYYY-MM-DD` per substantive release until the API
 stabilises). Breaking changes are clearly marked with **BREAKING**.
 
-## [Unreleased]
+## [0.35.0] - 2026-07-18
+
+Hardens the list data-plane and the presence surface, and makes GoFastr's UI
+capabilities discoverable by job-to-be-done: strict list-filter rejection
+(#100, **breaking**), opt-in presence topic authorization (#98), and a UI
+capability map (#102).
 
 ### Added
 
+- **UI capability map** (#102). A new `ui-capability-map.md` doc (browsable via
+  `gofastr docs` and the `framework_docs_*` MCP tools, linked from the README
+  and docs catalog) routes from a UI *problem* — live dashboard, optimistic
+  board, master/detail, server-authoritative reactive state — to the GoFastr
+  primitives that compose it and the runnable example that proves it, with
+  "see also" cross-links across the interactive-patterns / signal-store /
+  runtime-contract / events / presence / scaling docs. Adds a
+  UI-capability-discovery eval suite.
 - **Presence topic authorization** (#98). `island.Manager.AuthorizeTopic`, when
   set, gates which `?presence=<topic>` topics a connection may join. The hook
   runs once per requested topic at SSE-connect time with the request context

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.34.0
+through: v0.35.0
 
 releases:
   - version: v0.3.0
@@ -187,3 +187,13 @@ releases:
       - change: Generated typed client grows Token, batch, Watch, and Do
         breaking: false
         guidance: "entities/client gains an opt-in Token field (Authorization: Bearer), BatchCreate/BatchUpdate/BatchDelete<Entity>, Watch<Entity> (SSE), and a raw Do escape hatch. Regenerate the client (gofastr generate --force from your blueprint, or re-run pack+generate) to pick them up; existing call sites keep compiling."
+  - version: v0.35.0
+    title: Strict list filters + presence topic authorization
+    notes:
+      - change: Unknown list filters now return 400 (#100)
+        breaking: true
+        guidance: "The auto-CRUD List endpoint REJECTS an unknown top-level filter (a typo like ?stauts=open, or a suffixed op on a non-field) with a 400 naming the bad key, instead of silently dropping it and returning an UNFILTERED result set. Fix clients that send unrecognized params. An endpoint whose BeforeList hook reads its own non-column query params declares them via EntityConfig.AllowedFilterParams; EntityConfig.LenientFilters (or filter.Lenient()) restores the old drop-silently behavior. Also: ?per_page is now a ?limit alias and ?offset is honored on both buffered and streaming list paths."
+        detect: 'filter\.ParseFilters\('
+      - change: Presence topic authorization hook (#98)
+        breaking: false
+        guidance: "New island.Manager.AuthorizeTopic(ctx, topic) bool gates which ?presence= topics a connection may join, before any subscription or roster emission. Additive: a nil hook (the default) authorizes every topic, so existing presence apps are byte-identical. Opt in to protect private topics whose roster (display names can be emails) would otherwise leak to anyone who guesses the topic string."


### PR DESCRIPTION
## Release v0.35.0

Cuts the accumulated batch into a tagged release. Code already merged to `main` across #106/#107/#109/#110; this PR carries only the release notes + upgrade registry.

### In this release
- **#100** — strict list-filter rejection (**BREAKING**) + nested-hidden fix, `?offset` honored, `?per_page` alias (#107)
- **#98** — opt-in presence topic authorization (#110)
- **#102** — UI capability map + discovery eval (#109)
- 91/92/96/97 already shipped as v0.34.0 (#106)

### Changes here
- `CHANGELOG.md`: `[Unreleased]` → `## [0.35.0] - 2026-07-18`, plus the previously-missing **#102** Added note and a release summary.
- `cmd/gofastr/upgrades.yml`: bump `through` → `v0.35.0`; register the v0.35.0 migration entry (strict-filter **breaking** note with a `detect` regex + the additive presence hook).

After merge: tag the merge commit `v0.35.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)