### PR TITLE
Positioning: full-stack Go framework, blueprint optional

### DIFF
--- a/.claude/skills/plain-words/SKILL.md
+++ b/.claude/skills/plain-words/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: plain-words
+description: Write GoFastr-facing copy in plain, concrete words. Auto-load before writing or editing ANY user-facing sentence — taglines, README prose, site/UI text, headlines, docs, changelogs, marketing. Kills jargon, marketing adjectives, abstract nouns, and AI-slop phrasing. Triggers on writing/editing copy, tagline, hero, headline, lede, positioning, README prose, landing page, UI microcopy.
+---
+
+# Plain words
+
+You keep reaching for jargon and marketing words. Stop. This is the filter you run every sentence through before it ships.
+
+## The one test
+
+Before you write or keep a user-facing sentence, ask:
+
+**Would a working Go developer say this out loud to a coworker?**
+
+If it sounds like a landing page, a keynote, or a pitch deck — delete it and write what the thing actually does. If you can't say it at a desk with a straight face, it's wrong.
+
+## Banned — never use these words or phrases
+
+first-class, first-party, bolt-on, add-on, seamless(ly), powerful, robust, blazing(ly), lightning-fast, unlock, leverage, empower, enable (as filler), elevate, delight, craft(ed), journey, world-class, battle-tested, enterprise-grade, cutting-edge, next-gen, revolutionary, game-changer, supercharge, effortless, "out of the box" (as praise), "under the hood", "at the table", "wired for", "runs through", "baked in", introspect, **surface** (as a noun meaning API/tools/pages), projection, authoritative, paradigm, ecosystem, holistic, turnkey, native (as buzzword), rich (as praise), "just works", "so you can focus on what matters", "the way X should be", "not a bolt-on / not an afterthought".
+
+If one shows up, delete the sentence and start over with the concrete thing.
+
+## Rules
+
+1. **Name the real thing.** "an agent can call `posts_list`" — not "agents get a tool surface".
+2. **Plain verbs:** get, write, read, run, call, add, change, delete. Not: leverage, enable, empower, provide, deliver.
+3. **Show it.** A command, a file path, a route, a flag beats any adjective. Prefer a two-line code block over a sentence praising the code.
+4. **One idea per sentence. Cut every word that isn't load-bearing.** Long, comma-spliced sentences are where jargon hides.
+5. **No praise adjectives.** Facts don't need selling. Delete "powerful", "simple", "elegant", "clean".
+6. **No metaphors.** Say the literal thing. ("on-ramp", "batteries", "at the table" — cut.)
+7. **Every claim must be checkable.** If you can't point to a file, route, or behavior, don't write it.
+
+## After you write
+
+Re-read once. Strike every banned word. Replace every abstraction with the concrete thing it stands for. If the sentence still reads like copywriting, it is — say it the boring way instead. Boring and true beats clever and vague, every time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to GoFastr. Follows
 calendar versions (`YYYY-MM-DD` per substantive release until the API
 stabilises). Breaking changes are clearly marked with **BREAKING**.
 
+## [Unreleased]
+
+Positioning pass — GoFastr is presented as a full-stack Go framework that
+doesn't get in the way of you or your agents. The blueprint generator and the
+entity declaration are optional features, not the identity. No API changes.
+
+### Changed
+
+- **Embedded docs reframed** in plain words, full-stack-first. The
+  `framework/docs/content/*` corpus (browsable with `gofastr docs` and via the
+  `framework_docs_*` MCP tools) now leads with the framework and the two-layer
+  `core`/`framework` model instead of the blueprint pipeline, and marketing
+  language is removed throughout. Facts, flags, links, and code samples are
+  unchanged.
+- **README** repositioned to match: full-stack-framework-first, the blueprint
+  demoted to the last and clearly-optional design bet, the Quickstart reordered
+  so the Go entity form comes before the blueprint, and a "Built with GoFastr"
+  section that leads with a real production app. The executable-README
+  quickstart gate still passes.
+- **Docs site (`examples/site`)** reworked: the area hubs are now taught pages
+  (concept → real code → one reference link), the `/patterns` area is renamed
+  to `/framework` (its own copy already called it the framework layer), the
+  homepage gains a "Built with GoFastr" section, and page metadata, footer, and
+  the agent card move off "agents are first-class authors" onto the tagline.
+
 ## [0.33.0] - 2026-07-18
 
 Adds MCP Apps support to `core/mcp` (#90) and a durable, replica-safe

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # GoFastr
 
-> One `gofastr.yml` blueprint becomes a server-rendered UI **and** a REST API with secure per-user scopes — generated as plain Go you read, commit, and own.
+> The full-stack Go framework that doesn't get in the way of you or your agents.
 
-GoFastr is an experimental Go full-stack framework built around that one wedge. A blueprint *scaffolds* the whole app — database schema and migrations, REST CRUD with validation and owner/RBAC scoping, a server-rendered UI with island hydration, plus an OpenAPI spec and MCP tools for agents — and emits it as plain Go. The blueprint is an on-ramp, not a runtime: once it has scaffolded, the **generated Go is the source of truth**, owned and edited like any code you wrote by hand — and you never give up `database/sql`, `net/http`, or compile-time safety.
+GoFastr is an experimental full-stack Go framework. It covers the whole stack — database schema and migrations, a REST API, and a server-rendered UI — with opt-in batteries for auth, background jobs, search, and storage, and emits everything as plain Go you read, edit, and own. Nothing is hidden: no reflection, no generated code you can't open, no runtime you live inside — drop to `net/http` or `database/sql` whenever the framework is in your way. That inspectability is also why it works for agents: an agent can author ordinary Go, and the running app exposes its entities as MCP tools an agent can drive — under the same auth and access checks your users get.
 
-The start-to-finish walkthrough is the [blueprint tutorial](framework/docs/content/tutorial-blueprint-app.md).
+Start with [one entity in Go](#quickstart); scaffolding a whole app at once from a `gofastr.yml` blueprint is optional, and the running app never needs it.
 
 ## Why this exists
 
@@ -27,16 +27,17 @@ large alongside AI. A few things I wanted to dig into:
 - **Build something large, fun, and open source with AI.** Most of this
   repo was written alongside coding agents, so the workflow itself is
   part of the experiment.
-- **Make a framework that's AI-first both ways.** AI *authors* the app
-  — a small blueprint is a cheap prompt target — and AI *consumes* the
-  running app, because every entity emits MCP tools over a live server.
-  Low surface to author, high surface generated.
+- **Build for agents on both sides.** In production, the agents your
+  users bring call the app's data over MCP — with the same login and
+  permissions the users have. While you build, `gofastr dev` hands your
+  coding agent the running app's routes, config, and logs over MCP. Both
+  fall out of writing plain, readable Go.
 
 > **Status:** early / `v0.x` — MIT-licensed and usable, but the API may change
 > between releases, so pin a version (`go get …@v0.x.y`). A `v1.0.0` tag will
 > mark the stability promise. Ship at your own risk until then.
 
-> **Validation status (honest version).** The declaration → surfaces pipeline is
+> **Validation status (honest version).** The full declaration-to-app pipeline is
 > proven end-to-end by [`examples/meridian`](examples/meridian/) — the flagship:
 > one `gofastr.yml` becomes a SaaS billing console (customers, subscriptions,
 > invoices with status workflows, MRR + charts) *and* its marketing site, auth,
@@ -54,36 +55,34 @@ large alongside AI. A few things I wanted to dig into:
 > production adoption and load — this is a thesis framework, and that's stated
 > plainly rather than dressed up.
 
-**The promise:** opinionated input, boring output, small runtime, easy escape
-hatches. You write a typed declaration; the framework emits plain Go you can
-read, debug, and step through — then gets out of the way. It's a **code-
-generation platform for CRUD-heavy and AI-authored apps**, not a universal
-framework that owns your control flow. When it's in your way, drop to `core/`
-and write `net/http`.
+**The promise:** opinionated where you want defaults, plain Go where you don't.
+You declare an entity and the framework emits the database, the REST API, and a
+server-rendered UI as ordinary Go you can read, debug, and step through — then it
+gets out of the way. When it's in your way, drop to `core/` and write `net/http`.
+It's a full-stack framework, not a runtime that owns your control flow.
 
-A corollary for the AI era, and it cuts both ways. On the **output** side, an
-agent writing the code is a reason for it to be *more* inspectable, not less —
-normal Go on disk, no reflection injection, no hidden registries, no runtime
-mutation. On the **input** side, an agent doesn't need to learn the framework to
-author an app; it needs the blueprint schema — small, documented YAML. Low
-surface to author, high surface generated: one tool call scaffolds a multi-entity
-app. And once that app is running, agents reach it through **MCP into the live
-server** — introspecting its routes, config, and docs and driving the per-entity
-tools — instead of re-reading a file. Author-time is the blueprint; run-time is
-the live MCP surface.
+This cuts both ways in the AI era. On the **output** side, an agent writing your
+code is a reason for that code to be *more* readable, not less — plain Go on
+disk, no reflection, no hidden registries, no runtime mutation. On the **input**
+side, an agent doesn't have to learn a framework to add a feature: it writes the
+same entity declaration you would. And once the app is running, the agents your
+users bring reach it through MCP — reading its routes, config, and docs, and
+calling the per-entity tools with the same login and permissions the users have —
+instead of re-reading your files.
 
 ---
 
-## Why
+## The design bets
 
-Most Go web frameworks assume a human will hand-write every route, query, validator, migration, form, and authorization check. That glue is exactly what a declaration can generate — and increasingly the declaration is written by an AI agent, which makes inspectable output matter more, not less. GoFastr's bet:
+Most Go web frameworks assume a human will hand-write every route, query, validator, migration, form, and authorization check. That glue is exactly what an entity declaration can generate — and increasingly the declaration is written by an AI agent, which makes readable output matter more, not less. GoFastr's bets:
 
-- **The blueprint is a generator, not a source of truth.** A single `gofastr.yml` scaffolds a SQL schema, typed Go models, REST routes, *and* server-rendered screens with nav and islands — both halves of the app, emitted together in one pass so they start consistent. Then it gets out of the way: the generated Go is yours to own and edit, and the running app doesn't need the blueprint at all. It's an on-ramp — `rails g scaffold` / `ng generate` for a whole Go backend *and* UI — not a declaration you live in. See [`examples/meridian`](examples/meridian/) for the whole pipeline — a polished SaaS console + marketing site — live and tested.
+- **Two layers.** A small `core/` of stdlib-first primitives sits under an opinionated `framework/`. Use the framework for the common path; drop to core and write plain `net/http` when it's in your way. (The one external touchpoint is `core/middleware/tracing.go`, which pulls in OpenTelemetry; the rest of `core/` is stdlib-only.)
+- **One entity, many outputs.** Declare an entity once and get a SQL schema, typed Go models, REST routes, an OpenAPI spec, and MCP tools — plus server-rendered screens when you add the UI. All emitted together, so they start consistent.
+- **You own the output.** The generated code is normal Go you read, debug, commit, edit, and compose from your own `main` — not a black box the tool rewrites behind your back. No reflection, no hidden registries, no runtime mutation, no platform between your binary and your server.
 - **Secure scopes are part of the declaration.** `owner_field` makes auto-CRUD per-user (anonymous → 401, cross-user → 404), `access:` gates operations behind RBAC permissions (fail-closed 403), `multi_tenant` scopes by tenant — and `gofastr validate` errors when per-user data is exposed without any of them.
-- **You own the output.** The generated code is normal Go you read, debug, commit, edit, and compose from your own `main` — not a black box the tool rewrites behind your back. No reflection magic, no hidden registries, no runtime mutation, no platform between your binary and your server.
-- **Agent surfaces come free.** The same declaration emits an OpenAPI 3 spec and five MCP tools per entity (`products_list`, `products_create`, …) that respect the same owner/RBAC scopes — a byproduct of the pipeline, not a bolt-on.
-- **Two-layer architecture.** A small `core/` of stdlib-first primitives sits under an opinionated `framework/`. Drop down to core when the framework is in your way. (The one external touchpoint is `core/middleware/tracing.go`, which pulls in OpenTelemetry; the rest of `core/` is stdlib-only.)
+- **Agent tools are part of the same output, not an add-on.** The same declaration emits an OpenAPI 3 spec and five MCP tools per entity (`products_list`, `products_create`, …) that respect the same owner/RBAC scopes.
 - **Batteries included, not embedded.** Auth, cache, email, queue, search, storage are independent packages behind narrow interfaces — swap any one without forking.
+- **A blueprint scaffolds the whole app when you want a head start.** A single `gofastr.yml` generates both halves — SQL + REST + OpenAPI + MCP *and* the screens — in one pass, consistent from the start. Then it's plain Go you own and edit, and the running app never needs the blueprint again. Fully optional: start with [one entity in Go](#quickstart) and never touch it. See [`examples/meridian`](examples/meridian/) for the whole pipeline — a SaaS console + marketing site — live and tested.
 
 ## The repo in 60 seconds
 
@@ -99,12 +98,19 @@ Most Go web frameworks assume a human will hand-write every route, query, valida
 
 You import `framework` and the batteries you opt into — not 17 packages. The
 subpackage split is an internal seam (see `framework/ARCHITECTURE.md`); the
-public surface is `framework.X` plus the batteries you reach for.
+public API is `framework.X` plus the batteries you reach for.
 
 ## Built with GoFastr
 
-The framework runs on itself — GoFastr's own tooling and reference apps are built
-on the same `framework`, `core-ui`, and batteries a user app imports:
+In production:
+
+- **[Barcode & QR Code Maker](https://barcode.donaldmurillo.com/)** — a live,
+  no-signup tool to generate and read barcodes and QR codes (QR, EAN-13, UPC-A,
+  Code 128, Data Matrix, and more) as PNG, SVG, or PDF, with CSV/Excel batch
+  export to a ZIP, a REST API, and an MCP server. Built and running on GoFastr.
+
+The framework also runs on itself — GoFastr's own tooling and reference apps are
+built on the same `framework`, `core-ui`, and batteries a user app imports:
 
 - **`examples/site`**, the docs site and canonical component gallery, runs on
   `framework` + `framework/ui` + `framework/uihost` + the `core-ui` pattern
@@ -116,7 +122,7 @@ on the same `framework`, `core-ui`, and batteries a user app imports:
   (add/edit/delete) and the generated end-to-end test suite green.
 - **`examples/ecommerce`**, a second blueprint pipeline (five entities,
   owner-scoped orders), is generated the same way and exercised by its own
-  surface test.
+  end-to-end test.
 
 These are the tools the project uses on itself, not demos wired up for a
 screenshot. External production adopters are the part still ahead of us — see
@@ -214,6 +220,30 @@ curl 'http://localhost:8080/posts/search?q=gofastr'   # custom route the example
 curl http://localhost:8080/openapi.json | jq .info     # auto-generated spec
 ```
 
+### Declare an entity (Go)
+
+The smallest app above already declared an entity. Expand it — add fields, an
+enum, a relation, soft delete, and MCP tools — the same way:
+
+```go
+app.Entity("posts", framework.EntityConfig{
+    SoftDelete: true,
+    Fields: []schema.Field{
+        {Name: "title", Type: schema.String, Required: true},
+        {Name: "body", Type: schema.Text},
+        {Name: "status", Type: schema.Enum,
+            Values: []string{"draft", "published"}, Default: "draft"},
+        {Name: "author_id", Type: schema.Relation, To: "users"},
+    },
+    MCP: true,
+})
+```
+
+That's the common path: declare entities in Go and compose the app yourself.
+When you'd rather scaffold a whole app at once — both the backend and the
+screens — a blueprint does it in one pass. It's optional, and the running app
+never needs it.
+
 ### Declare an app (blueprint)
 
 A `gofastr.yml` blueprint is the declaration-first format — one file describing
@@ -290,30 +320,14 @@ See [`examples/meridian`](examples/meridian/) for the flagship blueprint — a S
 console + marketing site generated, built, and tested end-to-end — or
 [`examples/ecommerce`](examples/ecommerce/) for a five-entity owner-scoped pipeline.
 
-### Declare an entity (Go)
-
-```go
-app.Entity("posts", framework.EntityConfig{
-    SoftDelete: true,
-    Fields: []schema.Field{
-        {Name: "title", Type: schema.String, Required: true},
-        {Name: "body", Type: schema.Text},
-        {Name: "status", Type: schema.Enum,
-            Values: []string{"draft", "published"}, Default: "draft"},
-        {Name: "author_id", Type: schema.Relation, To: "users"},
-    },
-    MCP: true,
-})
-```
-
-Both forms produce the same OpenAPI and MCP tools. The route shapes below are
-identical too — the blueprint just serves them under its `app.api_prefix`
-(default `/api`), while the Go form above mounts at the bare path unless you
-add `framework.WithAPIPrefix`.
+Both forms — the entity in Go above and the blueprint — produce the same OpenAPI
+and MCP tools, and the same route shapes (below). The blueprint just serves them
+under its `app.api_prefix` (default `/api`), while the Go form mounts at the bare
+path unless you add `framework.WithAPIPrefix`.
 
 ## What you get from one entity declaration
 
-| Surface          | Auto-generated                                                                  |
+| Output           | Auto-generated                                                                  |
 |------------------|---------------------------------------------------------------------------------|
 | HTTP             | `GET / POST /posts`, `GET / PUT / PATCH / DELETE /posts/{id}`                   |
 | Batch endpoints  | `POST / PATCH / DELETE /posts/_batch` — atomic; one tx for all items            |
@@ -404,7 +418,7 @@ make test-race       # race detector across the whole repo
 Each Postgres test gets its own schema for isolation; the container is
 shared across the whole `go test` invocation so cold-start is amortised.
 
-## Surfaces
+## The packages
 
 ### `core/` — nineteen stdlib-first primitives
 
@@ -420,7 +434,7 @@ A separate, independently usable system for rendering interactive UIs from Go: s
 
 ### `battery/` — pluggable infrastructure
 
-`admin`, `auth`, `cache`, `email`, `embed`, `log`, `notify`, `print`, `queue`, `search`, `storage`, `webhook`. Each behind a small interface with at least one in-memory implementation suitable for tests and small examples; production swaps in Redis, S3, Postgres FTS, etc. (`battery/admin` is the auto-generated back-office; `battery/experimental` is internal and not part of the supported surface.)
+`admin`, `auth`, `cache`, `email`, `embed`, `log`, `notify`, `print`, `queue`, `search`, `storage`, `webhook`. Each behind a small interface with at least one in-memory implementation suitable for tests and small examples; production swaps in Redis, S3, Postgres FTS, etc. (`battery/admin` is the auto-generated back-office; `battery/experimental` is internal and not part of the supported API.)
 
 `battery/embed` is the local semantic-search battery: in-process vector index with brute-force cosine, optional hybrid keyword fusion, MMR diversity, snapshot/WAL persistence, and a fsnotify-free polling watcher. See [`framework/docs/content/embed.md`](framework/docs/content/embed.md).
 
@@ -452,12 +466,12 @@ gofastr embed query "<text>"        Top-K semantic hits as JSON
 ### `kiln/` — agent-driven build mode (experimental)
 
 Kiln lets you build a GoFastr app live by chatting with a coding agent.
-OMP with GLM-5.2 is the turnkey/default driver; Claude Code, Pi, Codex, and
+OMP with GLM-5.2 is the default driver; Claude Code, Pi, Codex, and
 custom commands remain adapters. The agent mutates an in-memory world over
 HTTP, the running app re-renders, and the schema migrates in-process.
 Freeze the journal when done and graduate to a `gofastr.yml` blueprint
 you commit. It's an experiment and not part of the supported framework
-surface — the full tool list, the agent wiring, and the safety model
+API — the full tool list, the agent wiring, and the safety model
 live in [kiln.md](framework/docs/content/kiln.md).
 
 ## Repository layout
@@ -481,7 +495,7 @@ Every doc below is embedded into the `gofastr` binary — `gofastr docs` browses
 them offline, and the `framework_docs_*` MCP tools expose them to agents
 connected to a running app.
 
-- [Blueprint tutorial](framework/docs/content/tutorial-blueprint-app.md) — **the thesis walkthrough**: blueprint → generated UI + API → auth + owner scoping + RBAC → customize in plain Go → deploy
+- [Blueprint tutorial](framework/docs/content/tutorial-blueprint-app.md) — **generate a whole app from one file**: blueprint → generated UI + API → auth + owner scoping + RBAC → customize in plain Go → deploy
 - [Kiln (experimental)](framework/docs/content/kiln.md) — agent-driven build mode
 - [UI getting started](framework/docs/content/ui-getting-started.md) — **the 15-minute path**: scaffold → design direction → theme → framework-native composition
 - [UI composition recipes](framework/docs/content/ui-composition-recipes.md) — product-shaped page structures built entirely from `framework/ui` primitives
@@ -499,7 +513,7 @@ connected to a running app.
 - [Horizontal scaling](framework/docs/content/scaling.md) — what's process-local by default and the replica-safe alternative for each
 - [Observability](framework/docs/content/observability.md) — metrics and tracing
 - [PWA](framework/docs/content/pwa.md) — installable app manifest + versioned offline shell via `uihost.WithPWA`
-- [Agent-ready](framework/docs/content/agent-ready.md) — the discovery surface for AI agents (llms.txt, agent card, MCP)
+- [Agent-ready](framework/docs/content/agent-ready.md) — the discovery endpoints for AI agents (llms.txt, agent card, MCP)
 
 The full, per-topic index lives in the docs site catalogue (`gofastr docs --list`, or `examples/site/docs_catalog.go`), which a parity test keeps in sync with every embedded page. The list above is a curated subset.
 

--- a/examples/site/layout.go
+++ b/examples/site/layout.go
@@ -120,15 +120,17 @@ func (h *HeaderComponent) Render() render.HTML {
 	return ui.SiteHeader(ui.SiteHeaderConfig{
 		Brand: brand,
 		NavItems: []ui.SiteHeaderLink{
-			{Label: "Docs", Href: "/docs/", MatchPrefix: true},
-			{Label: "Get started", Href: "/get-started", MatchPrefix: true},
+			{Label: "Primitives", Href: "/primitives", MatchPrefix: true},
+			{Label: "Framework", Href: "/framework", MatchPrefix: true},
+			{Label: "Agents", Href: "/agents", MatchPrefix: true},
+			{Label: "Interactivity", Href: "/interactivity", MatchPrefix: true},
+			{Label: "Generator", Href: "/generator", MatchPrefix: true},
 			{Label: "Examples", Href: "/examples", MatchPrefix: true},
-			{Label: "Components", Href: "/components/", MatchPrefix: true},
-			{Label: "Kiln", Href: "/kiln", MatchPrefix: true},
 		},
 		MobileExtraLinks: []ui.SiteHeaderLink{
 			{Label: "Home", Href: "/"},
-			{Label: "Philosophy", Href: "/philosophy", MatchPrefix: true},
+			{Label: "Docs (all)", Href: "/docs/", MatchPrefix: true},
+			{Label: "Get started", Href: "/get-started", MatchPrefix: true},
 			{Label: "GitHub ↗", Href: "https://github.com/DonaldMurillo/gofastr", External: true},
 		},
 		Actions:      render.Join(actionChildren...),
@@ -149,7 +151,7 @@ func (f *FooterComponent) Render() render.HTML {
 			html.Span(html.TextConfig{Class: "site-foot-brand__ver"}, render.Text("v"+siteVersion)),
 		),
 		html.Paragraph(html.TextConfig{Class: "site-foot-brand__copy"},
-			render.Text("A Go full-stack framework where agents are first-class authors. Early (v0.x). Built in public."),
+			render.Text("The full-stack Go framework that doesn't get in the way of you or your agents. Early (v0.x). Built in public."),
 		),
 	)
 

--- a/examples/site/main.go
+++ b/examples/site/main.go
@@ -166,7 +166,7 @@ func setupServer() *framework.App {
 		// ContentNegotiation field below.
 		uihost.WithPublicLLMMD(),
 		uihost.WithAppIcon(appIconPNG()),
-		uihost.WithDescription("An early (v0.x) Go full-stack framework where AI agents are first-class authors."),
+		uihost.WithDescription("The full-stack Go framework that doesn't get in the way of you or your agents. Declare your domain in Go and get server-rendered screens, a REST API, MCP tools, and migrations — plain Go you own. Early (v0.x)."),
 		uihost.WithOpenGraph(uihost.OG{
 			Title: "GoFastr",
 			URL:   "https://gofastr.dev",
@@ -186,13 +186,13 @@ func setupServer() *framework.App {
 		// discovery URLs.
 		uihost.WithAgentReady(uihost.AgentReadyConfig{
 			Title:              "GoFastr",
-			Summary:            "An early (v0.x) Go web framework where AI agents are first-class authors and consumers. MCP tools + framework docs are served at /mcp.",
+			Summary:            "The full-stack Go framework that doesn't get in the way of you or your agents. Declare your domain in Go and get server-rendered screens, a REST API, migrations, and MCP tools an agent can call with the same login and permissions your users have. Docs and tools at /mcp. Early (v0.x).",
 			AllowAIBots:        &allowAIBots,
 			ContentNegotiation: &markdownNeg,
 			ContentSignals:     "ai-train=no, search=yes, ai-input=yes",
 			AgentCard: &uihost.AgentCardConfig{
 				Name:        "GoFastr",
-				Description: "Framework docs + introspection agent for gofastr.dev.",
+				Description: "Framework docs and tools for gofastr.dev, served over MCP.",
 				MCPEndpoint: "/mcp",
 			},
 		}),
@@ -587,6 +587,7 @@ func htmlEscape(s string) string {
 // the palette seed stay editable side by side.
 func registerScreens(site *app.App) {
 	site.Register("/", &HomeScreen{}, nil)
+	registerHubs(site) // /primitives, /framework, /agents, /interactivity, /generator
 	site.Register("/get-started", &GetStartedScreen{}, nil)
 	site.Register("/docs/", &ConceptsIndexScreen{}, nil)
 	// One /docs/<slug> page per catalog entry, each rendering the embedded

--- a/examples/site/screen_home.go
+++ b/examples/site/screen_home.go
@@ -5,8 +5,8 @@ package main
 //
 //   HERO        version tag · h1 with amber span · 2 ledes · 2 CTAs · install
 //               RHS: code block (blog/main.go, hand-tokenized in code_block.go)
-//   §01         one file, a real app — blueprint + generate terminal | screen mock
-//   §02         release-notes-style list (7 rows, number · name · desc · file)
+//   §01         server-rendered UI — SSR/islands model | screen mock
+//   §02         explore grid — 6 route cards into the main areas of the site
 //   §03         arch cards: core / framework / batteries / core-ui
 //   §04         split pane: framework MCP (left) | Kiln (right + terminal mock)
 //   §05         6 example cards, each with path + name + desc + run command
@@ -28,8 +28,6 @@ package main
 // =============================================================================
 
 import (
-	"strings"
-
 	"github.com/DonaldMurillo/gofastr/core-ui/app"
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -40,9 +38,9 @@ type HomeScreen struct{}
 
 // ScreenTitle returns the bare page name; core-ui/app appends " — GoFastr"
 // (the app name) to form the <title>, so it must NOT be repeated here.
-func (s *HomeScreen) ScreenTitle() string { return "Full-stack Go, with agents at the table" }
+func (s *HomeScreen) ScreenTitle() string { return "Full-stack Go that doesn't get in your way" }
 func (s *HomeScreen) ScreenDescription() string {
-	return "An early (v0.x) Go full-stack framework where AI agents are first-class authors. Declare your domain in Go; get REST, MCP tools, OpenAPI, migrations, and a typed client — to disk, in plain Go."
+	return "An early (v0.x) full-stack Go framework that stays out of your way. Declare your domain in Go and get server-rendered screens, a REST API, MCP tools, migrations, and a typed query builder — plain Go you and your agents can read, edit, and own."
 }
 func (s *HomeScreen) ScreenType() app.ScreenType { return app.ScreenPage }
 
@@ -50,11 +48,8 @@ func (s *HomeScreen) Render() render.HTML {
 	return render.Join(
 		heroSection(),
 		realAppSection(),
-		generatesSection(),
-		architectureSection(),
-		agentsSection(),
-		examplesSection(),
-		alphaSection(),
+		exploreSection(),
+		builtWithSection(),
 	)
 }
 
@@ -76,23 +71,21 @@ func heroSection() render.HTML {
 	)
 
 	title := html.Heading(html.HeadingConfig{Level: 1, Class: "hero__title"},
-		render.Text("Full-stack Go, with "),
-		html.Span(html.TextConfig{Class: "amber"}, render.Text("agents at the table")),
+		render.Text("Full-stack Go that doesn't get in the way of "),
+		html.Span(html.TextConfig{Class: "amber"}, render.Text("you or your agents")),
 		render.Text("."),
 	)
 
 	lede1 := html.Paragraph(html.TextConfig{Class: "hero__lede"},
 		html.Strong(html.TextConfig{}, render.Text("GoFastr")),
-		render.Text(" is a Go full-stack framework. You wire your app in Go like you'd wire "),
-		html.Code(html.TextConfig{}, render.Text("net/http")),
-		render.Text(" — declare your domain and get "),
-		html.Strong(html.TextConfig{}, render.Text("screens")),
-		render.Text(", REST endpoints, MCP tools, an OpenAPI spec, SQL migrations, and a typed query builder, all on disk in plain Go you can read and step through."),
+		render.Text(" is a full-stack Go framework. Declare your domain in Go and get "),
+		html.Strong(html.TextConfig{}, render.Text("server-rendered screens")),
+		render.Text(", REST endpoints, MCP tools, an OpenAPI spec, SQL migrations, and a typed query builder — all as plain Go on disk that you own."),
 	)
 	lede2 := html.Paragraph(html.TextConfig{Class: "hero__lede"},
-		render.Text("The same surface is wired for AI agents from day one. Every entity ships with an MCP tool surface; "),
-		html.Strong(html.TextConfig{}, render.Text("Kiln")),
-		render.Text(" (experimental) is a separate binary that lets an agent author your app in chat while you watch the code change."),
+		render.Text("GoFastr is built for both the agentic web and AI-assisted development. The app you ship joins the agentic web: the agents your users bring call your data over MCP, with the same login and permissions your users have. While you build, "),
+		html.Code(html.TextConfig{}, render.Text("gofastr dev")),
+		render.Text(" hands your coding agent — Claude Code or Codex — the app's routes, config, and logs over MCP, to help build and debug it."),
 	)
 
 	ctas := html.Div(html.DivConfig{Class: "hero__ctas"},
@@ -110,145 +103,186 @@ func heroSection() render.HTML {
 	return html.Section(html.SectionConfig{Class: "hero", Label: "Hero"},
 		container(ui.HeroSplit(ui.HeroSplitConfig{
 			Copy:  copy,
-			Media: heroCodeBlock(),
+			Media: heroCodeTabs(),
 			Ratio: ui.HeroSplitMediaWide,
 			Class: "hero-home",
 		})),
 	)
 }
 
-// heroCodeBlock — the hand-tokenized blog/main.go shown in the hero. Built
-// line by line so a reader of this file can match the visual output 1:1.
-// Token helpers (kw, fn_, str_, pn, ty, com) live in code_block.go.
-func heroCodeBlock() render.HTML {
-	lines := []render.HTML{
-		ln(kw("package"), render.Text(" main")),
-		ln(),
-		ln(kw("import"), render.Text(" "), pn("(")),
-		ln(render.Text("  "), str_(`"github.com/DonaldMurillo/gofastr/framework"`)),
-		ln(render.Text("  "), str_(`"github.com/DonaldMurillo/gofastr/battery/auth"`)),
-		ln(render.Text("  f "), str_(`"github.com/DonaldMurillo/gofastr/framework/field"`)),
-		ln(pn(")")),
-		ln(),
-		ln(kw("func"), render.Text(" "), fn_("main"), pn("()"), render.Text(" "), pn("{")),
-		ln(render.Text("  app "), pn(":="), render.Text(" framework."), fn_("New"), pn("("), render.Text("framework."), ty("Config"), pn("{")),
-		ln(render.Text("    Name"), pn(":"), render.Text(" "), str_(`"blog"`), pn(",")),
-		ln(render.Text("    DB"), pn(":"), render.Text("   framework."), fn_("SQLite"), pn("("), str_(`"./blog.db"`), pn("),")),
-		ln(render.Text("  "), pn("})")),
-		ln(),
-		ln(render.Text("  app."), fn_("Use"), pn("("), render.Text("auth."), fn_("Memory"), pn("())"), render.Text("  "), com("// swap for auth.Postgres() in prod")),
-		ln(),
-		ln(render.Text("  "), com("// One call. Generates SQL, REST, MCP, OpenAPI, Go types.")),
-		ln(render.Text("  app."), fn_("Entity"), pn("("), str_(`"posts"`), pn(","), render.Text(" framework."), ty("Entity"), pn("{")),
-		ln(render.Text("    Fields"), pn(":"), render.Text(" framework."), ty("Fields"), pn("{")),
-		ln(render.Text("      "), str_(`"title"`), pn(":"), render.Text("  f."), fn_("String"), pn("()."), fn_("Required"), pn("(),")),
-		ln(render.Text("      "), str_(`"slug"`), pn(":"), render.Text("   f."), fn_("Slug"), pn("()."), fn_("From"), pn("("), str_(`"title"`), pn("),")),
-		ln(render.Text("      "), str_(`"body"`), pn(":"), render.Text("   f."), fn_("Markdown"), pn("(),")),
-		ln(render.Text("      "), str_(`"status"`), pn(":"), render.Text(" f."), fn_("Enum"), pn("("), str_(`"draft"`), pn(","), render.Text(" "), str_(`"published"`), pn(")."), fn_("Default"), pn("("), str_(`"draft"`), pn("),")),
-		ln(render.Text("    "), pn("},")),
-		ln(render.Text("    Timestamps"), pn(":"), render.Text(" "), kw("true"), pn(",")),
-		ln(render.Text("    Expose"), pn(":"), render.Text("     framework."), ty("Expose"), pn("{"), render.Text("REST"), pn(":"), render.Text(" "), kw("true"), pn(","), render.Text(" MCP"), pn(":"), render.Text(" "), kw("true"), pn("},")),
-		ln(render.Text("  "), pn("})")),
-		ln(),
-		ln(render.Text("  app."), fn_("Serve"), pn("("), str_(`":8080"`), pn(")")),
-		ln(pn("}")),
-	}
-	return codeBlock("blog/main.go", lines)
+// heroCodeTabs — three real, buildable examples shown as tabs: core-only
+// (stdlib primitives), framework + one entity, and the fuller "Donald's Way"
+// (SEO + MCP + auth + a couple of interactive pages). Every API call here is
+// real — sourced from examples/blog, examples/site, and examples/meridian —
+// so the homepage never teaches an API that doesn't exist.
+func heroCodeTabs() render.HTML {
+	coreSrc := `package main
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/DonaldMurillo/gofastr/core/handler"
+	"github.com/DonaldMurillo/gofastr/core/render"
+	"github.com/DonaldMurillo/gofastr/core/router"
+)
+
+type Pong struct {
+	Status string ` + "`json:\"status\"`" + `
+}
+
+func main() {
+	r := router.New()
+
+	// An HTML page.
+	r.Get("/", render.HTMLHandler(func(req *http.Request) render.HTML {
+		return render.Tag("h1", nil, render.Text("Hello from core."))
+	}))
+
+	// A typed JSON API route.
+	r.Get("/api/ping", handler.HandlerAdapter(func(ctx context.Context, _ struct{}) (Pong, error) {
+		return Pong{Status: "ok"}, nil
+	}))
+
+	http.ListenAndServe(":8080", r)
+}`
+
+	frameworkSrc := `package main
+
+import (
+	"database/sql"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func main() {
+	db, _ := sql.Open("sqlite3", "./blog.db")
+
+	app := framework.NewApp(
+		framework.WithDB(db),
+		framework.WithConfig(framework.AppConfig{Name: "blog"}),
+	)
+
+	app.Entity("posts", framework.EntityConfig{
+		Public: true,
+		Fields: []schema.Field{
+			{Name: "title", Type: schema.String, Required: true},
+			{Name: "body", Type: schema.Text},
+			{Name: "status", Type: schema.Enum, Values: []string{"draft", "published"}, Default: "draft"},
+		},
+	})
+
+	// Auto-migrates and serves REST + OpenAPI on :8080.
+	app.Start(":8080")
+}`
+
+	donaldSrc := `package main
+
+import (
+	"database/sql"
+
+	"github.com/DonaldMurillo/gofastr/battery/auth"
+	"github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework"
+	"github.com/DonaldMurillo/gofastr/framework/uihost"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func main() {
+	db, _ := sql.Open("sqlite3", "./notes.db")
+
+	// Two server-rendered pages. Each gets an auto-generated llm.md.
+	ui := app.NewApp("Notes")
+	ui.Register("/", &HomeScreen{}, nil)
+	ui.Register("/notes", &NotesScreen{}, nil)
+
+	// SEO for those pages.
+	host := uihost.New(ui,
+		uihost.WithDescription("A tiny notes app."),
+		uihost.WithOpenGraph(uihost.OG{Title: "Notes", Type: "website"}),
+		uihost.WithSitemap(uihost.SitemapConfig{BaseURL: "https://notes.example"}),
+	)
+
+	// MCP for agents.
+	fwApp := framework.NewUIHostApp(host,
+		framework.WithDB(db),
+		framework.WithAPIPrefix("/api"),
+		framework.WithMCP(),
+		framework.WithMCPIntrospection(),
+	)
+
+	// One entity → a REST API at /api/notes, MCP tools, and an auto llm.md.
+	// OwnerField scopes rows per user, so agents get the same access as people.
+	fwApp.Entity("notes", framework.EntityConfig{
+		OwnerField: "user_id",
+		Fields: []schema.Field{
+			{Name: "title", Type: schema.String, Required: true},
+			{Name: "body", Type: schema.Text},
+		},
+	})
+
+	// Login + sessions.
+	authMgr := auth.New(auth.AuthConfig{
+		UserStore:    auth.NewEntityUserStore(db, "auth_users"),
+		SessionStore: auth.NewEntitySessionStore(db, "auth_sessions"),
+	})
+	authMgr.Use(auth.NewCorePlugin())
+	authMgr.Init(fwApp)
+	fwApp.Use(auth.SessionMiddleware(authMgr))
+
+	fwApp.Start(":8080")
+}`
+
+	return ui.CodeTabs(
+		ui.CodeTabsConfig{Name: "hero-examples", Label: "Example apps", LineNumbers: true},
+		ui.CodeSample{Label: "core only", Language: "go", Filename: "main.go", Code: coreSrc},
+		ui.CodeSample{Label: "framework", Language: "go", Filename: "main.go", Code: frameworkSrc},
+		ui.CodeSample{Label: "Donald's Way", Language: "go", Filename: "main.go", Code: donaldSrc},
+	)
 }
 
 // -----------------------------------------------------------------------------
-// §01 — One file, a real app. A gofastr.yml blueprint generates a whole app
-// with screens — not just APIs. This beat leads the body: "a real app"
-// (pages, tables, forms) is what a visitor is evaluating, and the data/API
-// surfaces alone never showed it. The blueprint is the on-ramp; afterwards
-// the generated Go is canonical and the .yml is deletable.
+// §01 — Server-rendered UI. Most Go frameworks stop at the API; GoFastr renders
+// the pages too, on the server, with a small JS runtime that hydrates in place
+// and turns in-page changes into island calls. The screen mock shows the shape;
+// the left column explains the model. Blueprint is a one-line aside, not the
+// section's story.
 // -----------------------------------------------------------------------------
 
 func realAppSection() render.HTML {
-	codeText := func(s string) render.HTML { return html.Code(html.TextConfig{}, render.Text(s)) }
+	li := func(children ...render.HTML) render.HTML { return html.ListItem(html.ListItemConfig{}, children...) }
 
-	snippet := codeBlock("gofastr.yml", blueprintExcerptLines())
-	term := ui.TerminalBlock(ui.TerminalBlockConfig{Label: " $ gofastr generate --from=gofastr.yml"},
-		ui.TerminalOK("→ wrote main.go, entities/register.go, blueprint/screens.go\n"),
-		ui.TerminalOK("→ 1 entity · 3 screens · migrations/0001_init.up.sql\n"),
-		ui.TerminalOK("→ next: go run .\n"),
-	)
 	left := html.Div(html.DivConfig{Class: "realapp__left"},
-		snippet,
-		term,
-		html.Paragraph(html.TextConfig{Class: "realapp__hint"},
-			codeText("gofastr.yml"),
-			render.Text(" is the on-ramp, not a runtime lock-in — after generating, the Go is canonical and you can delete it. "),
-			html.Link(html.LinkConfig{Href: "/examples#meridian", Text: "→ See the Meridian blueprint"}),
+		html.Paragraph(html.TextConfig{},
+			render.Text("Most Go frameworks stop at the API. GoFastr renders the pages too — on the server, in Go, with no React or Vue on the client."),
+		),
+		html.UnorderedList(html.ListConfig{},
+			li(render.Text("Every page is full HTML on first load — fast, and readable by crawlers and agents.")),
+			li(render.Text("A small JS runtime hydrates that HTML in place. No re-render, no client router to ship.")),
+			li(render.Text("In-page changes — sort, paginate, add a row — are island calls: the server returns new HTML and the runtime swaps one part.")),
+			li(render.Text("You write screens in Go, composed from framework/ui components.")),
 		),
 	)
 
 	grid := html.Div(html.DivConfig{Class: "realapp__grid"}, left, screenMock())
 
 	head := sectionHead(
-		"One file. A whole app — screens included.",
-		render.Join(
-			render.Text("A "), codeText("gofastr.yml"), render.Text(" blueprint declares your entities "),
-			html.Strong(html.TextConfig{}, render.Text("and the screens")),
-			render.Text(" that render them — list tables, forms, detail pages, charts, a marketing site. "),
-			codeText("gofastr generate"), render.Text(" writes owned Go you read and edit. Not a CRUD scaffold."),
-		),
+		"Server-rendered screens, not just an API.",
+		render.Text("Below is the shape of a server-rendered screen — a data table with status badges and a create button, built from framework/ui components and served as plain HTML."),
 	)
 
-	return sectionWrap("01 / one file, a real app", "Real app", head, grid)
+	return sectionWrap("01 / server-rendered UI", "Server-rendered UI", head, grid)
 }
 
-// blueprintExcerptLines is a compact, format-valid gofastr.yml excerpt for the
-// homepage — entities plus one server-rendered list screen. Inline maps are
-// invalid in the blueprint format, so fields use indented form; only scalar
-// lists ([free, pro, …]) use the inline shorthand.
-func blueprintExcerptLines() []render.HTML {
-	const yml = `app:
-  name: Meridian
-
-entities:
-  - name: customers
-    fields:
-      - name: name
-        type: string
-        required: true
-      - name: plan
-        type: enum
-        values: [free, pro, enterprise]
-      - name: mrr
-        type: decimal
-      - name: status
-        type: enum
-        values: [active, churned]
-
-screens:
-  - name: customers
-    route: /customers
-    body:
-      - kind: page_header
-        props:
-          title: Customers
-      - kind: entity_list
-        entity: customers
-        create: true
-        fields: [name, plan, mrr, status]`
-	out := make([]render.HTML, 0, 40)
-	for _, l := range strings.Split(yml, "\n") {
-		if l == "" {
-			out = append(out, ln())
-		} else {
-			out = append(out, ln(render.Text(l)))
-		}
-	}
-	return out
-}
-
-// screenMock is a static, faithful preview of a blueprint-generated list
-// screen (Meridian's /customers): a page header plus a server-rendered data
-// table with formatted cells and status badges. It is not wired to live data
-// — it shows the SHAPE of what `gofastr generate` produces, so the homepage
-// can demonstrate "a real screen" without standing up the entity + RPC a live
-// DataTable island requires.
+// screenMock is a static, faithful preview of a server-rendered list screen
+// (Meridian's /customers): a page header plus a server-rendered data table with
+// formatted cells and status badges. It is not wired to live data — it shows
+// the SHAPE of a server-rendered screen, so the homepage can demonstrate "a
+// real screen" without standing up the entity + RPC a live DataTable island
+// requires.
 func screenMock() render.HTML {
 	badge := func(label string, tone ui.StatusVariant) render.HTML {
 		return ui.StatusBadge(ui.StatusBadgeConfig{Label: label, Variant: tone})
@@ -291,317 +325,100 @@ func screenMock() render.HTML {
 			table,
 		),
 		html.Paragraph(html.TextConfig{Class: "screen-mock__cap"},
-			render.Text("/customers — generated, server-rendered, owned Go you can edit."),
+			render.Text("/customers — a server-rendered screen from framework/ui, plain Go you own."),
 		),
 	)
 }
 
 // -----------------------------------------------------------------------------
-// §02 — release-notes-style list of generated surfaces.
+// §02 — Explore the framework. A routing grid into the main areas: core
+// primitives, composed patterns, the agentic/AI surface, the interactivity
+// model, the code generator, and the example apps. Each card links to a real
+// route on the site.
 // -----------------------------------------------------------------------------
 
-func generatesSection() render.HTML {
-	row := func(n, name string, desc, file render.HTML) render.HTML {
-		return html.Div(html.DivConfig{Class: "gen-row"},
-			html.Div(html.DivConfig{Class: "n"}, render.Text(n)),
-			html.Div(html.DivConfig{Class: "name"}, render.Text(name)),
-			html.Div(html.DivConfig{Class: "desc"}, desc),
-			html.Div(html.DivConfig{Class: "file"},
-				html.Code(html.TextConfig{}, file),
-			),
-		)
-	}
+func exploreSection() render.HTML {
 	codeText := func(s string) render.HTML { return html.Code(html.TextConfig{}, render.Text(s)) }
-
-	list := html.Div(html.DivConfig{Class: "gen-list"},
-		row("01", "SQL table + migration",
-			render.Join(
-				render.Text("Versioned, ordered, reversible. "),
-				codeText("up"), render.Text("/"), codeText("down"),
-				render.Text(" SQL emitted as plain files."),
-			),
-			render.Text("migrations/")),
-		row("02", "REST endpoints",
-			render.Text("List, get, create, update, delete, batch. Cursor + offset pagination. Filter DSL on the query string."),
-			render.Text("GET POST /posts")),
-		row("03", "MCP tool surface",
-			render.Join(
-				codeText("posts_list"), render.Text(", "),
-				codeText("posts_get"), render.Text(", "),
-				codeText("posts_create"), render.Text(", "),
-				codeText("posts_update"), render.Text(", "),
-				codeText("posts_delete"),
-				render.Text(". Same auth + access rules as REST."),
-			),
-			render.Text("core/mcp")),
-		row("04", "OpenAPI 3 spec",
-			render.Join(
-				render.Text("Schema, parameters, responses. Swagger UI auto-mounted at "),
-				codeText("/api/docs"), render.Text("."),
-			),
-			render.Text("/openapi.json")),
-		row("05", "Typed Go model + query builder",
-			render.Join(
-				codeText(`posts.Query(ctx).Where(posts.Status.Eq("published")).List(20)`),
-				render.Text(". No reflection, no "), codeText("interface{}"), render.Text("."),
-			),
-			render.Text("gen/entities/posts.go")),
-		row("06", "Lifecycle hook slots",
-			render.Join(
-				codeText("BeforeCreate"), render.Text(", "),
-				codeText("AfterUpdate"), render.Text(", "),
-				codeText("BeforeDelete"),
-				render.Text(" — your code runs in the parent transaction."),
-			),
-			render.Text("framework/hook")),
-		row("07", "Admin UI (opt-in)",
-			render.Join(
-				render.Text("A listing + form per entity. Off by default. Add "),
-				codeText("Admin: true"), render.Text(" to enable."),
-			),
-			render.Text("/admin/posts")),
-	)
-
-	head := sectionHead(
-		"One entity call generates the surfaces your app and your agent both need.",
-		render.Join(
-			render.Text("Output lands on disk under "),
-			codeText("gen/"),
-			render.Text(" as regular Go and SQL. There is no reflection at runtime; if something the framework does feels like magic, open the generated file and read it."),
-		),
-	)
-
-	return sectionWrap("02 / what it generates", "What it generates", head, list)
-}
-
-// -----------------------------------------------------------------------------
-// §03 — Architecture cards (custom .arch-card, not framework/ui.Card — the
-// latter ships its own padding/border tokens that fight v2).
-// -----------------------------------------------------------------------------
-
-func architectureSection() render.HTML {
-	card := func(title, pkg, lede string, members render.HTML) render.HTML {
-		return html.Article(html.ArticleConfig{Class: "arch-card"},
-			html.Heading(html.HeadingConfig{Level: 3}, render.Text(title)),
-			html.Div(html.DivConfig{Class: "pkg"}, render.Text(pkg)),
-			html.Paragraph(html.TextConfig{}, render.Text(lede)),
-			html.Div(html.DivConfig{Class: "members"}, members),
-		)
-	}
-	b := func(s string) render.HTML { return html.Strong(html.TextConfig{}, render.Text(s)) }
-	br := render.Raw("<br>")
-
-	core := card("The floor", "core/", "Twelve primitives. Stdlib only. Works standalone.",
-		render.Join(b("router"), render.Text("  "), b("handler"), render.Text("  "), b("middleware"), br,
-			b("query"), render.Text("  "), b("mcp"), render.Text("  "), b("schema"), render.Text("  "), b("migrate"), br,
-			b("render"), render.Text("  "), b("stream"), render.Text("  "), b("openapi"), br,
-			b("static"), render.Text("  "), b("upload"),
-		))
-
-	framework := card("The frame", "framework/", "The opinionated entity system, composed on top of core. ~25 packages.",
-		render.Join(b("entity"), render.Text("  "), b("crud"), render.Text("  "), b("filter"), render.Text("  "), b("dsl"), br,
-			b("hook"), render.Text("  "), b("migrate"), render.Text("  "), b("tenant"), render.Text("  "), b("access"), br,
-			b("file"), render.Text("  "), b("cron"), render.Text("  "), b("event"), render.Text("  "), b("log"), br,
-			b("ui"), render.Text("  …and more"),
-		))
-
-	batteries := card("Pluggable", "battery/", "One interface per concern. In-memory dev driver, production driver behind the same shape. Swap without forking.",
-		render.Join(b("auth"), render.Text("  "), b("cache"), render.Text("  "), b("email"), render.Text("  "), b("embed"), br,
-			b("notify"), render.Text("  "), b("queue"), render.Text("  "), b("search"), render.Text("  "), b("storage"), br,
-			b("webhook"), render.Text("  "), b("log"), render.Text("  "), b("admin"), render.Text("  "), b("print"),
-		))
-
-	coreUI := card("UI runtime", "core-ui/", "Server-driven. Signals + HTML primitives + islands + SSE. ~10 KB gz vanilla JS. No React.",
-		render.Join(b("signal"), render.Text("  "), b("html"), render.Text("  "), b("island"), render.Text("  "), b("stream"), br,
-			b("accordion"), render.Text("  "), b("tabs"), render.Text("  "), b("modal"), br,
-			b("drawer"), render.Text("  "), b("popover"), render.Text("  "), b("toast"),
-		))
-
-	grid := html.Div(html.DivConfig{Class: "arch__grid"}, core, framework, batteries, coreUI)
-
-	head := sectionHead(
-		"Two layers. Twelve batteries. Drop down whenever.",
-		render.Join(
-			html.Code(html.TextConfig{}, render.Text("core/")),
-			render.Text(" is stdlib-only Go primitives. "),
-			html.Code(html.TextConfig{}, render.Text("framework/")),
-			render.Text(" is the opinionated entity layer composed on top. If the framework is in your way, you drop down to core — the imports change, your code doesn't."),
-		),
-	)
-
-	return sectionWrap("03 / architecture", "Architecture", head, grid)
-}
-
-// -----------------------------------------------------------------------------
-// §04 — Agents split pane.
-// -----------------------------------------------------------------------------
-
-func agentsSection() render.HTML {
-	codeText := func(s string) render.HTML { return html.Code(html.TextConfig{}, render.Text(s)) }
-	li := func(children ...render.HTML) render.HTML {
-		return html.ListItem(html.ListItemConfig{}, children...)
-	}
-
-	left := html.Div(html.DivConfig{Class: "pane pane--left"},
-		html.Span(html.TextConfig{Class: "pane__lbl"}, render.Text("framework")),
-		html.Heading(html.HeadingConfig{Level: 3}, render.Text("Every entity is an MCP surface")),
-		html.Paragraph(html.TextConfig{},
-			render.Text("For each entity you declare, the framework registers MCP tools that map 1:1 to your REST surface. An agent connects to "),
-			codeText("/mcp"),
-			render.Text(" and calls them with the same auth context a human would have over HTTP."),
-		),
-		html.UnorderedList(html.ListConfig{},
-			li(codeText("posts_list"), render.Text(" — same access rules as "), codeText("GET /posts")),
-			li(codeText("posts_create"), render.Text(" — same validators, same hooks")),
-			li(codeText("posts_update"), render.Text(", "), codeText("posts_delete"), render.Text(" — same audit log")),
-			li(render.Text("Scope per tool with "), codeText(`Expose.MCP.Tools: []string{"list","get"}`)),
-		),
-	)
-
-	// Faux terminal — Kiln's boot banner. Static markup; not wired to a real
-	// stream yet. Once /kiln lands as a real page it can host a live SSE
-	// island instead and this becomes the placeholder fallback.
-	term := ui.TerminalBlock(ui.TerminalBlockConfig{Label: " $ kiln serve --agent claude-code"},
-		ui.TerminalOut("→ panel floats on  http://localhost:8765\n"),
-		ui.TerminalOut("→ MCP server live  at  /mcp\n"),
-		ui.TerminalOut("→ journal           in  .kiln/journal\n"),
-		ui.TerminalOK("→ ready · waiting for the agent."),
-	)
-
-	right := html.Div(html.DivConfig{Class: "pane pane--right"},
-		html.Span(html.TextConfig{Class: "pane__lbl"}, render.Text("kiln · experimental (separate binary)")),
-		html.Heading(html.HeadingConfig{Level: 3}, render.Text("An agent that authors your app")),
-		html.Paragraph(html.TextConfig{},
-			render.Text("Kiln mounts a floating chat panel on the running app. The agent calls a typed tool surface ("),
-			codeText("add_entity"), render.Text(", "),
-			codeText("add_field"), render.Text(", "),
-			codeText("propose_plan"),
-			render.Text(", …). Plans render as diffs you approve. The journal is committable."),
-		),
-		term,
-	)
-
-	split := html.Div(html.DivConfig{Class: "agents__split"}, left, right)
-
-	head := sectionHead(
-		"The agent's view of your app is the same as yours.",
-		render.Text("Same database, same routes, same files on disk. The MCP tool surface is just the REST surface in a different shape. Destructive changes require an approved plan; the agent cannot drop your tables without you clicking approve."),
-	)
-
-	return sectionWrap("04 / agents", "Agents", head, split)
-}
-
-// -----------------------------------------------------------------------------
-// §05 — Examples grid.
-// -----------------------------------------------------------------------------
-
-func examplesSection() render.HTML {
-	codeText := func(s string) render.HTML { return html.Code(html.TextConfig{}, render.Text(s)) }
-	// Each card deep-links to its row on /examples (anchored by slug), so
-	// "clone the one that looks like your problem" actually lands on it.
-	exCard := func(path, title string, desc render.HTML, cmd string) render.HTML {
-		slug := path[len("examples/"):]
+	card := func(href, eyebrow, title string, desc render.HTML) render.HTML {
 		return html.LinkHTML(html.LinkHTMLConfig{
-			Href:  "/examples#" + slug,
+			Href:  href,
 			Class: "ex-card",
 			Content: render.Join(
-				html.Span(html.TextConfig{Class: "path"}, render.Text(path)),
+				html.Span(html.TextConfig{Class: "path"}, render.Text(eyebrow)),
 				html.Heading(html.HeadingConfig{Level: 3}, render.Text(title)),
 				html.Paragraph(html.TextConfig{}, desc),
-				html.Code(html.TextConfig{Class: "cmd"}, render.Text(cmd)),
 			),
 		})
 	}
 
-	// Order matches /examples (01–07) so the two pages tell the same story.
 	grid := html.Div(html.DivConfig{Class: "ex__grid"},
-		exCard("examples/meridian", "Meridian — SaaS console",
-			render.Join(render.Text("The flagship. A billing console + marketing site + auth + admin, generated from one "), codeText("gofastr.yml"), render.Text(" with writable add/edit/delete screens.")),
-			"cd examples/meridian && go run ."),
-		exCard("examples/blog", "Go-declared blog",
-			render.Text("Users, posts, comments. Three entities. The smallest end-to-end example — start here."),
-			"cd examples/blog && go run ."),
-		exCard("examples/site", "This site",
-			render.Text("The site you're reading — every framework/ui + core-ui primitive showcased one page each, plus the docs, SEO, wizard, and print demos."),
-			"cd examples/site && go run ."),
-		exCard("examples/api-tour", "API tour",
-			render.Join(render.Text("Every REST endpoint as a chapter. Each chapter has a live "), codeText("curl"), render.Text(" example you run from the page.")),
-			"cd examples/api-tour && go run ."),
-		exCard("examples/embed-demo", "Local semantic search",
-			render.Join(render.Text("A markdown corpus indexed locally via "), codeText("battery/embed"), render.Text(". No external API key, ~180 LoC total.")),
-			"cd examples/embed-demo && go run ."),
-		exCard("examples/spa", "Vue + GoFastr API",
-			render.Text("For teams who already have a client app. Shows the framework is happy to just be your typed API."),
-			"cd examples/spa && go run ."),
-		exCard("examples/static-site", "Static-site mode",
-			render.Join(render.Text("Same renderer, no server. "), codeText("gofastr build"), render.Text(" emits a CDN-friendly bundle.")),
-			"cd examples/static-site && gofastr build"),
-	)
-
-	head := sectionHead(
-		"Seven reference apps. Each runs in one command.",
-		render.Text("Clone the one that looks like your problem; swap the entity declarations."),
-	)
-
-	return sectionWrap("05 / examples", "Examples", head, grid)
-}
-
-// -----------------------------------------------------------------------------
-// §06 — Pre-alpha disclosure + roadmap (no section__head; bespoke 2-col grid).
-// -----------------------------------------------------------------------------
-
-func alphaSection() render.HTML {
-	codeText := func(s string) render.HTML { return html.Code(html.TextConfig{}, render.Text(s)) }
-
-	copy := html.Div(html.DivConfig{Class: "alpha__copy"},
-		ui.StatusPill(ui.StatusPillConfig{Label: "early · v" + siteVersion, Tone: ui.StatusPillAccent, Dot: true, Class: "mb-md"}),
-		html.Heading(html.HeadingConfig{Level: 2}, render.Text("Built in public. Use it to learn, not to ship.")),
-		html.Paragraph(html.TextConfig{},
-			render.Text("APIs change between commits. "),
-			codeText("core-ui/"),
-			render.Text(" is the active research frontier. The journal is open; rough edges are visible by design. We say no to things — you should know what we're saying no to."),
+		card("/primitives", "core · core-ui", "The primitives",
+			render.Join(render.Text("Router, query builder, schema, "), codeText("render"), render.Text(", the MCP server, HTML primitives, and signals — stdlib-first Go you can use on their own.")),
+		),
+		card("/framework", "framework · framework/ui", "Framework",
+			render.Text("The opinionated layer: entities and CRUD, auth, access control, migrations — plus the framework/ui components and theming."),
+		),
+		card("/agents", "mcp · llm.md · well-known", "Agent-ready",
+			render.Join(render.Text("Per-entity MCP tools, auto "), codeText("llm.md"), render.Text(", tools that read the running app, and the agent-discovery endpoints your app serves.")),
+		),
+		card("/interactivity", "ssr · islands · signals", "Interactivity",
+			render.Text("The server-driven model: full SSR, island RPC, optimistic UI, and signals + SSE — no client framework to ship."),
+		),
+		card("/generator", "generate", "The code generator",
+			render.Text("Scaffold a Go app from a declaration when you want a head start. It writes plain Go you own and edit."),
+		),
+		card("/examples", "examples/", "The example apps",
+			render.Text("Runnable reference apps — a blog, a SaaS console, an API tour, semantic search, and this site — each in one command."),
 		),
 	)
 
-	dt := func(s string) render.HTML {
-		return html.DescriptionTerm(html.TextConfig{}, render.Text(s))
-	}
-	dd := func(children ...render.HTML) render.HTML {
-		return html.DescriptionDetail(html.TextConfig{}, children...)
-	}
-	when := func(s string) render.HTML { return html.Span(html.TextConfig{Class: "when"}, render.Text(s)) }
-
-	list := html.DescriptionList(html.TextConfig{Class: "alpha__list"},
-		dt("honest about"),
-		dd(render.Text("Breaking changes between commits — see "),
-			html.Link(html.LinkConfig{
-				Href: "https://github.com/DonaldMurillo/gofastr/commits/main",
-				Text: "the journal",
-			})),
-		dd(render.Text("Half-built batteries, marked WIP in source")),
-		dd(render.Text("No upgrade guide between minor versions yet")),
-
-		dt("will not do"),
-		dd(render.Text("Reflection-driven magic that hides what's running")),
-		dd(render.Text("Pricing pages, logo clouds, testimonial carousels")),
-		dd(render.Text("Lock-in — drop down to "), codeText("core/"), render.Text(" any time")),
-
-		dt("roadmap, in order"),
-		dd(render.Text("Lock "), codeText("framework/entity"), render.Text(" ABI"), when("Q3 '26")),
-		dd(render.Text("Land "), codeText("core-ui"), render.Text(" 1.0"), when("Q4 '26")),
-		dd(render.Text("First version we'd suggest shipping"), when("2027")),
+	head := sectionHead(
+		"Explore the framework.",
+		render.Text("Six ways in — pick the one that matches what you're building."),
 	)
 
-	grid := html.Div(html.DivConfig{Class: "alpha__grid"}, copy, list)
-
-	return ui.Section(ui.SectionConfig{
-		Eyebrow: "06 / state of the project",
-		Label:   "State of the project",
-		Class:   "section-v2",
-	}, container(grid))
+	return sectionWrap("02 / explore", "Explore the framework", head, grid)
 }
 
 // -----------------------------------------------------------------------------
+// §03 — Built with GoFastr. Real apps running on the framework: a production
+// tool (external) and the generated flagship. Proof it ships real software,
+// not just demos. Reuses the .ex-card / .ex__grid classes from the explore grid.
+// -----------------------------------------------------------------------------
+
+func builtWithSection() render.HTML {
+	card := func(href, eyebrow, title string, desc render.HTML, external bool) render.HTML {
+		attrs := html.Attrs{}
+		if external {
+			attrs["rel"] = "external"
+		}
+		return html.LinkHTML(html.LinkHTMLConfig{
+			Href:       href,
+			Class:      "ex-card",
+			ExtraAttrs: attrs,
+			Content: render.Join(
+				html.Span(html.TextConfig{Class: "path"}, render.Text(eyebrow)),
+				html.Heading(html.HeadingConfig{Level: 3}, render.Text(title)),
+				html.Paragraph(html.TextConfig{}, desc),
+			),
+		})
+	}
+
+	grid := html.Div(html.DivConfig{Class: "ex__grid"},
+		card("https://barcode.donaldmurillo.com/", "in production", "Barcode & QR Code Maker",
+			render.Text("A live, no-signup tool to generate and read barcodes and QR codes as PNG, SVG, or PDF — with CSV/Excel batch export, a REST API, and an MCP server."), true),
+		card("/examples#meridian", "examples/meridian", "Meridian — SaaS console",
+			render.Text("The flagship: a billing console with customers, subscriptions, invoices, MRR, and charts — plus its marketing site, auth, and admin — generated from one gofastr.yml."), false),
+	)
+
+	head := sectionHead(
+		"Built with GoFastr.",
+		render.Text("A real app in production, and the flagship the framework is proven against."),
+	)
+
+	return sectionWrap("03 / built with gofastr", "Built with GoFastr", head, grid)
+}
+
 // Shared section helpers.
 // -----------------------------------------------------------------------------
 

--- a/examples/site/screens_hubs.go
+++ b/examples/site/screens_hubs.go
@@ -1,0 +1,581 @@
+package main
+
+// Area hubs — one taught landing page per top-level area from the homepage
+// explore grid (Primitives, Framework, Agents, Interactivity, Generator). Each
+// hub reads top to bottom: a short intro with the area's pieces named up front,
+// then one "concept → show it → reference link" block per piece, then where to
+// go next. Examples keeps its own screen (/examples).
+//
+// The teaching machinery (TeachHubScreen, hubConcept, renderHubConcept) is
+// shared; each area supplies its own concepts. Every code sample is verified
+// real API — the site's standing rule is that no snippet teaches an API that
+// doesn't exist.
+
+import (
+	"github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
+	"github.com/DonaldMurillo/gofastr/core/render"
+	"github.com/DonaldMurillo/gofastr/framework/ui"
+)
+
+// registerHubs registers every area hub on the site. Each is a taught page.
+func registerHubs(site *app.App) {
+	site.Register("/primitives", primitivesHub(), nil)
+	site.Register("/framework", frameworkHub(), nil)
+	site.Register("/agents", agentsHub(), nil)
+	site.Register("/interactivity", interactivityHub(), nil)
+	site.Register("/generator", generatorHub(), nil)
+}
+
+// -----------------------------------------------------------------------------
+// Teaching hub — a taught area page. It reads top to bottom: a short intro with
+// the area's pieces named up front, then one "concept → show it → reference
+// link" block per piece, then where to go next. This is the exemplar for
+// /interactivity; the same shape repeats for every area, only the pieces change.
+// -----------------------------------------------------------------------------
+
+// hubConcept is one taught idea: a name, a plain explanation, an optional real
+// code sample, and the one reference that owns the full detail.
+type hubConcept struct {
+	Title    string
+	Body     []render.HTML
+	Code     string // raw source; auto-highlighted. Empty = no code block.
+	CodeLang string
+	CodeFile string
+	RefSlug  string // links to /docs/<RefSlug> unless RefHref is set
+	RefHref  string // external reference URL (e.g. pkg.go.dev); overrides RefSlug
+	RefText  string // visible link label; defaults to the target path + " →"
+}
+
+// refLink resolves a concept's reference href and label.
+func (c hubConcept) refLink() (href, label string) {
+	href = c.RefHref
+	if href == "" {
+		href = "/docs/" + c.RefSlug
+	}
+	label = c.RefText
+	if label == "" {
+		label = href + " →"
+	}
+	return href, label
+}
+
+// hubNextLink is a card at the bottom of a hub: where to go once the area clicks.
+type hubNextLink struct {
+	Title string
+	Href  string
+	Hint  string
+}
+
+// TeachHubScreen renders a taught area page from its concepts.
+type TeachHubScreen struct {
+	Name     string // area name — the eyebrow pill and the page <title>
+	Title    string // the h1
+	Desc     string // meta description
+	Lede     render.HTML
+	Moves    []string // the pieces of this area, named up front
+	Concepts []hubConcept
+	Next     []hubNextLink
+}
+
+func (h *TeachHubScreen) ScreenTitle() string        { return h.Name }
+func (h *TeachHubScreen) ScreenDescription() string  { return h.Desc }
+func (h *TeachHubScreen) ScreenType() app.ScreenType { return app.ScreenPage }
+
+func (h *TeachHubScreen) Render() render.HTML {
+	movePills := make([]render.HTML, 0, len(h.Moves))
+	for _, m := range h.Moves {
+		movePills = append(movePills, ui.StatusPill(ui.StatusPillConfig{Label: m, Tone: ui.StatusPillAccent}))
+	}
+	hero := html.Section(html.SectionConfig{Class: "ex-hero", Label: h.Name},
+		container(
+			html.Div(html.DivConfig{Class: "mb-lg"}, tagAccent(h.Name)),
+			html.Heading(html.HeadingConfig{Level: 1}, render.Text(h.Title)),
+			html.Paragraph(html.TextConfig{Class: "lede"}, h.Lede),
+			ui.Cluster(ui.ClusterConfig{Gap: ui.GapSM}, movePills...),
+		),
+	)
+
+	blocks := make([]render.HTML, 0, len(h.Concepts))
+	for _, c := range h.Concepts {
+		blocks = append(blocks, renderHubConcept(c))
+	}
+	concepts := html.Section(html.SectionConfig{Class: "section-v2", Label: "Concepts"},
+		container(ui.Stack(ui.StackConfig{Gap: ui.GapXL}, blocks...)),
+	)
+
+	return render.Join(hero, concepts, hubNext(h.Next))
+}
+
+// renderHubConcept renders one concept block: heading, prose, an optional real
+// code sample, then a single link to the one reference doc that owns it.
+func renderHubConcept(c hubConcept) render.HTML {
+	kids := []render.HTML{html.Heading(html.HeadingConfig{Level: 2}, render.Text(c.Title))}
+	kids = append(kids, c.Body...)
+	if c.Code != "" {
+		kids = append(kids, ui.CodeBlock(ui.CodeBlockConfig{
+			Lines:    ui.HighlightLines(c.Code, c.CodeLang),
+			Language: c.CodeLang,
+			Filename: c.CodeFile,
+			ShowCopy: true,
+		}))
+	}
+	href, label := c.refLink()
+	kids = append(kids, ui.LinkButton(ui.LinkButtonConfig{
+		Label:   label,
+		Href:    href,
+		Variant: ui.ButtonGhost,
+	}))
+	return ui.Stack(ui.StackConfig{Gap: ui.GapSM}, kids...)
+}
+
+// hubNext renders the "where next" card row at the bottom of a taught hub.
+func hubNext(links []hubNextLink) render.HTML {
+	cards := make([]render.HTML, 0, len(links))
+	for _, l := range links {
+		cards = append(cards, html.LinkHTML(html.LinkHTMLConfig{
+			Href:  l.Href,
+			Class: "ex-card",
+			Content: render.Join(
+				html.Heading(html.HeadingConfig{Level: 3}, render.Text(l.Title)),
+				html.Paragraph(html.TextConfig{}, render.Text(l.Hint)),
+			),
+		}))
+	}
+	return html.Section(html.SectionConfig{Class: "next", Label: "Where next"},
+		container(
+			html.Heading(html.HeadingConfig{Level: 2}, render.Text("Where next")),
+			html.Div(html.DivConfig{Class: "next__grid"}, cards...),
+		),
+	)
+}
+
+// interactivityHub is the taught /interactivity page. Code samples are filled
+// from verified real API usage; prose stands on its own without them.
+func interactivityHub() *TeachHubScreen {
+	p := func(s string) render.HTML { return html.Paragraph(html.TextConfig{}, render.Text(s)) }
+	return &TeachHubScreen{
+		Name:  "Interactivity",
+		Title: "The server drives the UI",
+		Desc:  "The server-driven UI model in GoFastr: islands, signals, server push over SSE, server-validated forms, and optimistic actions — no client framework to ship.",
+		Lede:  render.Text("You write Go. The browser gets HTML. There's no client framework to ship. Almost everything you'll do is one of five moves:"),
+		Moves: []string{"islands", "signals", "push (SSE)", "forms", "optimistic actions"},
+		Concepts: []hubConcept{
+			{
+				Title:    "Islands",
+				Body:     []render.HTML{p("A click changes one part of the page. The click calls the server, the server returns new HTML for that part, and the runtime swaps it in. Use it for sort, paginate, expand, add a row — anything that isn't a whole new page.")},
+				CodeFile: "customers.go",
+				CodeLang: "go",
+				Code: `// Sort headers fire an RPC instead of navigating. The handler
+// returns the new table HTML; the runtime swaps this island in place.
+ui.DataTable(ui.DataTableConfig{
+    Rows:           rows,
+    IslandSignal:   "customers",
+    IslandEndpoint: "/customers/table",
+})`,
+				RefSlug: "interactive-patterns",
+			},
+			{
+				Title:    "Signals",
+				Body:     []render.HTML{p("Typed client state you declare once. Many parts of the page read the same value; change it in one place and every reader updates. Use it for a cart count, a selected row, a filter shared across widgets.")},
+				CodeFile: "signals.go",
+				CodeLang: "go",
+				Code: `// One declaration — namespaced, typed, seeded into the client store.
+company := store.New("app").String("company", "Acme Corp")
+
+// Any number of readers; change it once and every binding updates.
+company.Bind(ctx, "span", map[string]string{"id": "co-name"})`,
+				RefSlug: "signal-store",
+			},
+			{
+				Title:    "Push (SSE)",
+				Body:     []render.HTML{p("For background events, not user clicks. The server sends an update over a Server-Sent Events stream and connected pages react. Use it for a live who's-here roster, a job that finished, a number that changed somewhere else.")},
+				CodeFile: "presence.go",
+				CodeLang: "go",
+				Code: `// On a background change, re-render and push to each open session.
+host.Islands.OnPresenceChange = func(topic string) {
+    roster := renderRoster(host.Islands.PresenceRoster(topic))
+    for _, sid := range host.Islands.PresenceSessions(topic) {
+        host.Islands.PushUpdate(island.IslandUpdate{
+            IslandID: "roster-" + topic,
+            HTML:     string(roster),
+        }, sid)
+    }
+}`,
+				RefSlug: "runtime-contract",
+			},
+			{
+				Title:    "Forms",
+				Body:     []render.HTML{p("The server validates. On error it returns the form with the messages already in place, swapped like any island — no full reload, and no client-side validation to keep in sync with the server's.")},
+				CodeFile: "login.go",
+				CodeLang: "go",
+				Code: `// errs is the server's validation result (ui.FieldErrors). On error
+// the form comes back with each message in place, swapped like an island.
+ui.Form(ui.FormConfig{Method: "POST", Action: "/login", SubmitLabel: "Sign in", Errors: errs},
+    ui.FormFieldFor(errs, "email", ui.FormFieldConfig{Label: "Email", For: "email", Input: emailInput}),
+)`,
+				RefSlug: "form-module",
+			},
+			{
+				Title:    "Optimistic actions",
+				Body:     []render.HTML{p("The button updates before the server answers. The runtime fires the request, shows the success label right away, and rolls back if the server returns an error. Use it for approve, archive, like — actions that almost always succeed.")},
+				CodeFile: "actions.go",
+				CodeLang: "go",
+				Code: `ui.OptimisticAction(ui.OptimisticActionConfig{
+    Endpoint:     "/posts/42/archive",
+    IdleLabel:    "Archive",
+    SuccessLabel: "Archived",
+    Variant:      ui.ButtonPrimary,
+})`,
+				RefSlug: "interactive-patterns",
+			},
+		},
+		Next: []hubNextLink{
+			{Title: "Build a real app", Href: "/get-started", Hint: "The four-minute guide, from install to a running page."},
+			{Title: "Next area: Framework", Href: "/framework", Hint: "Entities, auth, migrations, and the framework/ui components."},
+		},
+	}
+}
+
+// hubP is the plain-paragraph helper shared by the taught hubs.
+func hubP(s string) render.HTML { return html.Paragraph(html.TextConfig{}, render.Text(s)) }
+
+// primitivesHub is the taught /primitives page — core + core-ui, the
+// stdlib-first building blocks. Snippets verified against the real packages.
+func primitivesHub() *TeachHubScreen {
+	pkg := "https://pkg.go.dev/github.com/DonaldMurillo/gofastr/"
+	return &TeachHubScreen{
+		Name:  "Primitives",
+		Title: "Stdlib-first building blocks",
+		Desc:  "The core layer of GoFastr: router, typed handlers, render, schema, the MCP server, and a client store — plain stdlib-first Go you can use on their own.",
+		Lede:  render.Text("core and core-ui are small Go packages, each usable on its own — no framework required. When you want more, the framework composes them for you."),
+		Moves: []string{"router", "typed handlers", "render", "schema", "MCP server", "client store"},
+		Concepts: []hubConcept{
+			{
+				Title:    "Router",
+				Body:     []render.HTML{hubP("Built on net/http. Make a router and register routes with path patterns — the same shapes as the standard library, nothing new to learn.")},
+				CodeFile: "main.go",
+				CodeLang: "go",
+				Code: `r := router.New()
+r.Get("/", render.HTMLHandler(func(req *http.Request) render.HTML {
+    return render.Tag("h1", nil, render.Text("Hello from core."))
+}))
+http.ListenAndServe(":8080", r)`,
+				RefHref: pkg + "core/router",
+				RefText: "pkg.go.dev · core/router →",
+			},
+			{
+				Title:    "Typed handlers",
+				Body:     []render.HTML{hubP("A handler that takes a typed input struct and returns a typed output struct. HandlerAdapter does the JSON binding, panic recovery, and response encoding for you.")},
+				CodeFile: "main.go",
+				CodeLang: "go",
+				Code: `type Pong struct{ Status string }
+
+r.Get("/api/ping", handler.HandlerAdapter(
+    func(ctx context.Context, _ struct{}) (Pong, error) {
+        return Pong{Status: "ok"}, nil
+    }))`,
+				RefHref: pkg + "core/handler",
+				RefText: "pkg.go.dev · core/handler →",
+			},
+			{
+				Title:    "Render HTML from Go",
+				Body:     []render.HTML{hubP("Return HTML from a Go function. The html primitives map one-to-one to tags, and render.Text escapes text for you — no template language.")},
+				CodeFile: "screen.go",
+				CodeLang: "go",
+				Code: `render.HTMLHandler(func(req *http.Request) render.HTML {
+    return html.Div(html.DivConfig{Class: "card"},
+        html.Heading(html.HeadingConfig{Level: 2}, render.Text("Every doc · A–Z")),
+    )
+})`,
+				RefSlug: "ui-getting-started",
+			},
+			{
+				Title:    "Schema",
+				Body:     []render.HTML{hubP("Describe a field once — name, type, required, unique, enum values, default. The same []schema.Field drives the table, the validation, and the API.")},
+				CodeFile: "schema.go",
+				CodeLang: "go",
+				Code: `Fields: []schema.Field{
+    {Name: "title", Type: schema.String, Required: true},
+    {Name: "status", Type: schema.Enum,
+        Values: []string{"draft", "published"}, Default: "draft"},
+}`,
+				RefSlug: "entity-declarations",
+			},
+			{
+				Title:    "MCP server",
+				Body:     []render.HTML{hubP("The MCP server is a core package too — not something only entities produce. Register a tool with a name, a JSON schema, and a Go function.")},
+				CodeFile: "mcp.go",
+				CodeLang: "go",
+				Code: `s := mcp.NewServer()
+s.RegisterTool("greet", "Say hello", map[string]any{
+    "type":       "object",
+    "properties": map[string]any{"name": map[string]any{"type": "string"}},
+}, func(ctx context.Context, p map[string]any) (any, error) {
+    return "hello " + p["name"].(string), nil
+})`,
+				RefHref: pkg + "core/mcp",
+				RefText: "pkg.go.dev · core/mcp →",
+			},
+			{
+				Title:    "Client store",
+				Body:     []render.HTML{hubP("Typed client state, declared in Go and namespaced so two features don't collide. This is the same store the interactivity signals read from.")},
+				CodeFile: "store.go",
+				CodeLang: "go",
+				Code: `company := store.New("org").String("company", "Acme Corp")
+
+cart := store.New("cart")
+count := cart.Int("count", 0)`,
+				RefSlug: "signal-store",
+			},
+		},
+		Next: []hubNextLink{
+			{Title: "Next area: Framework", Href: "/framework", Hint: "The opinionated layer built on these primitives."},
+			{Title: "Next area: Interactivity", Href: "/interactivity", Hint: "How the client store powers server-driven UI."},
+		},
+	}
+}
+
+// frameworkHub is the taught /framework page — framework + framework/ui, the
+// opinionated layer on top of core. Code samples are verified real API.
+func frameworkHub() *TeachHubScreen {
+	return &TeachHubScreen{
+		Name:  "Framework",
+		Title: "The framework layer, on top of core",
+		Desc:  "The framework layer of GoFastr: entities and CRUD on the backend, composed components on the front — auth, access control, migrations, and theming.",
+		Lede:  render.Text("framework and framework/ui sit on top of the primitives. Declare an entity and get the database, API, and tools; compose screens from components that already match your theme."),
+		Moves: []string{"entities", "auth", "access control", "migrations", "components", "theming"},
+		Concepts: []hubConcept{
+			{
+				Title:    "Entities",
+				Body:     []render.HTML{hubP("Declare an entity in Go — fields, types, relations. One call gives you the table, REST endpoints, validation, an OpenAPI entry, and MCP tools.")},
+				CodeFile: "main.go",
+				CodeLang: "go",
+				Code: `app.Entity("posts", framework.EntityConfig{
+    Public: true,
+    Fields: []schema.Field{
+        {Name: "title", Type: schema.String, Required: true},
+        {Name: "body", Type: schema.Text},
+        {Name: "status", Type: schema.Enum,
+            Values: []string{"draft", "published"}, Default: "draft"},
+    },
+})`,
+				RefSlug: "entity-declarations",
+			},
+			{
+				Title:    "Auth",
+				Body:     []render.HTML{hubP("Login, sessions, OAuth, magic-link, 2FA, password reset. Each is a plugin you add to an auth manager; the middleware puts the signed-in user on the request.")},
+				CodeFile: "auth.go",
+				CodeLang: "go",
+				Code: `authMgr := auth.New(auth.AuthConfig{
+    UserStore:    auth.NewEntityUserStore(db, "auth_users"),
+    SessionStore: auth.NewEntitySessionStore(db, "auth_sessions"),
+})
+authMgr.Use(auth.NewCorePlugin())
+authMgr.Init(fwApp)
+fwApp.Use(auth.SessionMiddleware(authMgr))`,
+				RefSlug: "auth",
+			},
+			{
+				Title:    "Access control",
+				Body:     []render.HTML{hubP("Roles and permissions, plus per-user owner scoping. It fails closed: a request with no matching policy is denied, not allowed.")},
+				CodeFile: "entities.go",
+				CodeLang: "go",
+				Code: `app.Entity("notes", framework.EntityConfig{
+    OwnerField: "user_id", // every read and write is scoped to the signed-in user
+    Access: framework.AccessControl{
+        Read: "notes:read", Create: "notes:write",
+        Update: "notes:write", Delete: "notes:admin",
+    },
+})`,
+				RefSlug: "access-control",
+			},
+			{
+				Title:    "Migrations",
+				Body:     []render.HTML{hubP("Versioned, ordered, reversible schema changes. In dev the framework can auto-migrate from the declared entities; in production you run the ordered migrations.")},
+				CodeFile: "main.go",
+				CodeLang: "go",
+				Code: `// Derive the schema from the declared entities and apply it.
+if err := framework.AutoMigrate(db, app.Registry); err != nil {
+    log.Fatal(err)
+}`,
+				RefSlug: "migrations",
+			},
+			{
+				Title:    "Components",
+				Body:     []render.HTML{hubP("framework/ui composes intent, not tags: PageHeader, DataTable, Form, Card, charts. Each ships its own CSS through the theme, so a page inherits your look for free.")},
+				CodeFile: "screen.go",
+				CodeLang: "go",
+				Code: `ui.PageHeader(ui.PageHeaderConfig{
+    Eyebrow:  "Settings",
+    Title:    "Workspace settings",
+    Subtitle: "Tune defaults for everyone on this workspace.",
+    Actions:  ui.Button(ui.ButtonConfig{Label: "Save changes", Variant: ui.ButtonPrimary}),
+})`,
+				RefHref: "/components",
+				RefText: "/components — the live gallery →",
+			},
+			{
+				Title:    "Theming",
+				Body:     []render.HTML{hubP("One typed theme drives every color, space, and font as CSS variables. Change a token and every component updates — you never edit a component's CSS to reskin an app.")},
+				CodeFile: "theme.go",
+				CodeLang: "go",
+				Code: `t := theme.Default(theme.Overrides{
+    Primary:  "oklch(0.82 0.155 78)", // amber accent
+    Surface:  "oklch(0.17 0.006 75)",
+    RadiusMd: 6,
+})
+site.WithTheme(t)`,
+				RefSlug: "theming",
+			},
+		},
+		Next: []hubNextLink{
+			{Title: "Next area: Agents", Href: "/agents", Hint: "The MCP tools an entity gets, and the discovery your app serves."},
+			{Title: "Next area: Interactivity", Href: "/interactivity", Hint: "Server-driven UI: islands, signals, forms."},
+		},
+	}
+}
+
+// agentsHub is the taught /agents page — the two MCP layers. Code samples are
+// filled from verified real API.
+func agentsHub() *TeachHubScreen {
+	codeText := func(s string) render.HTML { return html.Code(html.TextConfig{}, render.Text(s)) }
+	return &TeachHubScreen{
+		Name:  "Agents",
+		Title: "Built for two kinds of agents",
+		Desc:  "GoFastr's agent surface: production MCP tools your users' agents call with their own login, and dev MCP that hands your coding agent the running app's routes, config, and logs.",
+		Lede:  render.Text("Two kinds of agents, two layers of MCP. In production, the agents your users bring call your data with the same login and permissions the users have. While you build, gofastr dev hands your coding agent the running app."),
+		Moves: []string{"production MCP", "dev MCP", "auto llm.md", "discovery", "local search"},
+		Concepts: []hubConcept{
+			{
+				Title:    "Production MCP tools",
+				Body:     []render.HTML{hubP("Turn on MCP and every CRUD entity gets tools an agent can call. The tools run through the same auth, owner, and tenant checks as your HTTP API — an agent gets exactly the access its user has, and nothing more.")},
+				CodeFile: "main.go",
+				CodeLang: "go",
+				Code: `fwApp := framework.NewUIHostApp(host,
+    framework.WithConfig(framework.AppConfig{Name: "app"}),
+    framework.WithMCP(),              // entities get MCP tools at /mcp
+    framework.WithMCPIntrospection(),
+)`,
+				RefSlug: "agent-ready",
+			},
+			{
+				Title: "Dev MCP",
+				Body: []render.HTML{html.Paragraph(html.TextConfig{},
+					codeText("gofastr dev"),
+					render.Text(" gives your coding agent — Claude Code, Codex — read access to the running app over MCP: its routes, config, readiness, embedded docs, and recent logs. It's livereload for agents.")),
+				},
+				CodeLang: "shell",
+				Code: `# GOFASTR_DEV=1 mounts read-only tools for your coding agent:
+#   app_routes, app_config, app_readiness, framework_docs_*, log_recent
+gofastr dev`,
+				RefSlug: "dev-livereload",
+			},
+			{
+				Title: "Auto llm.md",
+				Body: []render.HTML{html.Paragraph(html.TextConfig{},
+					render.Text("Every screen and every entity ships an "),
+					codeText("llm.md"),
+					render.Text(" automatically — a plain-text description an agent reads to understand the page or the API. On by default; opt one out with "),
+					codeText("NoLLMMD"),
+					render.Text(".")),
+				},
+				RefSlug: "agent-ready",
+			},
+			{
+				Title:    "Discovery endpoints",
+				Body:     []render.HTML{hubP("Turn on the agent-ready host options and your app serves the files agent scanners look for — an llms.txt and the .well-known endpoints — so an agent can find what your app does.")},
+				CodeLang: "",
+				Code: `GET /llms.txt
+GET /.well-known/agent-card.json
+GET /.well-known/agent.json`,
+				RefSlug: "agent-ready",
+			},
+			{
+				Title:    "Local semantic search",
+				Body:     []render.HTML{hubP("battery/embed indexes a corpus locally and answers similarity queries — no external API key, works offline.")},
+				CodeFile: "search.go",
+				CodeLang: "go",
+				Code: `idx, _ := embed.Open(embed.Options{
+    Embedder: embed.NewStubEmbedder(128),
+    Keyword:  embed.NewMemoryKeyword(),
+})
+idx.Add(ctx, docs...)
+hits, _ := idx.Query(ctx, embed.Query{Text: "how do hooks work", K: 5, Hybrid: true})`,
+				RefSlug: "embed",
+			},
+		},
+		Next: []hubNextLink{
+			{Title: "Next area: Primitives", Href: "/primitives", Hint: "The core/mcp package the tools are built on."},
+			{Title: "Build a real app", Href: "/get-started", Hint: "The four-minute guide, from install to a running page."},
+		},
+	}
+}
+
+// generatorHub is the taught /generator page — scaffold plain Go from a
+// declaration. Commands verified against cmd/gofastr.
+func generatorHub() *TeachHubScreen {
+	codeText := func(s string) render.HTML { return html.Code(html.TextConfig{}, render.Text(s)) }
+	return &TeachHubScreen{
+		Name:  "Generator",
+		Title: "Scaffold plain Go from a declaration",
+		Desc:  "GoFastr's code generators: app code from a blueprint, client SDKs, and a customer CLI. Each writes plain Go you own and edit — not a runtime you configure.",
+		Lede:  render.Text("When you want a head start, generate the code. It writes plain Go to disk — you own it, read it, and edit it. No runtime magic, nothing to keep regenerating against."),
+		Moves: []string{"code generation", "SDKs", "customer CLI", "blueprints"},
+		Concepts: []hubConcept{
+			{
+				Title:    "Code generation",
+				Body:     []render.HTML{hubP("gofastr generate turns a declaration into Go on disk. Config-driven generators write under gen/; every run is reproducible, and --dry-run shows you the plan first.")},
+				CodeLang: "shell",
+				Code: `# preview without writing
+gofastr generate --config gofastr.codegen.yml --dry-run --json
+
+# write the generated Go
+gofastr generate --config gofastr.codegen.yml`,
+				RefSlug: "codegen",
+			},
+			{
+				Title:    "SDKs",
+				Body:     []render.HTML{hubP("Generate a client for your API: a standalone Go module and a JS/TS ESM client. The app can host them behind a live docs page for your customers.")},
+				CodeLang: "shell",
+				Code:     `gofastr generate sdk --target=go,js --out=gen/sdk`,
+				RefSlug:  "sdk",
+			},
+			{
+				Title:    "Customer CLI",
+				Body:     []render.HTML{hubP("Generate a branded terminal client for your API, with scoped API-token auth. Your customers get a real CLI; you own the generated code under cmd/.")},
+				CodeLang: "shell",
+				Code: `gofastr generate cli --binary=meridian --only=customers,invoices
+
+# customers sign in with a scoped token, read from stdin
+echo "$TOKEN" | ./meridian login --url https://app.example.com --with-token`,
+				RefSlug: "app-cli",
+			},
+			{
+				Title: "Blueprints",
+				Body: []render.HTML{html.Paragraph(html.TextConfig{},
+					render.Text("A "), codeText("gofastr.yml"), render.Text(" is a bundle of entities and screens. "),
+					codeText("gofastr generate --from=gofastr.yml"),
+					render.Text(" writes the app as plain package main to your module root — a one-shot scaffold you then own, not a tree you keep regenerating.")),
+				},
+				CodeFile: "gofastr.yml",
+				CodeLang: "yaml",
+				Code: `entities:
+  - name: plans
+    crud: true
+    fields:
+      - name: name
+        type: string
+        required: true
+      - name: slug
+        type: string
+        unique: true`,
+				RefSlug: "blueprints",
+			},
+		},
+		Next: []hubNextLink{
+			{Title: "Next area: Framework", Href: "/framework", Hint: "What the generated code is built from."},
+			{Title: "Build a real app", Href: "/get-started", Hint: "The four-minute guide, by hand this time."},
+		},
+	}
+}

--- a/examples/site/site_test.go
+++ b/examples/site/site_test.go
@@ -167,12 +167,15 @@ func TestExamplesHaveSourceLinksAndAnchors(t *testing.T) {
 	}
 }
 
-func TestHomeExampleCardsDeepLink(t *testing.T) {
+func TestHomeLinksToExamples(t *testing.T) {
 	html := body(t, "/")
-	for _, slug := range []string{"blog", "site", "api-tour"} {
-		if !strings.Contains(html, `href="/examples#`+slug+`"`) {
-			t.Errorf("home example card should deep-link to /examples#%s", slug)
-		}
+	// The explore grid links to the examples hub; the "Built with GoFastr"
+	// section deep-links the flagship.
+	if !strings.Contains(html, `href="/examples"`) {
+		t.Error("home should link to the examples hub at /examples")
+	}
+	if !strings.Contains(html, `href="/examples#meridian"`) {
+		t.Error("home 'Built with GoFastr' section should deep-link the flagship at /examples#meridian")
 	}
 }
 

--- a/framework/docs/content/README.md
+++ b/framework/docs/content/README.md
@@ -10,9 +10,9 @@ results, the harness contract) are exempt — the exemption list lives in
 
 ## Start here
 
-- [Blueprint tutorial](tutorial-blueprint-app.md) — the thesis
-  walkthrough: blueprint → generated UI + API → auth + owner scoping
-  + RBAC → customize in plain Go → deploy.
+- [Blueprint tutorial](tutorial-blueprint-app.md) — walks through the
+  optional scaffolder: blueprint → generated UI + API → auth + owner
+  scoping + RBAC → customize in plain Go → deploy.
 - [Comparison](comparison.md) — vs PocketBase, Encore, Wasp, and
   hand-rolled Gin+sqlc; weaknesses stated honestly.
 
@@ -25,7 +25,7 @@ results, the harness contract) are exempt — the exemption list lives in
 - [`ROADMAP.md`](../ROADMAP.md) — forward-looking work (proposals,
   performance opportunities, in-flight plans).
 
-## Entity surface
+## Entity APIs
 
 - [Entity declarations](entity-declarations.md) — JSON + Go field types
   and the runtime/code-gen loaders.
@@ -42,7 +42,7 @@ results, the harness contract) are exempt — the exemption list lives in
 - [Query DSL](query-dsl.md) — agent-friendly query parser →
   `core/query` builder.
 
-## App surface
+## App features
 
 - [Hooks & transactions](hooks-and-transactions.md) — lifecycle hook
   points, `TxFromContext`, `App.InTx`, typed hooks.
@@ -59,8 +59,8 @@ results, the harness contract) are exempt — the exemption list lives in
 - [Audit log](audit-log.md) — `WithAuditLog`, transactional row
   writes, schema.
 - [Server logs](log.md) — `battery/log`: structured JSON access logs,
-  panic recovery, lifecycle events; fan-out to file (default or chosen
-  path) and webhook sinks.
+  panic recovery, lifecycle events; writes to a file (default or a
+  path you choose) and to webhook sinks.
 - [Plugins](plugins.md) — `Plugin` + optional capability interfaces.
 - [Heavy-JS plugin platform](plugin-platform.md) — sandboxed-iframe
   isolation host for megabyte-class client plugins; capability grants
@@ -101,7 +101,7 @@ results, the harness contract) are exempt — the exemption list lives in
 - [Signal store](signal-store.md) — `core-ui/store` typed shared
   client state with SSR seeding.
 
-## Operational surface
+## Operations
 
 - [Worktree isolation](isolation.md) — automatic local port, DB, and
   service-env isolation for linked Git worktrees.
@@ -119,8 +119,8 @@ results, the harness contract) are exempt — the exemption list lives in
   delivery, retry-with-backoff, dead-letter, glob event filters.
 - [Internationalization](i18n.md) — `core/i18n` translator,
   JSON catalogs, plurals, `Accept-Language` negotiation.
-- [Unified notifications](notifications.md) — `battery/notify`
-  multi-channel fan-out with per-channel templates.
+- [Unified notifications](notifications.md) — `battery/notify` sends
+  to multiple channels, each with its own template.
 - [Factories / fixtures](factories.md) — `framework/factory`
   Rails-style test setup helpers.
 - [Testkit](testkit.md) — `framework/testkit`: isolated per-test Postgres

--- a/framework/docs/content/access-control.md
+++ b/framework/docs/content/access-control.md
@@ -82,7 +82,7 @@ flips it to `session_id`. If your deployment overrides
 `Spec.SetSecurityScheme("cookieAuth", …)` replaces it by name.
 
 > **Important — `EntityConfig.Access` is HTTP-only.** It gates the HTTP
-> CRUD surface, not in-process repository or `CrudHandler` calls. This is
+> CRUD routes, not in-process repository or `CrudHandler` calls. This is
 > intentional: in-process Go code is trusted, while owner and tenant
 > isolation still apply at the data layer. SSR screens do not inherit
 > `EntityConfig.Access` checks automatically. Enforce per-row rules for SSR

--- a/framework/docs/content/accessibility.md
+++ b/framework/docs/content/accessibility.md
@@ -10,11 +10,11 @@ render can catch.
 
 `framework/ui` and `core-ui` components carry their ARIA contract
 internally — labelled landmarks, `aria-expanded` on disclosures,
-`aria-selected` mirroring on tabs, focus traps on modal surfaces,
+`aria-selected` mirroring on tabs, focus traps on modals,
 `aria-live` announcement regions, keyboard navigation on menus, trees,
 carousels, and sortable lists. Composing the design system instead of
-hand-rolling markup is the single highest-leverage accessibility
-decision an app makes (see the UI architecture doc's hard rules).
+hand-rolling markup is the single biggest accessibility win an app can
+make (see the UI architecture doc's hard rules).
 
 The typed HTML layer makes the remaining requirements *visible in the
 config struct*: `html.Image` has an `Alt` field, `html.Button` a
@@ -143,4 +143,4 @@ dev`'s server during development, or against a staging deploy in CI.
 - **Fixing the symptom in CSS.** An axe `color-contrast` finding on a
   component means the *token* is wrong (`--color-text-subtle` on
   `--color-surface`), not that one selector needs an override — fix the
-  theme so every surface inherits the correction.
+  theme so every component inherits the correction.

--- a/framework/docs/content/admin.md
+++ b/framework/docs/content/admin.md
@@ -126,7 +126,7 @@ app.RegisterBattery(admin.New(admin.Config{
 On the `?status=failed` view, each row gets a **Replay** button when the
 wired queue supports it (`DBQueue` does; in-memory / Redis don't yet). The
 replay route mutates state, so it runs behind the same admin gate as every
-other surface and carries a CSRF token — there is no unauthenticated way to
+other route and carries a CSRF token — there is no unauthenticated way to
 re-fire jobs.
 
 When `Queue` is nil, the overview section and Queue navigation item are hidden;
@@ -144,7 +144,7 @@ When `Config.Policy` + `Config.GrantStore` are wired, the admin exposes a
 **role→permission matrix** at `<PathPrefix>/rbac/roles`. When
 `Config.Auth` is wired, it exposes a **user→role assignment** screen at
 `<PathPrefix>/rbac/users`. Both are behind the same admin default-deny gate
-as every other surface.
+as every other route.
 
 ```go
 policy := framework.NewRolePolicy()
@@ -194,7 +194,7 @@ screen is not mounted.
 
 ## Authorization
 
-Every admin surface is gated and **secure by default**: the battery
+Every admin page is gated and requires authentication by default: the battery
 requires an authenticated user that holds the **admin role** (default
 `"admin"`). A user satisfies this when its `GetRoles() []string` includes
 the role — `battery/auth`'s `User` does. Anonymous callers get `401`;

--- a/framework/docs/content/agent-ready.md
+++ b/framework/docs/content/agent-ready.md
@@ -5,8 +5,8 @@ look for a small set of well-known discovery artifacts before they can use a
 site: a curated `/llms.txt`, an A2A agent card, sitemap + robots, `Link`
 response headers pointing at all of it, and markdown content negotiation.
 GoFastr already ships the *plumbing* — MCP tools, an OpenAPI spec, per-screen
-markdown docs, sitemap, robots — so the agent-readiness surface is mostly the
-*discovery* layer that makes those capabilities findable.
+markdown docs, sitemap, robots — so getting agent-ready mostly means adding
+the *discovery* layer that makes those capabilities findable.
 
 Every piece below is **opt-in and additive**: existing robots/sitemap/openapi/
 llm.md behavior is unchanged. Turn the sane defaults on in one call, or wire
@@ -128,7 +128,7 @@ available. Requests without the `Accept` header are unaffected.
 `framework.WithMCP()` exposes `app.MCP` at `/mcp` over Streamable HTTP (POST
 JSON-RPC + GET Server-Sent Events), replacing the manual
 `fwApp.Router().Handle("POST", "/mcp", fwApp.MCP)`. Combined with
-`WithMCPIntrospection()`, the server's ten introspection tools —
+`WithMCPIntrospection()`, the ten tools that read the running app's state —
 `app_routes`, `app_plugins`, `app_batteries`, `app_modules`, `app_config`,
 `app_readiness`, `app_routines`, `framework_docs_list`, `framework_docs_get`,
 `framework_docs_search` — are reachable at the canonical endpoint the
@@ -141,9 +141,9 @@ both options wired.
 running app (persisted through the module store, dependency-checked). Keep
 it off any `/mcp` reachable by untrusted callers.
 
-Auth on the tool surface splits by kind: entity CRUD tools re-dispatch
+Auth splits by tool kind: entity CRUD tools re-dispatch
 through the router, so session/JWT auth, owner scoping, and RBAC apply
-exactly as over HTTP (the caller's Cookie/Authorization from the `/mcp`
+exactly as they do over HTTP (the caller's Cookie/Authorization from the `/mcp`
 request carries through). Directly registered tools — custom
 `app.MCP.RegisterTool` handlers and `Endpoint.MCPHandler` twins — run
 without route middleware; gate them per-caller with `mcp.Gated` +
@@ -310,7 +310,7 @@ origin and every artifact stays consistent, including behind a proxy that sets
 
 ## Granular options
 
-| Option | Surface |
+| Option | Serves |
 |---|---|
 | `uihost.WithAgentReady(cfg)` | Bundle: llms.txt + card + AI-bot robots + Link headers (incl. OpenAPI `service-desc` when `cfg.OpenAPIEndpoint` is set, e.g. `"/openapi.json"`). |
 | `uihost.WithLLMsTxt(title, summary, sections)` | `/llms.txt` only. |
@@ -333,7 +333,7 @@ origin and every artifact stays consistent, including behind a proxy that sets
   does *not* mount MCP for you — call `framework.WithMCP()` alongside it.
 - **Advertising markdown negotiation without `WithPublicLLMMD`.**
   `WithMarkdownNegotiation` renders via the per-screen LLM doc, which only
-  exists when the markdown surface is public. Without it, the negotiated
+  exists when markdown rendering is public. Without it, the negotiated
   response falls through to HTML.
 - **Hand-writing per-route `/llm.md` links in `/llms.txt`.** Non-screen routes
   (`/api/*`, `/healthz`, `/.well-known/*`) have no markdown — link the

--- a/framework/docs/content/api-versioning.md
+++ b/framework/docs/content/api-versioning.md
@@ -9,7 +9,7 @@ projections and deprecation headers. Pick the smallest one that fits.
 - **Versions that deprecate, sunset, and reshape payloads** → the
   experimental `framework/experimental/apiversions` package.
 
-The prefix flows through *every* surface GoFastr generates — REST routes,
+The prefix applies everywhere GoFastr generates paths — REST routes,
 the OpenAPI document, and the MCP tools — so a client, an SDK generator,
 and an AI agent all see the same paths.
 
@@ -41,7 +41,7 @@ Input is normalised: `"api"`, `"/api"`, and `"/api/"` all become
 
 ### What the prefix touches
 
-| Surface | Behaviour under `WithAPIPrefix("/api/v1")` |
+| Where | Behaviour under `WithAPIPrefix("/api/v1")` |
 | --- | --- |
 | **REST routes** | mounted at `/api/v1/<table>` (list/get/create/update/delete, `_batch`, `_events`, …). |
 | **OpenAPI** (`/openapi.json`) | the prefix is expressed as the spec's **server URL** (`servers: [{ url: "/api/v1" }]`); operation paths stay bare (`/posts`). Generated SDKs prepend the server URL, so they call `/api/v1/posts`. |
@@ -84,7 +84,7 @@ date, reshape payloads between versions) use the **experimental**
 and adds the version-lifecycle pieces.
 
 > **Status:** experimental. The API may change; it lives under
-> `framework/experimental/` and is not part of the stable surface.
+> `framework/experimental/` and is not part of the stable API.
 
 ### Mount a version and deprecate it
 
@@ -162,7 +162,7 @@ for that version, so `v1` clients never see `summary`.
   via a middleware or reverse-proxy rewrite, update `AppConfig.OpenAPIServers`
   to match — otherwise SDK generators and agents read incorrect base paths.
 - **Using the `apiversions` package in stable production without pinning.**
-  The `framework/experimental/apiversions` package has an unstable API surface.
+  The `framework/experimental/apiversions` package has an API that can still change.
   Treat it like a preview: write tests that compile against the types you use
   so a breaking rename fails your build rather than silently misbehaving at
   runtime.

--- a/framework/docs/content/app-cli.md
+++ b/framework/docs/content/app-cli.md
@@ -5,8 +5,8 @@ client you distribute to *your* customers — the `stripe`/`gh` experience
 for the app you built. The output is a standalone, stdlib-only
 `package main` that imports exactly one thing: your generated
 `entities/client` package. Customers authenticate with a scoped API
-token minted in your app, and every entity gets the full CRUD surface
-plus batch operations and a live event stream.
+token minted in your app, and every entity gets the full set of CRUD
+operations plus batch operations and a live event stream.
 
 ```bash
 cd your-app        # the directory holding entities/

--- a/framework/docs/content/audit-deps.md
+++ b/framework/docs/content/audit-deps.md
@@ -9,9 +9,9 @@ of every call site, grouped by Go import path, sorted alphabetically.
 A malicious dependency that lands in your `go.mod` can run arbitrary Go
 code at process start. That's the same trust model as importing any Go
 package — `os.Exec`, `net.Dial`, file writes, and route hijacks are all
-available to it. The audit doesn't change that surface; it just makes
-the *most invisible* part of it visible: things that happen before
-`main()` runs.
+available to it. The audit doesn't change that attack surface; it just
+makes the *most invisible* part of it visible: things that happen
+before `main()` runs.
 
 In particular, the audit flags packages that contribute to GoFastr's
 global registries:

--- a/framework/docs/content/auth.md
+++ b/framework/docs/content/auth.md
@@ -9,7 +9,7 @@ password-reset code in.
 
 The lower-level primitives in `framework/auth` (argon2id, the typed
 `Guard`, dialect detection, the `TokenStore`) are dependencies of the
-plugins, not a parallel API surface. Apps wire `battery/auth`.
+plugins, not a second API to use directly. Apps wire `battery/auth`.
 
 ## Quickstart
 
@@ -367,7 +367,7 @@ ss.Create(ctx, sa)
 // then auth.IssueToken with OwnerKind: "service", OwnerID: sa.ID
 ```
 
-Service-account management has **no HTTP surface in v1** — create and
+Service-account management has **no HTTP endpoints in v1** — create and
 disable them from trusted server code (`SetDisabled`).
 
 ### Management endpoints (`TokensPlugin`)
@@ -545,7 +545,7 @@ users, total, err := mgr.ListUsers(ctx, auth.ListUsersOptions{
 `total` is the full row count (independent of the page), so a UI can
 render "showing 1–50 of 832". There is **no HTTP route** — call it
 from trusted server code (an admin handler you mount yourself), not
-the auth plugin surface.
+the auth plugin's routes.
 
 `ListUsers` type-asserts the configured `UserStore` for the optional
 `UserLister` interface. `EntityUserStore` implements it; a custom
@@ -636,7 +636,7 @@ client's expectations), set `AppConfig.JSONCase = "snake_case"`.
 
 ## Rate limiting
 
-Three independent surfaces:
+Three independent rate limits:
 
 ```go
 auth.AuthConfig{
@@ -694,7 +694,7 @@ auth.TwoFAConfig{ RateLimit: &auth.RateLimiterConfig{Store: shared} }
 ```
 
 One store instance can back every limiter: keys are namespaced by
-`RateLimiterConfig.Scope`, which each built-in surface defaults to a
+`RateLimiterConfig.Scope`, which each built-in limiter defaults to a
 distinct value (`login_ip`, `login_account`, `register`, `twofa`, …).
 A store error **fails closed** (denies with a short Retry-After) — an
 attacker must never lift the limit by degrading its backend. See
@@ -811,7 +811,7 @@ refresh grant (Google does), so the stored refresh token is retained.
 actually issues a refresh token.
 
 `RefreshOAuthToken` errors when no refresh token is stored — the user must
-re-authenticate. **Security-sensitive surface:** route changes here through
+re-authenticate. **Security-sensitive code:** route changes here through
 the auth audit gate before merge.
 
 ## OIDC (any compliant IdP)

--- a/framework/docs/content/batch-endpoints.md
+++ b/framework/docs/content/batch-endpoints.md
@@ -1,9 +1,9 @@
 # Batch endpoints
 
-Every entity with `CRUD` enabled exposes three transactional batch
-endpoints under the `_batch` suffix. All items in a single request
-share one database transaction: the first per-item failure rolls back
-the entire transaction.
+Any entity with `CRUD` enabled gets three transactional batch
+endpoints under the `_batch` suffix. All items in one request run in
+a single database transaction: the first per-item failure rolls back
+the whole transaction.
 
 ## Routes
 
@@ -31,21 +31,22 @@ the entire transaction.
 - The first per-item failure populates `error` (and optionally
   `fields` for validation failures) on that index. Later indices are
   marked `"skipped": true`.
-- Earlier successes still have their `data` recorded for diagnostic
-  purposes, but `committed: false` means nothing was persisted.
+- Earlier successes still show their `data` so you can see what
+  would have happened, but `committed: false` means none of it was
+  saved.
 
 ## Limits
 
-- `MaxBatchSize = 100` items per request. Exceeding it returns
+- `MaxBatchSize = 100` items per request. Go over that and you get
   `400 Bad Request` before any item runs.
-- `items` (or `ids`) cannot be empty.
+- `items` (or `ids`) can't be empty.
 
 ## Behaviour & guarantees
 
 - **Atomic.** One transaction; one commit or one rollback.
 - **Hooks run inside the transaction.** `BeforeCreate`, `AfterUpdate`,
   etc. fire per item. A hook error rolls back the whole batch.
-- **Events fire only on commit.** `entity.created` etc. emit after a
+- **Events fire only on commit.** `entity.created` etc. fire after a
   successful commit, in input order, one per item — never on rollback.
 - **No partial success.** If you need "skip failures and keep the
   rest", make `MaxBatchSize` individual calls instead.
@@ -75,11 +76,11 @@ curl -X DELETE http://localhost:8080/posts/_batch \
 
 ## Common mistakes
 
-- **Treating a non-committed response as a 200.** It returns 400.
-  Inspect `committed` before trusting `results[*].data`.
+- **Treating a non-committed response as a 200.** It's a 400. Check
+  `committed` before you trust `results[*].data`.
 - **Counting on event ordering across batches.** Within a batch,
-  events fire in input order. Across overlapping batches, ordering is
-  determined by transaction commit order — not predictable.
-- **Sending more than 100 items.** Split client-side.
+  events fire in input order. Across overlapping batches, order
+  depends on transaction commit order — don't count on it.
+- **Sending more than 100 items.** Split it client-side.
 - **Mixing batch and per-item requests in a saga.** Mixing makes
   rollback semantics ambiguous. Pick one.

--- a/framework/docs/content/benchmarks.md
+++ b/framework/docs/content/benchmarks.md
@@ -1,8 +1,8 @@
 # Benchmarks
 
 GoFastr ships a tiered set of Go benchmarks. Each tier maps to a category
-of claim or hot path; together they exercise the surfaces the README
-advertises against both SQLite and Postgres.
+of claim or hot path; together they exercise the parts of the framework
+the README makes claims about, against both SQLite and Postgres.
 
 ## Tiers
 
@@ -102,8 +102,8 @@ network round-trips dominate.
 
 ### 1.4 Streaming vs buffered
 **Known caveat:** `parsePagination` clamps `?limit=` to ≤100, so the
-streaming surface's intended workload (`limit ≥ streamListThreshold =
-1000`) is not reachable from the HTTP surface. The benchmark therefore
+workload streaming is meant for (`limit ≥ streamListThreshold =
+1000`) can't be reached over HTTP. The benchmark therefore
 exercises streaming at limit=100, which measures the per-row encode/write
 overhead but does not show the bounded-memory advantage. Worth fixing.
 
@@ -196,7 +196,7 @@ What to look for:
 Hand-rolled `net/http` + `database/sql` implementations of plaintext,
 JSON, single-query, and filtered list endpoints — paired with the same
 endpoints expressed through the framework. The delta is what the
-declare-once surface actually costs.
+declare-once style actually costs.
 
 What to look for:
 
@@ -210,9 +210,9 @@ What to look for:
 
 ## Tier 9 — UI runtime: streams, islands, full SSR
 
-The framework's value proposition isn't just JSON CRUD — it's the
-SSR-with-hydration runtime, the SSE/island plumbing, and the UI host.
-These benchmarks measure those paths.
+The framework does more than JSON CRUD: it also has an SSR-with-hydration
+runtime, SSE/island plumbing, and a UI host. These benchmarks measure
+those paths.
 
 | Bench | Workload |
 |-------|----------|
@@ -263,11 +263,11 @@ LOAD=500 make bench-resources    # override
 
 Three bench apps under `benchmarks/apps/<name>/`:
 
-| App       | Surface                                                              |
+| App       | What it uses                                                          |
 |-----------|----------------------------------------------------------------------|
 | `minimal` | `NewApp` + one plaintext route. No DB, no entities. Establishes the floor. |
 | `crud`    | One entity, SQLite + auto-migrate + CRUD routes.                     |
-| `full`    | Upper bound — every supported framework surface wired on: three related entities with relations, audit log, cron, MCP, UI host + one screen, file storage, in-memory search backend, RolePolicy + RequirePermission, multi-tenant scope, custom endpoints, plugin, OpenAPI + Swagger UI, lifecycle hooks. |
+| `full`    | Upper bound — every supported framework feature wired on: three related entities with relations, audit log, cron, MCP, UI host + one screen, file storage, in-memory search backend, RolePolicy + RequirePermission, multi-tenant scope, custom endpoints, plugin, OpenAPI + Swagger UI, lifecycle hooks. |
 
 Plus the two cmd binaries (`gofastr`, `kiln`) for build-only comparison.
 
@@ -286,7 +286,7 @@ Output is Markdown to stdout and `dist/bench/resources.md`:
   driver. Switching to a pure-Go driver (`modernc.org/sqlite`) would
   cut this in half but slow the binary a few %.
 - **Bin size delta `full` − `crud`** is what every other framework
-  surface costs at once: UI host, file storage, search backend, audit,
+  feature costs at once: UI host, file storage, search backend, audit,
   cron, MCP, access control, multi-tenant, OpenAPI/Swagger, plugins.
   About **+0.6 MB** total — they're code paths inside the framework
   and its sibling packages, not separate binaries' worth of code.

--- a/framework/docs/content/blueprints.md
+++ b/framework/docs/content/blueprints.md
@@ -1,10 +1,10 @@
 # Blueprints
 
-A `gofastr.yml` blueprint is GoFastr's single declaration format. It is a
-CLI codegen *on-ramp* — declare your entities, screens, nav, seed
-data, and endpoint/middleware stubs in one file, then scaffold owned Go from
-it. The blueprint is not a source of truth: after scaffolding, the generated
-Go is canonical and you can delete `gofastr.yml`. Generate with:
+A `gofastr.yml` blueprint is an optional way to scaffold a GoFastr app:
+declare your entities, screens, nav, seed data, and endpoint/middleware
+stubs in one file, then generate owned Go from it. The blueprint is not
+a source of truth: after scaffolding, the generated Go is canonical and
+you can delete `gofastr.yml`. Generate with:
 
 ```bash
 gofastr validate gofastr.yml
@@ -44,7 +44,7 @@ The blueprint scaffolds a working app, then gets out of the way. This table
 is what it produces *today* — everything else is ordinary owned Go you write
 against the framework (the emitted code is the starting point, not a ceiling).
 
-| Surface | Generated from the blueprint | Hand-written Go |
+| Area | Generated from the blueprint | Hand-written Go |
 |---|---|---|
 | **Marketing pages** | `hero`, `page_header`, `card`, `pricing`, `stat_row`, `callout`, `markdown`, `link_button` blocks composed from `framework/ui`; auth-aware header | Any bespoke section not in the block catalog |
 | **Auth** | Register/login/logout/me wiring, session middleware, `login_form`/`signup_form` screens, guest-only redirects, bootstrap admin | Custom auth flows (SSO, MFA policy, email verification UX) |
@@ -266,13 +266,13 @@ screens/endpoints/middleware/plugins through `RegisterGenerated` (in
 `app.go`, same `package main`), mounts the UI host, and serves
 `app.static_dir` through the generated UI host.
 
-The generated app is agent-ready out of the box: `framework.WithMCP()`
-mounts `/mcp` (POST JSON-RPC + GET SSE) plus the discovery well-knowns
+The generated app mounts MCP by default: `framework.WithMCP()` mounts
+`/mcp` (POST JSON-RPC + GET SSE) plus the discovery well-knowns
 (`/mcp/server-card`, `/.well-known/mcp/server-card.json`,
 `/.well-known/mcp/catalog.json`), serving the per-entity CRUD tools
 (`mcp: true`) alongside the `framework.WithMCPIntrospection()` set
-(`app_routes`, `app_readiness`, `framework_docs_search`, …). The
-introspection tools are read-only but reveal the app's shape — remove
+(`app_routes`, `app_readiness`, `framework_docs_search`, …). Those tools
+are read-only but let a caller read the app's routes and config — remove
 `WithMCPIntrospection()` from `main.go` if `/mcp` is reachable by
 untrusted callers in production.
 
@@ -437,10 +437,10 @@ gofastr pack examples/meridian -o recovered.yml
 
 Synthesized `/new` + `/{id}/edit` form screens are dropped (they weren't
 authored). Generate and pack are a matched inverse pair for the declarative
-surface — `app`, `entities`, `screens`, `nav`, and `seed` — so the invariant
+pieces — `app`, `entities`, `screens`, `nav`, and `seed` — so the invariant
 `parse(yml)` ≡ `parse(pack(generate(yml)))` holds for a blueprint of those
-constructs (modulo comments + formatting); the Meridian flagship round-trips
-exactly, gated by a test. When you add a new construct in that surface, teach
+constructs (modulo comments + formatting); the Meridian example round-trips
+exactly, gated by a test. When you add a new construct to that set, teach
 **both** the generator and pack, or that test fails.
 
 `endpoints`, `middleware`, `plugins`, and `helpers` are **not** recovered by
@@ -487,7 +487,7 @@ entity's `screen_<entity>_crud.go` mount func (run via `mountGenerated`), from
 that entity's `CrudHandler`, fields, and relations — see [Generated screen
 files](#generated-screen-files). `appBaseCSS()` (mounted
 ahead of `static/app.css`) is an owned, empty-by-default extension point for
-app-specific base CSS — every generated surface composes `framework/ui`
+app-specific base CSS — every generated screen composes `framework/ui`
 components and `core-ui/app` layouts that ship their own styling, so the
 generator itself emits zero bespoke CSS.
 
@@ -521,7 +521,7 @@ When any entity declares an `access:` block, its auto-CRUD API is permission-gat
 `access.RolePolicy` that grants the **admin role** (`app.admin.role`) the wildcard
 (`*`) and an `access.Middleware` that resolves the signed-in user's roles, mounted
 after the session middleware. The admin operator can therefore manage every entity
-through its own gated API (the same surface the back-office uses); add finer
+through its own gated API (the same API the back-office uses); add finer
 per-role `Grant`s in `RegisterGenerated` as you define more roles.
 
 ### UI component blocks (the framework/ui catalog)
@@ -538,9 +538,9 @@ The layout blocks map directly to `framework/ui`: `stack` and `cluster` accept
 semantic `gap`, `align`, and `justify` props (`cluster` also accepts
 `no_wrap`); `grid` accepts `min` and `gap`; `stat_grid` is the dashboard grid
 variant with a `12rem` default minimum. Spacing must use the shared
-`none|xs|sm|md|lg|xl|2xl` tokens—blueprints do not create a second CSS surface.
+`none|xs|sm|md|lg|xl|2xl` tokens—blueprints do not create a second styling system.
 
-**Long-form content** — `markdown` renders rich prose (`ui.Markdown`) from a
+**Long-form content** — `markdown` renders formatted prose (`ui.Markdown`) from a
 `text:` string (headings, **bold**, lists, etc.) at a readable measure; the plain
 `type: heading` / `type: paragraph` blocks are also typeset to a comfortable
 column on marketing pages. **Pricing** — a `pricing` block takes
@@ -661,7 +661,7 @@ endpoints mounted under `base_path`. The generated app also mounts
 `auth.SessionMiddleware` on the router, so the session cookie issued at
 login resolves to a user on every request — this is what makes
 `owner_field` and `access` scoping work for logged-in users on the
-generated CRUD/MCP surface. Without a valid session, owner-scoped
+generated CRUD and MCP endpoints. Without a valid session, owner-scoped
 entities fail closed (401/403) for reads and writes alike.
 
 The generated app also wires the **auth UX** so the session is reflected
@@ -691,7 +691,7 @@ generated app commits no credentials:
   no admin is seeded)
 
 When the blueprint holds any of these values, the generator also emits a
-`.env` carrying them (so the app runs out of the box) plus a
+`.env` carrying them (so the app runs without extra setup) plus a
 `.gitignore` that excludes it. The generated `main.go` loads
 `.env.local`/`.env` before opening the DB; a real process env var
 always wins over the files. `generate` is one-shot and refuses to
@@ -731,7 +731,7 @@ development.
 
 #### CSRF
 
-The generated app does **not** mount `auth.CSRF`. The generated surface
+The generated app does **not** mount `auth.CSRF`. The generated API
 is JSON-first (REST CRUD + `/mcp`), and the CSRF middleware rejects any
 unsafe-method request that doesn't echo the CSRF cookie back as an
 `X-CSRF-Token` header (or `_csrf` form field) — plain JSON and MCP
@@ -975,7 +975,7 @@ fields (names containing tokens like `email`, `phone`, `address`, `ssn`,
 every *authenticated* user could read and write every other user's row on
 the generated API (the secure-by-default gate already stops anonymous
 callers — the exposure here is cross-user). Enabling `app.auth` alone does
-**not** suppress the rule: a session is necessary to reach the surface but
+**not** suppress the rule: a session is necessary to reach the API but
 not sufficient to scope it — only per-entity scoping does that.
 `gofastr validate` reports this as an error (exit 1),
 naming the entity, the matched fields, and the remedies; `gofastr generate`
@@ -1010,8 +1010,8 @@ the app-generator boundary.
 ### Generated `e2e_test.go` is driver- and OS-portable
 
 Every generated app ships an `e2e_test.go` (gated by `-short`) that builds the
-binary, boots it as a child process, and drives the real HTTP surface. Two
-portability rules are baked into that template:
+binary, boots it as a child process, and drives the real HTTP endpoints. Two
+portability rules are built into that template:
 
 - **Windows binary name.** The build target gets a `.exe` suffix when
   `runtime.GOOS == "windows"` so `exec.Command(bin)` resolves on Windows —
@@ -1035,14 +1035,14 @@ portability rules are baked into that template:
   restart. Before deploying, set `DevMode: false` **and** a real
   `JWTSecret` (from a secret manager) in the generated `app.go`
   `auth.AuthConfig` — the emitted code is yours, so edit it rather than
-  regenerating. Serve HTTPS. (If you'd rather bake it in *before* the
+  regenerating. Serve HTTPS. (If you'd rather set it *before* the
   one-shot generate, set `dev_mode: false` + `jwt_secret` in the
   blueprint — but `dev_mode: false` without `jwt_secret` fails
   validation, and the generated app's auth battery would refuse to boot.)
 - **Expecting `app.auth: enabled` to protect entity data.** The
   session middleware is pass-through for anonymous requests. Only
   per-entity `owner_field`, `access`, or `multi_tenant` gate the
-  generated CRUD/MCP surface — that's why the unscoped-PII check fires
+  generated CRUD and MCP endpoints — that's why the unscoped-PII check fires
   even with auth enabled.
 - **Writing flow-style inline maps.** `core/yaml` rejects
   `{name: x, type: relation}` — every map must be indented

--- a/framework/docs/content/codegen.md
+++ b/framework/docs/content/codegen.md
@@ -1,6 +1,6 @@
 # Codegen
 
-GoFastr code generation is driven by a general YAML configuration surface.
+GoFastr code generation is configured through a general YAML format.
 Generators are project extensions that consume structured sources and emit any
 generated code files under a safe output root. This is distinct from the
 [blueprint](blueprints.md) pipeline (`gofastr generate --from=gofastr.yml`),
@@ -50,7 +50,7 @@ codegen:
 is a subdirectory under that root. Generated paths must be relative and cannot
 contain parent traversal.
 
-Each generator names an `extension`, with one first-party exception: a
+Each generator names an `extension`, with one built-in exception: a
 generator entry named `sdk` (no `extension`) runs the built-in SDK
 generator — the same output as `gofastr generate sdk`; see the
 [sdk](sdk.md) doc. Use optional `id` when running the same generator more
@@ -87,7 +87,7 @@ External extensions let projects add arbitrary code generation without linking
 that code into the `gofastr` CLI.
 
 The old built-in `gofastr generate ts` / `gofastr generate typescript` command
-has been removed from this surface. Projects that need TypeScript or frontend
+has been removed. Projects that need TypeScript or frontend
 artifacts should configure a project extension and decide their own output
 shape rather than relying on a maintained built-in TypeScript target.
 

--- a/framework/docs/content/comparison.md
+++ b/framework/docs/content/comparison.md
@@ -1,88 +1,96 @@
 # Comparison — where GoFastr sits
 
-GoFastr's claim, stated narrowly: **one blueprint becomes a
-server-rendered UI and a REST API with secure scopes — generated as
-plain Go you read, commit, and own.** Several excellent tools cover
-parts of that sentence; as far as we can tell, none in the Go ecosystem
-covers all of it. This page maps the neighbours honestly — including
+GoFastr is a Go framework: `framework/` and `framework/ui/`, built on
+stdlib-first primitives in `core/` and `core-ui/`. One part of it is a
+`gofastr.yml` blueprint — an optional scaffolder that turns a schema
+into a server-rendered UI and a REST API with scoped permissions,
+generated as plain Go you read, commit, and own. Several tools cover
+parts of that same job; as far as we can tell, none in the Go ecosystem
+cover all of it. This page maps the neighbours honestly — including
 the ways they are better — so you can pick the right tool, which is
 sometimes not this one.
 
 A note on "MCP tools from your schema": that was a differentiator in
 early 2025 and is table stakes now — Supabase ships an MCP server,
 PocketBase has community MCP servers, FastAPI has FastAPI-MCP. GoFastr
-generates MCP tools too, but that's supporting evidence, not the
-wedge. The wedge is the owned-codegen full-stack pipeline.
+generates MCP tools from entities too (on top of `core/mcp`, which any
+GoFastr app can use directly), but that's supporting evidence, not the
+main point of comparison here. What's different is the codegen
+pipeline that generates the whole stack and hands you the code to own.
 
 ## vs PocketBase
 
-**What PocketBase is:** a superb runtime BaaS — one prebuilt binary
-with embedded SQLite, an admin dashboard, auth, files, and realtime.
-You configure collections at runtime through the dashboard; you extend
-it by writing hooks (Go or JS) that run *inside* PocketBase's
-lifecycle.
+**What PocketBase is:** a runtime BaaS — one prebuilt binary with
+embedded SQLite, an admin dashboard, auth, files, and realtime. You
+configure collections at runtime through the dashboard; you extend it
+by writing hooks (Go or JS) that run *inside* PocketBase's lifecycle.
 
-**The difference in kind:** PocketBase is a host you configure;
-GoFastr is a scaffold-and-own generator plus library. A `gofastr.yml`
-blueprint scaffolds owned Go source (a flat `package main` — `main.go`,
-`app.go`, `screens.go` — plus `entities/`) that you commit, diff in code
-review, debug with a debugger, and refactor like any other package. There is no runtime schema
-store — and no canonical declaration you live inside: the blueprint is a
-one-way on-ramp you can delete once the code is yours, and the escape
-hatch is `net/http`, not a plugin API.
+**The difference in kind:** PocketBase is a host you configure.
+GoFastr generates Go source you then own: a `gofastr.yml` blueprint
+scaffolds a flat `package main` — `main.go`, `app.go`, `screens.go` —
+plus `entities/` — that you commit, diff in code review, debug with a
+debugger, and refactor like any other package. There's no runtime
+schema store and no canonical file you have to keep living inside: you
+generate once, then edit the Go directly, and you can delete the
+blueprint once the code is yours. If you want to drop below the
+framework, you write `net/http` — there's no plugin API to route
+around.
 
 **Choose PocketBase when** you want a backend in five minutes, the
-admin dashboard is the product, and you're happy living inside its
-extension points. It is more mature, far more battle-tested, and has a
-large community. **Choose GoFastr when** the output needs to be a Go
-codebase your team (or your agents) own and evolve — and you want the
-server-rendered UI generated from the same declaration as the API.
+admin dashboard is the product, and you're happy working inside its
+extension points. It's been in production longer, across more
+projects, and has a larger community. **Choose GoFastr when** the
+output needs to be a Go codebase your team (or your agents) can read
+and change directly — and you want the server-rendered UI generated
+from the same schema as the API.
 
 ## vs Encore.go
 
-**What Encore is:** a polished Go backend framework where
-infrastructure (Pub/Sub, cron, secrets, databases) is declared in code
-and provisioned by Encore's tooling, with excellent tracing and a
-dashboard. It's commercially backed and significantly more mature.
+**What Encore is:** a Go backend framework where infrastructure
+(Pub/Sub, cron, secrets, databases) is declared in code and provisioned
+by Encore's tooling, with tracing and a dashboard. It's commercially
+backed and more mature.
 
-**The difference in kind:** Encore's full value flows through its
-platform — its build system, its cloud/self-hosted runtime, its
-dashboard. GoFastr has no platform: `go build` emits a single static
-binary that runs anywhere a binary runs, and nothing phones home. The
-trade is real in both directions — Encore gives you provisioned infra
-and distributed tracing out of the box; GoFastr gives you zero
-coupling and a plain `go.mod`.
+**The difference in kind:** Encore's features depend on its platform —
+its build system, its cloud or self-hosted runtime, its dashboard.
+GoFastr has no platform: `go build` emits a single static binary that
+runs anywhere a binary runs, and it sends no telemetry. The trade-off
+is real in both directions: Encore sets up infrastructure and
+distributed tracing for you; GoFastr doesn't couple you to a platform
+and keeps a plain `go.mod`.
 
-**Also a scope difference:** Encore is backend-first; GoFastr
-generates the server-rendered UI (screens, nav, islands) from the same
-blueprint as the API. **Choose Encore when** you want managed-feeling
-infra and a mature toolchain. **Choose GoFastr when** you want nothing
-between your binary and your VPS.
+**Also a scope difference:** Encore is backend-first; GoFastr generates
+the server-rendered UI (screens, nav, islands) from the same blueprint
+as the API. **Choose Encore when** you want managed infrastructure and
+a mature toolchain. **Choose GoFastr when** you want nothing between
+your binary and your VPS.
 
 ## vs Wasp
 
-**What Wasp is:** the closest thing to the same thesis — a `main.wasp`
-declaration compiles to a full-stack app (auth, CRUD, jobs, email),
-and "the framework for the AI era" is literally their tagline. Wasp is
-more mature, has a team, a community, and production users.
+**What Wasp is:** the closest thing to the same approach — a
+`main.wasp` declaration compiles to a full-stack app (auth, CRUD, jobs,
+email), and "the framework for the AI era" is literally their tagline.
+Wasp is more mature, has a team, a community, and production users.
 
-**The difference in kind:** the generator philosophy, then the runtime
-model. Wasp (like Encore and Amplify) is a *canonical-declaration* tool —
-`main.wasp` *is* the program; you live in it and regenerate from it, and
-the emitted code is the tool's, not yours to hand-edit. GoFastr is
-*scaffold-and-own*: the blueprint is a one-way on-ramp that emits idiomatic
-Go you then own and edit; `generate` is one-shot and refuses to clobber an
-existing project (pass `--force` to regenerate), and you can delete the
-blueprint entirely once the code is yours. The trade is real — a canonical declaration promises "no
-drift" because there's one source; scaffold-and-own trades that for a
-plain Go codebase with no second language to grow into. On top of that
-sits the runtime difference: Wasp targets JS/TS — React SPA + Node +
-Prisma — while GoFastr is the Go counterpart: SSR-first HTML with island
-hydration instead of a client-side React app, one static binary instead of
-a Node deployment, `database/sql` instead of an ORM. If you're a
-TypeScript shop, Wasp is the obvious pick. If you want this thesis with
-Go's deployment story, compile-time guarantees, and owned output, that's
-the gap GoFastr exists to fill.
+**The difference in kind:** the generator model, then the runtime
+model. Wasp (like Encore and Amplify) is a *canonical-declaration*
+tool — `main.wasp` *is* the program; you live in it and regenerate
+from it, and the emitted code belongs to the tool, not to you to
+hand-edit. GoFastr scaffolds once and gets out of the way: the
+blueprint emits idiomatic Go you then own and edit directly; `generate`
+is one-shot and refuses to overwrite an existing project (pass
+`--force` to regenerate), and you can delete the blueprint entirely
+once the code is yours. The trade-off is real — a canonical
+declaration promises "no drift" because there's one source; GoFastr's
+approach trades that for a plain Go codebase with no second language to
+grow into. There's also a runtime difference: Wasp targets JS/TS —
+React SPA + Node + Prisma — while GoFastr is the Go counterpart:
+SSR-first HTML with island hydration instead of a client-side React
+app, one static binary instead of a Node deployment, `database/sql`
+instead of an ORM. If you're a TypeScript shop, Wasp is the obvious
+pick. If you want the same idea in Go — Go's deployment story,
+compile-time guarantees, and code you own — that's what GoFastr is
+for.
 
 ## vs hand-rolled Gin/Echo + sqlc
 
@@ -94,10 +102,10 @@ request validation, filtering/sorting/pagination math, batch
 endpoints, cursor paging, OpenAPI annotations kept in sync by hand, an
 MCP server if agents need tools, migrations, per-user scoping enforced
 in every query, RBAC checks in every handler, and any admin/UI layer.
-That glue is exactly what one entity declaration generates here — and
-because the output is plain Go on disk, "framework in the way" has the
-same exit as hand-rolling: delete the declaration, keep the code,
-write `net/http`.
+One entity declaration in `framework/entity` generates that glue — and
+because the output is plain Go on disk, dropping the framework costs
+the same either way: delete the declaration, keep the code, write
+`net/http`.
 
 **Choose hand-rolling when** the domain is small, the endpoints are
 few, or the requirements are unusual enough that generated CRUD is
@@ -112,32 +120,32 @@ would dominate the diff.
   the repo's own tooling, docs site, and the
   [`examples/meridian`](https://github.com/DonaldMurillo/gofastr/tree/main/examples/meridian)
   flagship — not by someone else's production traffic. This is a
-  thesis framework and says so.
+  young framework and says so.
 - **Solo maintainer.** Bus factor of one. Issues get read; SLAs don't
   exist.
 - **SQLite and Postgres only.** No MySQL, no MongoDB.
 - **No hosted anything.** No cloud, no dashboard-as-a-service, no
-  telemetry. That's a feature here, but if you want Encore's or
-  Supabase's managed experience, this isn't it.
+  telemetry. That's deliberate, but if you want Encore's or Supabase's
+  managed experience, this isn't it.
 - **Small community.** The docs are extensive and embedded in the
   binary (`gofastr docs`), but you won't find a thousand Stack
   Overflow answers.
 
-If those trade-offs read as disqualifying for your context, the tools
-above are genuinely good — use them. If they read as acceptable for a
-v0.x bet on owned, generated Go, start with the
+If those trade-offs are disqualifying for your context, the tools
+above are good — use them. If they're acceptable for a v0.x bet on Go
+you own, start with the
 [blueprint tutorial](tutorial-blueprint-app.md).
 
 ## Common mistakes
 
 - **Evaluating GoFastr as a BaaS.** There's no runtime collection
   editor; the blueprint is a compile-time scaffold input, not a live
-  schema store. And it isn't a source you keep round-tripping either —
-  once it scaffolds the owned Go, that Go is canonical; you edit it
-  directly and redeploy (you can delete the blueprint).
+  schema store. And it isn't something you keep regenerating from
+  either — once it scaffolds the Go, that Go is what you edit and
+  redeploy directly (you can delete the blueprint).
 - **Assuming MCP support is the differentiator.** It isn't anymore;
   most schema-bearing platforms expose MCP. Compare the codegen
-  pipeline and ownership story instead.
+  pipeline and the fact that you own the output instead.
 - **Comparing maturity 1:1.** Every alternative on this page is more
-  mature. The honest pitch is the wedge plus the trade-offs above, not
-  feature parity.
+  mature. The honest pitch is the difference above plus the
+  trade-offs above, not feature parity.

--- a/framework/docs/content/compute.md
+++ b/framework/docs/content/compute.md
@@ -7,9 +7,9 @@ the demand-loaded `compute` module dispatch structured-clone messages to it.
 Workers and Wasm bytes are served from same-origin, content-addressed URLs, so
 they remain compatible with the default CSP and immutable browser caching.
 
-## Public surface
+## Public API
 
-| Surface | Purpose |
+| API | Purpose |
 |---|---|
 | `compute.RegisterWorker(name string, js []byte)` | Register a classic, self-contained Worker script. |
 | `compute.RegisterWASM(name string, wasm []byte)` | Register WebAssembly bytes. |
@@ -247,8 +247,8 @@ with the app instead of pointing a worker at a CDN.
 
 `SharedArrayBuffer` and WebAssembly threads require cross-origin isolation,
 which means both COOP and COEP. GoFastr sets COOP to `same-origin` but does not
-enable COEP. Shared memory and Wasm threads are therefore unavailable on this
-surface. No COEP header is added by compute registration.
+enable COEP. Shared memory and Wasm threads are therefore unavailable here.
+No COEP header is added by compute registration.
 
 ## Common mistakes
 

--- a/framework/docs/content/dev-livereload.md
+++ b/framework/docs/content/dev-livereload.md
@@ -67,18 +67,18 @@ need to forward, set, or check the flag — it's transparent.
 
 ## The dev loop is also livereload for agents
 
-The same `GOFASTR_DEV` gate auto-enables the MCP agent surface:
-`framework.NewApp` mounts `/mcp` (skipping, with a warning, if the host
-hand-mounted one), registers the read-only introspection tools
-(`app_routes`, `app_readiness`, `framework_docs_search`, …) and the
-mutating control tools (`app_module_enable` / `app_module_disable`);
-every CRUD-enabled entity serves its MCP data tools without per-entity
+The same `GOFASTR_DEV` gate turns on MCP for agents: `framework.NewApp`
+mounts `/mcp` (skipping, with a warning, if the host hand-mounted one),
+registers read-only tools for reading the running app's state
+(`app_routes`, `app_readiness`, `framework_docs_search`, …) and tools
+that change it (`app_module_enable` / `app_module_disable`); every
+CRUD-enabled entity serves its MCP data tools without per-entity
 `mcp: true`; and battery/log — when registered — enables its
 `log_recent` / `log_filter` / `log_metrics` / `log_set_level` debug
-tools. A connected agent can orient, read recent requests and errors,
-read and write app data, and toggle modules on the running dev app
-with zero wiring. See [agent-ready](agent-ready.md). Opt out with
-`GOFASTR_DEV_MCP=0`.
+tools. A connected agent can check what's running, read recent
+requests and errors, read and write app data, and turn modules on or
+off on the running dev app without extra setup. See
+[agent-ready](agent-ready.md). Opt out with `GOFASTR_DEV_MCP=0`.
 
 ## Opting out
 
@@ -86,7 +86,7 @@ with zero wiring. See [agent-ready](agent-ready.md). Opt out with
 # Keep rebuild-on-save but disable browser refresh:
 GOFASTR_DEV_LIVERELOAD=0 gofastr dev
 
-# Keep rebuild + refresh but disable the dev MCP agent surface:
+# Keep rebuild + refresh but disable the dev MCP tools:
 GOFASTR_DEV_MCP=0 gofastr dev
 ```
 

--- a/framework/docs/content/embed.md
+++ b/framework/docs/content/embed.md
@@ -1,16 +1,16 @@
 # Embed — local semantic search
 
-`battery/embed` adds vector-based semantic retrieval to any GoFastr app. It is positioned next to `battery/search` (keyword) and `battery/cache`: one Go API, one HTTP surface, one CLI subcommand, one Kiln integration hook.
+`battery/embed` adds vector-based semantic retrieval to any GoFastr app. It sits alongside `battery/search` (keyword) and `battery/cache`: one Go API, one set of HTTP routes, one CLI subcommand, one Kiln integration hook.
 
 This doc covers the architecture, persistence, watcher, hybrid pipeline, and the agent integration. For the package-level cheatsheet and file map, see [`battery/embed/README.md`](../battery/embed/README.md).
 
-## Why this lives in the framework
+## Why this is in-process by default
 
-GoFastr's bet is that AI-era apps want retrieval as a primitive, not as a service. Three properties follow:
+Retrieval runs in the same process as your app, instead of requiring a separate vector DB or embedding service. A few things follow from that:
 
 - **In-process by default.** No vector DB, no embedding service. The default index runs in the same process as your routes, hooks, and Kiln agent.
 - **Pure-Go core.** Brute-force cosine, gob snapshot, polling watcher — no third-party deps in the core path. The only optional CGO is the ONNX runtime that drives the default embedder in M1.5.
-- **Composable surfaces.** Go API for in-app use; HTTP routes for cross-process/cross-host; CLI for ops; Kiln hook for agent context. The same index serves all four.
+- **Four entry points, one index.** Go API for in-app use; HTTP routes for cross-process/cross-host; CLI for ops; Kiln hook for agent context. The same index serves all four.
 
 ## Architecture
 
@@ -136,7 +136,7 @@ gofastr embed clear
 
 When `GOFASTR_URL` is set, `query` and `stats` are dispatched to that running server's `/embed/*` routes. `index`, `watch`, and `clear` are always local — they mutate state and we don't want two writers fighting for the same file.
 
-## HTTP surface
+## HTTP routes
 
 | Method | Path | Body | Status |
 | --- | --- | --- | --- |
@@ -236,7 +236,7 @@ if err := embedder.Probe(ctx); err != nil {
 
 ## Durable store (pgvector)
 
-The default [FlatStore] is in-process: fast, zero-dep, and the right choice for a single-replica app. Its limitation (called out above under "Why this lives in the framework") is that the index lives in one process's RAM. When you need a **shared, durable** index — multiple app replicas hitting the same vectors, or survival across restarts with no snapshot/WAL plumbing — use `PgVectorStore`, a [Store] backed by a Postgres table with a [pgvector](https://github.com/pgvector/pgvector) embedding column.
+The default [FlatStore] is in-process: fast, zero-dep, and the right choice for a single-replica app. Its limitation (called out above under "Why this is in-process by default") is that the index lives in one process's RAM. When you need a **shared, durable** index — multiple app replicas hitting the same vectors, or survival across restarts with no snapshot/WAL plumbing — use `PgVectorStore`, a [Store] backed by a Postgres table with a [pgvector](https://github.com/pgvector/pgvector) embedding column.
 
 ```go
 embedder := embed.NewOllamaEmbedder(embed.OllamaConfig{Model: "nomic-embed-text"})

--- a/framework/docs/content/entity-declarations.md
+++ b/framework/docs/content/entity-declarations.md
@@ -280,7 +280,8 @@ entities:
 
 `gofastr generate` prints a warning at the end of every run listing every
 entity left publicly readable/writable (i.e. every `public: true`
-declaration), so the open surface of a generated app is never silent.
+declaration), so a generated app's public entities are never a silent
+surprise.
 
 `gofastr dev`'s auto-registered entity MCP tools (and any `mcp: true`
 entity in production) dispatch through the same router + middleware chain
@@ -442,7 +443,7 @@ policy says yes.
 
 **Read-only.** `CrossOwnerRead` never touches Create/Update/Delete —
 those stay owner-scoped. A staff member can *see* every ticket but
-cannot PUT/PATCH/DELETE another user's row through the auto-CRUD surface.
+cannot PUT/PATCH/DELETE another user's row through auto-CRUD.
 Cross-user writes still return 404. Multi-tenant isolation is also
 preserved: a granted context in tenant A never sees tenant B rows.
 
@@ -619,8 +620,8 @@ This scaffolds the owned entity package into `entities/` at the module root:
   constants, typed repository, lifecycle subscriptions, and its own
   `app.Entity(...)` registration that self-registers via `init()`. A new
   entity is a new file; existing files are never rewritten.
-- `client/client.go` with a standalone Go HTTP client covering the full
-  CRUD surface per entity: list/get/create/update/patch/delete, the
+- `client/client.go` with a standalone Go HTTP client covering every
+  CRUD operation per entity: list/get/create/update/patch/delete, the
   atomic `_batch` endpoints (`BatchCreate<Entity>` /
   `BatchUpdate<Entity>` / `BatchDelete<Entity>`, returning the
   `{committed, results[]}` envelope even on rollback), and the live

--- a/framework/docs/content/events.md
+++ b/framework/docs/content/events.md
@@ -268,7 +268,7 @@ handler)` + `ob.StartRelay(ctx)`.
   parents). **Delivery to consumers is unaffected and prompt** — only the
   parent's `dispatched` bookkeeping (and retention/GC) lags by the grace.
 - **Dead-letter & replay.** A delivery that returns an error **or
-  panics** (the relay surfaces a panicking consumer as a delivery error
+  panics** (the relay reports a panicking consumer as a delivery error
   rather than swallowing it) increments its `attempts` and schedules an
   exponential backoff. After `MaxAttempts` (default 10) it is marked
   `dead`. `Replay(rowID)` resets all dead/abandoned deliveries of a row;

--- a/framework/docs/content/feature-flags.md
+++ b/framework/docs/content/feature-flags.md
@@ -1,10 +1,10 @@
 # Feature flags
 
-`core/featureflag` is GoFastr's feature-flag primitive — small enough
-to stay in-process, expressive enough to gate the cases that come up in
-real shipping: global kill switches, percentage rollouts, per-user
-overrides for beta testers, per-tenant enablement for design partners,
-and per-environment restriction so a staging-only flag never reaches
+`core/featureflag` is GoFastr's feature-flag package. It stays
+in-process and covers the cases that come up in real projects: global
+kill switches, percentage rollouts, per-user overrides for beta
+testers, per-tenant enablement for design partners, and
+per-environment restriction so a staging-only flag never reaches
 production.
 
 The package is named `featureflag` to avoid colliding with the standard

--- a/framework/docs/content/first-run.md
+++ b/framework/docs/content/first-run.md
@@ -33,8 +33,8 @@ file, so a crash mid-setup simply re-enters setup on the next boot.
 ## The interactive skin
 
 When setup is incomplete and required values are missing from the
-environment, `Start` binds the port but serves a **setup surface**
-instead of the app router: the SSR wizard (composed from the design
+environment, `Start` binds the port but serves setup pages instead
+of the app router: the SSR wizard (composed from the design
 system — `AuthCard`, `ProgressSteps`, `FormField`), plus `/healthz`
 and `/readyz`. Every other path answers 503 "setup required" — no
 entity CRUD, no OpenAPI, no admin, nothing reachable before bootstrap.

--- a/framework/docs/content/form-module.md
+++ b/framework/docs/content/form-module.md
@@ -1,6 +1,6 @@
 # Form Module
 
-Complete form infrastructure for GoFastr — HTML primitives, framework UI components, form patterns, validation, and accessibility.
+Form components for GoFastr: HTML primitives, framework UI components, form patterns, validation, and accessibility.
 
 ## Components
 
@@ -140,7 +140,7 @@ All components pass **axe-core 4.10** with zero violations:
 
 ## Demo Page
 
-`/components/forms` — comprehensive demo showcasing every form component with live examples, validation round-trip, and accessible markup.
+`/components/forms` — demo page showing every form component with live examples, validation round-trip, and accessible markup.
 
 ## Common mistakes
 

--- a/framework/docs/content/harness-architecture.md
+++ b/framework/docs/content/harness-architecture.md
@@ -43,7 +43,7 @@ engine itself knows about *clients*, never about transports.
   decisions is acknowledged and accepted.
 - **No bundled language-model SDK.** Raw HTTP per provider.
 - **No vendor-specific instruction format as primary.** AGENTS.md
-  and SKILL.md are the canonical surfaces; CLAUDE.md, .cursorrules,
+  and SKILL.md are canonical; CLAUDE.md, .cursorrules,
   GEMINI.md, .windsurfrules, .github/copilot-instructions.md are
   read if present and appended, never the source of truth.
 - **No "MVP-shaped" cut corners that would block a later
@@ -54,21 +54,21 @@ engine itself knows about *clients*, never about transports.
   dogfooded web client. The harness lives in the GoFastr monorepo
   and ships at the same SHA as the framework. Framework changes
   that break the web client are fixed in the same PR; the harness
-  is a first-class consumer of `framework/`, not a downstream pin.
+  is a direct consumer of `framework/`, not a downstream pin.
 
 ---
 
 ## Hard rules
 
 1. **The agent loop contains orchestration only.** No provider-specific
-   code, no surface-specific code, no profile-specific code, no skill
+   code, no transport-specific code, no profile-specific code, no skill
    business logic. If a behavior can be expressed as middleware, an
    event subscriber, or a plugin registration, it lives outside the
    loop. No exceptions.
 2. **No third-party imports.** Stdlib and `golang.org/x/*` only. The
    single import boundary is enforced by `go.mod` review and by the
    `harness/internal/depscheck` build tag.
-3. **AGENTS.md is the primary project-instruction surface.** Vendor
+3. **AGENTS.md is the primary source of project instructions.** Vendor
    files are additive fallbacks read by separate `ContextSource`
    implementations.
 4. **SKILL.md is the primary skill format.** Three-tier progressive
@@ -634,7 +634,7 @@ Typed pub/sub. Every interesting state change emits an event:
 | `MCPServerDown` | an MCP server gave up after exhausting restart budget; its tools entered degraded state. |
 | `SessionEnded` | engine shutdown reason (`idle`, `user`, `error`, `binary-shutdown`). |
 
-Surfaces, hooks, plugins, and the cost dashboard all subscribe.
+Clients, hooks, plugins, and the cost dashboard all subscribe.
 
 ### 4. Pluggable backends
 
@@ -742,8 +742,8 @@ path (Copilot 401 → OpenRouter with same model name) is pre-wired.
 ### Internal canonical message shape
 
 The engine works in an Anthropic-shape canonical form (it's the most
-expressive: tool_use/tool_result are first-class, content blocks are
-typed). Each provider adapter translates outbound and inbound. **Two
+expressive: tool_use/tool_result are modeled as full content blocks,
+and every content block is typed). Each provider adapter translates outbound and inbound. **Two
 honest limits on this canonicalization:**
 
 - **Thinking / reasoning blocks are provider-bound.** Anthropic
@@ -929,7 +929,7 @@ same scenarios (send / cancel / permission / disconnect / reconnect /
 multi-attach) against every transport so cross-transport drift gets
 caught early.
 
-### REST surface
+### REST API
 
 A handful of resources, JSON bodies, idempotent where possible:
 
@@ -959,7 +959,7 @@ GET    /v1/auth/token                        Issue capability token (when runnin
 mode (`?wait=turn`) or the streaming default (returns 202; events
 flow via SSE).
 
-### WebSocket surface
+### WebSocket API
 
 A single endpoint:
 
@@ -976,7 +976,7 @@ Bidirectional. Frames are tagged JSON:
 
 Reconnect resumes from a `lastEventId` query param.
 
-### MCP-server surface
+### MCP server API
 
 The harness exposes its own engine as an MCP server so any
 MCP-capable client (Claude Code, Codex, Cursor, custom agents, the
@@ -1052,16 +1052,16 @@ with a `skill: <name>` directive to run the skill inside the harness.
 
 #### Why this matters
 
-The interesting capability isn't "another way to attach a UI." It's
-**agent-driving-agent**: an outer agent (e.g. Claude Code in a
-different repo) can invoke `harness.run_agent_with_shell_access` and
-treat a whole harness session as a single capability. Composes
-naturally with sub-agents, parallel runs, CI orchestration, and the
-self-improvement loop (a harness in `--framework` mode driving
-another harness in default mode to test framework changes against a
-sample app). The honest tool name and identity-class enforcement are
-what make this capability transparent rather than a confused-deputy
-hazard.
+This is more than another way to attach a UI: it lets one agent
+drive another agent's harness session (**agent-driving-agent**). An
+outer agent (e.g. Claude Code in a different repo) can call
+`harness.run_agent_with_shell_access` and treat a whole harness
+session as a single tool call. That works for sub-agents, parallel
+runs, CI orchestration, and testing framework changes end-to-end (a
+harness in `--framework` mode driving another harness in default
+mode against a sample app). The tool's honest name and the
+identity-class enforcement are what keep this transparent instead of
+turning into a confused-deputy hazard.
 
 #### Observability of agent-driven sessions
 
@@ -1214,7 +1214,7 @@ was chosen (so the requester knows where to look):
 The requester must POST the code back within 60 s to receive the
 token. This blocks the simplest "any process running as the user
 mints tokens" attack — the attacker needs concurrent visibility of
-one of the user's trusted surfaces.
+one of the user's trusted clients.
 
 For headless/CI use, a pre-provisioned token file
 (`~/.config/gofastr/harness/ci-token.json`) is read at boot; the
@@ -1281,8 +1281,7 @@ session without exposing the rest of the harness.
 
 ## Protocol versioning & evolution
 
-The control protocol is the **long-term API surface** of the
-harness. Every external client (IDE plugin, TS SDK, Python client,
+The control protocol is the harness's **long-term API**. Every external client (IDE plugin, TS SDK, Python client,
 mobile app, agents driving us over MCP) commits to its shape. This
 section is normative — implementers MUST follow it, and the
 `control/conformance/` suite tests against it.
@@ -1360,7 +1359,7 @@ Transport-specific framing:
 
 ### Unknown-field policy
 
-| Surface | Unknown field rule |
+| Where | Unknown field rule |
 |---|---|
 | `Command` body fields | **Ignore unknown** (additive evolution) |
 | `Event` body fields | **Ignore unknown** |
@@ -1581,8 +1580,9 @@ hooks, and SSE plumbing all exercise themselves through the harness.
 
 ### External clients
 
-Anything that can speak HTTP or WebSocket is a first-class client.
-Reference implementations to ship in `docs/harness-clients/`:
+Anything that can speak HTTP or WebSocket can act as a client, no
+different from the bundled ones. Reference implementations to ship
+in `docs/harness-clients/`:
 
 - **curl recipes**: create a session, send input, stream events.
 - **TypeScript client**: thin npm package wrapping `fetch` +
@@ -1708,8 +1708,8 @@ with `«ttl-expired»`. Configurable per-profile.
   copied events are rewritten so the resumed engine can issue new
   tool_use blocks without colliding with the original conversation
   if both branches are later compared.
-- **Replay = step-through.** Drives a surface from the log for
-  debugging UIs. **Does not re-execute** — provider calls are not
+- **Replay = step-through.** Powers a debugging UI by replaying
+  from the log. **Does not re-execute** — provider calls are not
   re-issued. Cache state and live MCP connections are
   non-replayable; replay shows what happened, not "what would
   happen again." Re-execution under different conditions is a
@@ -1751,8 +1751,8 @@ cannot exfiltrate it from the harness's own memory.
 
 Per § Threat model, the default Bash permission preset **blocks**
 `security`, `secret-tool`, `keyctl`, and `kwalletcli` to prevent
-the obvious credential-exfiltration paths via the agent's own tool
-surface.
+the obvious credential-exfiltration paths via the agent's own
+tools.
 
 #### First-run setup — `gofastr harness creds`
 
@@ -2108,8 +2108,8 @@ when it isn't.
   Tried as middleware first; middleware is monomorphic
   (one-request-to-one-provider) and broke on every cross-provider
   concern.
-- **Parallel tool calls** — ToolMiddleware that fans out to N
-  concurrent dispatchers and aggregates. Engine sees one
+- **Parallel tool calls** — ToolMiddleware that dispatches to N
+  concurrent workers and aggregates the results. Engine sees one
   `ToolResult` per `ToolCall` either way.
 - **Cost budgets** — event subscriber on `CostIncremented` plus a
   RequestMiddleware that aborts when the cap is exceeded.
@@ -2135,7 +2135,7 @@ when it isn't.
   that instantiates a **child `EngineRun`** with a cheaper
   `Provider`. **Scoped sync-only in v0.x**: the tool blocks the
   parent turn; child events are not surfaced to parent clients
-  (the child has its own log + attach surface if observation is
+  (the child has its own log and attach point if observation is
   needed). A general parent/child `EngineGraph` model (cancellation
   propagation, event fan-in, multi-session ownership) is a v1+
   topic — calling out the limit now keeps `delegate` honest as a
@@ -2312,7 +2312,7 @@ encryption as the session log.
 | `context/` | https://agents.md/ |
 | `control/` | This doc § Control plane — especially auth, multi-client, Threat model |
 | `control/multiplex/` | This doc § Multi-client semantics |
-| `control/mcpserver/` | MCP spec **plus** this doc § MCP-server surface — note the renamed tool and identity-class rules |
+| `control/mcpserver/` | MCP spec **plus** this doc § MCP server API — note the renamed tool and identity-class rules |
 | `control/auth/` | This doc § Threat model and § Authentication |
 | `client/tui/` | This doc § TUI; `golang.org/x/term` package docs |
 | `client/web/` | `core-ui/ARCHITECTURE.md` (the UI runtime is what the web client dogfoods) |

--- a/framework/docs/content/i18n.md
+++ b/framework/docs/content/i18n.md
@@ -179,9 +179,9 @@ resolution is meaningless without a translator to resolve against.
 ## What's NOT in this package
 
 - **ICU-grade number/date/currency formatting.** Use stdlib (`time`,
-  `strconv`) or wrap a third-party formatter. The primitive that
-  matters most here — locale-aware lookups + pluralisation — is
-  already covered; bolt formatting on top.
+  `strconv`) or wrap a third-party formatter. The part that matters
+  most here — locale-aware lookups + pluralisation — is already
+  covered; add formatting on top yourself.
 - **Pre-bundled CLDR plural rules for every language.** Only English
   is built in; register more per locale as the app picks them up.
 - **Locale routing via path prefix (`/en/...`, `/fr/...`).** Roll your
@@ -239,8 +239,8 @@ key)` works the moment middleware attaches a locale, and the
 `framework/ui` component set now resolves its labels through the
 catalog too (see above). A "French" deployment shows French strings
 wherever the app calls `T` and on every `framework/ui` component that
-receives `r.Context()` via `Ctx`. The remaining English surfaces are
-deeper in the stack and need follow-up integration work:
+receives `r.Context()` via `Ctx`. The remaining places that still show
+English are deeper in the stack and need follow-up integration work:
 
 - **Entity field labels** — `entity.EntityConfig` has no `LabelKey`
   hook; CRUD / generated forms surface field names raw.
@@ -256,7 +256,7 @@ deeper in the stack and need follow-up integration work:
   hook today.
 
 These are tracked as a follow-up integration pass — call it Tier 2.5
-or "wire i18n through the framework's own surfaces". That pass adds
+or "wire i18n through the rest of the framework". That pass adds
 `LabelKey` / `MessageKey` style hooks to the relevant configs and
 shifts validators to return codes; the `framework/ui` label coverage
 landed here is the template for it.

--- a/framework/docs/content/image.md
+++ b/framework/docs/content/image.md
@@ -3,7 +3,7 @@
 `framework/image` is a chainable image pipeline — decode → transform →
 encode — implemented in pure Go on top of `image/jpeg`, `image/png`,
 `image/gif`, and `golang.org/x/image`. No CGo, no system libraries, no
-native build step. The API surface is inspired by Bun.Image; the
+native build step. The API is inspired by Bun.Image; the
 implementation is independent.
 
 ## Quickstart
@@ -371,7 +371,7 @@ hand it directly to `storage.Save`).
 - **Expecting WebP-lossless to match `cwebp` file sizes.** The pure-Go
   encoder tries five uniform predictor modes (1, 2, 11, 12, 13) per
   image and emits the smallest output, plus subtract-green and LZ77
-  + an 8-bit color cache. Honest comparison against `cwebp -z 9`
+  + an 8-bit color cache. Compared against `cwebp -z 9`
   (libwebp 1.6) and `png.BestCompression`:
 
   | Content (256×256) | PNG-best | Ours WebP-LL | `cwebp -z 9` | ours vs PNG | ours vs cwebp |
@@ -381,11 +381,11 @@ hand it directly to `storage.Save`).
   | natural photo | ~110k | 125.5k | 111.7k | 1.14× | **1.12×** |
   | white noise | ~197k | 196.8k | 196.7k | 1.00× | 1.00× |
 
-  The framing: **we beat PNG** on smooth and structured content by
+  In short: **we beat PNG** on smooth and structured content by
   2-3×; **`cwebp` beats us** by another 2-4× on the same content (its
   per-block adaptive mode + cross-color + palette path) but only by
   ~12% on natural photos and ~0% on noise. For PNG-replacement
-  delivery in the framework's UI pipeline, our output is competitive;
+  delivery in the framework's UI pipeline, our output is good enough;
   for "smallest-possible WebP" you'd still go to `cwebp`.
 
   The encoder infrastructure for per-block mode evaluation is in

--- a/framework/docs/content/interactive-patterns.md
+++ b/framework/docs/content/interactive-patterns.md
@@ -43,7 +43,7 @@ Go helpers: `interactive.SetLocal()`, `interactive.IncLocal()`,
 ### Counter
 
 `framework/ui.Counter` renders a numeric counter with +/− buttons.
-Uses `data-fui-signal-inc` under the hood. Configurable `Step` for
+Uses `data-fui-signal-inc`. Configurable `Step` for
 non-unit increments.
 
 ### Tabs
@@ -361,9 +361,9 @@ path** instead of a blanket rollback:
    oversized, non-JSON, or unreadable — including an empty body —
    falls back to the generic copy (today's behavior, backward
    compatible).
-2. When a valid message is present, it is surfaced through the polite
-   `aria-live` region (replacing the generic copy) and the framework
-   toast surface (`__gofastr.toast`, loaded on demand) when one is
+2. When a valid message is present, it is shown through the polite
+   `aria-live` region (replacing the generic copy) and the framework's
+   toast helper (`__gofastr.toast`, loaded on demand) when one is
    wired.
 3. If `ConflictRPC` is set, the runtime then GET-fetches it and
    replaces the destination list's `innerHTML` with the response
@@ -494,7 +494,7 @@ check that it uses `{id}`, not `:id`.
 
 `Action.WithConfirm` (above) uses native `window.confirm` — fine for
 admin/internal tools, but unthemed and unautomatable. For a destructive
-action in a user-facing surface, `framework/ui.ConfirmAction` renders a
+action in an app your users interact with directly, `framework/ui.ConfirmAction` renders a
 design-system **alertdialog** instead: a modal that matches your theme
 (light + dark, via tokens — zero bespoke CSS), traps focus, closes on Escape,
 and is drivable by tests.
@@ -564,13 +564,13 @@ island re-render). The status values are just data you supply.
 > an open connection to a given entity. Deriving the live roster —
 > binding the authenticated user to their SSE connection, observing
 > connect/disconnect, and aggregating that across replicas — is work an
-> app wires itself for now. A first-class presence source is tracked in
+> app wires itself for now. Adding this to the framework is tracked in
 > issue #47.
 
 ## Complex interactive components
 
 These are full components (not wrapper functions) that ship with their
-own runtime modules for rich client-side behavior.
+own runtime modules for client-side behavior.
 
 | Component | Runtime module | Behavior |
 |---|---|---|

--- a/framework/docs/content/kiln.md
+++ b/framework/docs/content/kiln.md
@@ -1,8 +1,9 @@
 # Kiln — agent-driven build mode
 
 > **Experimental.** Kiln is a separate binary for shaping a GoFastr app live.
-> Its durable graduation artifact is the same `gofastr.yml` blueprint consumed
-> by the current generator; generated Go remains the source of truth.
+> When you graduate, it writes the same `gofastr.yml` blueprint the generator
+> already reads — a scaffolder, not the thing you ship. The generated Go code
+> is what you keep; it's the source of truth, not the blueprint.
 
 Kiln gives an agent a small, journaled application IR. Each accepted edit is
 replayed into a fresh framework app, SQLite is migrated, and the browser sees
@@ -43,7 +44,7 @@ empty-state host and use the floating panel. Important endpoints are:
 | `POST/GET /mcp/app` | Rebuilt app's entity MCP tools. |
 | `GET /.kiln/events` | Journal/build SSE stream. |
 
-`kiln mcp` and `kiln acp` expose the same tool surface over stdio. Pass
+`kiln mcp` and `kiln acp` expose the same tools over stdio. Pass
 `--no-http` when a parent process owns the UI.
 
 ## Agent adapters
@@ -54,10 +55,10 @@ an agent. A free-form command is parsed as an executable plus arguments and
 receives the prompt as its final argument.
 
 Kiln injects `KILN_URL`, installs the current embedded skill, and enforces an
-HTTP boundary for built-in adapters: they must mutate the app through the tool
-surface, not by editing the repository.
+HTTP boundary for built-in adapters: they must mutate the app by calling
+Kiln's tools, not by editing the repository.
 
-## Tool surface
+## Tools
 
 Read and configuration:
 
@@ -123,8 +124,8 @@ Prefer design-system kinds:
 
 Semantic leaf kinds such as `heading`, `paragraph`, `text`, `link`, `form`,
 `input`, `button`, `list`, and table elements remain available. `class`,
-`style`, and `on*` props are rejected: pages compose the shared design system
-instead of inventing a second styling surface. Form actions that target CRUD
+`style`, and `on*` props are rejected: pages use the shared design system
+instead of a second way to style things. Form actions that target CRUD
 must use the API prefix, for example `/api/notes`.
 
 Example:
@@ -154,7 +155,7 @@ Example:
 ```
 
 `add_page` assigns stable node `_id` values and version `1`.
-`update_page_element` performs optimistic, surgical tree edits using those IDs
+`update_page_element` performs optimistic edits to that tree using those IDs
 and an optional `if_match` version.
 
 ## Graduate to owned Go
@@ -190,11 +191,11 @@ succeeded is guaranteed to re-parse into the same values.
 
 ## Security boundary
 
-Kiln's mutation surface is intentionally unauthenticated and local-development
+Kiln's HTTP endpoints are intentionally unauthenticated and local-development
 only. The default loopback bind is the primary boundary. Unsafe cross-origin
 browser requests are rejected; non-browser clients without an `Origin` header
 and same-origin requests are allowed. Binding `--addr 0.0.0.0:8765` is an
-explicit decision to expose the tool surface and should only be done behind an
+explicit decision to expose those endpoints and should only be done behind an
 appropriate network/auth boundary.
 
 ## Verification

--- a/framework/docs/content/log.md
+++ b/framework/docs/content/log.md
@@ -1,7 +1,7 @@
 # Server logs (`battery/log`)
 
 The `battery/log` plugin wires structured JSON-line server logs into the
-app. A single `*slog.Logger` fans out to one or more **sinks**; built-in
+app. A single `*slog.Logger` writes to one or more **sinks**; built-in
 sinks cover three destinations:
 
 1. A **default file** under the OS state dir (`$XDG_STATE_HOME/<app>/server.log`).
@@ -79,7 +79,7 @@ etc.) can call these to inspect the running app live:
 | `log_metrics`   | Current counter snapshot — same data as `Plugin.Metrics()`.                                          |
 | `log_set_level` | Mutate the runtime log level (e.g. flip to DEBUG for an investigation, back to INFO afterwards).     |
 
-Opt-in because the surface reveals a lot about the running app —
+Opt-in because these tools reveal a lot about the running app —
 weigh the disclosure before enabling on a production MCP server
 exposed to untrusted callers.
 
@@ -97,8 +97,8 @@ app.RegisterPlugin(log.New(log.Config{
 }))
 ```
 
-Pair with `framework.WithMCPIntrospection()` for parallel introspection
-of the app's routes / plugins / batteries / config / readiness — see
+Pair with `framework.WithMCPIntrospection()` so an agent can also ask
+the app about its routes / plugins / batteries / config / readiness — see
 `framework/mcp_introspection.go`.
 
 ## Metrics

--- a/framework/docs/content/migrations.md
+++ b/framework/docs/content/migrations.md
@@ -8,7 +8,8 @@ GoFastr has two migration paths:
    indexes and foreign keys) **and adds missing columns to existing
    tables** (`ALTER TABLE ADD COLUMN` — additive only, never a drop,
    rename, or type change). Runs on `App.Start`. Best for development
-   and for apps where the entity declaration is the source of truth.
+   and for apps that keep their schema in entity declarations rather
+   than hand-written SQL.
 2. **SQL files with directives.** `core/migrate` runs versioned `.sql`
    files. Best when you need to express data backfills, complex
    constraints, or anything the entity declaration can't.
@@ -290,7 +291,7 @@ on entity fields too.
 
 ## Stored routines (functions, procedures, triggers, views)
 
-Routines are first-class migration objects. A `migrate.Routine` runs on every
+Routines are migration objects, same as tables and views. A `migrate.Routine` runs on every
 boot (idempotent `CREATE OR REPLACE`) after tables migrate, and `migrate
 generate` tracks it so a changed body produces a reversible versioned
 migration (its `Down` restores the previous definition).
@@ -495,7 +496,7 @@ if err := app.DB.QueryRowContext(ctx, "SELECT debits, credits FROM compute_total
 
 In tests, point a fresh Postgres DB at the same `db/routines` directory via
 `App.RoutinesFS` — the routines land in one transaction with the schema, and
-`app_routines` introspection will report each one as `ledger_state=present`
+the `app_routines` tool will report each one as `ledger_state=present`
 once boot completes.
 
 ## Views (virtual tables built from entities)
@@ -610,7 +611,7 @@ CREATE TABLE _migrations (
 
 Created lazily on first `Up`/`Down`/`Status` call. The `checksum` and
 `dirty` columns are backfilled automatically onto tables created by an
-older GoFastr, so upgrading is seamless. When migration groups are in
+older GoFastr, so upgrading needs no manual fix. When migration groups are in
 use, the table additionally gains `group_name TEXT NOT NULL DEFAULT ''`
 and the primary key becomes `(group_name, version)` — upgraded in
 place the first time a non-default group is applied. Never edit the
@@ -746,8 +747,8 @@ that compiles in tests will fail in prod. The framework's
 
 ## Production safety
 
-The migration system is built to be relied on for critical infrastructure,
-not just dev convenience. The guarantees:
+The migration system is meant for production use, not just local
+development convenience. What it guarantees:
 
 - **Advisory locking.** Every migration run — auto-migrate on boot and
   the versioned `Up`/`Down`/`Force` — is serialized by a Postgres
@@ -780,11 +781,11 @@ not just dev convenience. The guarantees:
   without running it (adopt an existing database) or removes it (treat
   as pending) — and clears any dirty flag either way.
 
-These features map onto the production-grade feature set of mature
-migrators (golang-migrate, goose, Atlas): versioned up/down, advisory
-locking, transactional runs with a no-transaction escape hatch, dirty
-state, checksums/drift detection, baseline, and a destructive-change
-safety gate.
+This is the same feature set as other established migrators
+(golang-migrate, goose, Atlas): versioned up/down, advisory locking,
+transactional runs with a no-transaction escape hatch, dirty state,
+checksums/drift detection, baseline, and a destructive-change safety
+gate.
 
 ## Concurrency model
 

--- a/framework/docs/content/modules.md
+++ b/framework/docs/content/modules.md
@@ -55,7 +55,7 @@ topo-sort orders module init, and records the manifest.
 Registering two modules with the same name panics, exactly like a
 duplicate battery.
 
-## Attribution of surfaces
+## What gets attributed to a module
 
 During a module's `Init`, the framework marks the module as "current" and
 every registration funnel stamps ownership:
@@ -66,7 +66,7 @@ every registration funnel stamps ownership:
   disabling one does not affect the other. Entity CRUD routes (mounted
   by `app.Entity`) are attributed the same way.
 - **MCP tools**: every `app.MCP.RegisterTool` records tool → module.
-- **Entities**: `app.Entity` records entity → module for introspection.
+- **Entities**: `app.Entity` records entity → module so it can be reported later.
 - **Cron**: `app.AddCron(scheduler)` called from a module's `Init`
   stamps the scheduler with a gate that skips jobs when the module is
   disabled.
@@ -170,11 +170,11 @@ blocked on, rolled back, or dropped. See the migrations doc for details.
 `force --group=<name>` is the reconciliation escape hatch when a module
 is permanently removed.
 
-## Introspection
+## Reading module state
 
 The `app_modules` MCP tool (available via `WithMCPIntrospection`) lists
 every module's name, version, description, dependencies, migration
-group, enabled state, and owned surface counts (routes, entities, tools).
+group, enabled state, and how many routes, entities, and tools it owns.
 Enable/disable is Go-API-only for now — no mutating MCP tools.
 
 ## Common mistakes
@@ -193,9 +193,9 @@ Enable/disable is Go-API-only for now — no mutating MCP tools.
   registration inside the module's `Init`.
 - **Expecting process isolation.** A disabled module's code is still
   loaded in the process — its types, closures, and goroutines spawned
-  outside the gate are still live. The gates cover dispatch surfaces
-  (routes, cron, queue, MCP), not arbitrary Go code. Process isolation
-  is explicitly out of scope.
+  outside the gate are still live. The gates cover routes, cron, queue,
+  and MCP dispatch, not arbitrary Go code. Process isolation is
+  explicitly out of scope.
 - **Existence probing via trailing-slash redirects.** A `GET /modsub`
   for a module that registered `/modsub/` triggers Go ServeMux's
   automatic 307 redirect to `/modsub/` — before any gate fires.

--- a/framework/docs/content/notifications.md
+++ b/framework/docs/content/notifications.md
@@ -1,9 +1,10 @@
 # Unified notifications
 
-`battery/notify` is a small fan-out primitive: each notification has
-a type ("order.shipped", "password.reset"), a Recipient, and a free-
-form Data map. The Notifier renders a per-channel template against
-Data and fires every applicable channel concurrently.
+`battery/notify` sends one notification through several channels at
+once: each notification has a type ("order.shipped", "password.reset"),
+a Recipient, and a free-form Data map. The Notifier renders a
+per-channel template against Data and fires every applicable channel
+concurrently.
 
 It's deliberately small. Each channel is its own adapter; the
 package bundles `LoggerChannel` (dev) and `EmailChannel` (wrapping

--- a/framework/docs/content/observability.md
+++ b/framework/docs/content/observability.md
@@ -1,8 +1,7 @@
 # Observability (metrics & tracing)
 
-GoFastr ships production-grade HTTP metrics and OpenTelemetry tracing
-middleware. Both are **opt-in** so a minimal app stays minimal, but they
-are one option each to turn on.
+GoFastr includes HTTP metrics and OpenTelemetry tracing middleware. Both
+are **opt-in** — a minimal app stays minimal until you turn one on.
 
 ## Metrics (Prometheus)
 

--- a/framework/docs/content/overview.md
+++ b/framework/docs/content/overview.md
@@ -1,169 +1,168 @@
-# Overview — what GoFastr is, and everything it does
+# Overview
 
-GoFastr is a full-stack Go framework where **AI agents are first-class
-authors**. You describe a domain — entities, fields, relations — as a typed
-declaration, and the framework generates the database schema, a REST API, MCP
-tools for agents, OpenAPI, and a typed Go model from that one source. Everything
-else is regular, readable Go you can grep, debug, and step through. No
-reflection magic, no opaque runtime.
+GoFastr is a full-stack Go framework. You build the whole app in Go — database
+schema and migrations, a REST API, and a server-rendered UI — plus opt-in
+batteries for auth, background jobs, search, and storage. Everything it
+generates is plain Go on disk that you own: no reflection, no runtime you're
+stuck inside. When it's in your way, drop to `core/`, `net/http`, or
+`database/sql`.
 
-**The promise:** opinionated input, boring output, small runtime, easy escape
-hatches. GoFastr is a **code-generation platform for CRUD-heavy and AI-authored
-apps** — not a universal framework that owns your control flow. Start with one
-entity and add only what you need; when the framework is in your way, drop to
-`core/` and write plain `net/http`. And because an agent often writes the code,
-the output is built to be *more* inspectable, not less — plain Go on disk, no
-reflection injection or hidden registries.
+Agents work with it two ways. In production, the agents your users bring call
+your data over MCP, with the same login and permissions your users have. In
+development, `gofastr dev` gives your coding agent (Claude Code, Codex) the
+running app's routes, config, and logs over MCP, so it can help you build and
+debug.
 
-This page is the map. It explains the shape of the framework and links every
-feature to its reference doc. If you're new, read this top-to-bottom once, then
-jump to the section that matches what you're building.
+This page lists every feature and links to its doc. Read it once, then jump to
+what you need. New here? Start with
+[Get started](/get-started) and [Project structure](/docs/project-structure).
 
-> New to the framework? Pair this with
-> **[UI getting started](/docs/ui-getting-started)** for the
-> cold-machine-to-running-app path, and the
-> **[Project structure](/docs/project-structure)** guide for how a real app
-> is laid out and grows.
+## Two layers
 
-## The one idea
+GoFastr is two layers, and you can work at either one.
 
-Most frameworks assume a human hand-writes every route, query, validator,
-migration, and form. Agents already generate that code — but no framework treats
-their output as the canonical source. GoFastr inverts that: the **entity
-declaration is the source**, and the database, API, agent tools, and admin UI
-are generated from it. The agent writes the declaration; so does the human; the
-framework is what they both write to.
+**`core/` + `core-ui/` — the primitives.** stdlib-first building blocks: router,
+query, schema, render, mcp, openapi (core); HTML primitives, signals, the
+runtime (core-ui). Each works on its own, no framework required:
 
 ```go
-app := framework.NewApp()
-app.Entity("posts", entity.EntityConfig{
+// core only — a router and a handler.
+r := router.New()
+r.Get("/", render.HTMLHandler(func(req *http.Request) render.HTML {
+    return render.Tag("h1", nil, render.Text("Hello from core."))
+}))
+http.ListenAndServe(":8080", r)
+```
+
+**`framework/` + `framework/ui/` — the opinionated layer.** Built on those
+primitives. Declare an entity and the framework wires them together for you — a
+migrated table, a REST API with filtering/sorting/pagination, MCP tools, and an
+OpenAPI spec:
+
+```go
+// framework — one entity, wired end to end.
+app := framework.NewApp(framework.WithDB(db))
+app.Entity("posts", framework.EntityConfig{
     Fields: []schema.Field{
-        {Name: "title",     Type: schema.String,  Required: true},
-        {Name: "body",      Type: schema.Text},
-        {Name: "published", Type: schema.Bool},
+        {Name: "title", Type: schema.String, Required: true},
+        {Name: "body",  Type: schema.Text},
     },
 })
 app.Start(":8080")
 ```
 
-That declaration alone gives you migrated tables, a full CRUD REST API with
-filtering/sorting/pagination, MCP tools an agent can call, OpenAPI, and a typed
-Go model — see **[Entity declarations](/docs/entity-declarations)**.
+See [Entity declarations](/docs/entity-declarations). Generated code is regular
+Go at the module root (`main.go`, `app.go`, `screens.go`, `entities/`) — read
+it, edit it, commit it. When the framework is in your way, drop back to `core/`.
+You can also scaffold a set of entities from a `gofastr.yml` with the
+[code generator](/docs/codegen); the running app never needs the file.
 
-## Two layers
-
-Two packages, no more:
-
-- **`core/`** — eighteen dependency-light primitives (router, query, schema,
-  mcp, openapi, render, markdown, middleware, static, stream, upload, …), each
-  independently usable. All are stdlib-only except `core/middleware`, which
-  pulls in OpenTelemetry for tracing. When the framework is in your way, you
-  drop down to `core` and write plain Go.
-- **`framework/`** — the opinionated entity layer composed on top: entities,
-  CRUD, hooks, migrations, plugins, and the batteries below.
-
-There is no third layer of hidden magic. Generated code is regular, owned Go
-scaffolded straight into an idiomatic module-root layout (a flat `package main`
-— `main.go`, `app.go`, `screens.go` — plus `entities/`) — yours to read, edit,
-and commit — see
-**[Code generation](/docs/codegen)** and **[Blueprints](/docs/blueprints)**.
+(Only `core/middleware` pulls in a dependency — OpenTelemetry, for tracing.
+Everything else in `core/` is stdlib-only.)
 
 ## Modeling your domain
 
-One typed declaration fans out into every surface.
+Declare entities; get their tables, routes, and tools.
 
-- **[Entity declarations](/docs/entity-declarations)** — JSON or Go; both
-  produce the same tables, routes, and tools. Set `OwnerField` for per-user data.
-- **[Filter DSL](/docs/query-dsl)** — `?status=published&views_gte=10&sort=-created_at`
-  parses to a typed `Where`.
+- **[Entity declarations](/docs/entity-declarations)** — Go or a `gofastr.yml`;
+  both produce the same tables, routes, and tools. Set `OwnerField` for
+  per-user data.
+- **[Filter DSL](/docs/query-dsl)** —
+  `?status=published&views_gte=10&sort=-created_at` parses to a typed `Where`.
 - **[Eager loading](/docs/includes)** — `?include=author.profile` flattens the N+1.
 - **[Cursor pagination](/docs/cursor-pagination)** — keyset paging, opt-in.
 - **[Hooks & transactions](/docs/hooks-and-transactions)** — `BeforeCreate` /
   `AfterUpdate` hooks share the parent transaction.
-- **[Batch endpoints](/docs/batch-endpoints)** — create/update/delete many in one
-  request. **[Migrations](/docs/migrations)** — versioned, ordered, reversible.
+- **[Batch endpoints](/docs/batch-endpoints)** — create, update, or delete many
+  rows in one request. **[Migrations](/docs/migrations)** — versioned, ordered,
+  reversible.
 - **[Multi-tenant scope](/docs/multi-tenant)** — automatic `tenant_id` filtering.
 
 ## Serving HTTP
 
-Everything between the wire and your handler is on by default.
+The middleware between the socket and your handler, on by default.
 
 - **[Auth](/docs/auth)** — login, OAuth, magic-link, 2FA, password reset; each a
-  plugin. **[Access control](/docs/access-control)** — roles, permissions, policies.
+  plugin. **[Access control](/docs/access-control)** — roles, permissions,
+  policies.
 - **[Security defaults](/docs/security)** — CSP, CSRF, rate limit, headers.
 - **[Idempotency](/docs/idempotency)** — an `Idempotency-Key` header replays
-  mutations safely. **[Webhooks](/docs/webhooks)** — signed outbound delivery with
-  retry. **[Notifications](/docs/notifications)** — multi-channel fan-out.
+  mutations safely. **[Webhooks](/docs/webhooks)** — signed outbound delivery
+  with retry. **[Notifications](/docs/notifications)** — multi-channel delivery.
 - **[Health checks](/docs/health-checks)** · **[Plugins](/docs/plugins)** — the
-  lifecycle every battery plugs into.
+  lifecycle every battery uses.
 
 ## Building UI
 
-Server-rendered with islands: every page is fully SSR on first load; the runtime
-hydrates handlers onto the existing DOM; in-page state changes are island RPCs
-that swap just one fragment — no hard refreshes, no client re-render.
+Server-rendered with islands: every page is full HTML on first load; a small
+runtime attaches handlers to the existing DOM; in-page changes (sort, paginate,
+add a row) are island calls that swap one fragment — no hard refresh, no client
+re-render.
 
-- **[Getting started (UI)](/docs/ui-getting-started)** — scaffold → theme →
-  screen → custom component. **[UI wiring](/docs/ui-wiring)** — adding the UI
-  system to a plain `framework.App` by hand.
+- **[Getting started (UI)](/docs/ui-getting-started)** — scaffold, theme,
+  screen, custom component. **[UI wiring](/docs/ui-wiring)** — adding the UI to
+  a plain `framework.App` by hand.
 - **[Theming](/docs/theming)** — token catalog, dark mode, section overrides,
-  `--ui-*` knobs. **[Runtime contract](/docs/runtime-contract)** — the
-  SSR/hydration/island/SSE model + `data-fui-*` reference.
-- **[New components](/docs/ui-new-components)** — the minimal-register +
-  SSR-inline + hydrate contract. **[Widget builder](/docs/widgets)** — islands
+  `--ui-*` vars. **[Runtime contract](/docs/runtime-contract)** — the
+  SSR/hydration/island/SSE model and the full `data-fui-*` reference.
+- **[New components](/docs/ui-new-components)** — the minimal-register,
+  SSR-inline, hydrate contract. **[Widget builder](/docs/widgets)** — islands
   that hydrate against a registered handler.
-- **[Interactive patterns](/docs/interactive-patterns)** · **[Signal store](/docs/signal-store)** —
-  client state that fans out to many consumers from one declaration.
-- **[Forms](/docs/form-module)** — server-validated, island-swapped error states.
-- **[PWA](/docs/pwa)** — installable manifest + a safe offline shell via
-  `uihost.WithPWA`; works on the live server and in static exports.
-- **[Image pipeline](/docs/image)** — pure-Go resize + WebP. **[Print documents](/docs/print)** —
-  chrome-free print/PDF. **[Runtime modules](/docs/runtime-minification)** —
-  carved per-feature so a page ships only the JS it uses.
-- Browse every primitive live in the **[component gallery](/components/)**.
+- **[Interactive patterns](/docs/interactive-patterns)** ·
+  **[Signal store](/docs/signal-store)** — client state shared by many
+  consumers from one declaration.
+- **[Forms](/docs/form-module)** — server-validated, with island-swapped error
+  states.
+- **[PWA](/docs/pwa)** — installable manifest and an offline shell via
+  `uihost.WithPWA`; works live and in static exports.
+- **[Image pipeline](/docs/image)** — pure-Go resize and WebP.
+  **[Print documents](/docs/print)** — print-friendly HTML and PDF.
+  **[Runtime modules](/docs/runtime-minification)** — split per feature, so a
+  page ships only the JS it uses.
+- Browse every component live in the **[gallery](/components/)**.
 
 ## Persisting & migrating
 
 SQLite and Postgres, dialect-aware.
 
-- **[Audit log](/docs/audit-log)** — a row per Create/Update/Delete.
-- **[Isolation](/docs/isolation)** — per-worktree isolated local DBs.
-- **[Factories](/docs/factories)** — fixtures for tests. **[Full-text search](/docs/search)**.
-- **[Uploads](/docs/uploads)** — file/image fields with pluggable storage.
+- **[Audit log](/docs/audit-log)** — a row per Create, Update, and Delete.
+- **[Isolation](/docs/isolation)** — a separate local DB per git worktree.
+- **[Factories](/docs/factories)** — fixtures for tests.
+  **[Full-text search](/docs/search)**.
+- **[Uploads](/docs/uploads)** — file and image fields with pluggable storage.
 - **[Env / .env](/docs/dotenv)** — auto-loaded by `NewApp`.
 
 ## Working with agents
 
-- **[Kiln](/docs/kiln)** — the agent-driven build-mode binary: mutate an
-  in-memory IR over HTTP, no Go/JS/SQL by hand.
-- **[Embed](/docs/embed)** — local semantic search via brute-force cosine, no API
-  key. **[Audit deps](/docs/audit-deps)** — flag packages an agent shouldn't import.
-- **[Blueprints](/docs/blueprints)** — reusable bundles of entities + screens an
-  agent can apply.
+- **[Agent-readiness](/docs/agent-ready)** — per-entity MCP tools, auto
+  `llm.md`, and the discovery endpoints your app serves.
+- **[Embed](/docs/embed)** — local semantic search, no API key.
+  **[Audit deps](/docs/audit-deps)** — flag packages an agent shouldn't import.
+- **[Kiln](/docs/kiln)** — experimental build-mode binary: an agent edits an
+  in-memory model over HTTP.
 
 ## Operations
 
-- **[Logging](/docs/log)** — structured JSON with MCP query tools.
+- **[Logging](/docs/log)** — structured JSON, with MCP query tools.
 - **[Feature flags](/docs/feature-flags)** · **[i18n](/docs/i18n)** ·
-  **[Cron](/docs/cron)** · **[Events](/docs/events)** · **[Admin UI](/docs/admin)**.
+  **[Cron](/docs/cron)** · **[Events](/docs/events)** ·
+  **[Admin UI](/docs/admin)**.
 
-## Reference & internals
+## Reference
 
-- **[Benchmarks](/docs/benchmarks)** · **[Performance results](/docs/perf-results)** —
-  how it performs and how that's measured.
-- **[Codegen](/docs/codegen)** — what the scaffold emits (owned Go at the module root) and how to read it.
-- The **[full A–Z index](/docs/)** lists every embedded doc — nothing is hidden.
+- **[Benchmarks](/docs/benchmarks)** ·
+  **[Performance results](/docs/perf-results)** — how it performs and how
+  that's measured.
+- **[Code generation](/docs/codegen)** — what the scaffold writes and how to
+  read it.
+- The **[full A–Z index](/docs/)** lists every doc.
 
 ## Where to go next
 
-1. **[Get started](/get-started)** — running app in four minutes.
-2. **[Entity declarations](/docs/entity-declarations)** — the heart of the model.
-3. **[Examples](/examples)** — six reference apps, smallest first.
-4. **[Components](/components/)** — every UI primitive, one page each.
+1. **[Get started](/get-started)** — a running app in a few minutes.
+2. **[Entity declarations](/docs/entity-declarations)** — the core of the model.
+3. **[Examples](/examples)** — reference apps, smallest first.
+4. **[Components](/components/)** — every UI component, one page each.
 
-Every doc is grounded in the actual code, and every guide doc ends with a
-"common mistakes" callout (data/index artifacts like the benchmark results
-and the risk register are exempt — a test in `framework/docs` enforces the
-split). This same content is browsable offline with `gofastr docs`.
-
-- [plugin-platform](plugin-platform.md) — heavy-JS plugin isolation host + registry convention.
+Every doc is grounded in the code, and each guide ends with a "common mistakes"
+note. The same content is available offline with `gofastr docs`.

--- a/framework/docs/content/pane-host.md
+++ b/framework/docs/content/pane-host.md
@@ -6,7 +6,7 @@
 open, focus restore on close, and a responsive collapse). It does NOT
 own content loading.
 
-Use it for master/detail surfaces, inspector panels, a list + a live
+Use it for master/detail views, inspector panels, a list + a live
 preview — anywhere a primary region stays put while a side region opens
 and closes around it.
 

--- a/framework/docs/content/plugin-platform.md
+++ b/framework/docs/content/plugin-platform.md
@@ -105,8 +105,9 @@ the generic broker owns everything protocol-level.
 ## Opting out — the trusted mount
 
 Isolation is the default; a **loud, host-side opt-out** exists for
-plugins the app owner compiles in and vouches for (first-party code
-where the geometry/theming costs of the frame aren't worth paying).
+plugins the app owner compiles in and vouches for (code the team wrote
+itself, where the geometry/theming costs of the frame aren't worth
+paying).
 The wysiwyg plugin's `WithTrustedMount()` is the reference: same plugin
 API and protocol envelopes, transport swapped from postMessage to
 direct calls, no iframe. The opt-out is never a default and never

--- a/framework/docs/content/print.md
+++ b/framework/docs/content/print.md
@@ -1,6 +1,6 @@
 # Printable documents
 
-`battery/print` gives a GoFastr app printing out of the box. You **declare
+`battery/print` adds printing to a GoFastr app. You **declare
 a printable document** the same way you declare a screen/route — a named,
 route-addressable document — and the battery server-renders it into a
 clean, chrome-free, **print-friendly HTML** page: its own `@page` size and

--- a/framework/docs/content/process-modules.md
+++ b/framework/docs/content/process-modules.md
@@ -43,15 +43,15 @@ app.RegisterProcessModule(framework.ProcessModuleDescriptor{
 
 The fields:
 
-- **Routes** — the HTTP surface, host-registered behind the existing module
+- **Routes** — the HTTP routes, host-registered behind the existing module
   route gate. The child cannot add, rename, or reshape routes.
-- **Tools** — the optional MCP tool surface (see below). Digests are
-  byte-compared against `module.tool.list` at handshake.
+- **Tools** — the optional MCP tools the module declares (see below).
+  Digests are byte-compared against `module.tool.list` at handshake.
 - **RequestedGrants** — the verbatim `resource:verb` list the operator
   reviews at install. Effective grants = requested ∩ approved.
 - **TrustTier** — selects the runner: `TrustedTrusted` (crash isolation
-  only, dev/first-party) or `TrustUntrusted` (requires a probe-passing
-  sandbox, fail-closed otherwise).
+  only, for dev or in-house modules) or `TrustUntrusted` (requires a
+  probe-passing sandbox, fail-closed otherwise).
 - **MigrationGroup** — the `#33` migration group the module owns.
 
 ## Install + operator approval
@@ -137,8 +137,8 @@ Three load-bearing points:
    the `REVOKE` on `public` is the real boundary — the role holds no
    privileges outside its own schema regardless of `search_path`.
 2. **The DDL session authenticates AS `module_billing_role`** (a separate
-   login role, member of nothing), not a powerful session that `SET ROLE`s
-   down. Only then is `RESET ROLE` a no-op and `SET ROLE <powerful>`
+   login role, member of nothing), not an elevated session that `SET ROLE`s
+   down. Only then is `RESET ROLE` a no-op and `SET ROLE <an elevated role>`
    refused.
 3. **The tracking table is schema-local** (`module_billing._migrations`),
    so the runner's advisory-lock + checksum-integrity + single-transaction
@@ -175,9 +175,9 @@ removes registration but drops nothing. A destructive
 `DROP SCHEMA module_M CASCADE` is a separate, privileged control-plane
 action, never an uninstall side effect.
 
-## MCP tool surface
+## MCP tools
 
-A module may declare an AI-agent-callable **tool surface** in its
+A module may declare AI-agent-callable **tools** in its
 descriptor. The host — not the child — registers each tool into its
 existing `core/mcp.Server` under a namespaced id:
 
@@ -196,7 +196,7 @@ reverse `host.*` calls are checked as module-grant ∩ caller-authority
 route with the same grants couldn't; there is no separate tool-permission
 vocabulary.
 
-## UI surface
+## UI rendering
 
 A module owns *screen logic* only. It returns a bounded, declarative
 `ui.node.v1` node tree — a closed, host-owned component enum with typed
@@ -273,7 +273,7 @@ Three contracts the child MUST honor (the host enforces them; violation is
 terminal `Failed` or a per-call 503):
 
 - **The descriptor is authoritative.** Routes, tools, requested grants, and
-  the surface digest come from the operator-approved
+  the digest fields come from the operator-approved
   `ProcessModuleDescriptor`, never from the child. `module.handshake` only
   *echoes* `surface_sha256`; `module.tool.list` must be byte-equal to the
   descriptor's tool digests. A child that adds a route/tool or reshapes a
@@ -292,18 +292,19 @@ terminal `Failed` or a per-call 503):
   headers, so a child that dies mid-call yields a buffered 503, never a
   truncated 200.
 
-To install a built child, compute its surface digest
+To install a built child, compute the digest of its routes and tools
 (`framework.ComputeSurfaceSHA256`) and tool digests
-(`framework.ModuleToolDigest`) from the same surface the child serves, pin
-the executable's SHA-256, and `RegisterProcessModule` the descriptor; the
-gate test's `demoDescriptor` helper shows the exact bookkeeping.
+(`framework.ModuleToolDigest`) from the same routes and tools the child
+serves, pin the executable's SHA-256, and `RegisterProcessModule` the
+descriptor; the gate test's `demoDescriptor` helper shows the exact
+bookkeeping.
 
 ## Common mistakes
 
 - **Treating `search_path` as the isolation fence.** It is session-mutable
   and the publisher can `SET search_path TO public, module_M` freely. The
   fence is the `REVOKE` — the role holds no privileges outside its own
-  schema. Stating otherwise is the routine mis-sale of fixed `search_path`.
+  schema. Claiming otherwise is the common, wrong take on fixed `search_path`.
 - **Forgetting to run the migration coordinator.** A module with a
   declared migration group never reaches Ready until the coordinator stamps
   `MigrationsAppliedAt`; it looks "stuck disabled" with proxy 503s.

--- a/framework/docs/content/project-structure.md
+++ b/framework/docs/content/project-structure.md
@@ -38,7 +38,7 @@ default) or declared in a [`gofastr.yml` blueprint](blueprints.md). When you
 generate from a blueprint (`gofastr generate --from=gofastr.yml`), it scaffolds
 owned Go straight into this root layout — a flat `package main` (`main.go`,
 `app.go`, `screens.go`, …) plus the `entities/` package — that you read, edit,
-and commit. The blueprint is a one-way on-ramp, not a source of truth:
+and commit. The blueprint is optional and one-time, not a source of truth:
 `generate` is one-shot (it refuses to overwrite an existing project unless you
 pass `--force`), so once the code is yours you own and edit it directly, and
 you can delete `gofastr.yml` entirely — the running app does not need it. Most
@@ -47,8 +47,8 @@ small apps never need more than this.
 **`--out=<dir>` (or `output_dir:` in the blueprint's `app:` block) scaffolds into
 a subpackage** instead of the module root — useful when the repo is a monorepo or
 an example that also hosts its own Go test package and you want the app to live
-under, say, `app/`. The flagship [`examples/ecommerce`](https://github.com/DonaldMurillo/gofastr/tree/main/examples/ecommerce)
-uses `output_dir: app` for exactly this reason; develop it with
+under, say, `app/`. The [`examples/ecommerce`](https://github.com/DonaldMurillo/gofastr/tree/main/examples/ecommerce)
+example app uses `output_dir: app` for exactly this reason; develop it with
 `gofastr dev --dir app` (hot reload) or run it once with `go run ./app`. The
 subpackage is still owned Go — `--out` only changes *where* the scaffold
 lands, not whether you own it.
@@ -71,9 +71,9 @@ myapp/
 └── static/
 ```
 
-This is the one structural opinion worth holding: **organize by domain
-(`billing/`, `projects/`), not by layer (`controllers/`, `services/`,
-`repositories/`).** Everything about a feature lives together, which is easier
+The opinion GoFastr holds here: **organize by domain (`billing/`,
+`projects/`), not by layer (`controllers/`, `services/`, `repositories/`).**
+Everything about a feature lives together, which is easier
 to navigate and matches how the standard library and most large Go codebases
 are organized. `internal/` keeps these packages private to your module.
 
@@ -109,6 +109,7 @@ A domain package under `internal/` can mix framework entities and hand-written
   existing project (pass `--force` to regenerate the whole set).
 - **Layer-based packages (`services/`, `repositories/`).** In Go this scatters
   one feature across many directories. Organize by domain instead.
-- **Keeping `gofastr.yml` around as a source of truth.** It's a one-way on-ramp.
-  After scaffolding, the owned Go is canonical; you can delete the blueprint and
+- **Keeping `gofastr.yml` around as a source of truth.** It's an optional,
+  one-time input to the scaffold — the app never reads it again. After
+  scaffolding, the owned Go is canonical; you can delete the blueprint and
   the app still runs.

--- a/framework/docs/content/pwa.md
+++ b/framework/docs/content/pwa.md
@@ -112,8 +112,9 @@ the page set is closed and every byte is immutable — so the exported
 install — every page, every framework asset (including component
 stylesheets under their versioned `?v=` URLs), the shell — and
 navigations are served cache-first, tolerating static hosts' trailing-
-slash redirects, with the network as fallback. Land once, install the
-app, and every page works offline — including pages never visited.
+slash redirects, with the network as fallback. Visit the site once,
+install it, and every page works offline after that — even ones you
+never opened.
 
 User static-dir files are precached best-effort: one un-servable file
 does not fail the install and pin clients to a previous deployment.
@@ -164,7 +165,7 @@ default CSP blocks inline JS.)
 
 ## Static export
 
-`App.ExportStatic` emits the full PWA surface alongside the pages:
+`App.ExportStatic` emits all of the PWA files alongside the pages:
 `manifest.webmanifest`, `service-worker.js`,
 `__gofastr/pwa/register.js`, and `__gofastr/pwa/offline/index.html`.
 Under a non-root `BasePath` (e.g. a GitHub Pages project site) the
@@ -175,8 +176,8 @@ the exported app installs and works offline from the subpath. See
 
 ## Blueprint support
 
-`gofastr generate` scaffolds the whole surface from an `app.pwa` block —
-including replaceable placeholder icons. See
+`gofastr generate` scaffolds the whole PWA setup described above from an
+`app.pwa` block — including replaceable placeholder icons. See
 [Blueprints](/docs/blueprints).
 
 ## Common mistakes

--- a/framework/docs/content/scaling.md
+++ b/framework/docs/content/scaling.md
@@ -1,13 +1,13 @@
 # Horizontal scaling
 
 One replica of a GoFastr app is self-contained: sessions, rate limits,
-cron, queues, and live UI updates all work out of the box because their
-default state lives **in the process**. The moment you run a second
+cron, queues, and live UI updates all work with no extra setup because
+their default state lives **in the process**. The moment you run a second
 replica behind a load balancer, every one of those defaults needs a
-shared backend or a deliberate single-runner strategy. This page is the
-complete list — what breaks, why, and the replica-safe alternative.
+shared backend or a deliberate single-runner strategy. This page lists
+what breaks, why, and the replica-safe alternative for each one.
 
-## The one-line summary
+## Summary
 
 The database is the only state the replicas share. Anything that
 defaults to process memory must either move into the DB (or another

--- a/framework/docs/content/sdk.md
+++ b/framework/docs/content/sdk.md
@@ -93,8 +93,8 @@ gofastr generate sdk [--target=go,js] [--out=gen/sdk] [--name=<app>]
 
 Defaults can live in `gofastr.codegen.yml` as a generator entry named
 `sdk` (flags win). The same entry runs under `gofastr generate --config`
-via the built-in in-process generator — the first first-party generator in
-the codegen registry:
+via the built-in in-process generator — the first generator that ships
+built into the codegen registry:
 
 ```yaml
 codegen:
@@ -186,7 +186,7 @@ Files the export already produced (or the user static dir) always win.
 
 Custom entity `Endpoints` get no typed methods — both SDKs expose the
 `Do`/`do` escape hatch and the reference pages list them. Multipart
-uploads (Image/File fields) stay off the SDK surface, matching the CLI.
-Servers reconfigured to snake_case responses (`WithJSONCase`) should set
+uploads (Image/File fields) aren't available in the generated SDKs,
+matching the CLI. Servers reconfigured to snake_case responses (`WithJSONCase`) should set
 `sdkdocs.Config.SnakeCase` for the docs examples; the generated SDKs
 assume the camelCase default.

--- a/framework/docs/content/search.md
+++ b/framework/docs/content/search.md
@@ -97,8 +97,9 @@ using it in anything user-facing.
 
 `search.NewPostgres(db, cfg)` returns a backend that stores documents in a
 single Postgres table with a generated `TSVECTOR` column, so a Postgres-first
-app gets ranked full-text search with zero extra infrastructure. Call
-`EnsureSchema` once on boot, then `Index`/`Search` like any backend:
+app gets ranked full-text search without standing up separate search
+infrastructure. Call `EnsureSchema` once on boot, then `Index`/`Search` like
+any backend:
 
 ```go
 idx, err := search.NewPostgres(db, search.PostgresConfig{})
@@ -176,7 +177,7 @@ never matches. The Postgres backend encodes this as JSONB containment
 ### Prefix matching
 
 The query builder joins terms with AND and suffixes the **last** term with
-`:*`, so partial input matches as the user types — ideal for command palettes
+`:*`, so partial input matches as the user types — useful for command palettes
 and autocomplete. A query for `"pagin"` matches documents containing
 `"pagination"`.
 
@@ -192,9 +193,9 @@ every document.
 ## The SQLite FTS5 backend
 
 `search.NewSQLiteFTS(db, cfg)` returns a backend backed by a single SQLite FTS5
-virtual table, so a SQLite-first app gets ranked BM25 full-text search with
-zero extra infrastructure. Call `EnsureSchema` once on boot, then
-`Index`/`Search` like any backend:
+virtual table, so a SQLite-first app gets ranked BM25 full-text search without
+standing up separate search infrastructure. Call `EnsureSchema` once on boot,
+then `Index`/`Search` like any backend:
 
 ```go
 idx, err := search.NewSQLiteFTS(db, search.SQLiteFTSConfig{})
@@ -270,8 +271,9 @@ transaction — re-indexing the same id replaces in place with no duplicate rows
 
 - **Memory** — tests, single-binary demos, small read-only sites. Loses
   everything on restart.
-- **PostgresSearch** — a Postgres-first production app. Ranked search with
-  no extra infrastructure, plus weighted fields for title-vs-body ranking.
+- **PostgresSearch** — a Postgres-first production app. Ranked search
+  without standing up separate search infrastructure, plus weighted fields
+  for title-vs-body ranking.
 - **SQLiteFTS** — a SQLite-first app (embedded, single-file, edge). Ranked
   BM25 search without standing up Postgres. Needs the `sqlite_fts5` build tag.
 

--- a/framework/docs/content/security.md
+++ b/framework/docs/content/security.md
@@ -171,7 +171,7 @@ through `router.Post / router.Get / …` directly and don't carry
 schema metadata that the spec generator can consume. There is no
 plugin → OpenAPI extension hook today.
 
-Until that hook lands, the auth surface is documented through this
+Until that hook lands, the auth routes are documented through this
 file, the plugin source comments, and integration tests. If your
 deployment needs an OpenAPI document that includes the auth routes,
 hand-write them into a sibling spec and merge with the generated one
@@ -191,7 +191,7 @@ in the gateway / docs pipeline.
   `slowThreshold`). Preferred for production paths where the unsampled
   `Logging()` cost dominates the middleware chain.
 - `DiscardLogging()` — request-timing wrapper that emits no log lines;
-  for high-throughput surfaces where structured logging is handled by
+  for high-throughput paths where structured logging is handled by
   an upstream proxy or APM agent.
 - `SecurityHeaders(SecurityHeadersConfig)` — defensive headers above.
 - `CORS(CORSConfig)` — cross-origin headers + preflight.
@@ -264,9 +264,10 @@ tools registered directly via `app.MCP.RegisterTool` or
 [agent-ready](agent-ready.md)).
 
 `gofastr generate` prints a warning listing every entity left publicly
-readable/writable (`public: true`) so a generated app's open surface is
-never silent. See [entity-declarations](entity-declarations.md) →
-"Default CRUD authentication" for the blueprint YAML shape.
+readable/writable (`public: true`), so a generated app never has open
+entities you didn't get told about. See
+[entity-declarations](entity-declarations.md) → "Default CRUD
+authentication" for the blueprint YAML shape.
 
 ## Common mistakes
 

--- a/framework/docs/content/seo.md
+++ b/framework/docs/content/seo.md
@@ -1,9 +1,11 @@
 # SEO — meta tags, Open Graph, JSON-LD, sitemap, robots, icons
 
-Every SEO surface a crawler or social preview reads is a typed option or
-a small screen interface — no hand-written `<head>` strings, and every
-emitted value is HTML-escaped with URL fields scheme-checked (http(s)/
-relative only), so user-supplied titles or URLs can't inject markup.
+Everything a crawler or social preview reads — meta tags, Open Graph,
+JSON-LD, sitemap, robots.txt — comes from a typed option or a small
+interface on a screen component, not a hand-written `<head>` string.
+Every emitted value is HTML-escaped, and URL fields are scheme-checked
+(http(s)/relative only), so a user-supplied title or URL can't inject
+markup.
 
 Two declaration levels compose:
 
@@ -35,7 +37,7 @@ host := uihost.New(site,
 | `WithRobotsMeta` | `<meta name="robots">` on every page (e.g. `"noindex"` for staging) |
 | `WithSitemap(SitemapConfig{…})` | the `/sitemap.xml` endpoint (see below) |
 | `WithRobots(RobotsConfig{…})` | the `/robots.txt` endpoint (see below) |
-| `WithAppIcon(source)` | the full icon surface (see below) |
+| `WithAppIcon(source)` | every icon file the app needs (see below) |
 | `WithFavicon(href)` | a single `<link rel="icon">` for a hand-managed file |
 | `WithThemeColor`, `WithPreconnect` | `<meta name="theme-color">`, `<link rel="preconnect">` |
 
@@ -96,7 +98,7 @@ Both endpoints are **also written as files by static export**
 `--export-base` folded into every `<loc>` and the derived `Sitemap:`
 URL. See [Static-site export](/docs/static-export).
 
-## Icons: one source image → the whole surface
+## Icons: one source image → every icon file
 
 `WithAppIcon(source []byte)` takes one image (ideally ≥512px; non-square
 sources are center-cropped) and derives everything at startup:

--- a/framework/docs/content/signal-store.md
+++ b/framework/docs/content/signal-store.md
@@ -13,7 +13,7 @@ client consumers, and no client-side computed values.
 
 One **producer** (an island/widget or a screen loader) owns a value. Many
 **consumers** (pure presentational components) bind to it read-only. When the
-producer updates the value, the change fans out through a single signal to every
+producer updates the value, the change goes out through a single signal to every
 consumer **client-side** — no server round-trip per consumer.
 
 ```go

--- a/framework/docs/content/static-export.md
+++ b/framework/docs/content/static-export.md
@@ -115,8 +115,8 @@ against the serverless host:
 | `data-fui-open` (modals, ⌘K palette) | disabled | widget catalog needs the server |
 | SSE islands | not emitted | the SSE `<meta>` is omitted at render time |
 
-A dismissible "Static preview — run locally" banner (via the single shared
-`framework/ui.Banner` styling surface) is injected so server-backed demos
+A dismissible "Static preview — run locally" banner (using the shared
+`framework/ui.Banner` component) is injected so server-backed demos
 read as intentionally inactive rather than broken. The dismissal persists
 in `localStorage`.
 

--- a/framework/docs/content/testkit.md
+++ b/framework/docs/content/testkit.md
@@ -7,7 +7,7 @@ database on `t.Cleanup`.
 
 > **Framework-internal vs public.** The internal helpers in
 > `framework/internal/testdb` follow a schema-based isolation strategy
-> and are not exported. `testkit` is the stable public surface for
+> and are not exported. `testkit` is the stable public API for
 > host-app test code.
 
 ## Isolated databases

--- a/framework/docs/content/theming.md
+++ b/framework/docs/content/theming.md
@@ -1,18 +1,18 @@
 # Theming
 
-Every visual decision in the framework routes through one typed theme:
+Every visual decision in the framework goes through one typed theme:
 `core-ui/style.Theme`. Components never hardcode colors or spacing —
-they reference CSS custom properties (`var(--color-primary)`,
-`var(--spacing-md)`, …), and the host emits the theme as a `:root`
+they read CSS custom properties (`var(--color-primary)`,
+`var(--spacing-md)`, …), and the host writes the theme as a `:root`
 block at `/__gofastr/app.css`. Change a token value and every
-component, battery screen, and widget that references it updates —
-no component CSS is ever edited to re-skin an app.
+component, battery screen, and widget that reads it updates —
+you never edit a component's CSS to re-skin an app.
 
 ## The token catalog
 
-`style.Theme` is a struct of typed token groups. Every field is
-required (`WithTheme` panics at startup naming any missing token), and
-each group emits CSS variables with a fixed prefix:
+`style.Theme` is a struct made of typed token groups. Every field is
+required — `WithTheme` panics at startup and names any token you left
+out. Each group writes CSS variables with a fixed prefix:
 
 | Theme group | Emits | Examples |
 |---|---|---|
@@ -26,12 +26,12 @@ each group emits CSS variables with a fixed prefix:
 | `Easings` | `--easing-<name>` | `--easing-ease-out`, `--easing-spring` |
 | `Typography` | `--text-<name>` | `--text-sm`, `--text-base`, `--text-2xl` |
 | `Breakpoints` | `--breakpoint-<name>` | `--breakpoint-md` (informational — media queries can't read vars) |
-| `Layout` | `--spacing-touch-target` | the WCAG minimum tap target (44px) buttons and inputs size against |
-| `Code` | `--tk-<name>` | `--tk-kw`, `--tk-str`, `--tk-com` — the syntax-highlight palette code blocks read. The one *optional* group: unset slots fall back to the built-in palette. Dark values go in `Theme.DarkCode` (map, like `DarkColors`) |
+| `Layout` | `--spacing-touch-target` | the WCAG minimum tap-target size (44px); buttons and inputs use it for sizing |
+| `Code` | `--tk-<name>` | `--tk-kw`, `--tk-str`, `--tk-com` — the syntax-highlight colors code blocks read. This is the only optional group: leave a slot unset and it falls back to the built-in palette. Dark values go in `Theme.DarkCode` (a map, like `DarkColors`) |
 
-Token names auto-derive from the Go field path in kebab-case
-(`Colors.PrimaryFg` → `--color-primary-fg`); an explicit `Name` on a
-token overrides that. In component CSS written with
+Token names come from the Go field path, converted to kebab-case
+(`Colors.PrimaryFg` → `--color-primary-fg`). Set an explicit `Name` on
+a token to override that. In component CSS written with
 `style.ComponentSheet` or `ui.VariantCSS`, the `{group.name}` shorthand
 resolves to the variable: `{colors.primary}` → `var(--color-primary)`,
 `{spacing.lg}` → `var(--spacing-lg)`.
@@ -41,40 +41,43 @@ resolves to the variable: `{colors.primary}` → `var(--color-primary)`,
 Three entry points produce a `style.Theme` you pass to
 `site.WithTheme(...)`:
 
-- **`style.DefaultTheme()`** — the fully-populated lower-level light
-  baseline. It intentionally leaves `DarkColors` empty for compatibility.
+- **`style.DefaultTheme()`** — the fully-populated, lower-level light
+  baseline. It leaves `DarkColors` empty on purpose, for compatibility.
 - **`framework/ui/theme.Default(theme.Overrides{Primary: "#0F766E", DarkColors: map[string]string{"primary": "#5EEAD4"}})`**
-  — the framework's canonical adaptive theme used by fresh scaffolds. It
-  includes complete, contrast-safe light and dark palettes plus a flat override
-  struct for the tokens hosts most often swap: the light palette, explicit dark
-  token values, the three font stacks, and the radius scale. Light overrides
-  are deliberately not copied into dark mode because contrast-safe values
-  normally differ. Unset fields keep their defaults.
-- **`gofastr theme init`** — writes `theme/theme.go`, the complete
-  adaptive default as a literal you own and edit. Best for apps that will keep
-  diverging; edit `Colors` and `DarkColors` together.
+  — the adaptive theme fresh scaffolds start with. It ships complete,
+  contrast-safe light and dark palettes, plus a flat override struct for
+  the tokens hosts change most often: the light palette, explicit dark
+  token values, the three font stacks, and the radius scale. Light
+  overrides are not copied into dark mode automatically, because
+  contrast-safe values are usually different for dark. Any field you
+  don't set keeps its default.
+- **`gofastr theme init`** — writes `theme/theme.go`, the full adaptive
+  default as a literal you own and can edit directly. Use this for apps
+  that will keep changing their theme over time; edit `Colors` and
+  `DarkColors` together.
 
-Apps that need tokens beyond the canonical set embed `style.Theme` in
-their own struct and add fields; framework components only read the
-embedded canonical tokens, app components read the extras directly.
+If your app needs tokens beyond the built-in set, embed `style.Theme`
+in your own struct and add fields. Framework components only read the
+embedded built-in tokens; your own components can read the extra
+fields directly.
 
-Verify the result at `/__gofastr/app.css` — your values should appear
+Check the result at `/__gofastr/app.css` — your values should show up
 as `:root` custom properties.
 
 ## Self-hosting web fonts
 
 Setting `Fonts.Body`/`Fonts.Heading` to a custom family only names the
-font — the browser still needs the files, and **CDN font URLs are
-blocked by the default CSP** (`default-src 'self'`; see
-[security](security.md) → "Content-Security-Policy"). A
-`@font-face` pointing at `rsms.me`, Google Fonts, or any other origin
-silently fails and the stack falls through to its fallback. Self-host
-instead:
+font — the browser still needs the actual font files, and **the
+default CSP blocks CDN font URLs** (`default-src 'self'`; see
+[security](security.md) → "Content-Security-Policy"). A `@font-face`
+rule pointing at `rsms.me`, Google Fonts, or any other outside origin
+fails silently, and the browser uses the fallback font instead.
+Self-host the font instead:
 
 1. Put the font files under your static dir:
    `static/fonts/Inter-Variable.woff2` (serve it with
    `uihost.WithStaticDir("static")`).
-2. Register the `@font-face` through the styling surface — site CSS via
+2. Add the `@font-face` rule through site CSS —
    `uihost.WithCustomCSS` / `ReadCustomCSSFile("static/app.css")`:
 
    ```css
@@ -94,47 +97,48 @@ instead:
    t.Fonts.Heading.Value = t.Fonts.Body.Value
    ```
 
-Same-origin URLs pass the default CSP untouched. If you genuinely must
-load a third-party font, you have to override
-`ContentSecurityPolicy` explicitly — see the warning in
+Same-origin URLs pass the default CSP with no changes needed. If you
+really need to load a font from a third party, you have to override
+`ContentSecurityPolicy` yourself — read the warning in
 [security](security.md) before you do.
 
 ## Dark mode — `DarkColors` and `data-color-scheme`
 
-`Theme.DarkColors` is a map of color-token name → dark value
+`Theme.DarkColors` is a map from color-token name to its dark value
 (`"background": "#15141B"`, …). `framework/ui/theme.Default()` and
-`gofastr theme init` supply a complete map; the lower-level
-`style.DefaultTheme()` leaves it empty for compatibility.
+`gofastr theme init` fill in a complete map; the lower-level
+`style.DefaultTheme()` leaves it empty, for compatibility.
 
-When non-empty, the emitted CSS re-declares those tokens under
-`:root[data-color-scheme="dark"]`, plus a `prefers-color-scheme: dark`
-fallback that applies only while the user hasn't forced light. The
-**`data-color-scheme` attribute on `<html>` is the switch** —
-`ui.ThemeToggle` and the color-scheme bootstrap set it (and persist
-the choice), and every surface that emits theme CSS recolors through
-the variable cascade when it flips.
+When the map isn't empty, the generated CSS re-declares those tokens
+under `:root[data-color-scheme="dark"]`, plus a
+`prefers-color-scheme: dark` fallback that only applies while the user
+hasn't forced light mode. The **`data-color-scheme` attribute on
+`<html>` is the actual switch** — `ui.ThemeToggle` and the color-scheme
+bootstrap set it (and remember the choice), and any element reading a
+theme CSS variable picks up the new color the moment it flips.
 
-Two rules follow:
+Follow these rules:
 
 1. **Never gate your own light/dark styling on
-   `prefers-color-scheme`.** A media query can't see the user's
-   in-app toggle, so it disagrees with the attribute the moment the
-   user picks the non-OS scheme. Dark values belong in `DarkColors`
+   `prefers-color-scheme`.** A media query can't see the in-app toggle,
+   so it disagrees with the attribute as soon as the user picks a
+   scheme that doesn't match the OS. Put dark values in `DarkColors`
    (or a `:root[data-color-scheme="dark"]` scoped rule) so the toggle
-   drives everything.
-2. **Reference tokens, not literal colors,** in any CSS you write —
-   a hardcoded hex is invisible to the dark re-declaration and
-   becomes a light-colored island on a dark page.
-3. **Do not render `ui.ThemeToggle` with a light-only custom theme.** Keep the
-   scaffold's adaptive default or provide every semantic dark token first. The
-   toggle also updates the browser's native color-scheme state, so a partial
-   palette can mix dark UA link/control colors with light app surfaces.
+   controls everything.
+2. **Reference tokens, not literal colors,** in any CSS you write. A
+   hardcoded hex value is invisible to the dark re-declaration and
+   turns into a light-colored patch on a dark page.
+3. **Don't render `ui.ThemeToggle` with a light-only custom theme.**
+   Keep the scaffold's adaptive default, or supply every semantic dark
+   token yourself first. The toggle also changes the browser's native
+   color-scheme state, so a partial palette can end up mixing dark
+   browser link/control colors with light app colors.
 
 ## Section-level overrides — `ui.Themed`
 
-To re-skin one subtree (a dark marketing band, a branded callout,
-per-tenant accents) without touching the rest of the page, register an
-override theme and wrap the section:
+To re-skin one part of a page (a dark marketing band, a branded
+callout, per-tenant accents) without touching the rest of the page,
+register an override theme and wrap the section:
 
 ```go
 var Dark = style.RegisterThemeOverride(darkTheme)
@@ -146,83 +150,86 @@ ui.Themed(Dark,
 )
 ```
 
-`Themed` emits a `<div class="fui-theme-<hash>">`; the override's
-token block ships in `app.css` scoped to that class, and every
-descendant component dereferences `var(--color-…)` against it instead
-of `:root`. Registering the same theme twice returns the same handle,
-so the CSS ships once.
+`Themed` wraps the content in a `<div class="fui-theme-<hash>">`. The
+override's token block ships in `app.css` scoped to that class, and
+every component inside it reads `var(--color-…)` from that class
+instead of from `:root`. Registering the same theme twice returns the
+same handle, so its CSS only ships once.
 
 ## Per-component knobs — the `--ui-*` variables
 
 Some components expose dimensions or accents that aren't global
-tokens — a container's width cap, a doc layout's rail width, a code
-block's scroll max. These are published as `--ui-<component>-<knob>`
-variables with built-in fallbacks, so a host overrides them from its
-own stylesheet without forking the component:
+tokens — a container's max width, a doc layout's rail width, a code
+block's scroll max height. These are exposed as
+`--ui-<component>-<knob>` variables with built-in fallbacks, so a host
+can override them from its own stylesheet without forking the
+component:
 
 ```css
 /* app.css or a style.Contribute block */
 :root { --ui-container-wide: 1240px; }
 ```
 
-They also work scoped — set one inside a `ui.Themed` section or on a
-specific wrapper class to retune a single instance. The knobs are
-named in each component's source next to the CSS that reads them
-(e.g. `ui.Container`: `--ui-container-default/narrow/wide`;
+You can also scope them — set one inside a `ui.Themed` section, or on
+a specific wrapper class, to change a single instance. Each
+component's source lists its knobs next to the CSS that reads them
+(for example `ui.Container`: `--ui-container-default/narrow/wide`;
 `ui.DocLayout`: `--ui-doc-layout-rail/gap/max-width`) — grep
-`framework/ui` for `--ui-` to see the full set.
+`framework/ui` for `--ui-` to see the full list.
 
 ## Why you can't just override component CSS
 
-Component stylesheets and your site CSS load in an order you don't
-control. At SSR, the host emits the page's component-CSS bundle first
-and `/__gofastr/app.css` after it — but any component whose CSS loads
-lazily *after* hydration (it first appears in an island response, a
-widget, or an SPA navigation) gets its `<link>` appended to the end of
-`<head>`, after `app.css`. So an equal-specificity site rule against a
-component's internals (`.ui-button { background: … }`) wins on one
-page and silently loses on another, depending on how the component's
-sheet arrived; escalating with `!important` or higher-specificity
-selectors wins today and breaks on the next component change.
+Component stylesheets and your site CSS don't always load in the same
+order. At first paint, the host writes the page's component-CSS bundle
+first and `/__gofastr/app.css` after it. But if a component's CSS
+loads lazily, after hydration — because it first shows up in an island
+response, a widget, or an SPA navigation — its `<link>` gets appended
+to the end of `<head>`, after `app.css`. So a site rule with the same
+specificity as a component's internal rule (`.ui-button { background:
+… }`) wins on one page and silently loses on another, depending on how
+that component's stylesheet arrived. Reaching for `!important` or a
+higher-specificity selector "fixes" it today and breaks again the next
+time the component changes.
 
-Component internals are not the theming surface. Restyle through the
-supported channels instead — they behave identically regardless of
-load order:
+Don't restyle component internals directly. Use one of these instead —
+they work the same way no matter what order things loaded in:
 
-- **Token values** (this doc) for anything the palette/scale controls.
+- **Token values** (this doc) for anything the palette or scale
+  controls.
 - **`--ui-*` variables** for per-component knobs.
 - **Registered variants** (`ui.RegisterButtonVariant`,
   `RegisterCardVariant`, `RegisterStatusVariant`, …) for a new named
-  look — the variant CSS ships inside the component's own sheet and
-  joins render-time validation. See
+  look — the variant CSS ships inside the component's own stylesheet
+  and goes through the same render-time validation. See
   [ui-getting-started](ui-getting-started.md) § "Custom variants on
   framework components".
 
-If none of those can express what you need, the component is missing
-a config option or variant — extend it upstream rather than patching
-its internals from outside.
+If none of those can do what you need, the component is missing a
+config option or variant. Add it there, upstream, instead of patching
+its internals from the outside.
 
 ## Common mistakes
 
 - **Gating dark mode on `prefers-color-scheme` alone.** The in-app
   toggle sets `data-color-scheme` on `<html>`; a bare media query
   ignores it and fights the user's choice. Put dark values in
-  `Theme.DarkColors` and let the emitted CSS handle both signals.
-- **Overriding a component's internals from site CSS.** The relative
-  order of `app.css` and a component's sheet differs between first
-  paint (component CSS first) and lazy load after hydration (component
-  CSS last), so an equal-specificity override works on some pages and
-  silently fails on others. Use tokens, `--ui-*` knobs, or a
-  registered variant.
-- **Hardcoding a hex where a token belongs.** It renders fine in
-  light mode and turns into a wrong-colored island the first time
-  dark mode or a `ui.Themed` section wraps it. Write
-  `{colors.primary}` / `var(--color-primary)`.
-- **Booting with a half-populated theme.** Every token is required;
-  `WithTheme` panics at startup naming the missing field path. Start
-  from `style.DefaultTheme()` / `gofastr theme init` and edit values.
-- **Editing `--color-*` variables per component instead of theming.**
-  Re-declaring global tokens on one component's selector "works" but
-  is invisible to dark mode and other consumers of the token. For a
-  one-section reskin that's what `ui.Themed` + a registered override
-  theme is for.
+  `Theme.DarkColors` and let the generated CSS handle both signals.
+- **Overriding a component's internals from site CSS.** The order of
+  `app.css` and a component's stylesheet differs between first paint
+  (component CSS loads first) and a lazy load after hydration
+  (component CSS loads last), so an equal-specificity override works
+  on some pages and silently fails on others. Use tokens, `--ui-*`
+  knobs, or a registered variant instead.
+- **Hardcoding a hex value where a token belongs.** It looks fine in
+  light mode and turns into a wrong-colored patch the first time dark
+  mode or a `ui.Themed` section wraps it. Write `{colors.primary}` /
+  `var(--color-primary)` instead.
+- **Starting the app with a half-filled-in theme.** Every token is
+  required; `WithTheme` panics at startup and names the missing field
+  path. Start from `style.DefaultTheme()` or `gofastr theme init` and
+  edit values from there.
+- **Editing `--color-*` variables on one component instead of
+  theming.** Re-declaring a global token on one component's selector
+  "works," but dark mode and every other consumer of that token never
+  see it. For a one-section reskin, use `ui.Themed` plus a registered
+  override theme instead.

--- a/framework/docs/content/tutorial-blueprint-app.md
+++ b/framework/docs/content/tutorial-blueprint-app.md
@@ -1,6 +1,7 @@
 # Tutorial: one blueprint → UI + API you own
 
-This is the thesis tutorial. In about twenty minutes you will:
+This tutorial covers the optional `gofastr.yml` blueprint scaffolder
+end to end. In about twenty minutes you will:
 
 1. write a `gofastr.yml` blueprint and generate a working app — a
    server-rendered UI **and** a REST API (plus OpenAPI and MCP tools)
@@ -11,12 +12,12 @@ This is the thesis tutorial. In about twenty minutes you will:
 3. keep going in plain Go — a hand-written screen and role management;
 4. point at the deploy recipe for the single-binary Docker image.
 
-The one rule that shapes everything below: **`gofastr generate` is
-one-shot.** You run it once to scaffold. From that moment the emitted
-Go — not the blueprint — is the source of truth, and you evolve the app
-by editing it, exactly the way you would any Go project. The generator
-even refuses to overwrite an existing project without `--force`, so it
-can't silently clobber your work.
+One thing matters here: **`gofastr generate` is one-shot.** You run it
+once to scaffold. From that moment the emitted Go — not the blueprint —
+is the source of truth, and you evolve the app by editing it, the same
+way you'd edit any Go project. The generator refuses to overwrite an
+existing project without `--force`, so it can't silently clobber your
+work.
 
 Every command below is copy-paste runnable. Each step ends with a
 `curl` that proves the step worked.
@@ -83,8 +84,8 @@ screens:
 `auth.enabled` wires the auth battery — register/login/logout routes and
 session middleware — because you'll want a signed-in user in the next
 step. The `entity_list` gives you a server-rendered table with search,
-sort, and pagination out of the box. Once an entity has an enum, bool, or
-relation column, add `filters: [<column>, …]` to the block and the
+sort, and pagination without you writing any of that code. Once an
+entity has an enum, bool, or relation column, add `filters: [<column>, …]` to the block and the
 generated screen renders a `ui.FilterToolbar` of facet filters above the
 table — see the [`entity_list` reference](blueprints.md) for the details.
 
@@ -104,15 +105,14 @@ The scaffold is normal, owned Go — a flat `package main` at the module root:
 order (one `screen_<name>.go` per screen — the home page here), `app.go` the
 `RegisterGenerated` wiring
 (including the auth setup), `main.go` the entrypoint. Read them — they are
-short, there is no hidden layer underneath, and they carry no `DO NOT EDIT`
-header because they're yours to edit and commit. This is the whole point:
-`gofastr generate` is one-shot, so from here the owned Go — not the
-blueprint — is the source of truth. (Run it again and it refuses to
+short and carry no `DO NOT EDIT` header, because they're yours to edit
+and commit. `gofastr generate` is one-shot, so from here the owned Go —
+not the blueprint — is the source of truth. (Run it again and it refuses to
 overwrite; `--force` regenerates the *entire* set and would discard the
 edits you're about to make, so you won't use it past this first run.)
 
-Prove all three surfaces from a second terminal — the REST API lives
-under the `/api` prefix:
+Check the UI, the API, and the MCP tools from a second terminal — the
+REST API lives under the `/api` prefix:
 
 ```bash
 # The API — auto-CRUD with validation, filtering, pagination:
@@ -124,7 +124,7 @@ curl http://localhost:8080/api/notes
 # The UI — server-rendered screen at /:
 curl -s http://localhost:8080/ | grep "My Notes"
 
-# The agent surface — MCP tools generated from the same declaration:
+# The agent tools — MCP tools generated from the same declaration:
 curl -s -X POST http://localhost:8080/mcp \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
@@ -405,7 +405,7 @@ Go you own:
   PocketBase, Encore, Wasp, and hand-rolling.
 - [`examples/ecommerce`](https://github.com/DonaldMurillo/gofastr/tree/main/examples/ecommerce)
   — a five-entity blueprint (auth + owner-scoped orders) generated and
-  surface-tested end-to-end.
+  tested end-to-end.
 
 ## Common mistakes
 

--- a/framework/docs/content/ui-composition-recipes.md
+++ b/framework/docs/content/ui-composition-recipes.md
@@ -1,9 +1,9 @@
 # UI composition recipes
 
-GoFastr's component catalog answers “what exists.” This guide answers “what
-page grammar fits the user's task?” Choose a recipe after completing the
-project's `DESIGN.md`, then compose it from framework primitives. Applications
-ship no bespoke CSS and do not recreate structural markup.
+GoFastr's component catalog lists what components exist. This guide covers
+which layout pattern fits a given user task. Pick a recipe after filling out
+the project's `DESIGN.md`, then build it from framework primitives. Apps ship
+no CSS of their own and don't rebuild structural markup that already exists.
 
 These are decision recipes, not templates to copy unchanged. Preserve the
 hierarchy and responsive intent; adapt the content and components to the
@@ -64,8 +64,8 @@ ui.Container(ui.ContainerConfig{Width: ui.ContainerWide},
 ```
 
 `RecordSummary` controls the heading scale on phones, places its natural-width
-`Actions` in the lead region, and gives a concise `Aside` a purposeful support
-rail on wide canvases. On phones the action leads that support region instead
+`Actions` in the lead region, and gives a concise `Aside` a support rail on
+wide canvases. On phones the action leads that support region instead
 of falling below the full summary. Keep `Description` to one or two sentences,
 keep `Highlight` to one decision plus one short condition, and move the full
 narrative later. `MetricBand` stays one compact row on wide viewports and
@@ -191,10 +191,10 @@ active controls.
 6. Render at about 390px and 1440px in light and dark schemes.
 7. Identify the three weakest visible decisions and revise them.
 
-If the recipe cannot be expressed without local structural markup or CSS,
-record the missing reusable capability and add it to the design system. The
-application is the completeness test; it is not an exception to the styling
-contract.
+If a recipe can't be built without local structural markup or CSS, that's a
+missing piece in the design system — write it down and add it there. The app
+doesn't get an exception to the no-CSS rule; building it is how you find what's
+missing.
 
 ## Common mistakes
 

--- a/framework/docs/content/ui-getting-started.md
+++ b/framework/docs/content/ui-getting-started.md
@@ -1,6 +1,6 @@
 # UI getting started
 
-Take `gofastr init` → a themed, product-specific app composed from framework primitives. This doc is the linear path: do the steps in order; you'll have a working app after every one.
+Running `gofastr init` scaffolds a themed, product-specific app built from framework primitives. This doc walks through the setup steps in order — you'll have a working app after each one.
 
 The module is published — `go mod tidy` resolves it from the Go module proxy. Pin a tagged version (e.g. `v0.4.0`) rather than tracking `main`.
 
@@ -272,8 +272,8 @@ handle above still works and remains the simplest path for a single app.
 
 Open `DESIGN.md` before selecting components. Name the primary user and task,
 the dominant element on each route, the intended density and hierarchy, and
-what mobile keeps, condenses, or moves. Then choose the closest framework-native
-composition:
+what mobile keeps, condenses, or moves. Then choose the closest composition
+built from framework components:
 
 ```bash
 gofastr docs ui-composition-recipes

--- a/framework/docs/content/ui-wiring.md
+++ b/framework/docs/content/ui-wiring.md
@@ -5,7 +5,7 @@ case: you have a plain `framework.App` (entities, CRUD, batteries) and
 want to add server-rendered screens to it by hand — or you're reading a
 generated `main.go` and want to know what each line is for.
 
-Three objects, one bridge:
+This doc covers three objects and the bridge between them:
 
 | Object | Package | Owns |
 |---|---|---|

--- a/framework/docs/content/upgrading.md
+++ b/framework/docs/content/upgrading.md
@@ -23,8 +23,8 @@ gofastr upgrade --to vX.Y.Z    # plan against a specific release
 gofastr upgrade --apply        # also run go get / tidy / build / test
 ```
 
-The plan lists each in-between release's notes (BREAKING entries
-first-class), and where a change has a known code signature, the report
+The plan lists each in-between release's notes (BREAKING entries called
+out clearly), and where a change has a known code signature, the report
 points at the affected `file:line` in *your* project — the same guided
 style as `gofastr audit a11y`. `--apply` then runs the mechanical
 steps and stops at the first failure so you fix with the notes in hand.

--- a/framework/docs/content/webhooks.md
+++ b/framework/docs/content/webhooks.md
@@ -239,8 +239,8 @@ ring belongs in your KMS adapter.
 
 ## Auto-bridging from `framework/event`
 
-When you want every internal event to fan out to webhook subscribers
-without per-event glue, call `webhook.Bridge`:
+To send every internal event to webhook subscribers without writing
+per-event glue, call `webhook.Bridge`:
 
 ```go
 cancel := webhook.Bridge(app.Events(), mgr)              // entity.created/updated/deleted

--- a/framework/docs/content/widgets.md
+++ b/framework/docs/content/widgets.md
@@ -11,12 +11,12 @@ are distinct from components:
 
 Examples of widgets the framework already supports:
 
-- **FloatingPanel** — corner-anchored chat / devtools / agent surface
+- **FloatingPanel** — corner-anchored chat / devtools / agent panel
 - **Modal** — center dialog with backdrop, ESC + click-outside dismiss
 - **Toast** — ephemeral bottom notifications
 - **Drawer** — edge-mounted sliding panel
 - **Banner** — top strip for build progress, version warnings, etc.
-- **Popover** — click-triggered anchored surface, no backdrop dim, no focus trap. ESC + click-outside dismiss. Use for help panels, share menus, per-row expanders.
+- **Popover** — click-triggered anchored panel, no backdrop dim, no focus trap. ESC + click-outside dismiss. Use for help panels, share menus, per-row expanders.
 
 `kiln/chat/panel.go` is the canonical real-world consumer: the agent
 chat panel is implemented as a `FloatingPanel` widget.
@@ -42,7 +42,7 @@ widget.Mount(router, &panel)
 
 To open a widget from the page, wire any element with
 `data-fui-open="<widget-name>"` — the runtime handles the click, shows
-the widget, and (for modal surfaces) moves focus in:
+the widget, and (for modals) moves focus in:
 
 ```html
 <button data-fui-open="my-panel">Open panel</button>
@@ -119,9 +119,9 @@ component owns only its internal content and layout. Per position:
   `min/max-inline-size` caps, and `overflow: auto` so tall content
   scrolls inside the dialog. A modal using `header`, `body`, and
   `footer` slots therefore reads as ONE dialog card, and a plain
-  `preset.Modal` looks like a dialog out of the box — bodies must
-  **not** re-paint background / padding / radius on their root (that
-  double-pads the panel).
+  `preset.Modal` looks like a dialog with no extra styling — bodies
+  must **not** re-paint background / padding / radius on their root
+  (that double-pads the panel).
 
 Full-bleed modal bodies (media viewers, custom chrome) opt out of the
 centered panel so the body owns every pixel: the panel stays a
@@ -334,8 +334,8 @@ come from `widget.MountRuntime(r)` — once per host, not per widget.
 
 ## Theming
 
-Widgets resolve through `core-ui/style` and pick up the framework
-default theme out of the box. Token overrides flow through:
+Widgets resolve through `core-ui/style` and use the framework default
+theme without extra setup. Token overrides flow through:
 
 1. `core-ui/widget/theme.PageTheme(overrides ...style.Theme)` returns
    a merged `style.Theme`. Use it to author custom widget chrome.
@@ -359,12 +359,12 @@ The framework runtime is **strict-CSP safe**. The bootstrap never:
 (`style`, `srcdoc`, `on*=`) so a bad agent turn can't poison the page.
 
 Compose typed `framework/ui` components, `core-ui/patterns`, or semantic
-`core-ui/html` primitives. App-local utility-class palettes are a second
-styling surface and are not part of the current contract.
+`core-ui/html` primitives. App-local utility-class palettes are a
+separate styling approach and are not part of the current contract.
 
 ## Testing
 
-`examples/site` exercises every widget surface end-to-end —
+`examples/site` exercises every widget kind end-to-end —
 Modal (`/components/modal`), Drawer (`/components/drawer`), Toast
 (`/components/toast`), Menu (`/components/menu`), Sidebar
 (`/components/sidebar`), and the trigger-anchored Popover preset
@@ -376,7 +376,7 @@ scroll-tracking, and the trigger-active highlight contract.
 For backend-only verification (no chromedp), see
 `core-ui/widget/widget_test.go` and
 `core-ui/widget/preset/preset_test.go` — they cover the builder
-semantics, mounted route surface, preset defaults, and JSON state
+semantics, the mounted routes, preset defaults, and JSON state
 encoding.
 
 ## Common mistakes


### PR DESCRIPTION
Repositions GoFastr away from "the blueprint tool" and toward a full-stack Go framework **that doesn't get in the way of you or your agents**. Blueprint and the entity declaration are optional features, not the identity. No framework API changes.

## What's in it

- **Embedded docs reframed** in plain words, full-stack-first (`framework/docs/content/*`, browsable via `gofastr docs` + the `framework_docs_*` MCP tools). Leads with the two-layer `core`/`framework` model instead of the blueprint pipeline; marketing language removed. Facts, flags, links, and code samples unchanged.
- **README repositioned**: killed the "code-generation platform" identity line, blueprint demoted to the last/optional design bet, Quickstart reordered (Go entity form before blueprint), and a "Built with GoFastr" section leading with a real production app ([barcode.donaldmurillo.com](https://barcode.donaldmurillo.com/)). The executable-README quickstart gate still passes.
- **Docs site (`examples/site`)**: area hubs are now taught pages (concept → real code → one reference link); `/patterns` renamed to `/framework` (its own copy already called it the framework layer); homepage gains a "Built with GoFastr" section; footer, meta/OpenGraph, and the agent card move off "agents are first-class authors" onto the tagline.
- **`plain-words` skill** — a writing guardrail (banned-word list + the coworker test) so copy stays plain.
- **CHANGELOG** entry under `[Unreleased]` (no release cut).

## Verification

Gated locally before pushing: `go build ./...`, `go vet`, `framework/docs` tests, the executable README quickstart test, the full `examples/site` e2e suite, and the axe a11y gate. Every code sample on the taught hubs was verified against real API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)