### PR TITLE
Fix the ten confirmed findings from the weekend-range review (v0.32–v0.37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,74 @@ All notable changes to GoFastr. Follows
 calendar versions (`YYYY-MM-DD` per substantive release until the API
 stabilises). Breaking changes are clearly marked with **BREAKING**.
 
+## [Unreleased]
+
+Post-release review of the v0.32.0–v0.37.0 weekend range (multi-model pass:
+Claude + GLM + Sol) found ten confirmed bugs, all in code merged that
+weekend. Every fix landed test-first; the failing tests are in the same
+commits.
+
+### Added
+
+- **Cron schedules in a named timezone.** `DurableScheduleBuilder.RegisterAt`
+  with a time in an IANA zone (e.g. `America/New_York`) evaluates the cron
+  spec in that zone's wall-clock time, across DST transitions. The zone name
+  persists with the schedule (`tz` column, idempotent migration). `Register()`
+  still anchors in UTC — existing schedules keep their fire times, and
+  `time.Local` / fixed-offset zones deliberately collapse to UTC because they
+  would resolve differently per replica.
+
+### Fixed
+
+- **SQLite: failed statement no longer breaks transaction rollback.** A
+  statement failing inside an explicit transaction (e.g. a multi-row `INSERT`
+  hitting `UNIQUE`) used to flush and replace pager state, so a later
+  `ROLLBACK` silently kept the transaction's earlier writes. Statement
+  rollback is now a pure in-memory snapshot that preserves the transaction's
+  pre-`BEGIN` page images.
+- **SQLite: multi-row `UPDATE` enforces `UNIQUE` across its own rows.**
+  `UPDATE t SET u = 3` over two rows used to commit both; pending rows are
+  now checked against each other (with partial-index predicates honored) and
+  the statement fails like real SQLite.
+- **SQLite: `UPDATE` maintains secondary indexes.** The index write sat in an
+  error branch, so a successful update never refreshed indexes and stale
+  entries kept matching the old value. Updates now delete the old index
+  entries and re-insert per the new row.
+- **SQLite: dynamic column defaults survive reopen.** `DEFAULT
+  CURRENT_TIMESTAMP` (and other expressions) now serialize with the schema
+  (`default_expr`), so file-backed databases no longer fail `NOT NULL`
+  inserts after a restart. Legacy files keep their constant defaults —
+  including empty-string defaults like `lane TEXT NOT NULL DEFAULT ''`.
+- **SQLite: `INTEGER` affinity keeps fractional values REAL.** `DEFAULT 1.5`
+  stored `1`; conversion now happens only when lossless, matching SQLite's
+  affinity rule.
+- **SQLite: partial unique indexes honor their `WHERE` predicate** at
+  creation, on insert, and on update. Out-of-predicate duplicates no longer
+  reject index creation, and enforcement applies only to matching rows.
+  Partial indexes stay out of scan planning (correctness over speed).
+- **Queue: non-UTC cron schedules no longer kill the scheduler.** A schedule
+  registered with a non-UTC anchor errored on its first tick, and that error
+  stopped `Start` — taking every other schedule with it. Evaluation now
+  follows the registration zone, and a schedule that cannot produce a due
+  tick is logged and skipped instead of being fatal.
+- **Queue: changing a schedule's cadence self-heals.** Re-registering with a
+  different cron/interval stranded the old watermark and hit the same fatal
+  error; the scheduler now advances to the next valid occurrence of the new
+  spec through the same version-guarded compare-and-swap as a normal tick.
+- **Outbox: legacy timestamp formats no longer corrupt lease comparisons.**
+  Rows written by mattn/go-sqlite3 (space-separated timestamps) compare
+  lexicographically against the pure driver's RFC3339 values, so an active
+  future lease read as expired — reclaiming in-flight deliveries (double
+  delivery) and mis-timing grace cutoffs. The relay now normalizes legacy
+  values to the canonical format at start (idempotent, sqlite-only); the
+  atomic single-`UPDATE` claim path is unchanged.
+- **Auth: scope-denied responses use the canonical error envelope.**
+  `RequireAPIScopes` / `RequireScope` returned a nested
+  `{"error":{...}}` with `Content-Type: text/plain`, which the generated JS
+  SDK rendered as `api: 403: [object Object]`. Both now emit the flat
+  `{"error","success","code"}` envelope as `application/json`; every
+  `battery/auth` error response now carries the `code` field.
+
 ## [0.37.0] - 2026-07-19
 
 Accuracy-and-fixes release: closes two adapter/queue issues and runs a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 Post-release review of the v0.32.0–v0.37.0 weekend range (multi-model pass:
 Claude + GLM + Sol) found ten confirmed bugs, all in code merged that
-weekend. Every fix landed test-first; the failing tests are in the same
-commits.
+weekend. A second round — rotated reviewers plus an adversarial pass over
+the first round's fixes — found twelve more, including one security fix.
+Every fix landed test-first; the failing tests are in the same commits.
 
 ### Added
 
@@ -66,6 +67,44 @@ commits.
   delivery) and mis-timing grace cutoffs. The relay now normalizes legacy
   values to the canonical format at start (idempotent, sqlite-only); the
   atomic single-`UPDATE` claim path is unchanged.
+- **Security — hidden columns can no longer be probed through include
+  scoped filters.** `?include=rel(password_hash_like=SEC%)` accepted
+  filters on `Hidden` columns of the include target; the related row's
+  presence in the response leaked whether the value matched
+  (prefix-bruteforceable) — the same oracle the strict-filter release
+  closed on the flat, nested, and `?where=` paths. A hidden field now gets
+  the identical "not on target entity" rejection a nonexistent field gets.
+- **SQLite (round 2): nine more engine fixes**, found by reviewing the
+  first round's fixes and sweeping untouched paths for the same defect
+  classes: DDL inside a rolled-back transaction no longer resurfaces after
+  reopen (schema flushes are deferred to commit; rollback restores the
+  header, schema pointer, allocated pages, and file length); `ALTER TABLE
+  ADD COLUMN` no longer corrupts indexed reads (index records were decoded
+  as table records and padded with defaults, returning the wrong row);
+  plain multi-row `VALUES` inserts now enforce separately created unique
+  indexes; `RENAME COLUMN` renames through index metadata, unique
+  constraints, and partial-index predicates; a valid multi-row `UPDATE`
+  key shift (`SET u = u - 1`) is no longer rejected; partial-index
+  predicates use SQL truthiness (`0.5` is true); `INSERT OR REPLACE` is
+  implemented (it previously failed to parse); `DELETE` and upsert paths
+  maintain index entries; REAL/NUMERIC/TEXT affinity conversions match
+  SQLite (signed/padded numeric text, lossless-integral to INTEGER,
+  numbers to text, blobs stay blobs).
+- **Queue: legacy timestamp formats normalized, like the outbox.** The
+  same mixed-format lexicographic comparison reclaimed in-flight jobs with
+  active leases (double execution) and ran future-scheduled jobs
+  immediately (retry backoff voided). `NewDBQueue` now normalizes the job
+  and scheduler tables the way the outbox relay does.
+- **Queue: DST transitions follow vixie cron.** A schedule in a zone that
+  falls back no longer fires twice in the repeated hour, and one whose
+  wall time is skipped by spring-forward fires once at the transition
+  instant instead of silently losing the day (registration and watermark
+  advance included).
+- **Outbox: normalization is idempotent on the CGO driver too.** The
+  canonical-format check now probes the layout the connected driver
+  actually binds, so hosts on mattn/go-sqlite3 no longer rewrite every row
+  at every relay start; a failed table probe other than "no such table"
+  (e.g. a locked file) is now logged instead of silently skipping.
 - **Auth: scope-denied responses use the canonical error envelope.**
   `RequireAPIScopes` / `RequireScope` returned a nested
   `{"error":{...}}` with `Content-Type: text/plain`, which the generated JS

--- a/battery/auth/apitoken_middleware.go
+++ b/battery/auth/apitoken_middleware.go
@@ -273,7 +273,7 @@ func RequireAPIScopes(apiPrefix string) middleware.Middleware {
 				verb = "read"
 			}
 			if !scopeMatches(held, resource+":"+verb) {
-				http.Error(w, `{"error":{"code":403,"message":"insufficient token scope"}}`, http.StatusForbidden)
+				writeAuthError(w, http.StatusForbidden, "insufficient token scope")
 				return
 			}
 			next.ServeHTTP(w, r)
@@ -292,7 +292,7 @@ func RequireScope(scope string) middleware.Middleware {
 				next.ServeHTTP(w, r)
 				return
 			}
-			http.Error(w, `{"error":{"code":403,"message":"insufficient token scope"}}`, http.StatusForbidden)
+			writeAuthError(w, http.StatusForbidden, "insufficient token scope")
 		})
 	}
 }

--- a/battery/auth/apitoken_scope_envelope_test.go
+++ b/battery/auth/apitoken_scope_envelope_test.go
@@ -1,0 +1,60 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Scope rejections use the canonical flat error envelope
+// {"error": "<message>", "success": false, "code": 403} with a JSON
+// content type — the shape the generated SDKs and sdkdocs document.
+func TestScopeErrorFlatEnvelope(t *testing.T) {
+	reject := func(t *testing.T, h http.Handler, req *http.Request) {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403", rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+			t.Fatalf("Content-Type = %q, want application/json", ct)
+		}
+		var envelope struct {
+			Error   any   `json:"error"`
+			Success *bool `json:"success"`
+			Code    int   `json:"code"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+			t.Fatalf("body is not JSON: %v (%q)", err, rec.Body.String())
+		}
+		msg, ok := envelope.Error.(string)
+		if !ok || msg == "" {
+			t.Fatalf(`"error" = %#v, want non-empty string (flat envelope)`, envelope.Error)
+		}
+		if envelope.Success == nil || *envelope.Success {
+			t.Fatalf(`"success" = %v, want false`, envelope.Success)
+		}
+		if envelope.Code != http.StatusForbidden {
+			t.Fatalf(`"code" = %d, want 403`, envelope.Code)
+		}
+	}
+
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("RequireAPIScopes", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/customers", nil)
+		req = req.WithContext(context.WithValue(req.Context(), tokenScopesKey{}, []string{"invoices:read"}))
+		reject(t, RequireAPIScopes("/api")(ok), req)
+	})
+	t.Run("RequireScope", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/anything", nil)
+		req = req.WithContext(context.WithValue(req.Context(), tokenScopesKey{}, []string{"other:read"}))
+		reject(t, RequireScope("posts:read")(ok), req)
+	})
+}

--- a/battery/auth/core.go
+++ b/battery/auth/core.go
@@ -569,12 +569,17 @@ func (c *CorePlugin) registerHandler() http.HandlerFunc {
 	}
 }
 
-// writeAuthError is the shared error response helper (kept from original).
+// writeAuthError is the shared error helper: it emits the canonical flat
+// envelope {"error","success","code"} with Content-Type application/json —
+// the shape framework/crud/crud.go's writeJSONError uses and the generated
+// SDKs and sdkdocs document. battery/auth keeps a local copy because
+// batteries may not import framework/crud.
 func writeAuthError(w http.ResponseWriter, status int, msg string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(map[string]any{
 		"error":   msg,
 		"success": false,
+		"code":    status,
 	})
 }

--- a/battery/queue/db.go
+++ b/battery/queue/db.go
@@ -178,6 +178,12 @@ func NewDBQueue(db *sql.DB, opts ...DBQueueOption) (*DBQueue, error) {
 	if err := q.ensureTable(); err != nil {
 		return nil, fmt.Errorf("ensure table: %w", err)
 	}
+	// Canonicalize any space-separated (legacy mattn/go-sqlite3) timestamps
+	// in the queue and scheduler tables before the first claim query runs.
+	// SQLite-only no-op on Postgres; idempotent. See legacy_normalize.go.
+	if err := q.normalizeLegacyTimestamps(context.Background()); err != nil {
+		return nil, fmt.Errorf("normalize legacy timestamps: %w", err)
+	}
 	return q, nil
 }
 

--- a/battery/queue/durable_scheduler.go
+++ b/battery/queue/durable_scheduler.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -61,13 +62,13 @@ type DurableScheduleBuilder struct {
 	priority    int
 	maxAttempts int
 }
-
 type durableSchedule struct {
 	id          string
 	jobType     string
 	payload     json.RawMessage
 	interval    time.Duration
 	cronSpec    string
+	tz          string
 	lane        string
 	priority    int
 	maxAttempts int
@@ -169,9 +170,12 @@ func (b *DurableScheduleBuilder) MaxAttempts(n int) *DurableScheduleBuilder {
 }
 
 // Register persists the schedule definition without resetting an existing
-// watermark.
+// watermark. The anchor is UTC, so cron field evaluation keeps the
+// historical "0 2 * * *" = 02:00 UTC semantics regardless of the server's
+// local zone; register with RegisterAt and a time in a named IANA zone to
+// evaluate a cron spec in that zone's wall-clock time.
 func (b *DurableScheduleBuilder) Register() error {
-	return b.RegisterAt(time.Now())
+	return b.RegisterAt(time.Now().UTC())
 }
 
 // RegisterAt is Register with a deterministic first-run anchor.
@@ -204,15 +208,16 @@ func (b *DurableScheduleBuilder) RegisterAt(base time.Time) error {
 	}
 	_, err := b.scheduler.queue.db.Exec(
 		fmt.Sprintf(`INSERT INTO %s
-			(id, job_type, payload, interval_ns, cron_spec,
+			(id, job_type, payload, interval_ns, cron_spec, tz,
 			 lane, priority, max_attempts,
 			 next_run, updated_at)
-			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
 			ON CONFLICT(id) DO UPDATE SET
 				job_type=excluded.job_type,
 				payload=excluded.payload,
 				interval_ns=excluded.interval_ns,
 				cron_spec=excluded.cron_spec,
+				tz=excluded.tz,
 				lane=excluded.lane,
 				priority=excluded.priority,
 				max_attempts=excluded.max_attempts,
@@ -220,7 +225,7 @@ func (b *DurableScheduleBuilder) RegisterAt(base time.Time) error {
 				version=%s.version+1`,
 			b.scheduler.queue.schedulerSchedulesTable(),
 			b.scheduler.queue.schedulerSchedulesTable()),
-		b.id, b.jobType, payload, int64(b.interval), b.cronSpec,
+		b.id, b.jobType, payload, int64(b.interval), b.cronSpec, tzName(base.Location()),
 		b.lane, b.priority, b.maxAttempts,
 		next.UTC(), time.Now().UTC(),
 	)
@@ -253,9 +258,24 @@ func (s *DurableScheduler) runOnce(ctx context.Context, now time.Time) (bool, er
 	for _, schedule := range due {
 		ticks, nextRun, err := schedule.dueTicks(now, s.maxCatchUpOccurrences)
 		if err != nil {
-			return true, err
+			// A single corrupted schedule (genuine data corruption, since
+			// tz and cadence-change mismatches are handled inside dueTicks)
+			// must not abort evaluation of the remaining due schedules.
+			// Surface it via the logger so operators notice, then continue.
+			slog.Default().Error("queue: durable scheduler skipping schedule",
+				"schedule_id", schedule.id, "err", err.Error())
+			continue
 		}
 		if len(ticks) == 0 {
+			// Even with no ticks due, the cursor may need advancing — the
+			// cadence-change path returns a corrected nextRun strictly after
+			// the stored watermark. Persist it so the schedule stops waking
+			// the loop every heartbeat and resumes firing on the new cadence.
+			if !nextRun.IsZero() && !nextRun.Equal(schedule.nextRun) {
+				if err := s.commitOccurrences(ctx, schedule, nil, nextRun, fence, now); err != nil {
+					return true, err
+				}
+			}
 			continue
 		}
 		if s.beforeOccurrenceCommit != nil {
@@ -392,7 +412,7 @@ func (s *DurableScheduler) acquireLease(ctx context.Context, now time.Time) (int
 
 func (s *DurableScheduler) loadDue(ctx context.Context, now time.Time) ([]durableSchedule, error) {
 	rows, err := s.queue.db.QueryContext(ctx,
-		fmt.Sprintf(`SELECT id, job_type, payload, interval_ns, cron_spec,
+		fmt.Sprintf(`SELECT id, job_type, payload, interval_ns, cron_spec, tz,
 				lane, priority, max_attempts,
 				next_run, updated_at, version
 			FROM %s WHERE next_run <= $1 ORDER BY next_run, id`,
@@ -410,7 +430,7 @@ func (s *DurableScheduler) loadDue(ctx context.Context, now time.Time) ([]durabl
 		var intervalNS int64
 		var nextRun, updatedAt any
 		if err := rows.Scan(&row.id, &row.jobType, &payload, &intervalNS,
-			&row.cronSpec, &row.lane, &row.priority, &row.maxAttempts,
+			&row.cronSpec, &row.tz, &row.lane, &row.priority, &row.maxAttempts,
 			&nextRun, &updatedAt, &row.version); err != nil {
 			return nil, err
 		}
@@ -571,6 +591,7 @@ func (s *DurableScheduler) ensureTables() error {
 			payload TEXT NOT NULL,
 			interval_ns BIGINT NOT NULL DEFAULT 0,
 			cron_spec TEXT NOT NULL DEFAULT '',
+			tz TEXT NOT NULL DEFAULT '',
 			lane TEXT NOT NULL DEFAULT '',
 			priority INTEGER NOT NULL DEFAULT 0,
 			max_attempts INTEGER NOT NULL DEFAULT 0,

--- a/battery/queue/durable_scheduler.go
+++ b/battery/queue/durable_scheduler.go
@@ -195,7 +195,11 @@ func (b *DurableScheduleBuilder) RegisterAt(base time.Time) error {
 		if err != nil {
 			return err
 		}
-		next = sc.Next(base)
+		// DST-aware next-fire: a spec naming a wall-clock minute that the
+		// location's next spring-forward will skip lands at the transition
+		// instant (vixie/cronie parity), not silently a day later. See
+		// durable_scheduler_dst.go.
+		next = nextFire(sc, base.Location(), base, time.Time{})
 	} else {
 		if b.interval <= 0 {
 			return errors.New("queue: durable interval must be positive")
@@ -546,7 +550,17 @@ func (s *DurableScheduler) commitOccurrences(
 			Priority:     schedule.priority,
 			MaxAttempts:  schedule.maxAttempts,
 			CreatedAt:    now,
-			ScheduledAt:  tick,
+			// A cron-fired job is the execution of an already-due event, so it
+			// must be dequeue-eligible the moment it is committed. `tick` is the
+			// audit instant (preserved in the occurrence's scheduled_tick
+			// column) but the job's scheduled_at is the worker readiness gate:
+			// binding it to a future tick (which only happens when RunOnce is
+			// driven with a future test clock; in production tick ≤ wall clock)
+			// would stall the job until that tick and break test drains that
+			// cycle the queue via Dequeue. Use the earlier of tick or the
+			// process wall clock so overdue production ticks are preserved
+			// while future test-time ticks become immediately ready.
+			ScheduledAt: earliestTime(tick, s.queue.now()),
 		}); err != nil {
 			return err
 		}
@@ -626,6 +640,14 @@ func (s *DurableScheduler) ensureTables() error {
 	}
 	if err := s.ensureHardeningSchema(); err != nil {
 		return err
+	}
+	// With the scheduler tables freshly ensured (or pre-existing), canonicalize
+	// their legacy timestamps too. NewDBQueue already ran this pass, but it may
+	// have run before these tables existed (a host that constructs DBQueue
+	// first, then DurableScheduler). The pass is idempotent and existence-
+	// checked, so re-running on already-canonical rows is a cheap no-op.
+	if err := s.queue.normalizeLegacyTimestamps(context.Background()); err != nil {
+		return fmt.Errorf("normalize scheduler legacy timestamps: %w", err)
 	}
 	return nil
 }

--- a/battery/queue/durable_scheduler_catchup.go
+++ b/battery/queue/durable_scheduler_catchup.go
@@ -43,13 +43,18 @@ func boundedDueTicks(schedule durableSchedule, now time.Time, limit int) ([]time
 	if err != nil {
 		return nil, time.Time{}, err
 	}
+	loc := schedule.location()
 	// Search backwards so a long outage costs a fixed amount of memory and
-	// retains the newest audit rows instead of the oldest ones.
-	candidate := now.Truncate(time.Minute)
+	// retains the newest audit rows instead of the oldest ones. Cron field
+	// matching is location-sensitive (the spec "0 2 * * *" means 02:00 in
+	// the schedule's registration location, not 02:00 UTC), so the cursor
+	// we walk minute-by-minute is rendered in that location before the
+	// field comparison. The absolute instant is what we store.
+	candidate := now.Truncate(time.Minute).In(loc)
 	reversed := make([]time.Time, 0, limit)
 	for scanned := 0; scanned < maxCronCatchUpSearchMinutes && !candidate.Before(cursor); scanned++ {
 		if parsed.Matches(candidate) {
-			reversed = append(reversed, candidate)
+			reversed = append(reversed, candidate.UTC())
 			if len(reversed) == limit {
 				break
 			}
@@ -57,15 +62,78 @@ func boundedDueTicks(schedule durableSchedule, now time.Time, limit int) ([]time
 		candidate = candidate.Add(-time.Minute)
 	}
 	if len(reversed) == 0 {
-		return nil, time.Time{}, fmt.Errorf("queue: schedule %q did not produce a due cron tick", schedule.id)
+		// Cadence-change recovery: the stored cursor is not an occurrence
+		// of the current spec (typical after re-registering an existing
+		// schedule with a different cron, or after switching interval→
+		// cron — `ON CONFLICT ... DO UPDATE` deliberately preserves the
+		// old next_run to fence concurrent claimants). Advance to the
+		// next valid occurrence strictly after the cursor instead of
+		// erroring: the caller persists the recovered watermark so the
+		// schedule keeps firing on the new cadence without operator
+		// intervention.
+		next := parsed.Next(cursor.In(loc))
+		if next.IsZero() {
+			return nil, time.Time{}, fmt.Errorf("queue: schedule %q did not advance", schedule.id)
+		}
+		nextUTC := next.UTC()
+		if nextUTC.After(now) {
+			return nil, nextUTC, nil
+		}
+		nextNext := parsed.Next(next)
+		if nextNext.IsZero() || !nextNext.After(next) {
+			return nil, time.Time{}, fmt.Errorf("queue: schedule %q did not advance", schedule.id)
+		}
+		return []time.Time{nextUTC}, nextNext.UTC(), nil
 	}
 	ticks := make([]time.Time, len(reversed))
 	for i := range reversed {
 		ticks[len(reversed)-1-i] = reversed[i]
 	}
-	next := parsed.Next(now)
+	next := parsed.Next(now.In(loc))
 	if next.IsZero() || !next.After(now) {
 		return nil, time.Time{}, fmt.Errorf("queue: schedule %q did not advance", schedule.id)
 	}
 	return ticks, next.UTC(), nil
+}
+
+// tzName returns the IANA location name to persist for a schedule registered
+// in loc. Empty means "evaluate in UTC" — the column default, which keeps
+// pre-existing rows backward-compatible with the original UTC-only behaviour.
+// A fixed offset zone (time.FixedZone) has no IANA name and cannot represent
+// DST transitions, so it collapses to the empty default rather than persisting
+// an un-loadable label.
+func tzName(loc *time.Location) string {
+	if loc == nil || loc == time.UTC {
+		return ""
+	}
+	name := loc.String()
+	if name == "" || name == "Local" {
+		// "Local" round-trips through LoadLocation but resolves to
+		// whatever zone the READING process runs in — replica-dependent
+		// evaluation. Persist the UTC default instead; a schedule that
+		// wants local-time semantics must register with a named IANA
+		// zone.
+		return ""
+	}
+	// FixedZone produces names like "UTC-05" that LoadLocation cannot resolve
+	// back; round-trip fidelity requires a loadable IANA name.
+	if _, err := time.LoadLocation(name); err != nil {
+		return ""
+	}
+	return name
+}
+
+// location rebuilds the schedule's registration *time.Location from the
+// persisted tz column. Empty (legacy rows, interval schedules, or un-loadable
+// names recorded before tzName guarded them) falls back to UTC, preserving
+// the pre-fix evaluation semantics.
+func (s durableSchedule) location() *time.Location {
+	if s.tz == "" {
+		return time.UTC
+	}
+	loc, err := time.LoadLocation(s.tz)
+	if err != nil || loc == nil {
+		return time.UTC
+	}
+	return loc
 }

--- a/battery/queue/durable_scheduler_catchup.go
+++ b/battery/queue/durable_scheduler_catchup.go
@@ -44,52 +44,37 @@ func boundedDueTicks(schedule durableSchedule, now time.Time, limit int) ([]time
 		return nil, time.Time{}, err
 	}
 	loc := schedule.location()
-	// Search backwards so a long outage costs a fixed amount of memory and
-	// retains the newest audit rows instead of the oldest ones. Cron field
-	// matching is location-sensitive (the spec "0 2 * * *" means 02:00 in
-	// the schedule's registration location, not 02:00 UTC), so the cursor
-	// we walk minute-by-minute is rendered in that location before the
-	// field comparison. The absolute instant is what we store.
-	candidate := now.Truncate(time.Minute).In(loc)
-	reversed := make([]time.Time, 0, limit)
-	for scanned := 0; scanned < maxCronCatchUpSearchMinutes && !candidate.Before(cursor); scanned++ {
-		if parsed.Matches(candidate) {
-			reversed = append(reversed, candidate.UTC())
-			if len(reversed) == limit {
-				break
-			}
-		}
-		candidate = candidate.Add(-time.Minute)
+	// Forward walk in absolute minutes, evaluating the cron fields against
+	// each minute rendered in the schedule's registration location. Cron
+	// field matching is location-sensitive (the spec "0 2 * * *" means 02:00
+	// in the schedule's registration location, not 02:00 UTC). DST transition
+	// semantics (vixie/cronie parity) are implemented by firesInRange: a
+	// wall-clock match in a fall-back repeated hour fires only at its earlier
+	// absolute instant, and a skipped wall-clock minute inside a spring-
+	// forward gap fires once at the transition instant. The absolute instant
+	// is what we store. See durable_scheduler_dst.go.
+	ticks, err := firesInRange(parsed, loc, cursor, now, limit)
+	if err != nil {
+		return nil, time.Time{}, err
 	}
-	if len(reversed) == 0 {
-		// Cadence-change recovery: the stored cursor is not an occurrence
-		// of the current spec (typical after re-registering an existing
-		// schedule with a different cron, or after switching interval→
-		// cron — `ON CONFLICT ... DO UPDATE` deliberately preserves the
-		// old next_run to fence concurrent claimants). Advance to the
-		// next valid occurrence strictly after the cursor instead of
-		// erroring: the caller persists the recovered watermark so the
-		// schedule keeps firing on the new cadence without operator
-		// intervention.
-		next := parsed.Next(cursor.In(loc))
-		if next.IsZero() {
-			return nil, time.Time{}, fmt.Errorf("queue: schedule %q did not advance", schedule.id)
-		}
-		nextUTC := next.UTC()
-		if nextUTC.After(now) {
-			return nil, nextUTC, nil
-		}
-		nextNext := parsed.Next(next)
-		if nextNext.IsZero() || !nextNext.After(next) {
-			return nil, time.Time{}, fmt.Errorf("queue: schedule %q did not advance", schedule.id)
-		}
-		return []time.Time{nextUTC}, nextNext.UTC(), nil
+	// Advance the watermark past `now`, fenced against the LAST fired tick so
+	// a fall-back repeat immediately after a fire is skipped (prevFire is the
+	// wall-minute already consumed).
+	var next time.Time
+	if len(ticks) > 0 {
+		next = nextFire(parsed, loc, now, ticks[len(ticks)-1])
+	} else {
+		// Cadence-change recovery: the stored cursor is not an occurrence of
+		// the current spec (typical after re-registering an existing schedule
+		// with a different cron, or after switching interval→cron — `ON
+		// CONFLICT ... DO UPDATE` deliberately preserves the old next_run to
+		// fence concurrent claimants). Advance to the next valid occurrence
+		// strictly after the cursor instead of erroring: the caller persists
+		// the recovered watermark so the schedule keeps firing on the new
+		// cadence without operator intervention. With DST-aware nextFire this
+		// also self-corrects across a spring-forward inside the gap.
+		next = nextFire(parsed, loc, cursor, time.Time{})
 	}
-	ticks := make([]time.Time, len(reversed))
-	for i := range reversed {
-		ticks[len(reversed)-1-i] = reversed[i]
-	}
-	next := parsed.Next(now.In(loc))
 	if next.IsZero() || !next.After(now) {
 		return nil, time.Time{}, fmt.Errorf("queue: schedule %q did not advance", schedule.id)
 	}

--- a/battery/queue/durable_scheduler_dst.go
+++ b/battery/queue/durable_scheduler_dst.go
@@ -1,0 +1,224 @@
+package queue
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/DonaldMurillo/gofastr/framework/cron"
+)
+
+// This file implements vixie/cronie-parity DST semantics for location-aware
+// cron schedules, as a thin wrapper around framework/cron's location-blind
+// bitmask matching. The framework parser/matcher is unchanged: it evaluates
+// cron fields against a time.Time's wall-clock fields (.Minute(), .Hour(),
+// .Day(), .Month(), .Weekday()) regardless of zone, so the only thing it
+// gets wrong on its own is the DST transition itself — a minute-by-minute
+// absolute-time walk skips over (spring-forward) or double-counts
+// (fall-back) the transition's wall-clock minutes. The two helpers below
+// wrap that walk to recover vixie semantics:
+//
+//   - Fall-back (wall clock repeats): a wall-clock match in the REPEATED
+//     hour fires only at its EARLIER absolute instant (the EDT side for US
+//     Eastern). Detected via the zone-offset change between two absolute
+//     minutes that render the same wall-clock Y-M-D H:M.
+//   - Spring-forward (wall clock skips): a wall-clock match inside the
+//     transition's skipped window fires once AT the transition instant (the
+//     first absolute minute after the skip). Detected by an absolute-minute
+//     step that advances the wall clock by more than one minute; each
+//     skipped wall minute is tested against the cron fields.
+//
+// These rules implement what queue.md's "including across DST shifts" claim
+// promises. All logic lives here (no framework/cron change) because the
+// semantics belong to the durable scheduler's location-aware catch-up, not
+// to the location-agnostic in-process scheduler that shares the parser.
+
+// wallMinuteKey is the Y-M-D H:M tuple of a time rendered in its location —
+// the identity of a "wall-clock minute" independent of the zone offset it
+// was reached through. Used to dedupe fall-back repeats: two absolute
+// instants with the same wallMinuteKey but different offsets are the same
+// vixie fire, and only the earlier absolute instant is kept.
+type wallMinuteKey struct {
+	year              int
+	month             time.Month
+	day, hour, minute int
+}
+
+func wallKey(t time.Time) wallMinuteKey {
+	return wallMinuteKey{t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute()}
+}
+
+// nextFire returns the earliest cron firing strictly after `after` (evaluated
+// in `loc`), with vixie DST semantics. prevFire, when non-zero, is the
+// previous fire whose wall-minute must not be repeated in a fall-back window
+// (used by boundedDueTicks when advancing the watermark after a fire landed
+// inside a repeated hour). Returns the zero Time if no match exists within
+// the cron search horizon.
+//
+// The walk is forward in absolute minutes starting one minute after `after`.
+// At each step:
+//
+//  1. If the step crossed a spring-forward gap whose skipped window contains
+//     a cron match, the transition instant (the post-step minute) is the
+//     next fire.
+//  2. Otherwise if the post-step minute's wall clock matches the cron fields
+//     AND its wall-minute has not already fired (prevFire fall-back repeat),
+//     it is the next fire.
+//
+// Spring-forward detection runs before the direct match so a fire inside the
+// skipped window lands at the transition rather than at the next ordinary
+// match (which could be a day later for a daily spec).
+func nextFire(parsed cron.Schedule, loc *time.Location, after, prevFire time.Time) time.Time {
+	t := after.UTC().Truncate(time.Minute).Add(time.Minute).In(loc)
+	var seen map[wallMinuteKey]bool
+	if !prevFire.IsZero() {
+		seen = map[wallMinuteKey]bool{wallKey(prevFire.In(loc)): true}
+	}
+	prevWall := t.Add(-time.Minute).In(loc)
+	for range maxCronCatchUpSearchMinutes {
+		if skippedMatchInGap(parsed, loc, prevWall, t) {
+			if seen == nil || !seen[wallKey(t)] {
+				return t.UTC()
+			}
+		}
+		if parsed.Matches(t) {
+			k := wallKey(t)
+			if seen == nil || !seen[k] {
+				return t.UTC()
+			}
+		}
+		prevWall = t
+		t = t.Add(time.Minute).In(loc)
+	}
+	return time.Time{}
+}
+
+// firesInRange enumerates cron matches in the closed interval [cursor, now]
+// (both truncated to the minute, evaluated in `loc`), with vixie DST
+// semantics. At most `limit` ticks are returned; when more are due the NEWEST
+// `limit` are kept, matching the original backwards-walk retention so a long
+// outage costs a bounded amount of memory and retains the newest audit rows.
+//
+// The walk is forward in absolute minutes. Fall-back dedup uses a per-day
+// wall-minute set: a match whose wall-minute was already emitted (at an
+// earlier absolute instant) is skipped. The set is reset on every calendar
+// date change so it cannot grow unbounded for a minute-resolution spec
+// evaluated over a multi-year outage (DST repeats are intra-day, so a
+// same-date bound is correct).
+//
+// Spring-forward: when the absolute-minute step skipped wall minutes, each
+// skipped wall minute is tested; if any matches, a single tick is emitted at
+// the transition instant (the post-step minute). At most one transition tick
+// per transition — matching vixie cron, which fires skipped-window jobs once
+// at the transition rather than once per matching skipped minute.
+func firesInRange(parsed cron.Schedule, loc *time.Location, cursor, now time.Time, limit int) ([]time.Time, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("queue: cron catch-up limit must be positive, got %d", limit)
+	}
+	start := cursor.UTC().Truncate(time.Minute).In(loc)
+	end := now.UTC().Truncate(time.Minute).In(loc)
+	if end.Before(start) {
+		return nil, nil
+	}
+	var all []time.Time
+	seen := make(map[wallMinuteKey]bool)
+	var seenDate wallMinuteKey // date component only (hour/minute zeroed)
+	t := start
+	prevWall := t.Add(-time.Minute).In(loc)
+	for scanned := 0; scanned < maxCronCatchUpSearchMinutes && !t.After(end); scanned++ {
+		// Reset the fall-back dedup set on every calendar date change. DST
+		// repeats happen inside a single day; bounding by date keeps the set
+		// small even for minute-resolution specs over long outages.
+		day := wallMinuteKey{t.Year(), t.Month(), t.Day(), 0, 0}
+		if day != seenDate {
+			seen = make(map[wallMinuteKey]bool)
+			seenDate = day
+		}
+
+		// Spring-forward: a gap-crossing step whose skipped window contains a
+		// cron match emits exactly one tick at the transition (t).
+		if skippedMatchInGap(parsed, loc, prevWall, t) {
+			k := wallKey(t)
+			if !seen[k] {
+				seen[k] = true
+				all = append(all, t.UTC())
+			}
+		}
+
+		// Direct match at t. Fall-back dedup against any earlier absolute
+		// instant that already fired at this wall-minute.
+		if parsed.Matches(t) {
+			k := wallKey(t)
+			if !seen[k] {
+				seen[k] = true
+				all = append(all, t.UTC())
+			}
+		}
+
+		prevWall = t
+		t = t.Add(time.Minute).In(loc)
+	}
+
+	// Retain the newest `limit` ticks (matches the original backwards-walk
+	// memory-bounded retention so audit history keeps the most recent rows).
+	if len(all) > limit {
+		all = all[len(all)-limit:]
+	}
+	return all, nil
+}
+
+// skippedMatchInGap reports whether the absolute-minute step from `a` to `b`
+// (where b = a.Add(time.Minute)) crossed a spring-forward DST transition
+// whose skipped wall-clock window contains a cron match. Both `a` and `b`
+// are interpreted in `loc` (the schedule's registration zone).
+//
+// A spring-forward is detected by the zone offset INCREASING from a to b
+// (e.g., US Eastern EST→EDT shifts the offset from -5 to -4). Real-world DST
+// is ≤ 1h so the skipped window is at most 60 minutes — but the loop is
+// bounded by the wall-clock gap regardless, so a pathological shift would
+// still terminate.
+//
+// Each skipped wall-minute is tested by constructing a synthetic time.Time
+// in a FixedZone matching a's offset. The fixed offset means time.Date does
+// not scale the wall fields (the way it would if `loc` were used, since Go
+// pre-normalizes nonexistent wall times inside `loc`). cron.Matches inspects
+// only wall fields (.Minute/.Hour/.Day/.Month/.Weekday), so a synthetic time
+// with the desired wall fields matches correctly even though the absolute
+// instant it represents never occurs in `loc`.
+func skippedMatchInGap(parsed cron.Schedule, loc *time.Location, a, b time.Time) bool {
+	aWall := a.In(loc)
+	bWall := b.In(loc)
+	_, aOff := aWall.Zone()
+	_, bOff := bWall.Zone()
+	if bOff <= aOff {
+		return false // not a spring-forward (offset didn't increase)
+	}
+	fixed := time.FixedZone("dst-gap", aOff)
+	start := time.Date(aWall.Year(), aWall.Month(), aWall.Day(),
+		aWall.Hour(), aWall.Minute(), 0, 0, fixed).Add(time.Minute)
+	end := time.Date(bWall.Year(), bWall.Month(), bWall.Day(),
+		bWall.Hour(), bWall.Minute(), 0, 0, fixed)
+	// Safety cap (real DST shifts are ≤ 60 minutes); the bound also keeps
+	// this O(1) per transition regardless of the gap size.
+	const maxGapMinutes = 120
+	for range maxGapMinutes {
+		if !start.Before(end) {
+			break
+		}
+		if parsed.Matches(start) {
+			return true
+		}
+		start = start.Add(time.Minute)
+	}
+	return false
+}
+
+// earliestTime returns the earlier of a or b. Used by commitOccurrences to
+// pin a cron-fired job's scheduled_at to no later than the process wall
+// clock so the job is dequeue-eligible immediately. Both inputs are taken
+// as-is (no UTC normalization); callers normalize if needed.
+func earliestTime(a, b time.Time) time.Time {
+	if b.Before(a) {
+		return b
+	}
+	return a
+}

--- a/battery/queue/durable_scheduler_dst_test.go
+++ b/battery/queue/durable_scheduler_dst_test.go
@@ -1,0 +1,108 @@
+package queue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gosqlite "github.com/DonaldMurillo/gofastr/sqlite"
+)
+
+func dstScheduler(t *testing.T, owner string) *DurableScheduler {
+	t.Helper()
+	db, err := gosqlite.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	q, err := NewDBQueue(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewDurableScheduler(q, DurableSchedulerConfig{
+		OwnerID: owner, LeaseDuration: time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// Fall-back: America/New_York repeats the 01:00–02:00 wall-clock hour on
+// 2026-11-01 (02:00 EDT -> 01:00 EST). A "daily at 01:30" schedule fires
+// ONCE that day — at the first occurrence (01:30 EDT, 05:30 UTC) — like
+// vixie cron, not twice.
+func TestCronFallBackFiresOnce(t *testing.T) {
+	s := dstScheduler(t, "fallback")
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 10, 31, 12, 0, 0, 0, loc)
+	if err := s.Cron("night", "30 1 * * *").Job("job", nil).RegisterAt(base); err != nil {
+		t.Fatal(err)
+	}
+
+	// Heartbeat at the first 01:30 (EDT, 05:30 UTC): fires.
+	firstHalfHour := time.Date(2026, 11, 1, 5, 30, 0, 0, time.UTC)
+	if err := s.RunOnce(context.Background(), firstHalfHour); err != nil {
+		t.Fatalf("RunOnce at 01:30 EDT: %v", err)
+	}
+	if jobs := pendingJobs(t, s.queue); len(jobs) != 1 {
+		t.Fatalf("first 01:30 fired %d jobs, want 1", len(jobs))
+	}
+	drainPending(t, s.queue)
+
+	// Heartbeat at the repeated 01:30 (EST, 06:30 UTC): the wall clock
+	// shows 01:30 again, but the schedule already ran today — no second
+	// fire (vixie parity).
+	repeatedHalfHour := time.Date(2026, 11, 1, 6, 30, 0, 0, time.UTC)
+	if err := s.RunOnce(context.Background(), repeatedHalfHour); err != nil {
+		t.Fatalf("RunOnce at repeated 01:30 EST: %v", err)
+	}
+	if jobs := pendingJobs(t, s.queue); len(jobs) != 0 {
+		t.Fatalf("repeated 01:30 fired %d extra jobs, want 0", len(jobs))
+	}
+}
+
+// Spring-forward: America/New_York skips 02:00–03:00 on 2026-03-08. A
+// "daily at 02:00" schedule fires ONCE that day, at the transition instant
+// (03:00 EDT, 07:00 UTC) — like vixie cron — instead of silently skipping
+// the whole day.
+func TestCronSpringForwardFiresAtTransition(t *testing.T) {
+	s := dstScheduler(t, "springfwd")
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 3, 7, 12, 0, 0, 0, loc)
+	if err := s.Cron("early", "0 2 * * *").Job("job", nil).RegisterAt(base); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sunday's 02:00 does not exist (clocks jump 02:00 EST -> 03:00 EDT);
+	// the fire lands at the transition instant instead of skipping the day.
+	if err := s.RunOnce(context.Background(), time.Date(2026, 3, 8, 8, 0, 0, 0, loc)); err != nil {
+		t.Fatalf("RunOnce post-transition: %v", err)
+	}
+	jobs := pendingJobs(t, s.queue)
+	if len(jobs) != 1 {
+		t.Fatalf("spring-forward day enqueued %d jobs, want exactly 1 (fired at the transition)", len(jobs))
+	}
+}
+
+// drainPending consumes every pending job so subsequent assertions count
+// only newly enqueued work.
+func drainPending(t *testing.T, q *DBQueue) {
+	t.Helper()
+	for {
+		job, err := q.Dequeue(context.Background(), "job")
+		if err != nil {
+			return
+		}
+		if err := q.Ack(context.Background(), job.ID); err != nil {
+			t.Fatalf("ack drained job: %v", err)
+		}
+	}
+}

--- a/battery/queue/durable_scheduler_postgres_test.go
+++ b/battery/queue/durable_scheduler_postgres_test.go
@@ -45,3 +45,32 @@ func TestPG_DurableSchedulerVersionCASIgnoresTimestampRoundTrip(t *testing.T) {
 			len(jobs), version, nextRun.Format(time.RFC3339Nano), occurrences, queueRows)
 	}
 }
+
+// The tz column round-trips through Postgres: a cron schedule registered in
+// a non-UTC location fires at its local wall-clock time.
+func TestPG_CronNonUTCTick(t *testing.T) {
+	db := pgtest.DB(t)
+	q := newDurableTestQueue(t, db)
+	sched, err := NewDurableScheduler(q, DurableSchedulerConfig{
+		OwnerID: "postgres-tz", LeaseDuration: time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	base := time.Date(2026, 1, 15, 1, 0, 0, 0, loc)
+	if err := sched.Cron("daily-local", "0 2 * * *").Job("job", nil).RegisterAt(base); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	tick := time.Date(2026, 1, 15, 2, 0, 0, 0, loc)
+	if err := sched.RunOnce(context.Background(), tick.Add(time.Microsecond)); err != nil {
+		t.Fatalf("RunOnce at local 02:00: %v", err)
+	}
+	if jobs := pendingJobs(t, q); len(jobs) != 1 {
+		t.Fatalf("enqueued %d jobs at local 02:00 tick, want 1", len(jobs))
+	}
+}

--- a/battery/queue/durable_scheduler_retention.go
+++ b/battery/queue/durable_scheduler_retention.go
@@ -49,6 +49,9 @@ func (s *DurableScheduler) ensureHardeningSchema() error {
 	if err := s.ensureScheduleOptionsColumns(); err != nil {
 		return err
 	}
+	if err := s.ensureScheduleTZColumn(); err != nil {
+		return err
+	}
 	for _, statement := range []string{
 		fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s (schedule_id, enqueued_job_id)",
 			s.queue.schedulerIndex("scheduler_occurrences_schedule_job_idx"),
@@ -167,6 +170,57 @@ func (s *DurableScheduler) ensureScheduleOptionsColumns() error {
 		if err != nil && !isDuplicateColumnErr(err) {
 			return err
 		}
+	}
+	return nil
+}
+
+// ensureScheduleTZColumn adds the tz column that records the IANA location
+// name a cron schedule was registered in, so cron field evaluation happens
+// in the schedule's wall-clock location instead of UTC. Idempotent: Postgres
+// uses ADD COLUMN IF NOT EXISTS, and the SQLite path scans PRAGMA
+// table_info first so we only ALTER when the column is actually missing
+// (matching ensureScheduleVersionColumn / ensureScheduleOptionsColumns).
+// The column is additive NOT NULL DEFAULT ”, so existing rows — and
+// interval schedules, which never consult tz — evaluate exactly as before.
+func (s *DurableScheduler) ensureScheduleTZColumn() error {
+	table := s.queue.schedulerSchedulesTable()
+	if s.queue.dialect == dialectPostgres {
+		_, err := s.queue.db.Exec(fmt.Sprintf(
+			"ALTER TABLE %s ADD COLUMN IF NOT EXISTS tz TEXT NOT NULL DEFAULT ''",
+			table))
+		return err
+	}
+	rows, err := s.queue.db.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		return err
+	}
+	present := false
+	for rows.Next() {
+		var cid, notNull, pk int
+		var name, typ string
+		var dflt any
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &dflt, &pk); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if strings.EqualFold(name, "tz") {
+			present = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if present {
+		return nil
+	}
+	_, err = s.queue.db.Exec(fmt.Sprintf(
+		"ALTER TABLE %s ADD COLUMN tz TEXT NOT NULL DEFAULT ''", table))
+	if err != nil && !isDuplicateColumnErr(err) {
+		return err
 	}
 	return nil
 }

--- a/battery/queue/durable_scheduler_tz_schema_test.go
+++ b/battery/queue/durable_scheduler_tz_schema_test.go
@@ -1,0 +1,312 @@
+package queue
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	gosqlite "github.com/DonaldMurillo/gofastr/sqlite"
+)
+
+// TestDurableSchedulerMigratesExistingSchedulesTableTZ proves the tz column
+// is added idempotently to a schedules table created before tz shipped, the
+// same way ensureScheduleVersionColumn / ensureScheduleOptionsColumns do.
+func TestDurableSchedulerMigratesExistingSchedulesTableTZ(t *testing.T) {
+	db := openDurableSchedulerDB(t)
+	q := newDurableTestQueue(t, db)
+	if _, err := db.Exec(`CREATE TABLE ` + q.schedulerSchedulesTable() + ` (
+		id TEXT PRIMARY KEY,
+		job_type TEXT NOT NULL,
+		payload TEXT NOT NULL,
+		interval_ns BIGINT NOT NULL DEFAULT 0,
+		cron_spec TEXT NOT NULL DEFAULT '',
+		next_run DATETIME NOT NULL,
+		updated_at DATETIME NOT NULL
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewDurableScheduler(q, DurableSchedulerConfig{}); err != nil {
+		t.Fatalf("upgrade scheduler schema: %v", err)
+	}
+	rows, err := db.Query("PRAGMA table_info(" + q.schedulerSchedulesTable() + ")")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	found := false
+	for rows.Next() {
+		var cid, notNull, pk int
+		var name, typ string
+		var dflt any
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &dflt, &pk); err != nil {
+			t.Fatal(err)
+		}
+		if name == "tz" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("existing schedules table was not upgraded with tz column")
+	}
+	// Second construction must be a no-op (idempotent).
+	if _, err := NewDurableScheduler(q, DurableSchedulerConfig{}); err != nil {
+		t.Fatalf("second construction failed: %v", err)
+	}
+}
+
+// TestDurableSchedulerFreshSchemaHasTZColumn proves a brand-new schedules
+// table carries the tz column from creation, not only via migration.
+func TestDurableSchedulerFreshSchemaHasTZColumn(t *testing.T) {
+	db := openDurableSchedulerDB(t)
+	q := newDurableTestQueue(t, db)
+	if _, err := NewDurableScheduler(q, DurableSchedulerConfig{}); err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	row := db.QueryRow("SELECT COUNT(*) FROM pragma_table_info(?) WHERE name='tz'",
+		strings.Trim(q.schedulerSchedulesTable(), `"`))
+	if err := row.Scan(&found); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		// pragma_table_info's table-valued form may be unavailable; fall back
+		// to a structural scan.
+		found = scanForTZColumn(t, db, q.schedulerSchedulesTable())
+	}
+	if !found {
+		t.Fatal("fresh schedules table missing tz column")
+	}
+}
+
+func scanForTZColumn(t *testing.T, db *sql.DB, table string) bool {
+	t.Helper()
+	rows, err := db.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid, notNull, pk int
+		var name, typ string
+		var dflt any
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &dflt, &pk); err != nil {
+			t.Fatal(err)
+		}
+		if name == "tz" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDurableSchedulerPersistsTZOnRegistration proves the tz name round-trips
+// through SQLite: a schedule registered in America/New_York re-emerges with
+// the same location and fires at the local wall-clock time after reload.
+func TestDurableSchedulerPersistsTZOnRegistration(t *testing.T) {
+	db, err := gosqlite.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	q, err := NewDBQueue(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load NY: %v", err)
+	}
+	first, err := NewDurableScheduler(q, DurableSchedulerConfig{
+		OwnerID: "first", LeaseDuration: time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 1, 15, 1, 0, 0, 0, loc)
+	if err := first.Cron("daily-local", "0 2 * * *").Job("digest", nil).RegisterAt(base); err != nil {
+		t.Fatal(err)
+	}
+	var stored string
+	if err := db.QueryRow("SELECT tz FROM "+q.schedulerSchedulesTable()+" WHERE id=$1", "daily-local").Scan(&stored); err != nil {
+		t.Fatalf("read tz: %v", err)
+	}
+	if stored != "America/New_York" {
+		t.Fatalf("stored tz = %q, want America/New_York", stored)
+	}
+}
+
+// TestDurableSchedulerPoisonedScheduleDoesNotKillOthers proves the design
+// invariant from the fix brief: a single schedule that returns an error from
+// dueTicks (only triggerable post-fix by genuine corruption — here simulated
+// by directly corrupting cron_spec to an unsatisfiable / invalid spec on
+// disk) must not stop RunOnce from evaluating the remaining due schedules.
+func TestDurableSchedulerPoisonedScheduleDoesNotKillOthers(t *testing.T) {
+	db := openDurableSchedulerDB(t)
+	q := newDurableTestQueue(t, db)
+	sched, err := NewDurableScheduler(q, DurableSchedulerConfig{
+		OwnerID: "isolated", LeaseDuration: time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	if err := sched.Every("healthy", time.Minute).Job("healthy", nil).RegisterAt(base); err != nil {
+		t.Fatal(err)
+	}
+	// Seed a poison-pilled schedule by writing an invalid cron spec directly
+	// to the row — `Register` would have rejected it. This stands in for
+	// genuine data corruption (operator typo in a manual row edit, partial
+	// restore, schema drift) that survives restart.
+	if _, err := db.Exec(
+		"INSERT INTO "+q.schedulerSchedulesTable()+
+			" (id, job_type, payload, interval_ns, cron_spec, tz, lane, priority, max_attempts, next_run, updated_at, version)"+
+			" VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)",
+		"poison", "poison-job", "null", 0, "not a cron", "",
+		"", 0, 0, base.Add(time.Minute), base, 0,
+	); err != nil {
+		t.Fatal(err)
+	}
+	// Both schedules are due at base+1m. Without the isolation fix,
+	// loadDue's ORDER BY next_run, id would visit "healthy" first (it sorts
+	// before "poison"), but corrupting the healthy row instead proves the
+	// case where the poisoned schedule sorts first. We cover both.
+	if err := sched.RunOnce(context.Background(), base.Add(time.Minute)); err != nil {
+		t.Fatalf("poisoned schedule propagated error: %v", err)
+	}
+	jobs := pendingJobs(t, q)
+	if len(jobs) != 1 {
+		t.Fatalf("healthy schedule did not fire alongside poisoned one: pending=%d want 1", len(jobs))
+	}
+	if jobs[0].Type != "healthy" {
+		t.Fatalf("enqueued job type = %q, want healthy", jobs[0].Type)
+	}
+}
+
+// TestDurableSchedulerTZNameHelper pins the helper's edge cases: UTC and nil
+// collapse to the empty default (preserving the legacy UTC-evaluation
+// behaviour), fixed-offset zones are un-loadable so they also collapse, and
+// real IANA names survive the round trip.
+func TestDurableSchedulerTZNameHelper(t *testing.T) {
+	if got := tzName(time.UTC); got != "" {
+		t.Fatalf("tzName(UTC) = %q, want empty", got)
+	}
+	if got := tzName(nil); got != "" {
+		t.Fatalf("tzName(nil) = %q, want empty", got)
+	}
+	fixed := time.FixedZone("UTC-05", -5*3600)
+	if got := tzName(fixed); got != "" {
+		t.Fatalf("tzName(FixedZone) = %q, want empty (un-loadable)", got)
+	}
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load NY: %v", err)
+	}
+	if got := tzName(ny); got != "America/New_York" {
+		t.Fatalf("tzName(NY) = %q, want America/New_York", got)
+	}
+}
+
+// TestDurableSchedulerLocationHelper proves the durableSchedule.location
+// resolver degrades to UTC on empty / un-loadable names so a corrupted tz
+// column cannot strand the schedule.
+func TestDurableSchedulerLocationHelper(t *testing.T) {
+	if got := (&durableSchedule{}).location(); got != time.UTC {
+		t.Fatalf("empty tz location = %v, want UTC", got)
+	}
+	if got := (&durableSchedule{tz: "not-a-real-zone"}).location(); got != time.UTC {
+		t.Fatalf("un-loadable tz location = %v, want UTC fallback", got)
+	}
+	ny, _ := time.LoadLocation("America/New_York")
+	if got := (&durableSchedule{tz: "America/New_York"}).location(); got.String() != ny.String() {
+		t.Fatalf("NY tz location = %v, want America/New_York", got)
+	}
+}
+
+// TestBoundedDueTicksCadenceChangeRecovery exercises the cadence-change
+// recovery branch directly: a stored cursor that is NOT an occurrence of the
+// current cron spec heals to the next valid occurrence instead of erroring.
+func TestBoundedDueTicksCadenceChangeRecovery(t *testing.T) {
+	base := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	// Stored watermark from a previous interval schedule: 00:01. The current
+	// spec "0 2 * * *" has no occurrence at 00:01 — pre-fix this errored.
+	schedule := durableSchedule{
+		id:       "switch",
+		cronSpec: "0 2 * * *",
+		nextRun:  base.Add(time.Minute),
+	}
+	// Evaluate at 00:01: no tick yet, but the watermark must advance to 02:00.
+	ticks, nextRun, err := boundedDueTicks(schedule, base.Add(time.Minute), 100)
+	if err != nil {
+		t.Fatalf("cadence-change recovery returned error: %v", err)
+	}
+	if len(ticks) != 0 {
+		t.Fatalf("recovery emitted %d ticks, want 0 before the new cadence", len(ticks))
+	}
+	wantNext := time.Date(2026, 1, 15, 2, 0, 0, 0, time.UTC)
+	if !nextRun.Equal(wantNext) {
+		t.Fatalf("recovery advanced to %s, want %s", nextRun.Format(time.RFC3339), wantNext.Format(time.RFC3339))
+	}
+
+	// At 02:00 the recovered cadence fires exactly once.
+	ticks, _, err = boundedDueTicks(schedule, wantNext, 100)
+	if err != nil {
+		t.Fatalf("recovered cadence fire error: %v", err)
+	}
+	if len(ticks) != 1 || !ticks[0].Equal(wantNext) {
+		t.Fatalf("recovered cadence ticks = %v, want [%s]", ticks, wantNext.Format(time.RFC3339))
+	}
+
+	// And the same recovery branch fires immediately when the next
+	// occurrence is already in the past — e.g. a long outage between
+	// cadence change and the first evaluation.
+	later := time.Date(2026, 1, 15, 5, 0, 0, 0, time.UTC)
+	ticks, _, err = boundedDueTicks(schedule, later, 100)
+	if err != nil {
+		t.Fatalf("recovered cadence late-fire error: %v", err)
+	}
+	if len(ticks) != 1 || !ticks[0].Equal(time.Date(2026, 1, 15, 2, 0, 0, 0, time.UTC)) {
+		t.Fatalf("recovered cadence late ticks = %v, want [02:00]", ticks)
+	}
+}
+
+// TestBoundedDueTicksCronMatchesInScheduleLocation proves the cron field
+// comparison happens in the schedule's wall-clock location, not UTC: the
+// stored next_run is a UTC instant, but the cron spec "0 2 * * *" must fire
+// at 02:00 America/New_York (07:00 UTC in January) rather than 02:00 UTC.
+func TestBoundedDueTicksCronMatchesInScheduleLocation(t *testing.T) {
+	if _, err := time.LoadLocation("America/New_York"); err != nil {
+		t.Fatalf("load NY: %v", err)
+	}
+	// next_run is the UTC instant for 02:00 NY on 2026-01-15 (EST = UTC-5).
+	nextRun := time.Date(2026, 1, 15, 7, 0, 0, 0, time.UTC)
+	schedule := durableSchedule{
+		id:       "daily-local",
+		cronSpec: "0 2 * * *",
+		tz:       "America/New_York",
+		nextRun:  nextRun,
+	}
+	// Evaluate at 02:00 NY = 07:00 UTC: must produce a tick at exactly that
+	// instant and advance to the next 02:00-NY occurrence.
+	ticks, _, err := boundedDueTicks(schedule, nextRun, 100)
+	if err != nil {
+		t.Fatalf("NY-local cron fire error: %v", err)
+	}
+	if len(ticks) != 1 || !ticks[0].Equal(nextRun) {
+		t.Fatalf("NY-local cron ticks = %v, want [%s UTC]", ticks, nextRun.Format(time.RFC3339))
+	}
+
+	// Sanity: the same spec registered in UTC would also fire at 02:00 UTC,
+	// but a NY-registered schedule must NOT treat 02:00 UTC (21:00 NY prev
+	// day) as a tick — proving the location actually drives the match.
+	utcSchedule := schedule
+	utcSchedule.tz = ""
+	utcSchedule.nextRun = time.Date(2026, 1, 15, 2, 0, 0, 0, time.UTC)
+	ticks, _, err = boundedDueTicks(utcSchedule, utcSchedule.nextRun, 100)
+	if err != nil {
+		t.Fatalf("UTC cron fire error: %v", err)
+	}
+	if len(ticks) != 1 || !ticks[0].Equal(utcSchedule.nextRun) {
+		t.Fatalf("UTC cron ticks = %v, want [%s UTC]", ticks, utcSchedule.nextRun.Format(time.RFC3339))
+	}
+}

--- a/battery/queue/durable_scheduler_tz_test.go
+++ b/battery/queue/durable_scheduler_tz_test.go
@@ -1,0 +1,106 @@
+package queue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gosqlite "github.com/DonaldMurillo/gofastr/sqlite"
+)
+
+func newTZScheduler(t *testing.T, owner string) *DurableScheduler {
+	t.Helper()
+	db, err := gosqlite.Open()
+	if err != nil {
+		t.Fatalf("open pure sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	q, err := NewDBQueue(db)
+	if err != nil {
+		t.Fatalf("new queue: %v", err)
+	}
+	s, err := NewDurableScheduler(q, DurableSchedulerConfig{
+		OwnerID: owner, LeaseDuration: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("new scheduler: %v", err)
+	}
+	return s
+}
+
+// A cron schedule registered in a non-UTC location fires at its local time.
+func TestCronNonUTCTick(t *testing.T) {
+	s := newTZScheduler(t, "tz")
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	base := time.Date(2026, 1, 15, 1, 0, 0, 0, loc)
+	if err := s.Cron("daily-local", "0 2 * * *").Job("job", nil).RegisterAt(base); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	tick := time.Date(2026, 1, 15, 2, 0, 0, 0, loc)
+	if err := s.RunOnce(context.Background(), tick); err != nil {
+		t.Fatalf("RunOnce at local 02:00: %v", err)
+	}
+	jobs := pendingJobs(t, s.queue)
+	if len(jobs) != 1 {
+		t.Fatalf("enqueued %d jobs at local 02:00 tick, want 1", len(jobs))
+	}
+}
+
+// Re-registering a schedule with a different cadence must not strand the
+// stored watermark: the next valid occurrence of the NEW cadence fires,
+// and evaluation at the old watermark is not an error.
+func TestCadenceChangeKeepsFiring(t *testing.T) {
+	s := newTZScheduler(t, "cadence")
+	base := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	if err := s.Every("switch", time.Minute).Job("job", nil).RegisterAt(base); err != nil {
+		t.Fatalf("register interval: %v", err)
+	}
+	if err := s.Cron("switch", "0 2 * * *").Job("job", nil).RegisterAt(base); err != nil {
+		t.Fatalf("re-register cron: %v", err)
+	}
+
+	// Old interval watermark (00:01) is not an occurrence of the new cron.
+	if err := s.RunOnce(context.Background(), base.Add(time.Minute)); err != nil {
+		t.Fatalf("RunOnce at stale watermark: %v", err)
+	}
+	if jobs := pendingJobs(t, s.queue); len(jobs) != 0 {
+		t.Fatalf("enqueued %d jobs before the new cadence is due, want 0", len(jobs))
+	}
+
+	// First real occurrence of the new cron cadence.
+	if err := s.RunOnce(context.Background(), time.Date(2026, 1, 15, 2, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("RunOnce at new cadence tick: %v", err)
+	}
+	jobs := pendingJobs(t, s.queue)
+	if len(jobs) != 1 {
+		t.Fatalf("enqueued %d jobs at the new cadence tick, want 1", len(jobs))
+	}
+}
+
+// Register() (wall-clock registration) keeps the historical UTC cron
+// semantics: it must not persist the process-local zone. "Local" resolves
+// differently on every replica, and existing schedules registered before
+// the tz column fired in UTC.
+func TestRegisterKeepsUTCCron(t *testing.T) {
+	s := newTZScheduler(t, "wall-clock")
+	if err := s.Cron("nightly", "0 2 * * *").Job("job", nil).Register(); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	var tz string
+	if err := s.queue.db.QueryRow(
+		"SELECT tz FROM " + s.queue.schedulerSchedulesTable() + " WHERE id='nightly'",
+	).Scan(&tz); err != nil {
+		t.Fatalf("select tz: %v", err)
+	}
+	if tz != "" {
+		t.Fatalf("Register() persisted tz=%q, want \"\" (UTC evaluation)", tz)
+	}
+	if got := tzName(time.Local); got != "" {
+		t.Fatalf("tzName(time.Local) = %q, want \"\" (replica-dependent zone)", got)
+	}
+}

--- a/battery/queue/legacy_normalize.go
+++ b/battery/queue/legacy_normalize.go
@@ -1,0 +1,341 @@
+package queue
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// normalizeLegacyTimestamps rewrites space-separated (legacy mattn/go-sqlite3)
+// timestamp strings in the time columns of the queue and scheduler tables to
+// the canonical text the pure driver binds for time.Time. SQLite stores these
+// columns as TEXT, and the queue's claim/lease/scheduled_at predicates
+// (claimed_at <= $1, scheduled_at <= $2, expires_at <= $3, next_run <= $4)
+// compare them lexicographically. A same-day legacy value like
+// '2026-07-20 23:59:59+00:00' sorts BEFORE the canonical same-day value
+// '2026-07-20T23:59:59…Z' because space (0x20) precedes 'T' (0x54), so an
+// un-expired FUTURE lease compares as expired and is reclaimed (double
+// delivery of an in-flight job), and a not-yet-due scheduled_at compares as
+// due (retry backoff voided). Same root cause the outbox fixed in 84b0e167;
+// this is the local port for the queue tables.
+//
+// Postgres stores real TIMESTAMPTZ values, so this is a sqlite-only no-op
+// there. Idempotent: a row whose stored value already round-trips through
+// parseQueueTime to the canonical layout is skipped. Runs from NewDBQueue
+// (after schema ensure/migrations) and NewDurableScheduler.ensureTables
+// (after the scheduler tables are created) so the very first claim query of
+// a freshly-opened upgraded DB sees canonical values. queueTime in scanJob,
+// loadDue and nextWakeDelay remains as the post-scan safety net for any
+// value written after construction by a non-pure driver sharing the file.
+func (q *DBQueue) normalizeLegacyTimestamps(ctx context.Context) error {
+	if q.dialect != dialectSQLite {
+		return nil
+	}
+	if err := q.normalizeQueueJobsTimes(ctx); err != nil {
+		return err
+	}
+	if err := q.normalizeSchedulesTimes(ctx); err != nil {
+		return err
+	}
+	if err := q.normalizeOccurrencesTimes(ctx); err != nil {
+		return err
+	}
+	return q.normalizeLeaseTimes(ctx)
+}
+
+// probeBindLayout detects the text layout the connected driver produces when a
+// time.Time is bound as a parameter — the format the queue's own predicates
+// compare against, and therefore the canonical target for normalization. The
+// pure driver binds RFC3339Nano; mattn/go-sqlite3 binds a space-separated
+// form. Rows already in the probed layout are canonical FOR THIS HOST and
+// skipped, which keeps the pass idempotent on either driver instead of
+// rewriting every row on every queue open when the host runs mattn. An
+// unrecognized probe result falls back to RFC3339Nano (the rewrite still
+// self-corrects, because the rewritten value is bound as time.Time and the
+// driver formats it). Ported from framework/outbox/legacy_normalize.go.
+func (q *DBQueue) probeBindLayout(ctx context.Context) string {
+	ref := time.Date(2001, 2, 3, 4, 5, 6, 789012345, time.UTC)
+	var got string
+	if err := q.db.QueryRowContext(ctx, `SELECT CAST($1 AS TEXT)`, ref).Scan(&got); err != nil {
+		return time.RFC3339Nano
+	}
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999-07:00", // mattn/go-sqlite3
+	} {
+		if ref.Format(layout) == got {
+			return layout
+		}
+	}
+	return time.RFC3339Nano
+}
+
+// normalizeQueueJobsTimes canonicalizes created_at / scheduled_at /
+// claimed_at in queue_jobs, keyed by id. claimed_at is nullable, so NULL is
+// preserved (no SET fragment). Reads are fully drained before any UPDATE:
+// the queue is typically opened with SetMaxOpenConns(1) and an UPDATE issued
+// while the SELECT's rows cursor still holds the one connection deadlocks.
+func (q *DBQueue) normalizeQueueJobsTimes(ctx context.Context) error {
+	if !q.queueTableExists(ctx, q.qt()) {
+		return nil
+	}
+	rows, err := q.db.QueryContext(ctx, fmt.Sprintf(
+		`SELECT id, created_at, scheduled_at, claimed_at FROM %s`, q.qt()))
+	if err != nil {
+		return err
+	}
+	type row struct {
+		id                          string
+		created, scheduled, claimed any
+	}
+	var collected []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.created, &r.scheduled, &r.claimed); err != nil {
+			rows.Close()
+			return err
+		}
+		collected = append(collected, r)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, r := range collected {
+		sets, args, err := queueTimeSets([]queueTimeCol{
+			{"created_at", r.created},
+			{"scheduled_at", r.scheduled},
+			{"claimed_at", r.claimed},
+		})
+		if err != nil {
+			return err
+		}
+		if len(sets) == 0 {
+			continue
+		}
+		args = append(args, r.id)
+		stmt := fmt.Sprintf(`UPDATE %s SET %s WHERE id=$%d`,
+			q.qt(), strings.Join(sets, ", "), len(args))
+		if _, err := q.db.ExecContext(ctx, stmt, args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// normalizeSchedulesTimes canonicalizes next_run / updated_at in
+// scheduler_schedules, keyed by id. Runs when the DurableScheduler has been
+// constructed (the table exists); no-op otherwise.
+func (q *DBQueue) normalizeSchedulesTimes(ctx context.Context) error {
+	tbl := q.schedulerSchedulesTable()
+	if !q.queueTableExists(ctx, tbl) {
+		return nil
+	}
+	rows, err := q.db.QueryContext(ctx, fmt.Sprintf(
+		`SELECT id, next_run, updated_at FROM %s`, tbl))
+	if err != nil {
+		return err
+	}
+	type row struct {
+		id            string
+		next, updated any
+	}
+	var collected []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.next, &r.updated); err != nil {
+			rows.Close()
+			return err
+		}
+		collected = append(collected, r)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, r := range collected {
+		sets, args, err := queueTimeSets([]queueTimeCol{
+			{"next_run", r.next},
+			{"updated_at", r.updated},
+		})
+		if err != nil {
+			return err
+		}
+		if len(sets) == 0 {
+			continue
+		}
+		args = append(args, r.id)
+		stmt := fmt.Sprintf(`UPDATE %s SET %s WHERE id=$%d`,
+			tbl, strings.Join(sets, ", "), len(args))
+		if _, err := q.db.ExecContext(ctx, stmt, args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// normalizeOccurrencesTimes canonicalizes scheduled_tick / created_at in
+// scheduler_occurrences, keyed by occurrence_id.
+func (q *DBQueue) normalizeOccurrencesTimes(ctx context.Context) error {
+	tbl := q.schedulerOccurrencesTable()
+	if !q.queueTableExists(ctx, tbl) {
+		return nil
+	}
+	rows, err := q.db.QueryContext(ctx, fmt.Sprintf(
+		`SELECT occurrence_id, scheduled_tick, created_at FROM %s`, tbl))
+	if err != nil {
+		return err
+	}
+	type row struct {
+		id            string
+		tick, created any
+	}
+	var collected []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.tick, &r.created); err != nil {
+			rows.Close()
+			return err
+		}
+		collected = append(collected, r)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, r := range collected {
+		sets, args, err := queueTimeSets([]queueTimeCol{
+			{"scheduled_tick", r.tick},
+			{"created_at", r.created},
+		})
+		if err != nil {
+			return err
+		}
+		if len(sets) == 0 {
+			continue
+		}
+		args = append(args, r.id)
+		stmt := fmt.Sprintf(`UPDATE %s SET %s WHERE occurrence_id=$%d`,
+			tbl, strings.Join(sets, ", "), len(args))
+		if _, err := q.db.ExecContext(ctx, stmt, args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// normalizeLeaseTimes canonicalizes expires_at / heartbeat_at in
+// scheduler_leases, keyed by name. These columns back the lease fencing
+// (acquireLease's "expires_at <= $1" reclaim and the heartbeat "expires_at >
+// $1" re-check); a legacy space-separated value makes an active lease look
+// expired so a second replica steals the fence and double-fires schedules.
+func (q *DBQueue) normalizeLeaseTimes(ctx context.Context) error {
+	tbl := q.schedulerLeaseTable()
+	if !q.queueTableExists(ctx, tbl) {
+		return nil
+	}
+	rows, err := q.db.QueryContext(ctx, fmt.Sprintf(
+		`SELECT name, expires_at, heartbeat_at FROM %s`, tbl))
+	if err != nil {
+		return err
+	}
+	type row struct {
+		name               string
+		expires, heartbeat any
+	}
+	var collected []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.name, &r.expires, &r.heartbeat); err != nil {
+			rows.Close()
+			return err
+		}
+		collected = append(collected, r)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, r := range collected {
+		sets, args, err := queueTimeSets([]queueTimeCol{
+			{"expires_at", r.expires},
+			{"heartbeat_at", r.heartbeat},
+		})
+		if err != nil {
+			return err
+		}
+		if len(sets) == 0 {
+			continue
+		}
+		args = append(args, r.name)
+		stmt := fmt.Sprintf(`UPDATE %s SET %s WHERE name=$%d`,
+			tbl, strings.Join(sets, ", "), len(args))
+		if _, err := q.db.ExecContext(ctx, stmt, args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type queueTimeCol struct {
+	col string
+	raw any
+}
+
+// queueTimeSets builds SET-clause fragments and bind args for the time
+// columns whose stored value isn't already in canonical RFC3339Nano form.
+// NULL columns produce no fragment (left untouched). Canonical values parse
+// and reformat to the same string → skipped, which makes the whole pass
+// idempotent. Unparseable values return an error: a value parseQueueTime
+// can't handle is data corruption, and silently keeping it would leave the
+// bug in place. The bound value is normalized to UTC and bound as time.Time
+// so the driver writes exactly what its own predicate binds compare against
+// (the driver formats time.Time into the probed layout, which is what every
+// claim/lease query then compares to).
+func queueTimeSets(cols []queueTimeCol) ([]string, []any, error) {
+	var sets []string
+	var args []any
+	for _, c := range cols {
+		if c.raw == nil {
+			continue
+		}
+		parsed, err := queueTime(c.raw)
+		if err != nil {
+			return nil, nil, fmt.Errorf("queue: decode legacy %s: %w", c.col, err)
+		}
+		canonical := parsed.UTC().Format(time.RFC3339Nano)
+		if s, ok := c.raw.(string); ok && s == canonical {
+			continue
+		}
+		sets = append(sets, fmt.Sprintf("%s=$%d", c.col, len(args)+1))
+		args = append(args, parsed.UTC())
+	}
+	return sets, args, nil
+}
+
+// queueTableExists reports whether the already-quoted table is queryable.
+// The probe is a SELECT … LIMIT 1 so it works on both sqlite drivers (the
+// pure driver implements PRAGMA but does not expose sqlite_master, and we
+// want one code path). Errors are treated as "absent": ensureTable /
+// ensureTables has already run by the time normalization is reached, so a
+// real error here most likely means the table genuinely doesn't exist yet
+// (e.g., NewDBQueue before any DurableScheduler has been constructed — the
+// scheduler tables are absent), and there is nothing to normalize.
+func (q *DBQueue) queueTableExists(ctx context.Context, quotedTable string) bool {
+	var n int
+	err := q.db.QueryRowContext(ctx, fmt.Sprintf("SELECT 1 FROM %s LIMIT 1", quotedTable)).Scan(&n)
+	if err == nil || err == sql.ErrNoRows {
+		return true
+	}
+	return false
+}

--- a/battery/queue/legacy_time_test.go
+++ b/battery/queue/legacy_time_test.go
@@ -1,0 +1,99 @@
+package queue
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	gosqlite "github.com/DonaldMurillo/gofastr/sqlite"
+)
+
+const legacyTimeLayout = "2006-01-02 15:04:05.999999999-07:00"
+
+// legacyQueueDB creates the queue schema, seeds rows through rawInsert in
+// the legacy mattn space-separated text format (as an old binary would
+// have written them), then constructs a fresh DBQueue over the same DB —
+// the upgrade scenario a new binary sees at startup.
+func legacyQueueDB(t *testing.T, rawInsert func(t *testing.T, db *sql.DB)) *DBQueue {
+	t.Helper()
+	db, err := gosqlite.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	if _, err := NewDBQueue(db); err != nil {
+		t.Fatalf("bootstrap queue: %v", err)
+	}
+	rawInsert(t, db)
+	q, err := NewDBQueue(db)
+	if err != nil {
+		t.Fatalf("reopen queue: %v", err)
+	}
+	return q
+}
+
+// A job claimed moments ago by a legacy-format writer keeps its lease: the
+// space-separated claimed_at must not compare as expired against the pure
+// driver's RFC3339 binds (lexicographic TEXT comparison), which would
+// double-run an in-flight job.
+func TestLegacyActiveLeaseNotReclaimedQueue(t *testing.T) {
+	now := time.Now().UTC()
+	q := legacyQueueDB(t, func(t *testing.T, db *sql.DB) {
+		past := now.Add(-time.Hour).Format(legacyTimeLayout)
+		if _, err := db.Exec(`INSERT INTO "queue_jobs"
+			(id, occurrence_id, type, payload, priority, lane, attempts, max_attempts,
+			 created_at, scheduled_at, status, claimed_at)
+			VALUES ('j1','', 'work','null',0,'',1,3,?,?,'claimed',?)`,
+			past, past, now.Format(legacyTimeLayout)); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if _, err := q.Dequeue(context.Background(), "work"); !errors.Is(err, ErrNoJob) {
+		t.Fatalf("in-flight job with an active legacy lease was reclaimed (err=%v)", err)
+	}
+}
+
+// A pending job whose legacy-format scheduled_at is an hour in the future
+// (e.g. retry backoff written by an old binary) must wait, not run now.
+func TestLegacyFutureScheduledWaits(t *testing.T) {
+	now := time.Now().UTC()
+	q := legacyQueueDB(t, func(t *testing.T, db *sql.DB) {
+		past := now.Add(-time.Hour).Format(legacyTimeLayout)
+		if _, err := db.Exec(`INSERT INTO "queue_jobs"
+			(id, occurrence_id, type, payload, priority, lane, attempts, max_attempts,
+			 created_at, scheduled_at, status)
+			VALUES ('j2','', 'work','null',0,'',0,3,?,?,'pending')`,
+			past, now.Add(time.Hour).Format(legacyTimeLayout)); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if _, err := q.Dequeue(context.Background(), "work"); !errors.Is(err, ErrNoJob) {
+		t.Fatalf("job scheduled an hour ahead (legacy format) dequeued now (err=%v)", err)
+	}
+}
+
+// An expired legacy-format lease is still reclaimed — guards against
+// "fixing" the comparison by ignoring legacy rows.
+func TestLegacyExpiredLeaseReclaimed(t *testing.T) {
+	now := time.Now().UTC()
+	q := legacyQueueDB(t, func(t *testing.T, db *sql.DB) {
+		past := now.Add(-2 * time.Hour).Format(legacyTimeLayout)
+		if _, err := db.Exec(`INSERT INTO "queue_jobs"
+			(id, occurrence_id, type, payload, priority, lane, attempts, max_attempts,
+			 created_at, scheduled_at, status, claimed_at)
+			VALUES ('j3','', 'work','null',0,'',1,3,?,?,'claimed',?)`,
+			past, past, now.Add(-time.Hour).Format(legacyTimeLayout)); err != nil {
+			t.Fatal(err)
+		}
+	})
+	job, err := q.Dequeue(context.Background(), "work")
+	if err != nil {
+		t.Fatalf("expired legacy lease not reclaimed: %v", err)
+	}
+	if job.ID != "j3" {
+		t.Fatalf("reclaimed job = %q, want j3", job.ID)
+	}
+}

--- a/cmd/gofastr/build.go
+++ b/cmd/gofastr/build.go
@@ -20,11 +20,12 @@ func runBuild(args []string) {
 		osExit(1)
 	}
 
-	// Step 1: run the codegen extension protocol when a gofastr.codegen.yml
 	if err := validateBuildTarget(opts.pkg); err != nil {
 		fail("Build target %q is invalid: %v", opts.pkg, err)
 		osExit(1)
 	}
+
+	// Step 1: run the codegen extension protocol when a gofastr.codegen.yml
 	// is present. Blueprint generation (gofastr generate --from) is an
 	// explicit, separate step — `gofastr build` does not guess a blueprint.
 	if !opts.noGenerate {

--- a/examples/site/docs_catalog.go
+++ b/examples/site/docs_catalog.go
@@ -50,7 +50,7 @@ var docIntents = []docIntent{
 		Path: []string{"Overview", "Tutorial: blueprint app", "Project structure"},
 		Docs: []docEntry{
 			{"overview", "Overview", "What the framework is, the two layers, and a linked map of every capability."},
-			{"tutorial-blueprint-app", "Tutorial: blueprint app", "The thesis tutorial: one blueprint becomes a UI + API you own, in about twenty minutes."},
+			{"tutorial-blueprint-app", "Tutorial: blueprint app", "The optional blueprint scaffolder end to end: one gofastr.yml becomes a UI + API you own, in about twenty minutes."},
 			{"project-structure", "Project structure", "Start flat; grow into internal/<domain> as real boundaries appear. Structure follows the app."},
 			{"comparison", "Comparison", "Where GoFastr sits relative to other full-stack frameworks."},
 			{"upgrading", "Upgrading", "Move an app (and the CLI) to a newer release — plus gofastr upgrade, the guided helper."},

--- a/framework/crud/include.go
+++ b/framework/crud/include.go
@@ -204,7 +204,17 @@ func splitIncludePath(s string) []string {
 func parseScopedFilters(raw string, fields []schema.Field, pathForErrors string) ([]filter.ParsedFilter, error) {
 	knownField := map[string]bool{}
 	for _, f := range fields {
-		knownField[f.Name] = true
+		// A Hidden column is treated as NOT declared — the identical
+		// "not on target entity" error a nonexistent field gets. The
+		// eager loader scrubs Hidden columns from the OUTPUT, but a
+		// scoped filter on one would still reach the WHERE clause, and
+		// the related row's presence/absence in the response leaks
+		// whether the value matched — the same value-disclosure oracle
+		// the top-level and nested filter paths close (see
+		// nested_filter.go), one relation hop away.
+		if !f.Hidden {
+			knownField[f.Name] = true
+		}
 	}
 	suffixes := []struct {
 		suffix string

--- a/framework/crud/include_hidden_test.go
+++ b/framework/crud/include_hidden_test.go
@@ -1,0 +1,51 @@
+package crud
+
+import (
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+)
+
+// A Hidden column on an include target is treated exactly like a column
+// that does not exist: scoped filters on it are rejected with the
+// identical error, so include=rel(hidden_like=...) can be neither a
+// value-disclosure oracle (presence/absence of the related row leaking
+// prefix matches) nor an existence oracle for the column name. Mirrors
+// the nested-filter and top-level Hidden exclusions from #107.
+func TestScopedFilterHiddenFieldRejected(t *testing.T) {
+	fields := []schema.Field{
+		{Name: "name"},
+		{Name: "password_hash", Hidden: true},
+	}
+
+	if _, err := parseScopedFilters("name=alice", fields, "author"); err != nil {
+		t.Fatalf("visible field rejected: %v", err)
+	}
+
+	hiddenErr := func(expr string) string {
+		t.Helper()
+		_, err := parseScopedFilters(expr, fields, "author")
+		if err == nil {
+			t.Fatalf("scoped filter %q on hidden field accepted", expr)
+		}
+		return err.Error()
+	}
+	_, absentErr := parseScopedFilters("no_such_field=x", fields, "author")
+	if absentErr == nil {
+		t.Fatal("scoped filter on absent field accepted")
+	}
+
+	for _, expr := range []string{
+		"password_hash=x",
+		"password_hash_like=SEC%",
+		"password_hash_in=a|b",
+		"password_hash_gte=0",
+	} {
+		got := hiddenErr(expr)
+		want := absentErr.Error()
+		// Same error shape as an absent field, modulo the field name.
+		if len(got) == 0 || len(want) == 0 {
+			t.Fatalf("empty error text: got %q want-shape %q", got, want)
+		}
+	}
+}

--- a/framework/docs/content/queue.md
+++ b/framework/docs/content/queue.md
@@ -405,6 +405,31 @@ The options columns (`lane`, `priority`, `max_attempts`) are added to an
 existing `scheduler_schedules` table by an idempotent migration during
 `NewDurableScheduler` — no manual schema work is required on upgrade.
 
+Cron field evaluation follows the location of the registration anchor.
+`Register()` anchors in UTC, so `"0 2 * * *"` fires at 02:00 UTC — the
+behavior schedules have always had. To evaluate a spec in a zone's
+wall-clock time (including across DST shifts), register with `RegisterAt`
+and a time in a named IANA zone:
+
+```go
+loc, _ := time.LoadLocation("America/New_York")
+if err := durable.Cron("nightly-rollup", "0 2 * * *").
+    Job("nightly-rollup", nil).
+    RegisterAt(time.Now().In(loc)); err != nil {
+    log.Fatal(err)
+}
+```
+
+The zone name persists with the schedule (a `tz` column added by the same
+idempotent migration as the options columns). UTC, fixed-offset zones
+(`time.FixedZone`), and `time.Local` store the empty default and evaluate
+in UTC — `time.Local` would resolve to a different zone on every replica.
+Re-registering a schedule with a different cadence keeps the stored
+watermark and self-heals: evaluation advances to the next valid occurrence
+of the new spec instead of failing. A schedule whose stored state cannot
+produce a due tick is logged and skipped each heartbeat; other schedules
+keep firing.
+
 One replica holds a heartbeat-expiry lease for efficient evaluation. Every
 lease acquisition after expiry increments a fencing token. Before committing
 an occurrence, the scheduler re-checks that exact owner/token row. The

--- a/framework/docs/content/queue.md
+++ b/framework/docs/content/queue.md
@@ -424,6 +424,11 @@ The zone name persists with the schedule (a `tz` column added by the same
 idempotent migration as the options columns). UTC, fixed-offset zones
 (`time.FixedZone`), and `time.Local` store the empty default and evaluate
 in UTC — `time.Local` would resolve to a different zone on every replica.
+The in-memory `Scheduler` differs here: it has no persistence, so its cron
+specs evaluate against the process clock in the process's local zone.
+Moving a schedule from `Scheduler` to `DurableScheduler.Register()` on a
+non-UTC host shifts its fire time to the UTC wall clock — pass the
+intended zone via `RegisterAt` to keep local-time semantics.
 Re-registering a schedule with a different cadence keeps the stored
 watermark and self-heals: evaluation advances to the next valid occurrence
 of the new spec instead of failing. A schedule whose stored state cannot

--- a/framework/outbox/legacy_lease_test.go
+++ b/framework/outbox/legacy_lease_test.go
@@ -1,0 +1,78 @@
+package outbox
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DonaldMurillo/gofastr/framework/event"
+	gosqlite "github.com/DonaldMurillo/gofastr/sqlite"
+)
+
+const legacyLayout = "2006-01-02 15:04:05.999999999-07:00"
+
+func legacyLeaseOutbox(t *testing.T, claimedUntil time.Time) (*Outbox, chan struct{}) {
+	t.Helper()
+	db, err := gosqlite.Open()
+	if err != nil {
+		t.Fatalf("open pure sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+
+	o, err := New(db, WithHandlerGrace(0), WithPollInterval(5*time.Millisecond))
+	if err != nil {
+		t.Fatalf("new outbox: %v", err)
+	}
+
+	created := time.Now().UTC().Add(-time.Minute).Format(legacyLayout)
+	if _, err := db.Exec(`INSERT INTO event_outbox (id, type, payload, status, attempts, created_at)
+		VALUES ('row1', 'evt', '{}', 'pending', 0, $1)`, created); err != nil {
+		t.Fatalf("insert legacy event: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO event_outbox_delivery (row_id, consumer, status, attempts, created_at, claimed_until)
+		VALUES ('row1', 'legacy-consumer', 'pending', 0, $1, $2)`,
+		created, claimedUntil.UTC().Format(legacyLayout)); err != nil {
+		t.Fatalf("insert legacy delivery: %v", err)
+	}
+
+	called := make(chan struct{}, 1)
+	o.Consume("legacy-consumer", "evt", func(context.Context, event.Event) error {
+		called <- struct{}{}
+		return nil
+	})
+	return o, called
+}
+
+// A delivery whose legacy-format (space-separated) lease is still in the
+// future must not be reclaimed by the relay.
+func TestLegacyActiveLeaseNotReclaimed(t *testing.T) {
+	o, called := legacyLeaseOutbox(t, time.Now().UTC().Add(time.Hour))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stop := o.StartRelay(ctx)
+	defer stop()
+
+	select {
+	case <-called:
+		t.Fatal("handler called while a future lease is active")
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+// A delivery whose legacy-format lease has expired is picked up again.
+func TestLegacyExpiredLeaseDelivers(t *testing.T) {
+	o, called := legacyLeaseOutbox(t, time.Now().UTC().Add(-time.Hour))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stop := o.StartRelay(ctx)
+	defer stop()
+
+	select {
+	case <-called:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expired legacy lease was never redelivered")
+	}
+}

--- a/framework/outbox/legacy_normalize.go
+++ b/framework/outbox/legacy_normalize.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/DonaldMurillo/gofastr/core/query"
 )
 
-// normalizeLegacyTimestamps rewrites space-separated (legacy mattn/go-sqlite3)
-// timestamp strings in the time columns of the parent and delivery tables to
-// the canonical RFC3339Nano text the pure driver binds for time.Time. SQLite
+// normalizeLegacyTimestamps rewrites timestamp strings in the time columns
+// of the parent and delivery tables to the canonical text layout the
+// CONNECTED driver binds for time.Time (RFC3339Nano on the pure driver,
+// space-separated on mattn/go-sqlite3 — see probeBindLayout). SQLite
 // stores these columns as TEXT, and the relay's lease/grace SQL predicates
 // (claimed_until <= $1, created_at <= $2) compare them lexicographically. A
 // same-day legacy value like '2026-07-20 23:59:59+00:00' sorts BEFORE the
@@ -32,15 +34,43 @@ func (o *Outbox) normalizeLegacyTimestamps(ctx context.Context) error {
 	if o.dialect != dialectSQLite {
 		return nil
 	}
-	if err := o.normalizeParentTimes(ctx); err != nil {
+	layout := o.probeBindLayout(ctx)
+	if err := o.normalizeParentTimes(ctx, layout); err != nil {
 		return err
 	}
-	return o.normalizeDeliveryTimes(ctx)
+	return o.normalizeDeliveryTimes(ctx, layout)
+}
+
+// probeBindLayout detects the text layout the connected driver produces
+// when a time.Time is bound as a parameter — the format the relay's own
+// predicates compare against, and therefore the canonical target for
+// normalization. The pure driver binds RFC3339Nano; mattn/go-sqlite3
+// binds a space-separated form. Rows already in the probed layout are
+// canonical FOR THIS HOST and skipped, which keeps the pass idempotent on
+// either driver instead of rewriting every row on every relay start when
+// the host runs mattn. An unrecognized probe result falls back to
+// RFC3339Nano (the rewrite still self-corrects, because the rewritten
+// value is bound as time.Time and the driver formats it).
+func (o *Outbox) probeBindLayout(ctx context.Context) string {
+	ref := time.Date(2001, 2, 3, 4, 5, 6, 789012345, time.UTC)
+	var got string
+	if err := o.db.QueryRowContext(ctx, `SELECT CAST($1 AS TEXT)`, ref).Scan(&got); err != nil {
+		return time.RFC3339Nano
+	}
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999-07:00", // mattn/go-sqlite3
+	} {
+		if ref.Format(layout) == got {
+			return layout
+		}
+	}
+	return time.RFC3339Nano
 }
 
 // normalizeParentTimes canonicalizes the four time columns of event_outbox,
 // keyed by id.
-func (o *Outbox) normalizeParentTimes(ctx context.Context) error {
+func (o *Outbox) normalizeParentTimes(ctx context.Context, layout string) error {
 	if !o.tableExists(ctx, o.table) {
 		return nil
 	}
@@ -74,7 +104,7 @@ func (o *Outbox) normalizeParentTimes(ctx context.Context) error {
 		return err
 	}
 	for _, r := range collected {
-		sets, args, err := legacyTimeSets([]timeCol{
+		sets, args, err := legacyTimeSets(layout, []timeCol{
 			{"created_at", r.created},
 			{"dispatched_at", r.dispatched},
 			{"next_attempt_at", r.next},
@@ -100,7 +130,7 @@ func (o *Outbox) normalizeParentTimes(ctx context.Context) error {
 // event_outbox_delivery, keyed by (row_id, consumer). Reads are fully
 // drained before any UPDATE for the same MaxOpenConns(1) reason as the
 // parent path.
-func (o *Outbox) normalizeDeliveryTimes(ctx context.Context) error {
+func (o *Outbox) normalizeDeliveryTimes(ctx context.Context, layout string) error {
 	if !o.tableExists(ctx, o.deliveryTable) {
 		return nil
 	}
@@ -130,7 +160,7 @@ func (o *Outbox) normalizeDeliveryTimes(ctx context.Context) error {
 		return err
 	}
 	for _, r := range collected {
-		sets, args, err := legacyTimeSets([]timeCol{
+		sets, args, err := legacyTimeSets(layout, []timeCol{
 			{"created_at", r.created},
 			{"next_attempt_at", r.next},
 			{"claimed_until", r.claimed},
@@ -158,15 +188,15 @@ type timeCol struct {
 }
 
 // legacyTimeSets builds SET-clause fragments and bind args for the time
-// columns whose stored value isn't already in canonical RFC3339Nano form.
-// NULL columns produce no fragment (left untouched). Canonical values parse
-// and reformat to the same string → skipped, which makes the whole pass
-// idempotent. Unparseable values return an error: a value parseOutboxTime
-// can't handle is data corruption, and silently keeping it would leave the
-// bug in place. The bound value is normalized to UTC so the rewrite matches
-// what the relay itself writes (now().UTC()), keeping 'Z' suffixes uniform
-// across rows for stable lexicographic comparison.
-func legacyTimeSets(cols []timeCol) ([]string, []any, error) {
+// columns whose stored value isn't already in the canonical layout for the
+// connected driver (see probeBindLayout). NULL columns produce no fragment
+// (left untouched). Canonical values parse and reformat to the same string
+// → skipped, which makes the whole pass idempotent on either driver.
+// Unparseable values return an error: a value parseOutboxTime can't handle
+// is data corruption, and silently keeping it would leave the bug in
+// place. The bound value is normalized to UTC and bound as time.Time, so
+// the driver writes exactly what its own predicate binds compare against.
+func legacyTimeSets(layout string, cols []timeCol) ([]string, []any, error) {
 	var sets []string
 	var args []any
 	for _, c := range cols {
@@ -177,7 +207,7 @@ func legacyTimeSets(cols []timeCol) ([]string, []any, error) {
 		if err != nil {
 			return nil, nil, fmt.Errorf("outbox: decode legacy %s: %w", c.col, err)
 		}
-		canonical := parsed.UTC().Format(time.RFC3339Nano)
+		canonical := parsed.UTC().Format(layout)
 		if s, ok := c.raw.(string); ok && s == canonical {
 			continue
 		}
@@ -201,6 +231,15 @@ func (o *Outbox) tableExists(ctx context.Context, bareName string) bool {
 	err := o.db.QueryRowContext(ctx, q).Scan(&n)
 	if err == nil || err == sql.ErrNoRows {
 		return true
+	}
+	// "no such table" is the expected WithoutEnsureTable-before-migration
+	// case and stays silent. Anything else (e.g. SQLITE_BUSY from another
+	// process holding the file lock) also skips normalization — the relay
+	// keeps working via the post-scan parse fallback — but is worth a
+	// trace, since silence here would hide a persistent fault.
+	if !strings.Contains(strings.ToLower(err.Error()), "no such table") {
+		slog.Default().Warn("outbox: table probe failed; skipping timestamp normalization this start",
+			"table", bareName, "err", err)
 	}
 	return false
 }

--- a/framework/outbox/legacy_normalize.go
+++ b/framework/outbox/legacy_normalize.go
@@ -1,0 +1,206 @@
+package outbox
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/DonaldMurillo/gofastr/core/query"
+)
+
+// normalizeLegacyTimestamps rewrites space-separated (legacy mattn/go-sqlite3)
+// timestamp strings in the time columns of the parent and delivery tables to
+// the canonical RFC3339Nano text the pure driver binds for time.Time. SQLite
+// stores these columns as TEXT, and the relay's lease/grace SQL predicates
+// (claimed_until <= $1, created_at <= $2) compare them lexicographically. A
+// same-day legacy value like '2026-07-20 23:59:59+00:00' sorts BEFORE the
+// canonical same-day value '2026-07-20T23:59:59…Z' because space (0x20)
+// precedes 'T' (0x54), so an un-expired FUTURE lease compares as expired and
+// is reclaimed (double delivery), and a not-yet-old parent compares as old
+// (wrong completion/abandonment).
+//
+// Postgres stores real TIMESTAMPTZ values, so this is a sqlite-only no-op
+// there. Idempotent: a row whose stored value already round-trips to the same
+// canonical text is skipped. Runs at relay start (see relayLoop) so the
+// claim/grace queries see canonical values from the first pump; parsing via
+// parseOutboxTime in scanOutboxRow/listDeliveries remains as the post-scan
+// safety net for any value written after construction by a non-pure driver
+// sharing the file.
+func (o *Outbox) normalizeLegacyTimestamps(ctx context.Context) error {
+	if o.dialect != dialectSQLite {
+		return nil
+	}
+	if err := o.normalizeParentTimes(ctx); err != nil {
+		return err
+	}
+	return o.normalizeDeliveryTimes(ctx)
+}
+
+// normalizeParentTimes canonicalizes the four time columns of event_outbox,
+// keyed by id.
+func (o *Outbox) normalizeParentTimes(ctx context.Context) error {
+	if !o.tableExists(ctx, o.table) {
+		return nil
+	}
+	// Read every row first and close the iterator before any UPDATE: the
+	// outbox is typically opened with SetMaxOpenConns(1) (SQLite serialises
+	// writers on a single in-memory page), and an UPDATE issued while the
+	// SELECT's rows cursor still holds the one connection deadlocks.
+	rows, err := o.db.QueryContext(ctx, fmt.Sprintf(
+		`SELECT id, created_at, dispatched_at, next_attempt_at, claimed_until FROM %s`,
+		o.qt()))
+	if err != nil {
+		return err
+	}
+	type parentRow struct {
+		id                                 string
+		created, dispatched, next, claimed any
+	}
+	var collected []parentRow
+	for rows.Next() {
+		var r parentRow
+		if err := rows.Scan(&r.id, &r.created, &r.dispatched, &r.next, &r.claimed); err != nil {
+			rows.Close()
+			return err
+		}
+		collected = append(collected, r)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, r := range collected {
+		sets, args, err := legacyTimeSets([]timeCol{
+			{"created_at", r.created},
+			{"dispatched_at", r.dispatched},
+			{"next_attempt_at", r.next},
+			{"claimed_until", r.claimed},
+		})
+		if err != nil {
+			return err
+		}
+		if len(sets) == 0 {
+			continue
+		}
+		args = append(args, r.id)
+		q := fmt.Sprintf(`UPDATE %s SET %s WHERE id=$%d`,
+			o.qt(), strings.Join(sets, ", "), len(args))
+		if _, err := o.db.ExecContext(ctx, q, args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// normalizeDeliveryTimes canonicalizes the four time columns of
+// event_outbox_delivery, keyed by (row_id, consumer). Reads are fully
+// drained before any UPDATE for the same MaxOpenConns(1) reason as the
+// parent path.
+func (o *Outbox) normalizeDeliveryTimes(ctx context.Context) error {
+	if !o.tableExists(ctx, o.deliveryTable) {
+		return nil
+	}
+	rows, err := o.db.QueryContext(ctx, fmt.Sprintf(
+		`SELECT row_id, consumer, created_at, next_attempt_at, claimed_until, dispatched_at FROM %s`,
+		o.qd()))
+	if err != nil {
+		return err
+	}
+	type deliveryRow struct {
+		rowID, consumer                    string
+		created, next, claimed, dispatched any
+	}
+	var collected []deliveryRow
+	for rows.Next() {
+		var r deliveryRow
+		if err := rows.Scan(&r.rowID, &r.consumer, &r.created, &r.next, &r.claimed, &r.dispatched); err != nil {
+			rows.Close()
+			return err
+		}
+		collected = append(collected, r)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, r := range collected {
+		sets, args, err := legacyTimeSets([]timeCol{
+			{"created_at", r.created},
+			{"next_attempt_at", r.next},
+			{"claimed_until", r.claimed},
+			{"dispatched_at", r.dispatched},
+		})
+		if err != nil {
+			return err
+		}
+		if len(sets) == 0 {
+			continue
+		}
+		args = append(args, r.rowID, r.consumer)
+		q := fmt.Sprintf(`UPDATE %s SET %s WHERE row_id=$%d AND consumer=$%d`,
+			o.qd(), strings.Join(sets, ", "), len(args)-1, len(args))
+		if _, err := o.db.ExecContext(ctx, q, args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type timeCol struct {
+	col string
+	raw any
+}
+
+// legacyTimeSets builds SET-clause fragments and bind args for the time
+// columns whose stored value isn't already in canonical RFC3339Nano form.
+// NULL columns produce no fragment (left untouched). Canonical values parse
+// and reformat to the same string → skipped, which makes the whole pass
+// idempotent. Unparseable values return an error: a value parseOutboxTime
+// can't handle is data corruption, and silently keeping it would leave the
+// bug in place. The bound value is normalized to UTC so the rewrite matches
+// what the relay itself writes (now().UTC()), keeping 'Z' suffixes uniform
+// across rows for stable lexicographic comparison.
+func legacyTimeSets(cols []timeCol) ([]string, []any, error) {
+	var sets []string
+	var args []any
+	for _, c := range cols {
+		if c.raw == nil {
+			continue
+		}
+		parsed, err := outboxTime(c.raw)
+		if err != nil {
+			return nil, nil, fmt.Errorf("outbox: decode legacy %s: %w", c.col, err)
+		}
+		canonical := parsed.UTC().Format(time.RFC3339Nano)
+		if s, ok := c.raw.(string); ok && s == canonical {
+			continue
+		}
+		sets = append(sets, fmt.Sprintf("%s=$%d", c.col, len(args)+1))
+		args = append(args, parsed.UTC())
+	}
+	return sets, args, nil
+}
+
+// tableExists reports whether the bare-named table is queryable. The probe is
+// a SELECT … LIMIT 1 so it works on both sqlite drivers (the pure driver
+// implements PRAGMA but does not expose sqlite_master, and we want one code
+// path). Errors are treated as "absent": ensureTable has already run by the
+// time normalization is reached (when not WithoutEnsureTable), so a real
+// error here most likely means the host set WithoutEnsureTable and the
+// migration hasn't created the table yet — nothing to normalize, and the
+// relay's own queries will surface any genuine DB fault.
+func (o *Outbox) tableExists(ctx context.Context, bareName string) bool {
+	var n int
+	q := fmt.Sprintf("SELECT 1 FROM %s LIMIT 1", query.QuoteIdent(bareName))
+	err := o.db.QueryRowContext(ctx, q).Scan(&n)
+	if err == nil || err == sql.ErrNoRows {
+		return true
+	}
+	return false
+}

--- a/framework/outbox/legacy_normalize_test.go
+++ b/framework/outbox/legacy_normalize_test.go
@@ -1,0 +1,200 @@
+package outbox
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	gosqlite "github.com/DonaldMurillo/gofastr/sqlite"
+)
+
+// openPureOutbox opens a fresh pure-sqlite DB + Outbox so the normalizer's
+// dialect path (the one that matters for legacy timestamps) is exercised.
+func openPureOutbox(t *testing.T) (*sql.DB, *Outbox) {
+	t.Helper()
+	db, err := gosqlite.Open()
+	if err != nil {
+		t.Fatalf("open pure sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	o, err := New(db, WithHandlerGrace(0), WithPollInterval(time.Millisecond))
+	if err != nil {
+		t.Fatalf("new outbox: %v", err)
+	}
+	return db, o
+}
+
+const (
+	legacySpaceLayout    = "2006-01-02 15:04:05.999999999-07:00"
+	legacySpaceNoTZ      = "2006-01-02 15:04:05.999999999"
+	canonicalRFC3339Nano = time.RFC3339Nano
+)
+
+// TestNormalize_RewritesLegacyParentAndDelivery inserts rows with
+// space-separated timestamps directly (bypassing Append so they stay legacy),
+// then re-opens the outbox to trigger normalization and asserts the on-disk
+// values are now canonical RFC3339Nano text.
+func TestNormalize_RewritesLegacyParentAndDelivery(t *testing.T) {
+	db, o := openPureOutbox(t)
+	ctx := context.Background()
+
+	// Future lease in legacy layout — the exact shape that breaks the relay
+	// (an un-expired lease that sorts as expired).
+	futureLegacy := time.Now().UTC().Add(time.Hour).Format(legacySpaceLayout)
+	pastLegacy := time.Now().UTC().Add(-time.Hour).Format(legacySpaceLayout)
+
+	if _, err := db.ExecContext(ctx, `INSERT INTO event_outbox (id, type, payload, status, attempts, created_at)
+		VALUES ('p1', 'evt', '{}', 'pending', 0, $1)`, pastLegacy); err != nil {
+		t.Fatalf("insert parent: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO event_outbox_delivery (row_id, consumer, status, attempts, created_at, claimed_until)
+		VALUES ('p1', 'c', 'pending', 0, $1, $2)`, pastLegacy, futureLegacy); err != nil {
+		t.Fatalf("insert delivery: %v", err)
+	}
+
+	// Re-open: New() runs normalization.
+	if err := o.normalizeLegacyTimestamps(ctx); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+
+	var parentCreated string
+	if err := db.QueryRowContext(ctx, `SELECT created_at FROM event_outbox WHERE id='p1'`).Scan(&parentCreated); err != nil {
+		t.Fatalf("read parent: %v", err)
+	}
+	if strings.Contains(parentCreated, " ") {
+		t.Fatalf("parent created_at still legacy %q (must be canonical RFC3339Nano)", parentCreated)
+	}
+	if _, err := time.Parse(canonicalRFC3339Nano, parentCreated); err != nil {
+		t.Fatalf("parent created_at %q is not RFC3339Nano: %v", parentCreated, err)
+	}
+
+	var claimed string
+	if err := db.QueryRowContext(ctx, `SELECT claimed_until FROM event_outbox_delivery WHERE row_id='p1' AND consumer='c'`).Scan(&claimed); err != nil {
+		t.Fatalf("read delivery: %v", err)
+	}
+	if strings.Contains(claimed, " ") {
+		t.Fatalf("delivery claimed_until still legacy %q (must be canonical RFC3339Nano)", claimed)
+	}
+	if _, err := time.Parse(canonicalRFC3339Nano, claimed); err != nil {
+		t.Fatalf("delivery claimed_until %q is not RFC3339Nano: %v", claimed, err)
+	}
+
+	// The future lease must still compare as FUTURE relative to now — i.e.
+	// the SQL predicate the relay uses must say "not expired". This is the
+	// behavior fix the whole normalizer exists for.
+	var leased int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM event_outbox_delivery WHERE row_id='p1' AND consumer='c' AND (claimed_until IS NULL OR claimed_until <= $1)`,
+		time.Now().UTC()).Scan(&leased); err != nil {
+		t.Fatalf("compare: %v", err)
+	}
+	if leased != 0 {
+		t.Fatalf("after normalization a future lease still compares as expired: leased=%d (claimed_until=%q)", leased, claimed)
+	}
+}
+
+// TestNormalize_Idempotent asserts a second normalization pass writes nothing
+// because every value is already canonical. We measure this by counting
+// rows-affected across both passes — the second pass must touch zero rows.
+func TestNormalize_Idempotent(t *testing.T) {
+	db, o := openPureOutbox(t)
+	ctx := context.Background()
+
+	// Insert one legacy row.
+	pastLegacy := time.Now().UTC().Add(-time.Hour).Format(legacySpaceLayout)
+	if _, err := db.ExecContext(ctx, `INSERT INTO event_outbox (id, type, payload, status, attempts, created_at)
+		VALUES ('p1', 'evt', '{}', 'pending', 0, $1)`, pastLegacy); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := o.normalizeLegacyTimestamps(ctx); err != nil {
+		t.Fatalf("first normalize: %v", err)
+	}
+	var after1 string
+	if err := db.QueryRowContext(ctx, `SELECT created_at FROM event_outbox WHERE id='p1'`).Scan(&after1); err != nil {
+		t.Fatalf("read after first: %v", err)
+	}
+	// Second pass: must not change anything.
+	if err := o.normalizeLegacyTimestamps(ctx); err != nil {
+		t.Fatalf("second normalize: %v", err)
+	}
+	var after2 string
+	if err := db.QueryRowContext(ctx, `SELECT created_at FROM event_outbox WHERE id='p1'`).Scan(&after2); err != nil {
+		t.Fatalf("read after second: %v", err)
+	}
+	if after1 != after2 {
+		t.Fatalf("normalize not idempotent: first=%q second=%q", after1, after2)
+	}
+}
+
+// TestNormalize_PreservesNulls asserts that NULL time columns survive
+// normalization as NULL (a row that has never been claimed/dispatched must
+// keep those columns empty, not get stamped with a zero time).
+func TestNormalize_PreservesNulls(t *testing.T) {
+	db, o := openPureOutbox(t)
+	ctx := context.Background()
+
+	pastLegacy := time.Now().UTC().Add(-time.Hour).Format(legacySpaceLayout)
+	if _, err := db.ExecContext(ctx, `INSERT INTO event_outbox (id, type, payload, status, attempts, created_at)
+		VALUES ('p1', 'evt', '{}', 'pending', 0, $1)`, pastLegacy); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := o.normalizeLegacyTimestamps(ctx); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	var dispatched, nextAttempt, claimed sql.NullString
+	if err := db.QueryRowContext(ctx,
+		`SELECT dispatched_at, next_attempt_at, claimed_until FROM event_outbox WHERE id='p1'`).
+		Scan(&dispatched, &nextAttempt, &claimed); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	for _, col := range []struct {
+		name string
+		v    sql.NullString
+	}{
+		{"dispatched_at", dispatched},
+		{"next_attempt_at", nextAttempt},
+		{"claimed_until", claimed},
+	} {
+		if col.v.Valid {
+			t.Fatalf("%s must stay NULL after normalization, got %q", col.name, col.v.String)
+		}
+	}
+}
+
+// TestNormalize_NoOpOnCanonical asserts that rows the relay itself wrote
+// (canonical RFC3339Nano via the pure driver binding time.Time) pass through
+// normalization unchanged.
+func TestNormalize_NoOpOnCanonical(t *testing.T) {
+	db, o := openPureOutbox(t)
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if _, err := o.Append(ctx, tx, "evt", map[string]any{"k": "v"}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	var before string
+	if err := db.QueryRowContext(ctx, `SELECT created_at FROM event_outbox`).Scan(&before); err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+	if strings.Contains(before, " ") {
+		t.Fatalf("relay wrote non-canonical created_at %q — test setup is wrong", before)
+	}
+	if err := o.normalizeLegacyTimestamps(ctx); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	var after string
+	if err := db.QueryRowContext(ctx, `SELECT created_at FROM event_outbox`).Scan(&after); err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if before != after {
+		t.Fatalf("normalize changed a canonical value: before=%q after=%q", before, after)
+	}
+}

--- a/framework/outbox/legacy_probe_test.go
+++ b/framework/outbox/legacy_probe_test.go
@@ -1,0 +1,66 @@
+package outbox
+
+import (
+	"testing"
+	"time"
+
+	gosqlite "github.com/DonaldMurillo/gofastr/sqlite"
+)
+
+// Normalization's idempotency check must be driver-aware: on a host whose
+// driver binds the space-separated format (mattn/go-sqlite3), rows in
+// that format ARE canonical — rewriting them on every relay start is
+// wasted write churn on the whole table. legacyTimeSets therefore
+// compares against the layout the current driver binds, not a hardcoded
+// RFC3339Nano.
+func TestLegacyTimeSetsDriverAwareIdempotency(t *testing.T) {
+	const mattnLayout = "2006-01-02 15:04:05.999999999-07:00"
+	ref := time.Date(2026, 7, 20, 23, 59, 59, 0, time.UTC)
+
+	// Pure-driver host: RFC3339Nano is canonical; space-format rewrites.
+	sets, _, err := legacyTimeSets(time.RFC3339Nano, []timeCol{
+		{"claimed_until", ref.Format(time.RFC3339Nano)},
+	})
+	if err != nil || len(sets) != 0 {
+		t.Fatalf("RFC3339Nano row on pure driver: sets=%v err=%v, want none", sets, err)
+	}
+	sets, _, err = legacyTimeSets(time.RFC3339Nano, []timeCol{
+		{"claimed_until", ref.Format(mattnLayout)},
+	})
+	if err != nil || len(sets) != 1 {
+		t.Fatalf("space row on pure driver: sets=%v err=%v, want 1 rewrite", sets, err)
+	}
+
+	// mattn host: space format is canonical; RFC3339 rewrites.
+	sets, _, err = legacyTimeSets(mattnLayout, []timeCol{
+		{"claimed_until", ref.Format(mattnLayout)},
+	})
+	if err != nil || len(sets) != 0 {
+		t.Fatalf("space row on mattn driver: sets=%v err=%v, want none (already canonical)", sets, err)
+	}
+	sets, _, err = legacyTimeSets(mattnLayout, []timeCol{
+		{"claimed_until", ref.Format(time.RFC3339Nano)},
+	})
+	if err != nil || len(sets) != 1 {
+		t.Fatalf("RFC3339 row on mattn driver: sets=%v err=%v, want 1 rewrite", sets, err)
+	}
+}
+
+// probeBindLayout detects which text layout the connected driver uses for
+// time.Time binds; the pure driver must probe as RFC3339Nano.
+func TestProbeBindLayoutPureDriver(t *testing.T) {
+	db, err := gosqlite.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	o, err := New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	layout := o.probeBindLayout(t.Context())
+	if layout != time.RFC3339Nano {
+		t.Fatalf("pure driver probed layout %q, want RFC3339Nano", layout)
+	}
+}

--- a/framework/outbox/relay.go
+++ b/framework/outbox/relay.go
@@ -63,6 +63,20 @@ func (o *Outbox) Nudge() {
 func (o *Outbox) relayLoop(ctx context.Context, stop <-chan struct{}) {
 	ticker := time.NewTicker(o.pollInterval)
 	defer ticker.Stop()
+	// Normalize any space-separated (legacy mattn/go-sqlite3) timestamp
+	// strings still in the tables before the first claim/sweep, so the
+	// relay's lexicographic time predicates (claimed_until <= $1,
+	// created_at <= cutoff) compare correctly from the first pump. No-op
+	// on Postgres and idempotent; runs here rather than at New so rows
+	// staged between construction and relay start are covered too. A
+	// failure logs once and continues — the relay tolerates a transient
+	// DB outage by polling, and claimErrLogged is the existing surface
+	// for "delivery is stalled".
+	if err := o.normalizeLegacyTimestamps(ctx); err != nil {
+		slog.Default().Error("outbox: legacy timestamp normalization failed; delivery stalled until this clears",
+			"table", o.table, "err", err)
+		o.claimErrLogged = true
+	}
 	for {
 		// A full batch may mean a backlog — drain immediately instead
 		// of waiting for the next tick. Still honour stop/ctx between

--- a/sqlite/ast.go
+++ b/sqlite/ast.go
@@ -110,6 +110,7 @@ type InsertStmt struct {
 	Values    [][]Expr    // Multiple rows of values
 	Select    *SelectStmt // INSERT ... SELECT ...
 	OrIgnore  bool
+	OrReplace bool
 	Conflict  *InsertConflict
 	Returning []string
 }

--- a/sqlite/engine.go
+++ b/sqlite/engine.go
@@ -35,6 +35,7 @@ type PagerInterface interface {
 	StatementRestore(*pagerStatementSnapshot)
 	GetSchemaPage() int
 	SetSchemaPage(page int)
+	IsInTxn() bool
 	BeginTxn()
 	CommitTxn()
 	RollbackTxn() error
@@ -316,6 +317,14 @@ func (e *Engine) SaveSchema() error {
 		pn++
 	}
 
+	// Defer the flush when inside a transaction: flushed pages cannot
+	// be un-flushed by RollbackTxn's cache restore, so writing now
+	// would let a rolled-back DDL (CREATE TABLE / CREATE INDEX inside
+	// BEGIN ... ROLLBACK) leak to disk and resurface after reopen.
+	// CommitTxn performs the deferred flush at transaction end.
+	if e.pager.IsInTxn() {
+		return nil
+	}
 	return e.pager.Flush()
 }
 
@@ -1344,7 +1353,7 @@ func (e *Engine) executeInsert(s *InsertStmt, params []Value) (*Result, error) {
 	if err := validateReturningColumns(tableInfo, s.Returning); err != nil {
 		return nil, err
 	}
-	if s.OrIgnore || s.Conflict != nil || len(s.Returning) > 0 || len(tableInfo.UniqueConstraints) > 0 || s.Select != nil {
+	if s.OrIgnore || s.OrReplace || s.Conflict != nil || len(s.Returning) > 0 || len(e.uniqueConstraints(tableInfo)) > 0 || s.Select != nil {
 		return e.executeInsertWithConflict(s, params, tableInfo)
 	}
 
@@ -1496,10 +1505,30 @@ func (e *Engine) executeUpdate(s *UpdateStmt, params []Value) (*Result, error) {
 		if err := validateUpdatedRow(tableInfo, row, newRow); err != nil {
 			return nil, err
 		}
-		if _, _, duplicate, err := e.findInsertConflict(tableInfo, newRow, nil, rowid); err != nil {
+		conflictRowID, _, duplicate, err := e.findInsertConflict(tableInfo, newRow, nil, rowid)
+		if err != nil {
 			return nil, err
-		} else if duplicate {
-			return nil, &engineError{"UNIQUE constraint failed"}
+		}
+		if duplicate {
+			// The on-disk B-tree scan sees rows at their PRE-statement
+			// image. When the row it flagged as a conflict is itself
+			// staged for update by this statement, its stale image will
+			// be replaced before commit — the pairwise pending check
+			// below is the authoritative conflict test for staged-vs-
+			// staged, so a conflict against a staged rowid is not (yet)
+			// a real violation. This matches SQLite, which evaluates
+			// UNIQUE per final row image: UPDATE t SET u=u-1 over
+			// (1,1),(2,2) succeeds with (1,0),(2,1).
+			staged := false
+			for _, prior := range toUpdate {
+				if prior.rowid == conflictRowID {
+					staged = true
+					break
+				}
+			}
+			if !staged {
+				return nil, &engineError{"UNIQUE constraint failed"}
+			}
 		}
 		// findInsertConflict only sees the on-disk table state, so two
 		// rows updated by the SAME statement could pick the same key
@@ -1571,22 +1600,34 @@ func (e *Engine) executeDelete(s *DeleteStmt, params []Value) (*Result, error) {
 
 	// If no WHERE, delete all rows efficiently
 	if s.Where == nil {
-		// Recreate the B-tree
-		newRoot, err := e.btree.CreateBTree()
-		if err != nil {
-			return nil, err
-		}
-		// Count rows first for RowsAffected
+		// Walk every row once to drop its secondary-index entries
+		// before the table B-tree is rebuilt; otherwise each index
+		// retains entries pointing into a now-empty table, and any
+		// later INSERT at a recycled rowid would resurface the stale
+		// value.
 		cursor, err := e.btree.Scan(tableInfo.RootPage)
 		if err != nil {
 			return nil, err
 		}
 		var count int64
 		for cursor.Next() {
+			rowid, _, err := cursor.Get()
+			if err != nil {
+				cursor.Close()
+				return nil, err
+			}
+			if err := e.deleteFromIndexes(tableName, rowid); err != nil {
+				cursor.Close()
+				return nil, err
+			}
 			count++
 		}
 		cursor.Close()
-
+		// Recreate the (now-empty) table B-tree root.
+		newRoot, err := e.btree.CreateBTree()
+		if err != nil {
+			return nil, err
+		}
 		tableInfo.RootPage = newRoot
 		return &Result{RowsAffected: count}, nil
 	}
@@ -1643,6 +1684,12 @@ func (e *Engine) executeDelete(s *DeleteStmt, params []Value) (*Result, error) {
 			return nil, err
 		}
 		if err := e.btree.Delete(tableInfo.RootPage, rowid); err != nil {
+			return nil, err
+		}
+		// Removing the table row must also remove every secondary-index
+		// entry keyed by this rowid, or a subsequently recycled rowid
+		// resurfaces under the dead row's indexed value.
+		if err := e.deleteFromIndexes(tableInfo.Name, rowid); err != nil {
 			return nil, err
 		}
 	}
@@ -1857,7 +1904,101 @@ func (e *Engine) executeAlterRenameColumn(s *AlterRenameColumnStmt) (*Result, er
 	if !found {
 		return nil, &engineError{"no such column: " + s.OldName}
 	}
+	// Propagate the rename into every place column names are cached, so
+	// constraints and indexes stay attached to the renamed column.
+	// SQLite's own ALTER TABLE RENAME COLUMN rewrites the schema SQL of
+	// every dependent object; here we rewrite the equivalent in-memory
+	// metadata directly.
+	oldLower := strings.ToLower(s.OldName)
+	for i, uc := range ti.UniqueConstraints {
+		for j, col := range uc {
+			if strings.EqualFold(col, s.OldName) {
+				ti.UniqueConstraints[i][j] = s.NewName
+			}
+		}
+	}
+	for _, idx := range e.schema.IndexesForTable(ti.Name) {
+		for i, col := range idx.Columns {
+			if strings.EqualFold(col, s.OldName) {
+				idx.Columns[i] = s.NewName
+			}
+		}
+		if idx.WhereExpr != nil {
+			idx.WhereExpr = renameColumnRefs(idx.WhereExpr, oldLower, s.NewName)
+		}
+	}
 	return &Result{}, nil
+}
+
+// renameColumnRefs walks an expression tree and returns a copy in which
+// every ColumnRef whose name matches oldName (case-insensitive) has been
+// replaced with newName. Expr node types are VALUES, so this returns
+// rebuilt nodes rather than mutating in place; the caller reassigns the
+// root. Used by ALTER TABLE RENAME COLUMN to keep partial-index WHERE
+// predicates consistent after a column rename.
+func renameColumnRefs(expr Expr, oldLower, newName string) Expr {
+	if expr == nil {
+		return nil
+	}
+	switch e := expr.(type) {
+	case ColumnRef:
+		if strings.ToLower(e.Column) == oldLower {
+			e.Column = newName
+		}
+		return e
+	case BinaryExpr:
+		e.Left = renameColumnRefs(e.Left, oldLower, newName)
+		e.Right = renameColumnRefs(e.Right, oldLower, newName)
+		return e
+	case UnaryExpr:
+		e.Expr = renameColumnRefs(e.Expr, oldLower, newName)
+		return e
+	case FunctionCall:
+		for i, arg := range e.Args {
+			e.Args[i] = renameColumnRefs(arg, oldLower, newName)
+		}
+		return e
+	case IsNullExpr:
+		e.Expr = renameColumnRefs(e.Expr, oldLower, newName)
+		return e
+	case BetweenExpr:
+		e.Expr = renameColumnRefs(e.Expr, oldLower, newName)
+		e.Low = renameColumnRefs(e.Low, oldLower, newName)
+		e.High = renameColumnRefs(e.High, oldLower, newName)
+		return e
+	case InExpr:
+		e.Expr = renameColumnRefs(e.Expr, oldLower, newName)
+		for i, v := range e.Values {
+			e.Values[i] = renameColumnRefs(v, oldLower, newName)
+		}
+		return e
+	case LikeExpr:
+		e.Expr = renameColumnRefs(e.Expr, oldLower, newName)
+		e.Pattern = renameColumnRefs(e.Pattern, oldLower, newName)
+		if e.Escape != nil {
+			e.Escape = renameColumnRefs(e.Escape, oldLower, newName)
+		}
+		return e
+	case ParenExpr:
+		e.Expr = renameColumnRefs(e.Expr, oldLower, newName)
+		return e
+	case CastExpr:
+		e.Expr = renameColumnRefs(e.Expr, oldLower, newName)
+		return e
+	case CaseExpr:
+		if e.Operand != nil {
+			e.Operand = renameColumnRefs(e.Operand, oldLower, newName)
+		}
+		for _, w := range e.Whens {
+			w.Condition = renameColumnRefs(w.Condition, oldLower, newName)
+			w.Result = renameColumnRefs(w.Result, oldLower, newName)
+		}
+		if e.Else != nil {
+			e.Else = renameColumnRefs(e.Else, oldLower, newName)
+		}
+		return e
+	}
+	return expr
 }
 
 func (e *Engine) executePragma(s *PragmaStmt) (*Result, error) {
@@ -2945,16 +3086,20 @@ func (e *Engine) tryIndexScan(tableName string, where Expr, params []Value) [][]
 		if err != nil {
 			return nil
 		}
-		// Index record: [col_value, rowid]
-		recVals := recordToValues(record, tableInfo)
-		if len(recVals) < 2 {
+		// Index records carry the indexed-column values followed by the
+		// rowid ([v0, v1, ..., rowid]) — they are NOT table rows and
+		// must not be padded to table width (recordToValues pads with
+		// DEFAULTs after ALTER ADD COLUMN, which would mask the rowid
+		// and yield the wrong table row on lookup).
+		idxVals := record.Columns
+		if len(idxVals) < 2 {
 			continue
 		}
 		// Compare the indexed column value
-		if CompareValues(recVals[0], val) == 0 {
-			// Match — get the rowid (last value in index record)
-			rowid := recVals[len(recVals)-1]
-			if rv, ok := rowid.AsInt64(); ok {
+		if CompareValues(idxVals[0], val) == 0 {
+			// Match — the rowid is the last value in the index record.
+			rowidVal := idxVals[len(idxVals)-1]
+			if rv, ok := rowidVal.AsInt64(); ok {
 				// Fetch the actual table row
 				rec, err := e.btree.Search(tableInfo.RootPage, rv)
 				if err != nil {

--- a/sqlite/engine.go
+++ b/sqlite/engine.go
@@ -31,8 +31,8 @@ type PagerInterface interface {
 	SetPageData(num int, data []byte) error
 	Flush() error
 	Close() error
-	Snapshot() []byte
-	Restore([]byte) error
+	StatementSnapshot() *pagerStatementSnapshot
+	StatementRestore(*pagerStatementSnapshot)
 	GetSchemaPage() int
 	SetSchemaPage(page int)
 	BeginTxn()
@@ -151,10 +151,7 @@ func (e *Engine) LoadSchema() error {
 				IsPrimaryKey: cd.IsPK,
 				IsRowID:      cd.IsRowID,
 			}
-			if cd.HasDefault {
-				v := TextValue(cd.Default)
-				col.Default = &v
-			}
+			loadColumnDefault(&col, cd)
 			ti.Columns = append(ti.Columns, col)
 		}
 		for _, fd := range td.ForeignKeys {
@@ -174,12 +171,57 @@ func (e *Engine) LoadSchema() error {
 			RootPage:  idx.RootPage,
 			Unique:    idx.Unique,
 			SQL:       idx.SQL,
+			Where:     idx.Where,
 		}
 		ii.Columns = append(ii.Columns, idx.Columns...)
+		if idx.Where != "" {
+			if expr, err := ParseExpression(idx.Where); err == nil && expr != nil {
+				ii.WhereExpr = expr
+			}
+		}
 		e.schema.indexes[strings.ToLower(ii.Name)] = ii
 	}
 
 	return nil
+}
+
+// loadColumnDefault restores a column's DEFAULT from its serialized form.
+// New-format files always carry the DEFAULT expression source in
+// default_expr (SaveSchema renders the AST via FormatExpr); re-parsing it
+// restores both constant fast-path values and non-constant defaults
+// (CURRENT_TIMESTAMP et al.). Legacy files stored only the raw TextVal of
+// the constant: numbers as their digits, text UNQUOTED (so `pending` must
+// not be fed to ParseExpression as the source of truth — it reads as an
+// identifier), and non-text non-numeric values as "". For legacy data a
+// literal parse is accepted only for non-text types (the numeric
+// round-trip); everything else stays the raw text — including the empty
+// string, which is a real default (lane TEXT NOT NULL DEFAULT ”) in
+// legacy files.
+func loadColumnDefault(col *ColumnDef, cd colData) {
+	switch {
+	case cd.HasDefault && cd.DefaultExpr != "":
+		if expr, err := ParseExpression(cd.DefaultExpr); err == nil && expr != nil {
+			col.DefaultExpr = expr
+			if lit, ok := expr.(LiteralExpr); ok {
+				if val, err := (&ExprEval{}).Eval(lit); err == nil {
+					col.Default = &val
+				}
+			}
+		}
+	case cd.HasDefault:
+		if expr, err := ParseExpression(cd.Default); err == nil {
+			if lit, ok := expr.(LiteralExpr); ok && lit.Type != DataTypeText {
+				if val, err := (&ExprEval{}).Eval(lit); err == nil {
+					col.Default = &val
+					col.DefaultExpr = expr
+				}
+			}
+		}
+		if col.Default == nil {
+			v := TextValue(cd.Default)
+			col.Default = &v
+		}
+	}
 }
 
 // SaveSchema persists the current schema to the database.
@@ -198,6 +240,17 @@ func (e *Engine) SaveSchema() error {
 				cd.HasDefault = true
 				cd.Default = c.Default.TextVal
 			}
+			// Persist non-constant defaults (CURRENT_TIMESTAMP,
+			// datetime('now'), parenthesized expressions, ...) by
+			// rendering their AST back to source text that LoadSchema
+			// can re-parse. Without this, file-backed databases lose
+			// dynamic defaults on reopen and NOT NULL inserts fail.
+			if c.DefaultExpr != nil {
+				if src := FormatExpr(c.DefaultExpr); src != "" {
+					cd.DefaultExpr = src
+					cd.HasDefault = true
+				}
+			}
 			d.Columns = append(d.Columns, cd)
 		}
 		for _, fk := range ti.ForeignKeys {
@@ -206,7 +259,16 @@ func (e *Engine) SaveSchema() error {
 		sd.Tables = append(sd.Tables, d)
 	}
 	for _, ii := range e.schema.indexes {
-		sd.Indexes = append(sd.Indexes, indexData{Name: ii.Name, Table: ii.TableName, RootPage: ii.RootPage, Unique: ii.Unique, SQL: ii.SQL, Columns: ii.Columns})
+		id := indexData{Name: ii.Name, Table: ii.TableName, RootPage: ii.RootPage, Unique: ii.Unique, SQL: ii.SQL, Columns: ii.Columns}
+		if ii.WhereExpr != nil {
+			if src := FormatExpr(ii.WhereExpr); src != "" {
+				id.Where = src
+			}
+		} else if ii.Where != "" {
+			// Legacy/unparsed source retained verbatim.
+			id.Where = ii.Where
+		}
+		sd.Indexes = append(sd.Indexes, id)
 	}
 
 	data, err := json.Marshal(sd)
@@ -1439,6 +1501,28 @@ func (e *Engine) executeUpdate(s *UpdateStmt, params []Value) (*Result, error) {
 		} else if duplicate {
 			return nil, &engineError{"UNIQUE constraint failed"}
 		}
+		// findInsertConflict only sees the on-disk table state, so two
+		// rows updated by the SAME statement could pick the same key
+		// without ever tripping the B-tree check. SQLite evaluates
+		// constraints per-row and fails the statement on the first
+		// collision; mirror that by also checking each pending row we
+		// have already accumulated. Statement atomicity (Fix 1) then
+		// guarantees no partial application leaks through.
+		for _, prior := range toUpdate {
+			for _, c := range e.uniqueConstraints(tableInfo) {
+				if c.Predicate != nil {
+					if !rowMatchesPredicate(tableInfo, prior.values, c.Predicate) {
+						continue
+					}
+					if !rowMatchesPredicate(tableInfo, newRow, c.Predicate) {
+						continue
+					}
+				}
+				if rowsConflict(tableInfo, prior.values, newRow, c.Columns) {
+					return nil, &engineError{"UNIQUE constraint failed"}
+				}
+			}
+		}
 
 		if err := e.checkForeignKeyInsert(tableInfo, newRow); err != nil {
 			return nil, err
@@ -1453,12 +1537,19 @@ func (e *Engine) executeUpdate(s *UpdateStmt, params []Value) (*Result, error) {
 		appendReturningRow(result, tableInfo, newRow)
 	}
 
-	// Apply updates
+	// Apply updates. Insert at the existing rowid overwrites the table
+	// row in place. For each index we delete the entry for this rowid
+	// first so a row that has moved OUT of a partial-index predicate
+	// leaves no stale entry behind; insertIntoIndexes then re-adds the
+	// entry only if the NEW row matches the predicate.
 	for _, u := range toUpdate {
 		if err := e.btree.Insert(tableInfo.RootPage, u.rowid, u.record); err != nil {
-			if err := e.insertIntoIndexes(tableInfo.Name, u.rowid, u.values); err != nil {
-				return nil, err
-			}
+			return nil, err
+		}
+		if err := e.deleteFromIndexes(tableInfo.Name, u.rowid); err != nil {
+			return nil, err
+		}
+		if err := e.insertIntoIndexes(tableInfo.Name, u.rowid, u.values); err != nil {
 			return nil, err
 		}
 	}
@@ -1601,7 +1692,7 @@ func (e *Engine) executeCreateIndex(s *CreateIndexStmt) (*Result, error) {
 		return nil, &engineError{"no such table: " + s.Table}
 	}
 	if s.Unique {
-		if err := e.validateUniqueIndex(tableInfo, indexColumns(s.Columns)); err != nil {
+		if err := e.validateUniqueIndex(tableInfo, indexColumns(s.Columns), s.Where); err != nil {
 			return nil, err
 		}
 	}
@@ -1627,6 +1718,12 @@ func (e *Engine) executeCreateIndex(s *CreateIndexStmt) (*Result, error) {
 
 		// Build index key from indexed columns
 		vals := recordToValues(record, tableInfo)
+		// A partial index only contains rows the predicate selects;
+		// skip everything else so the index B-tree never holds entries
+		// for out-of-predicate rows.
+		if s.Where != nil && !rowMatchesPredicate(tableInfo, vals, s.Where) {
+			continue
+		}
 		idxCols := indexColumns(s.Columns)
 		keyVals := make([]Value, len(idxCols))
 		for i, colName := range idxCols {
@@ -1650,13 +1747,18 @@ func (e *Engine) executeCreateIndex(s *CreateIndexStmt) (*Result, error) {
 	}
 	cursor.Close()
 
-	e.schema.AddIndex(&IndexInfo{
+	ii := &IndexInfo{
 		Name:      s.Name,
 		TableName: s.Table,
 		RootPage:  rootPage,
 		Columns:   indexColumns(s.Columns),
 		Unique:    s.Unique,
-	})
+	}
+	if s.Where != nil {
+		ii.WhereExpr = s.Where
+		ii.Where = FormatExpr(s.Where)
+	}
+	e.schema.AddIndex(ii)
 
 	return &Result{}, nil
 }
@@ -2713,15 +2815,24 @@ func (e *Engine) evalJoinOn(join JoinClause, tables []joinEntry, joinIdx int, co
 	return ok && b != 0
 }
 
-// insertIntoIndexes adds a row to all indexes on the given table.
+// insertIntoIndexes adds a row to every index on the given table that
+// the row belongs in. For a partial index the row is added only when it
+// satisfies the index's WHERE predicate; otherwise the index skips it
+// (no entry is created, mirroring SQLite). The caller is responsible
+// for removing any stale entry from a prior version of the row — see
+// deleteFromIndexes, which UPDATE uses to handle rows that have moved
+// out of the predicate.
 func (e *Engine) insertIntoIndexes(tableName string, rowid int64, rowValues []Value) error {
 	indexes := e.schema.IndexesForTable(tableName)
+	tableInfo, hasTable := e.schema.GetTable(tableName)
+	if !hasTable {
+		return nil
+	}
 	for _, idx := range indexes {
 		if idx.RootPage == 0 {
 			continue
 		}
-		tableInfo, ok := e.schema.GetTable(tableName)
-		if !ok {
+		if idx.WhereExpr != nil && !rowMatchesPredicate(tableInfo, rowValues, idx.WhereExpr) {
 			continue
 		}
 		keyVals := make([]Value, len(idx.Columns))
@@ -2736,6 +2847,27 @@ func (e *Engine) insertIntoIndexes(tableName string, rowid int64, rowValues []Va
 		allVals := append(keyVals, IntegerValue(rowid))
 		idxRecord := valuesToRecord(allVals)
 		if err := e.btree.Insert(idx.RootPage, rowid, idxRecord); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// deleteFromIndexes removes a rowid from every index on the table.
+// UPDATE calls this before insertIntoIndexes so that a row moving OUT
+// of a partial index's predicate has its stale entry removed, and so
+// that re-inserting an unconditional index replaces the prior key
+// cleanly without depending on Insert-overwrites-rowid semantics.
+func (e *Engine) deleteFromIndexes(tableName string, rowid int64) error {
+	indexes := e.schema.IndexesForTable(tableName)
+	for _, idx := range indexes {
+		if idx.RootPage == 0 {
+			continue
+		}
+		// btree.Delete returns nil for a missing rowid, which is the
+		// correct outcome for a partial index that never contained
+		// this row — no special-casing needed.
+		if err := e.btree.Delete(idx.RootPage, rowid); err != nil {
 			return err
 		}
 	}
@@ -2772,6 +2904,14 @@ func (e *Engine) tryIndexScan(tableName string, where Expr, params []Value) [][]
 	indexes := e.schema.IndexesForTable(tableName)
 	var idx *IndexInfo
 	for _, i := range indexes {
+		// Partial indexes only contain rows matching their predicate, so
+		// using one for a generic equality scan would silently drop
+		// non-matching rows from the result set. Keep them out of scan
+		// planning until predicate-aware scan routing exists —
+		// correctness over speed.
+		if i.WhereExpr != nil {
+			continue
+		}
 		if len(i.Columns) == 1 && strings.EqualFold(i.Columns[0], colRef.Column) && i.RootPage != 0 {
 			idx = i
 			break
@@ -2850,14 +2990,15 @@ type tableData struct {
 }
 
 type colData struct {
-	Name       string `json:"name"`
-	Type       string `json:"type"`
-	Affinity   int    `json:"affinity"`
-	NotNull    bool   `json:"not_null"`
-	HasDefault bool   `json:"has_default"`
-	Default    string `json:"default"`
-	IsPK       bool   `json:"is_pk"`
-	IsRowID    bool   `json:"is_rowid"`
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Affinity    int    `json:"affinity"`
+	NotNull     bool   `json:"not_null"`
+	HasDefault  bool   `json:"has_default"`
+	Default     string `json:"default,omitempty"`
+	DefaultExpr string `json:"default_expr,omitempty"`
+	IsPK        bool   `json:"is_pk"`
+	IsRowID     bool   `json:"is_rowid"`
 }
 
 type fkDataSer struct {
@@ -2871,6 +3012,7 @@ type indexData struct {
 	Table    string   `json:"table"`
 	RootPage int      `json:"root_page"`
 	Unique   bool     `json:"unique"`
-	SQL      string   `json:"sql"`
+	SQL      string   `json:"sql,omitempty"`
 	Columns  []string `json:"columns"`
+	Where    string   `json:"where,omitempty"`
 }

--- a/sqlite/format_expr.go
+++ b/sqlite/format_expr.go
@@ -1,0 +1,254 @@
+package sqlite
+
+import (
+	"strconv"
+	"strings"
+)
+
+// FormatExpr renders an Expr back to SQL source text suitable for
+// re-parsing by the engine's own parser. It exists to make non-constant
+// column DEFAULT expressions (CURRENT_TIMESTAMP, datetime('now'), etc.)
+// and partial-index WHERE predicates survive SaveSchema / LoadSchema.
+//
+// The renderer covers the AST forms that are legal in those positions:
+// literals, column references (including the bare CURRENT_TIMESTAMP /
+// CURRENT_DATE / CURRENT_TIME keywords, which the parser produces as
+// ColumnRef), function calls, unary and binary expressions, and
+// parenthesized expressions. Anything it cannot render returns "" so
+// the caller can fall back to dropping the default rather than writing
+// a value the parser would later reject.
+func FormatExpr(expr Expr) string {
+	if expr == nil {
+		return ""
+	}
+	switch e := expr.(type) {
+	case LiteralExpr:
+		return formatLiteralExpr(e)
+	case ColumnRef:
+		if e.Table != "" {
+			return quoteIdent(e.Table) + "." + quoteIdent(e.Column)
+		}
+		return quoteIdent(e.Column)
+	case FunctionCall:
+		return formatFunctionCall(e)
+	case ParenExpr:
+		inner := FormatExpr(e.Expr)
+		if inner == "" {
+			return ""
+		}
+		return "(" + inner + ")"
+	case UnaryExpr:
+		inner := FormatExpr(e.Expr)
+		if inner == "" {
+			return ""
+		}
+		op, ok := formatUnaryOp(e.Op)
+		if !ok {
+			return ""
+		}
+		if op == "NOT" {
+			return "NOT " + inner
+		}
+		return op + inner
+	case BinaryExpr:
+		left := FormatExpr(e.Left)
+		right := FormatExpr(e.Right)
+		if left == "" || right == "" {
+			return ""
+		}
+		op, ok := formatBinaryOp(e.Op)
+		if !ok {
+			return ""
+		}
+		return left + " " + op + " " + right
+	default:
+		return ""
+	}
+}
+
+func formatLiteralExpr(l LiteralExpr) string {
+	switch l.Type {
+	case DataTypeNull:
+		return "NULL"
+	case DataTypeInteger:
+		return strconv.FormatInt(l.IntVal, 10)
+	case DataTypeFloat:
+		// Match the parser's float literal form so the value round-trips.
+		return strconv.FormatFloat(l.FloatVal, 'g', -1, 64)
+	case DataTypeText:
+		return quoteStringLiteral(l.TextVal)
+	case DataTypeBlob:
+		var b strings.Builder
+		b.WriteString("X'")
+		const hex = "0123456789ABCDEF"
+		for _, c := range l.BlobVal {
+			b.WriteByte(hex[c>>4])
+			b.WriteByte(hex[c&0x0F])
+		}
+		b.WriteByte('\'')
+		return b.String()
+	default:
+		return ""
+	}
+}
+
+func formatFunctionCall(fc FunctionCall) string {
+	var b strings.Builder
+	b.WriteString(fc.Name)
+	b.WriteByte('(')
+	if fc.Star {
+		b.WriteByte('*')
+	} else {
+		if fc.Distinct {
+			b.WriteString("DISTINCT ")
+		}
+		for i, arg := range fc.Args {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			rendered := FormatExpr(arg)
+			if rendered == "" {
+				return ""
+			}
+			b.WriteString(rendered)
+		}
+	}
+	b.WriteByte(')')
+	return b.String()
+}
+
+func formatUnaryOp(op UnaryOp) (string, bool) {
+	switch op {
+	case OpNegate:
+		return "-", true
+	case OpBitNot:
+		return "~", true
+	case OpNot:
+		return "NOT", true
+	default:
+		return "", false
+	}
+}
+
+func formatBinaryOp(op BinaryOp) (string, bool) {
+	switch op {
+	case OpAdd:
+		return "+", true
+	case OpSub:
+		return "-", true
+	case OpMul:
+		return "*", true
+	case OpDiv:
+		return "/", true
+	case OpMod:
+		return "%", true
+	case OpConcat:
+		return "||", true
+	case OpEq:
+		return "=", true
+	case OpNe:
+		return "!=", true
+	case OpLt:
+		return "<", true
+	case OpLe:
+		return "<=", true
+	case OpGt:
+		return ">", true
+	case OpGe:
+		return ">=", true
+	case OpAnd:
+		return "AND", true
+	case OpOr:
+		return "OR", true
+	case OpBitAnd:
+		return "&", true
+	case OpBitOr:
+		return "|", true
+	case OpShiftLeft:
+		return "<<", true
+	case OpShiftRight:
+		return ">>", true
+	default:
+		return "", false
+	}
+}
+
+// quoteStringLiteral returns a single-quoted SQL string literal with
+// embedded single quotes doubled, matching how the lexer reads them.
+func quoteStringLiteral(s string) string {
+	var b strings.Builder
+	b.WriteByte('\'')
+	for _, r := range s {
+		if r == '\'' {
+			b.WriteString("''")
+			continue
+		}
+		b.WriteRune(r)
+	}
+	b.WriteByte('\'')
+	return b.String()
+}
+
+// quoteIdent renders an identifier. Bare ASCII identifiers that the
+// lexer accepts as TokenIdent (letters, digits, underscore, not starting
+// with a digit) are written as-is; anything else uses double quotes so
+// it survives a re-parse.
+func quoteIdent(name string) string {
+	if name == "" {
+		return "\"\""
+	}
+	if isBareIdent(name) {
+		return name
+	}
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range name {
+		if r == '"' {
+			b.WriteString(`""`)
+			continue
+		}
+		b.WriteRune(r)
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+func isBareIdent(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if r == '_' || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') {
+			continue
+		}
+		if i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// ParseExpression parses a single SQL expression (the source form
+// produced by FormatExpr) back into an AST. It returns nil, nil for an
+// empty input so callers can use it uniformly for "absent".
+func ParseExpression(src string) (Expr, error) {
+	src = strings.TrimSpace(src)
+	if src == "" {
+		return nil, nil
+	}
+	p := NewParser(src)
+	expr, err := p.parseExpression()
+	if err != nil {
+		return nil, err
+	}
+	// Tolerate a trailing semicolon so callers can pass through text
+	// that originated as part of a statement.
+	if p.cur.Type == TokenSemicolon {
+		p.advance()
+	}
+	if p.cur.Type != TokenEOF {
+		return nil, &ParseError{Msg: "unexpected trailing input in expression: " + p.cur.Value}
+	}
+	return expr, nil
+}

--- a/sqlite/index_maintenance_internal_test.go
+++ b/sqlite/index_maintenance_internal_test.go
@@ -1,0 +1,176 @@
+package sqlite
+
+import (
+	"strings"
+	"testing"
+)
+
+// scanIndexRowids opens the B-tree backing the named index and returns
+// the (key, rowid) pairs it currently holds, in B-tree order. Internal
+// helper for tests that need to prove the index B-tree's actual contents
+// — not just that a fetch-miss is tolerated.
+func scanIndexRecords(t *testing.T, e *Engine, indexName string) [][2]Value {
+	t.Helper()
+	idx, ok := e.schema.GetIndex(indexName)
+	if !ok {
+		t.Fatalf("no such index: %s", indexName)
+	}
+	if idx.RootPage == 0 {
+		return nil
+	}
+	cur, err := e.btree.Scan(idx.RootPage)
+	if err != nil {
+		t.Fatalf("scan index %s: %v", indexName, err)
+	}
+	defer cur.Close()
+	var out [][2]Value
+	for cur.Next() {
+		_, rec, err := cur.Get()
+		if err != nil {
+			t.Fatalf("get from index %s: %v", indexName, err)
+		}
+		cols := rec.Columns
+		if len(cols) < 2 {
+			continue
+		}
+		out = append(out, [2]Value{cols[0], cols[len(cols)-1]})
+	}
+	return out
+}
+
+func indexContains(t *testing.T, e *Engine, indexName string, key string, rowid int64) bool {
+	t.Helper()
+	for _, pair := range scanIndexRecords(t, e, indexName) {
+		if asString(pair[0]) == key {
+			if rv, ok := pair[1].AsInt64(); ok && rv == rowid {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func asString(v Value) string {
+	switch v.Type {
+	case DataTypeText:
+		return v.TextVal
+	case DataTypeBlob:
+		return string(v.BlobVal)
+	}
+	return v.String()
+}
+
+// TestInternalDeleteMaintainsIndexBTree proves the DELETE WHERE path
+// evicts the row's index entry from the index B-tree itself — not just
+// that a later lookup happens to miss. A recycled rowid at the old key
+// must not resurface under the deleted value.
+func TestInternalDeleteMaintainsIndexBTree(t *testing.T) {
+	e := newTestEngine(t)
+	exec(t, e, "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+	exec(t, e, "CREATE INDEX t_v ON t(v)")
+	exec(t, e, "INSERT INTO t VALUES (1, 'old')")
+
+	if !indexContains(t, e, "t_v", "old", 1) {
+		t.Fatal("index missing entry for (old, rowid=1) after insert")
+	}
+
+	exec(t, e, "DELETE FROM t WHERE id = 1")
+
+	if indexContains(t, e, "t_v", "old", 1) {
+		t.Fatal("DELETE WHERE left a stale index entry for the deleted rowid")
+	}
+	if got := len(scanIndexRecords(t, e, "t_v")); got != 0 {
+		t.Fatalf("index B-tree has %d entries after DELETE, want 0", got)
+	}
+}
+
+// TestInternalUnqualifiedDeleteMaintainsIndexBTree proves the no-WHERE
+// DELETE path also clears the index B-tree — previously it rebuilt only
+// the table B-tree and left every index entry pointing at dead rowids.
+func TestInternalUnqualifiedDeleteMaintainsIndexBTree(t *testing.T) {
+	e := newTestEngine(t)
+	exec(t, e, "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+	exec(t, e, "CREATE INDEX t_v ON t(v)")
+	exec(t, e, "INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+
+	exec(t, e, "DELETE FROM t")
+
+	if got := len(scanIndexRecords(t, e, "t_v")); got != 0 {
+		t.Fatalf("index B-tree has %d entries after unqualified DELETE, want 0", got)
+	}
+}
+
+// TestInternalUpsertMaintainsIndexBTree proves ON CONFLICT DO UPDATE
+// replaces (not duplicates) the index entry for the upserted row —
+// the prior key must be gone and the new key must point at the same rowid.
+func TestInternalUpsertMaintainsIndexBTree(t *testing.T) {
+	e := newTestEngine(t)
+	exec(t, e, "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+	exec(t, e, "CREATE INDEX t_v ON t(v)")
+	exec(t, e, "INSERT INTO t VALUES (1, 'old')")
+
+	exec(t, e, "INSERT INTO t VALUES (1, 'new') ON CONFLICT(id) DO UPDATE SET v=excluded.v")
+
+	if indexContains(t, e, "t_v", "old", 1) {
+		t.Fatal("ON CONFLICT DO UPDATE left stale index entry for pre-upsert value 'old'")
+	}
+	if !indexContains(t, e, "t_v", "new", 1) {
+		t.Fatal("ON CONFLICT DO UPDATE failed to add index entry for post-upsert value 'new'")
+	}
+	// Exactly one entry should exist after the upsert.
+	if got := len(scanIndexRecords(t, e, "t_v")); got != 1 {
+		t.Fatalf("index B-tree has %d entries after upsert, want 1", got)
+	}
+}
+
+// TestInternalInsertOrReplaceMaintainsIndexBTree proves INSERT OR REPLACE
+// removes the index entry for the replaced row before inserting the new
+// one — both the table row and its index pointer must reflect the new
+// value only.
+func TestInternalInsertOrReplaceMaintainsIndexBTree(t *testing.T) {
+	e := newTestEngine(t)
+	exec(t, e, "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+	exec(t, e, "CREATE INDEX t_v ON t(v)")
+	exec(t, e, "INSERT INTO t VALUES (1, 'old')")
+
+	exec(t, e, "INSERT OR REPLACE INTO t VALUES (1, 'new')")
+
+	if indexContains(t, e, "t_v", "old", 1) {
+		t.Fatal("INSERT OR REPLACE left stale index entry for replaced value 'old'")
+	}
+	if !indexContains(t, e, "t_v", "new", 1) {
+		t.Fatal("INSERT OR REPLACE failed to add index entry for new value 'new'")
+	}
+	if got := len(scanIndexRecords(t, e, "t_v")); got != 1 {
+		t.Fatalf("index B-tree has %d entries after INSERT OR REPLACE, want 1", got)
+	}
+}
+
+// TestInternalPartialIndexUpsertMaintainsPredicate proves ON CONFLICT
+// DO UPDATE removes a row's partial-index entry when the updated row no
+// longer matches the partial-index WHERE predicate (it "moved out").
+func TestInternalPartialIndexUpsertMaintainsPredicate(t *testing.T) {
+	e := newTestEngine(t)
+	exec(t, e, "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT, active INTEGER)")
+	exec(t, e, "CREATE INDEX t_active_v ON t(v) WHERE active = 1")
+	exec(t, e, "INSERT INTO t VALUES (1, 'keep', 1)")
+
+	if !indexContains(t, e, "t_active_v", "keep", 1) {
+		t.Fatal("partial index missing entry for matching row")
+	}
+
+	// Move the row out of the predicate: active 1 -> 0. The partial
+	// index must no longer contain an entry for this rowid.
+	exec(t, e, "INSERT INTO t VALUES (1, 'keep', 0) ON CONFLICT(id) DO UPDATE SET active=excluded.active")
+
+	if indexContains(t, e, "t_active_v", "keep", 1) {
+		t.Fatal("partial index retained entry after upsert moved row out of predicate")
+	}
+	if got := len(scanIndexRecords(t, e, "t_active_v")); got != 0 {
+		t.Fatalf("partial index B-tree has %d entries after move-out, want 0", got)
+	}
+}
+
+// Ensure the helpers don't get pruned if the test set above grows; a
+// tiny smoke check that the strings import stays used.
+var _ = strings.EqualFold

--- a/sqlite/insert_compat.go
+++ b/sqlite/insert_compat.go
@@ -212,12 +212,13 @@ func (e *Engine) findInsertConflict(
 	allConstraints := e.uniqueConstraints(tableInfo)
 	constraints := allConstraints
 	if conflict != nil && len(conflict.Target) > 0 {
-		constraints = nil
+		filtered := constraints[:0:0]
 		for _, constraint := range allConstraints {
-			if sameColumns(constraint, conflict.Target) {
-				constraints = append(constraints, constraint)
+			if sameColumns(constraint.Columns, conflict.Target) {
+				filtered = append(filtered, constraint)
 			}
 		}
+		constraints = filtered
 		if len(constraints) == 0 {
 			return 0, nil, false, &engineError{"ON CONFLICT clause does not match a UNIQUE constraint"}
 		}
@@ -240,7 +241,19 @@ func (e *Engine) findInsertConflict(
 		}
 		existing := recordToValues(record, tableInfo)
 		for _, constraint := range constraints {
-			if rowsConflict(tableInfo, existing, candidate, constraint) {
+			// A partial UNIQUE constraint only applies to rows the
+			// predicate selects on BOTH sides — the existing row and
+			// the candidate. If either side is out of the predicate,
+			// the constraint cannot fire between them.
+			if constraint.Predicate != nil {
+				if !rowMatchesPredicate(tableInfo, existing, constraint.Predicate) {
+					continue
+				}
+				if !rowMatchesPredicate(tableInfo, candidate, constraint.Predicate) {
+					continue
+				}
+			}
+			if rowsConflict(tableInfo, existing, candidate, constraint.Columns) {
 				return rowid, existing, true, nil
 			}
 		}

--- a/sqlite/insert_compat.go
+++ b/sqlite/insert_compat.go
@@ -43,6 +43,33 @@ func (e *Engine) executeInsertWithConflict(s *InsertStmt, params []Value, tableI
 			switch {
 			case s.OrIgnore || (s.Conflict != nil && s.Conflict.DoNothing):
 				continue
+			case s.OrReplace:
+				// REPLACE conflict resolution: delete EVERY existing row
+				// that conflicts with the candidate (there can be more
+				// than one when multiple UNIQUE constraints overlap),
+				// then fall through to the plain-insert path below to
+				// write the new row. Each deletion removes both the
+				// table row and its secondary-index entries so no stale
+				// index pointers remain.
+				// See https://www.sqlite.org/lang_conflict.html
+				seen := map[int64]bool{}
+				for {
+					cid, _, conflict, err := e.findInsertConflict(tableInfo, rowValues, nil, 0)
+					if err != nil {
+						return nil, err
+					}
+					if !conflict || seen[cid] {
+						break
+					}
+					seen[cid] = true
+					if err := e.btree.Delete(tableInfo.RootPage, cid); err != nil {
+						return nil, err
+					}
+					if err := e.deleteFromIndexes(tableInfo.Name, cid); err != nil {
+						return nil, err
+					}
+				}
+				// Fall through: insert the new row below.
 			case s.Conflict != nil:
 				updated, err := applyConflictUpdates(tableInfo, conflictRow, rowValues, s.Conflict.Updates, params)
 				if err != nil {
@@ -60,6 +87,16 @@ func (e *Engine) executeInsertWithConflict(s *InsertStmt, params []Value, tableI
 					return nil, err
 				}
 				if err := e.btree.Insert(tableInfo.RootPage, conflictRowID, valuesToRecord(updated)); err != nil {
+					return nil, err
+				}
+				// ON CONFLICT DO UPDATE is a row REPLACEMENT: delete
+				// the prior index entries for this rowid before
+				// inserting the updated ones, mirroring plain UPDATE.
+				// Without this, a partial-index row whose predicate is
+				// now false would retain a stale entry, and an
+				// unconditional index entry whose key changed would
+				// duplicate.
+				if err := e.deleteFromIndexes(tableInfo.Name, conflictRowID); err != nil {
 					return nil, err
 				}
 				if err := e.insertIntoIndexes(tableInfo.Name, conflictRowID, updated); err != nil {

--- a/sqlite/load_default_test.go
+++ b/sqlite/load_default_test.go
@@ -1,0 +1,56 @@
+package sqlite
+
+import "testing"
+
+// Legacy files (pre-default_expr) serialized only the raw TextVal of a
+// constant default; new files carry the expression source. Both must load.
+func TestLoadColumnDefaultBothFormats(t *testing.T) {
+	load := func(cd colData) ColumnDef {
+		col := ColumnDef{Name: cd.Name}
+		loadColumnDefault(&col, cd)
+		return col
+	}
+
+	// Legacy: empty-string default is a real default, not "no default".
+	col := load(colData{Name: "lane", HasDefault: true, Default: ""})
+	if col.Default == nil || col.Default.Type != DataTypeText || col.Default.TextVal != "" {
+		t.Fatalf("legacy DEFAULT '' = %+v, want empty text value", col.Default)
+	}
+
+	// Legacy: unquoted text must stay text, never parse as an identifier.
+	col = load(colData{Name: "status", HasDefault: true, Default: "pending"})
+	if col.Default == nil || col.Default.Type != DataTypeText || col.Default.TextVal != "pending" {
+		t.Fatalf("legacy DEFAULT pending = %+v, want text \"pending\"", col.Default)
+	}
+
+	// Legacy: numbers round-trip as numbers.
+	col = load(colData{Name: "n", HasDefault: true, Default: "42"})
+	if col.Default == nil || col.Default.Type != DataTypeInteger || col.Default.IntVal != 42 {
+		t.Fatalf("legacy DEFAULT 42 = %+v, want integer 42", col.Default)
+	}
+	col = load(colData{Name: "x", HasDefault: true, Default: "1.5"})
+	if col.Default == nil || col.Default.Type != DataTypeFloat || col.Default.FloatVal != 1.5 {
+		t.Fatalf("legacy DEFAULT 1.5 = %+v, want float 1.5", col.Default)
+	}
+
+	// New format: quoted text literal.
+	col = load(colData{Name: "status", HasDefault: true, DefaultExpr: "'pending'"})
+	if col.Default == nil || col.Default.Type != DataTypeText || col.Default.TextVal != "pending" {
+		t.Fatalf("default_expr 'pending' = %+v, want text \"pending\"", col.Default)
+	}
+
+	// New format: dynamic default has an expression but no constant.
+	col = load(colData{Name: "created_at", HasDefault: true, DefaultExpr: "CURRENT_TIMESTAMP"})
+	if col.DefaultExpr == nil {
+		t.Fatal("default_expr CURRENT_TIMESTAMP did not restore an expression")
+	}
+	if col.Default != nil {
+		t.Fatalf("dynamic default cached a constant %+v, want nil", col.Default)
+	}
+
+	// No default at all.
+	col = load(colData{Name: "plain"})
+	if col.Default != nil || col.DefaultExpr != nil {
+		t.Fatalf("no-default column loaded %+v / %+v", col.Default, col.DefaultExpr)
+	}
+}

--- a/sqlite/pager.go
+++ b/sqlite/pager.go
@@ -471,37 +471,70 @@ func (p *Pager) Close() error {
 	return nil
 }
 
-// Snapshot returns a byte snapshot of all pager state for transaction rollback.
-func (p *Pager) Snapshot() []byte {
-	p.Flush()
-	size := p.file.Len()
-	data := make([]byte, size)
-	if size > 0 {
-		p.file.ReadAt(data, 0)
-	}
-	return data
+// pagerStatementSnapshot captures in-memory pager state at a statement
+// boundary so a failed statement can be rolled back WITHOUT disturbing
+// the enclosing transaction's COW rollback journal.
+//
+// This is intentionally separate from the transaction's own COW
+// rollback state (txnOrigPages). The transaction journal stores the
+// pre-BEGIN page images so ROLLBACK can restore the table to its
+// state before BEGIN. The statement snapshot stores the state at the
+// statement boundary so a failed statement inside the transaction
+// does not leak its partial writes into either the transaction's
+// eventual commit or its rollback.
+//
+// Critically, this snapshot NEVER flushes the page cache to disk.
+// Inside a transaction the on-disk file is unchanged (only the
+// in-memory cache is mutated); flushing here would race with the
+// outer transaction's eventual rollback, which assumes the file still
+// reflects the pre-BEGIN state. The old Snapshot()/Restore() pair
+// flushed and then replaced the file contents, which silently
+// discarded txnOrigPages' ability to recover pre-BEGIN images —
+// see TestRollbackAfterFailedStatement.
+type pagerStatementSnapshot struct {
+	pages     [][]byte
+	dirty     []bool
+	pageCount int
+	origPages map[int][]byte
 }
 
-// Restore restores pager state from a snapshot.
-func (p *Pager) Restore(data []byte) error {
-	// Clear cache
-	p.pages = make([][]byte, 0, 64)
-	p.dirty = make([]bool, 0, 64)
-	// Write data back to file
-	if err := p.file.Truncate(int64(len(data))); err != nil {
-		return err
-	}
-	if len(data) > 0 {
-		if _, err := p.file.WriteAt(data, 0); err != nil {
-			return err
+// StatementSnapshot captures pager state for statement-level rollback.
+// It does not flush.
+func (p *Pager) StatementSnapshot() *pagerStatementSnapshot {
+	pages := make([][]byte, len(p.pages))
+	for i, pg := range p.pages {
+		if pg != nil {
+			cp := make([]byte, p.pageSize)
+			copy(cp, pg)
+			pages[i] = cp
 		}
 	}
-	// Recalculate page count
-	p.pageCount = len(data) / p.pageSize
-	if p.pageCount < 1 {
-		p.pageCount = 1
+	dirty := append([]bool(nil), p.dirty...)
+	origPages := make(map[int][]byte, len(p.txnOrigPages))
+	for k, v := range p.txnOrigPages {
+		cp := make([]byte, len(v))
+		copy(cp, v)
+		origPages[k] = cp
 	}
-	return nil
+	return &pagerStatementSnapshot{
+		pages:     pages,
+		dirty:     dirty,
+		pageCount: p.pageCount,
+		origPages: origPages,
+	}
+}
+
+// StatementRestore restores pager state captured by StatementSnapshot,
+// including the transaction's pre-BEGIN page images, so statement
+// rollback composes with transaction rollback.
+func (p *Pager) StatementRestore(s *pagerStatementSnapshot) {
+	if s == nil {
+		return
+	}
+	p.pages = s.pages
+	p.dirty = s.dirty
+	p.pageCount = s.pageCount
+	p.txnOrigPages = s.origPages
 }
 
 // BeginTxn starts a page-level COW transaction.

--- a/sqlite/pager.go
+++ b/sqlite/pager.go
@@ -187,9 +187,17 @@ type Pager struct {
 	dirty     []bool   // tracks which pages need flushing
 	pool      *pagePool
 
-	// Transaction COW: maps page number -> original page data (before first mutation in txn)
-	txnOrigPages map[int][]byte
-	inTxn        bool
+	// Transaction COW state. txnOrigPages captures the original content
+	// of pages mutated during the transaction so RollbackTxn can restore
+	// them. txnOrigPageCount and txnOrigHeader capture the page-count
+	// and database header at BEGIN time so a rollback fully undoes DDL
+	// that allocated pages or moved the schema-page pointer — without
+	// this, CREATE TABLE inside a rolled-back transaction leaks past
+	// ROLLBACK once the file is closed and reopened.
+	txnOrigPages     map[int][]byte
+	txnOrigPageCount int
+	txnOrigHeader    *DatabaseHeader
+	inTxn            bool
 }
 
 // pagePool manages reusable page-sized buffers.
@@ -496,6 +504,12 @@ type pagerStatementSnapshot struct {
 	dirty     []bool
 	pageCount int
 	origPages map[int][]byte
+	// header holds the cached DatabaseHeader at the statement boundary
+	// so a failed mid-transaction statement that moved the schema-page
+	// pointer (or bumped DatabaseSizePages via AllocatePage) can be
+	// fully undone. Without this the header mutation leaks into the
+	// enclosing transaction's eventual commit.
+	header *DatabaseHeader
 }
 
 // StatementSnapshot captures pager state for statement-level rollback.
@@ -516,11 +530,17 @@ func (p *Pager) StatementSnapshot() *pagerStatementSnapshot {
 		copy(cp, v)
 		origPages[k] = cp
 	}
+	var hdr *DatabaseHeader
+	if p.header != nil {
+		cp := *p.header
+		hdr = &cp
+	}
 	return &pagerStatementSnapshot{
 		pages:     pages,
 		dirty:     dirty,
 		pageCount: p.pageCount,
 		origPages: origPages,
+		header:    hdr,
 	}
 }
 
@@ -535,21 +555,74 @@ func (p *Pager) StatementRestore(s *pagerStatementSnapshot) {
 	p.dirty = s.dirty
 	p.pageCount = s.pageCount
 	p.txnOrigPages = s.origPages
+	if s.header != nil {
+		if p.header != nil {
+			*p.header = *s.header
+		} else {
+			cp := *s.header
+			p.header = &cp
+		}
+		// Rewrite page 1 so the cached page image matches the restored
+		// header struct (the schema-page pointer lives in page 1's
+		// header bytes via ReservedExpansion).
+		hdrBuf := WriteHeader(p.header)
+		if page1 := p.cachedPage(1); page1 != nil {
+			copy(page1, hdrBuf)
+			if 1 < len(p.dirty) {
+				p.dirty[1] = true
+			}
+		}
+	}
+}
+
+// IsInTxn reports whether a COW transaction is currently open. The
+// engine uses this to defer SaveSchema's Flush to commit time so DDL
+// inside a rolled-back transaction cannot leak to disk.
+func (p *Pager) IsInTxn() bool {
+	return p.inTxn
 }
 
 // BeginTxn starts a page-level COW transaction.
 func (p *Pager) BeginTxn() {
 	p.inTxn = true
 	p.txnOrigPages = make(map[int][]byte)
+	p.txnOrigPageCount = p.pageCount
+	if p.header != nil {
+		cp := *p.header
+		p.txnOrigHeader = &cp
+	} else {
+		p.txnOrigHeader = nil
+	}
 }
 
-// CommitTxn finishes a COW transaction, discarding saved originals.
+// CommitTxn finishes a COW transaction. SaveSchema defers its Flush
+// while a transaction is open, so a successful commit is the point at
+// which every transactional mutation (DDL page allocations, schema
+// page moves, row writes) actually reaches disk.
 func (p *Pager) CommitTxn() {
+	// Flush any deferred dirty pages accumulated during the txn.
+	if p.inTxn {
+		_ = p.Flush()
+	}
 	p.inTxn = false
 	p.txnOrigPages = nil
+	p.txnOrigPageCount = 0
+	p.txnOrigHeader = nil
 }
 
-// RollbackTxn restores only the pages that were modified during the transaction.
+// RollbackTxn undoes every page mutation the transaction made:
+//   - Restores the original content of pages that were modified in
+//     place (txnOrigPages).
+//   - Drops pages allocated during the txn from the cache and rolls
+//     pageCount back, so new schema/table B-tree roots vanish.
+//   - Restores the database header (page 1 + the cached struct),
+//     including the schema-page pointer — SetSchemaPage mutates the
+//     header directly and would otherwise leak a rolled-back DDL's
+//     schema location past reopen.
+//   - Truncates the file if it grew past txnOrigPageCount, so any
+//     pages flushed to disk before the rollback are removed too.
+//   - Flushes the restored state so a subsequent Close writes the
+//     pre-transaction image.
 func (p *Pager) RollbackTxn() error {
 	for pageNum, orig := range p.txnOrigPages {
 		if pageNum < len(p.pages) && p.pages[pageNum] != nil {
@@ -557,11 +630,53 @@ func (p *Pager) RollbackTxn() error {
 			p.dirty[pageNum] = true
 		}
 	}
+	// Drop newly allocated pages from the cache so their stale content
+	// cannot be flushed after the rollback.
+	if p.pageCount > p.txnOrigPageCount {
+		for i := p.txnOrigPageCount + 1; i <= p.pageCount && i < len(p.pages); i++ {
+			p.pages[i] = nil
+			if i < len(p.dirty) {
+				p.dirty[i] = false
+			}
+		}
+		p.pageCount = p.txnOrigPageCount
+	}
+	// Restore the cached header struct AND rewrite page 1 so the on-
+	// disk header matches (DatabaseSizePages + schema-page pointer).
+	if p.txnOrigHeader != nil {
+		if p.header != nil {
+			*p.header = *p.txnOrigHeader
+		} else {
+			cp := *p.txnOrigHeader
+			p.header = &cp
+		}
+		hdrBuf := WriteHeader(p.header)
+		if page1 := p.cachedPage(1); page1 != nil {
+			copy(page1, hdrBuf)
+			if 1 < len(p.dirty) {
+				p.dirty[1] = true
+			}
+		}
+	}
+	// If pages were already flushed past the original length (e.g. an
+	// outer auto-commit statement before the explicit BEGIN, or a
+	// prior transaction), truncate the file back so the rolled-back
+	// pages do not resurface on reopen.
+	if p.file != nil {
+		origLen := int64(p.txnOrigPageCount) * int64(p.pageSize)
+		if p.file.Len() > origLen {
+			if err := p.file.Truncate(origLen); err != nil {
+				return err
+			}
+		}
+	}
 	if err := p.Flush(); err != nil {
 		return err
 	}
 	p.inTxn = false
 	p.txnOrigPages = nil
+	p.txnOrigPageCount = 0
+	p.txnOrigHeader = nil
 	return nil
 }
 

--- a/sqlite/parser.go
+++ b/sqlite/parser.go
@@ -734,10 +734,13 @@ func (p *Parser) parseInsert() (*InsertStmt, error) {
 	}
 	if p.cur.Type == TokenOR {
 		p.advance()
-		if err := p.expectWord("IGNORE"); err != nil {
-			return nil, err
+		if p.consumeWord("IGNORE") {
+			stmt.OrIgnore = true
+		} else if p.consumeWord("REPLACE") {
+			stmt.OrReplace = true
+		} else {
+			return nil, p.errorf("expected IGNORE or REPLACE, got %s (%q)", tokenTypeName(p.cur.Type), p.cur.Value)
 		}
-		stmt.OrIgnore = true
 	}
 	if _, err := p.expect(TokenINTO); err != nil {
 		return nil, err

--- a/sqlite/round2_regress_test.go
+++ b/sqlite/round2_regress_test.go
@@ -1,0 +1,270 @@
+package sqlite_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	gosqlite "github.com/DonaldMurillo/gofastr/sqlite"
+)
+
+// DDL created inside a rolled-back transaction stays rolled back after the
+// file is closed and reopened — SaveSchema must not leak flushed schema
+// state past ROLLBACK.
+func TestDDLRollbackNotResurrected(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ddl.db")
+	db, err := gosqlite.OpenFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, db, `CREATE TABLE base (id INTEGER PRIMARY KEY, v TEXT)`)
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(`CREATE TABLE rolled_back (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("create in txn: %v", err)
+	}
+	if _, err := tx.Exec(`CREATE INDEX rolled_back_idx ON base(v)`); err != nil {
+		t.Fatalf("create index in txn: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err = gosqlite.OpenFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`CREATE TABLE rolled_back (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatalf("rolled-back table resurrected after reopen: %v", err)
+	}
+	if _, err := db.Exec(`CREATE INDEX rolled_back_idx ON base(v)`); err != nil {
+		t.Fatalf("rolled-back index resurrected after reopen: %v", err)
+	}
+}
+
+// ALTER TABLE ADD COLUMN must not corrupt indexed reads: index records
+// keep their [value, rowid] shape regardless of later table width.
+func TestAddColumnKeepsIndexReads(t *testing.T) {
+	db := openTest(t)
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`)
+	mustExec(t, db, `CREATE INDEX t_v ON t(v)`)
+	mustExec(t, db, `INSERT INTO t VALUES (1,'x'),(2,'y')`)
+	mustExec(t, db, `ALTER TABLE t ADD COLUMN extra INTEGER DEFAULT 1`)
+
+	var id int
+	if err := db.QueryRow(`SELECT id FROM t WHERE v='y'`).Scan(&id); err != nil {
+		t.Fatalf("indexed select after ADD COLUMN: %v", err)
+	}
+	if id != 2 {
+		t.Fatalf("indexed select after ADD COLUMN returned id=%d, want 2", id)
+	}
+}
+
+// A unique index created separately from the table definition is enforced
+// on plain multi-row VALUES inserts.
+func TestValuesInsertHonorsUniqueIndex(t *testing.T) {
+	db := openTest(t)
+	mustExec(t, db, `CREATE TABLE t (v TEXT)`)
+	mustExec(t, db, `CREATE UNIQUE INDEX ux ON t(v)`)
+	if _, err := db.Exec(`INSERT INTO t VALUES ('dup'), ('dup')`); err == nil {
+		t.Fatal("duplicate VALUES insert against a unique index succeeded")
+	}
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM t`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("%d rows survived a failed unique insert, want 0", n)
+	}
+}
+
+// RENAME COLUMN keeps unique indexes (and their enforcement) attached to
+// the renamed column.
+func TestRenameColumnKeepsUniqueIndex(t *testing.T) {
+	db := openTest(t)
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`)
+	mustExec(t, db, `CREATE UNIQUE INDEX ux ON t(v)`)
+	mustExec(t, db, `INSERT INTO t VALUES (1, 'dup')`)
+	mustExec(t, db, `ALTER TABLE t RENAME COLUMN v TO w`)
+	if _, err := db.Exec(`INSERT INTO t VALUES (2, 'dup')`); err == nil {
+		t.Fatal("duplicate accepted after RENAME COLUMN (unique index detached)")
+	}
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM t`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("row count = %d after rejected duplicate, want 1", n)
+	}
+}
+
+// A multi-row UPDATE where one row vacates the key another row takes (in
+// statement order) is valid: UPDATE t SET u = u - 1 over (1,1),(2,2)
+// yields (1,0),(2,1), like real SQLite.
+func TestUpdateKeyShiftAllowed(t *testing.T) {
+	db := openTest(t)
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, u INTEGER UNIQUE)`)
+	mustExec(t, db, `INSERT INTO t VALUES (1,1),(2,2)`)
+	if _, err := db.Exec(`UPDATE t SET u = u - 1`); err != nil {
+		t.Fatalf("valid key-shift UPDATE rejected: %v", err)
+	}
+	for id, want := range map[int]int{1: 0, 2: 1} {
+		var u int
+		if err := db.QueryRow(`SELECT u FROM t WHERE id=$1`, id).Scan(&u); err != nil {
+			t.Fatal(err)
+		}
+		if u != want {
+			t.Fatalf("row %d: u=%d, want %d", id, u, want)
+		}
+	}
+}
+
+// SQL truthiness: any nonzero numeric predicate value is true, including
+// fractional ones. A partial unique index WHERE flag applies to rows with
+// flag=0.5.
+func TestPartialIndexFractionalPredicate(t *testing.T) {
+	db := openTest(t)
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT, flag REAL)`)
+	mustExec(t, db, `CREATE UNIQUE INDEX ux ON t(v) WHERE flag`)
+	mustExec(t, db, `INSERT INTO t VALUES (1,'dup',0.5)`)
+	if _, err := db.Exec(`INSERT INTO t VALUES (2,'dup',0.5)`); err == nil {
+		t.Fatal("duplicate accepted: fractional predicate value treated as false")
+	}
+}
+
+// DELETE removes index entries: a recycled rowid must not resurface under
+// the deleted row's indexed value.
+func TestDeleteMaintainsIndex(t *testing.T) {
+	db := openTest(t)
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`)
+	mustExec(t, db, `CREATE INDEX t_v ON t(v)`)
+	mustExec(t, db, `INSERT INTO t VALUES (1,'old'),(2,'keep')`)
+	mustExec(t, db, `DELETE FROM t WHERE id=1`)
+	mustExec(t, db, `INSERT INTO t VALUES (1,'fresh')`)
+
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM t WHERE v='old'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("stale index entry matched %d row(s) for deleted value, want 0", n)
+	}
+
+	// Unqualified DELETE too.
+	mustExec(t, db, `DELETE FROM t`)
+	mustExec(t, db, `INSERT INTO t VALUES (1,'other')`)
+	if err := db.QueryRow(`SELECT COUNT(*) FROM t WHERE v='fresh'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("stale index entry after unqualified DELETE matched %d row(s), want 0", n)
+	}
+}
+
+// ON CONFLICT DO UPDATE refreshes index entries like a plain UPDATE.
+func TestUpsertMaintainsIndex(t *testing.T) {
+	db := openTest(t)
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`)
+	mustExec(t, db, `CREATE INDEX t_v ON t(v)`)
+	mustExec(t, db, `INSERT INTO t VALUES (1,'old')`)
+	mustExec(t, db, `INSERT INTO t VALUES (1,'new') ON CONFLICT(id) DO UPDATE SET v=excluded.v`)
+
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM t WHERE v='old'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("stale index entry for pre-upsert value matched %d row(s), want 0", n)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM t WHERE v='new'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("post-upsert value matched %d row(s), want 1", n)
+	}
+}
+
+// INSERT OR REPLACE parses and replaces, maintaining indexes.
+func TestInsertOrReplace(t *testing.T) {
+	db := openTest(t)
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`)
+	mustExec(t, db, `CREATE INDEX t_v ON t(v)`)
+	mustExec(t, db, `INSERT INTO t VALUES (1,'old')`)
+	if _, err := db.Exec(`INSERT OR REPLACE INTO t VALUES (1,'new')`); err != nil {
+		t.Fatalf("INSERT OR REPLACE rejected: %v", err)
+	}
+	var v string
+	if err := db.QueryRow(`SELECT v FROM t WHERE id=1`).Scan(&v); err != nil {
+		t.Fatal(err)
+	}
+	if v != "new" {
+		t.Fatalf("v=%q after INSERT OR REPLACE, want new", v)
+	}
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM t WHERE v='old'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("stale index entry for replaced value matched %d row(s), want 0", n)
+	}
+}
+
+// Affinity text/number conversions follow SQLite: REAL affinity parses
+// whitespace-padded and signed numeric text; NUMERIC affinity stores
+// losslessly integral values as INTEGER; TEXT affinity converts numbers
+// to text and keeps blobs as blobs.
+func TestAffinityConversions(t *testing.T) {
+	db := openTest(t)
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, r REAL, n NUMERIC, s TEXT, b TEXT)`)
+	mustExec(t, db, `INSERT INTO t VALUES (1, ' 3.5 ', '3.0e+5', 42, X'4142')`)
+	mustExec(t, db, `INSERT INTO t VALUES (2, '+4.25', 4.0, 3.5, 'plain')`)
+
+	var r1, n1, s1, b1 any
+	if err := db.QueryRow(`SELECT r, n, s, b FROM t WHERE id=1`).Scan(&r1, &n1, &s1, &b1); err != nil {
+		t.Fatal(err)
+	}
+	if f, ok := r1.(float64); !ok || f != 3.5 {
+		t.Fatalf("REAL ' 3.5 ' stored as %T %v, want float64 3.5", r1, r1)
+	}
+	if i, ok := n1.(int64); !ok || i != 300000 {
+		t.Fatalf("NUMERIC '3.0e+5' stored as %T %v, want int64 300000", n1, n1)
+	}
+	if s, ok := asString(s1); !ok || s != "42" {
+		t.Fatalf("TEXT 42 stored as %T %v, want text \"42\"", s1, s1)
+	}
+	if _, isBlob := b1.([]byte); !isBlob {
+		// Blob under TEXT affinity stays a blob in SQLite; a string scan
+		// destination would coerce, so assert the raw scan type.
+		t.Fatalf("TEXT-affinity blob stored as %T %v, want []byte", b1, b1)
+	}
+
+	var r2, n2, s2 any
+	if err := db.QueryRow(`SELECT r, n, s FROM t WHERE id=2`).Scan(&r2, &n2, &s2); err != nil {
+		t.Fatal(err)
+	}
+	if f, ok := r2.(float64); !ok || f != 4.25 {
+		t.Fatalf("REAL '+4.25' stored as %T %v, want float64 4.25", r2, r2)
+	}
+	if i, ok := n2.(int64); !ok || i != 4 {
+		t.Fatalf("NUMERIC 4.0 stored as %T %v, want int64 4", n2, n2)
+	}
+	if s, ok := asString(s2); !ok || s != "3.5" {
+		t.Fatalf("TEXT 3.5 stored as %T %v, want text \"3.5\"", s2, s2)
+	}
+}
+
+func asString(v any) (string, bool) {
+	switch s := v.(type) {
+	case string:
+		return s, true
+	case []byte:
+		return string(s), true
+	}
+	return "", false
+}

--- a/sqlite/row_constraints.go
+++ b/sqlite/row_constraints.go
@@ -1,5 +1,7 @@
 package sqlite
 
+import "strings"
+
 func validateUpdatedRow(table *TableInfo, previous, updated []Value) error {
 	for i, column := range table.Columns {
 		if column.NotNull && updated[i].IsNull() {
@@ -15,25 +17,75 @@ func validateUpdatedRow(table *TableInfo, previous, updated []Value) error {
 	return nil
 }
 
-func (e *Engine) uniqueConstraints(table *TableInfo) [][]string {
-	constraints := make([][]string, len(table.UniqueConstraints))
+// uniqueConstraintInfo describes a single UNIQUE constraint that applies
+// to a table: the column set it covers and, for a partial unique index,
+// the predicate a row must match for the constraint to be enforced.
+type uniqueConstraintInfo struct {
+	Columns   []string
+	Predicate Expr // nil for an unconditional constraint
+}
+
+func (e *Engine) uniqueConstraints(table *TableInfo) []uniqueConstraintInfo {
+	constraints := make([]uniqueConstraintInfo, 0, len(table.UniqueConstraints))
 	for i := range table.UniqueConstraints {
-		constraints[i] = append([]string(nil), table.UniqueConstraints[i]...)
+		constraints = append(constraints, uniqueConstraintInfo{
+			Columns: append([]string(nil), table.UniqueConstraints[i]...),
+		})
 	}
 	for _, index := range e.schema.IndexesForTable(table.Name) {
 		if !index.Unique {
 			continue
 		}
+		// A partial unique index (index.WhereExpr != nil) is a DISTINCT
+		// constraint from any unconditional UNIQUE on the same columns:
+		// it only fires on rows the predicate selects, so it does not
+		// deduplicate against the column-only constraints.
 		duplicate := false
-		for _, constraint := range constraints {
-			if sameColumns(constraint, index.Columns) {
-				duplicate = true
-				break
+		if index.WhereExpr == nil {
+			for _, constraint := range constraints {
+				if constraint.Predicate == nil && sameColumns(constraint.Columns, index.Columns) {
+					duplicate = true
+					break
+				}
 			}
 		}
 		if !duplicate {
-			constraints = append(constraints, append([]string(nil), index.Columns...))
+			constraints = append(constraints, uniqueConstraintInfo{
+				Columns:   append([]string(nil), index.Columns...),
+				Predicate: index.WhereExpr,
+			})
 		}
 	}
 	return constraints
+}
+
+// rowMatchesPredicate reports whether a row satisfies a partial-index
+// or partial-constraint predicate. A nil predicate always matches.
+// The row is the values slice indexed by table column position (the
+// same shape buildInsertRow / recordToValues produce).
+func rowMatchesPredicate(table *TableInfo, row []Value, predicate Expr) bool {
+	if predicate == nil {
+		return true
+	}
+	columnMap := make(map[string]int, len(table.Columns)+1)
+	columnMap["rowid"] = 0
+	for i, col := range table.Columns {
+		columnMap[strings.ToLower(col.Name)] = i + 1
+	}
+	indexed := make([]Value, len(table.Columns)+1)
+	copy(indexed[1:], row)
+	eval := &ExprEval{
+		Row:       indexed,
+		ColumnMap: columnMap,
+		TableMap: map[string]map[string]int{
+			strings.ToLower(table.Name): columnMap,
+		},
+		Engine: nil,
+	}
+	val, err := eval.Eval(predicate)
+	if err != nil || val.IsNull() {
+		return false
+	}
+	b, ok := val.AsInt64()
+	return ok && b != 0
 }

--- a/sqlite/row_constraints.go
+++ b/sqlite/row_constraints.go
@@ -86,6 +86,32 @@ func rowMatchesPredicate(table *TableInfo, row []Value, predicate Expr) bool {
 	if err != nil || val.IsNull() {
 		return false
 	}
-	b, ok := val.AsInt64()
-	return ok && b != 0
+	return isTruthyValue(val)
+}
+
+// isTruthyValue reports whether a Value is true under SQLite's
+// boolean semantics: NULL and BLOBs are false; numeric values are true
+// when nonzero (including fractional floats); text is true only when it
+// parses as a nonzero number. See https://www.sqlite.org/lang_expr.html#boolean
+// ("a zero or NULL is false ... any other string is considered to be true
+// if it is numeric and nonzero").
+func isTruthyValue(v Value) bool {
+	switch v.Type {
+	case DataTypeNull:
+		return false
+	case DataTypeInteger:
+		return v.IntVal != 0
+	case DataTypeFloat:
+		return v.FloatVal != 0
+	case DataTypeText:
+		// SQLite evaluates numeric-looking text as its numeric value;
+		// non-numeric text is treated as 0 (false).
+		if f, ok := v.AsFloat64(); ok {
+			return f != 0
+		}
+		return false
+	case DataTypeBlob:
+		return false
+	}
+	return false
 }

--- a/sqlite/schema.go
+++ b/sqlite/schema.go
@@ -294,9 +294,14 @@ func ApplyAffinity(v Value, affinity ColumnAffinity) Value {
 		}
 
 	case AffinityText:
-		if v.Type == DataTypeBlob {
-			// BLOB to TEXT
-			return TextValue(string(v.BlobVal))
+		// SQLite TEXT affinity converts INTEGER and REAL values into
+		// their text form, but leaves BLOBs untouched (a blob stays a
+		// blob). https://www.sqlite.org/datatype3.html#type_affinity
+		switch v.Type {
+		case DataTypeInteger:
+			return TextValue(formatInt64(v.IntVal))
+		case DataTypeFloat:
+			return TextValue(formatFloat64(v.FloatVal))
 		}
 
 	case AffinityBlob:
@@ -306,17 +311,23 @@ func ApplyAffinity(v Value, affinity ColumnAffinity) Value {
 		}
 
 	case AffinityNumeric:
-		// Try integer first, then float
-		if v.Type == DataTypeText {
-			s := v.TextVal
-			// Check if it looks like an integer
-			if looksLikeInteger(s) {
-				if n, err := parseInt64(s); err == nil {
+		// NUMERIC affinity stores a value as INTEGER when it can be
+		// represented losslessly as an integer, and as REAL otherwise.
+		// This applies to both TEXT inputs (parsed as a number first)
+		// and REAL inputs (e.g. the literal 4.0 under a NUMERIC column
+		// is stored as INTEGER 4). Non-numeric TEXT is kept as TEXT.
+		// https://www.sqlite.org/datatype3.html#type_affinity
+		switch v.Type {
+		case DataTypeText:
+			if f, ok := v.AsFloat64(); ok {
+				if n, ok := losslessInt64FromFloat(f); ok {
 					return IntegerValue(n)
 				}
-			}
-			if f, ok := v.AsFloat64(); ok {
 				return FloatValue(f)
+			}
+		case DataTypeFloat:
+			if n, ok := losslessInt64FromFloat(v.FloatVal); ok {
+				return IntegerValue(n)
 			}
 		}
 	}

--- a/sqlite/schema.go
+++ b/sqlite/schema.go
@@ -43,7 +43,8 @@ type IndexInfo struct {
 	RootPage  int
 	Columns   []string
 	Unique    bool
-	Where     string // Partial index WHERE clause
+	Where     string // Partial index WHERE predicate (raw source, serialized)
+	WhereExpr Expr   // Parsed predicate; nil for non-partial indexes
 	SQL       string // Original CREATE INDEX statement
 }
 
@@ -173,6 +174,9 @@ func (s *Schema) Copy() *Schema {
 	}
 	for k, v := range s.indexes {
 		cp := *v
+		// WhereExpr is an immutable AST shared across schema snapshots;
+		// a shallow copy is sufficient and avoids deep-walking the
+		// expression on every statement-level snapshot.
 		c.indexes[k] = &cp
 	}
 	return c
@@ -269,7 +273,14 @@ func ApplyAffinity(v Value, affinity ColumnAffinity) Value {
 			}
 		}
 		if v.Type == DataTypeFloat {
-			return IntegerValue(int64(v.FloatVal))
+			// SQLite INTEGER affinity converts a REAL to INTEGER only
+			// when the conversion is lossless (the float has no
+			// fractional component and fits in int64). A literal like
+			// DEFAULT 1.5 must stay REAL.
+			// https://www.sqlite.org/datatype3.html#type_affinity
+			if n, ok := losslessInt64FromFloat(v.FloatVal); ok {
+				return IntegerValue(n)
+			}
 		}
 
 	case AffinityReal:
@@ -330,6 +341,27 @@ func looksLikeInteger(s string) bool {
 		}
 	}
 	return true
+}
+
+// losslessInt64FromFloat reports whether f has an exact integer
+// representation that fits in an int64. Used by ApplyAffinity to decide
+// whether INTEGER affinity may convert a REAL storage class to INTEGER
+// without losing information (SQLite's lossless-only rule).
+func losslessInt64FromFloat(f float64) (int64, bool) {
+	if f != f { // NaN
+		return 0, false
+	}
+	// 2^63 is exactly representable as a float64; values >= 2^63 or
+	// < -2^63 cannot fit in an int64 even if mathematically integral.
+	const int64Edge = 9223372036854775808.0
+	if f >= int64Edge || f < -int64Edge {
+		return 0, false
+	}
+	n := int64(f)
+	if float64(n) == f {
+		return n, true
+	}
+	return 0, false
 }
 
 // BuildTableInfo creates a TableInfo from a parsed CREATE TABLE statement.

--- a/sqlite/schema_test.go
+++ b/sqlite/schema_test.go
@@ -389,11 +389,23 @@ func TestApplyAffinityReal(t *testing.T) {
 }
 
 func TestApplyAffinityText(t *testing.T) {
-	// BLOB → TEXT
+	// INTEGER → TEXT
+	result := ApplyAffinity(IntegerValue(42), AffinityText)
+	if result.Type != DataTypeText || result.TextVal != "42" {
+		t.Errorf("ApplyAffinity(IntegerValue(42), TEXT) = %v, want text \"42\"", result)
+	}
+	// REAL → TEXT
+	result = ApplyAffinity(FloatValue(3.5), AffinityText)
+	if result.Type != DataTypeText || result.TextVal != "3.5" {
+		t.Errorf("ApplyAffinity(FloatValue(3.5), TEXT) = %v, want text \"3.5\"", result)
+	}
+	// BLOB stays as BLOB — SQLite TEXT affinity does NOT coerce blobs.
+	// (Cross-checked against the sqlite3 CLI: a blob stored in a TEXT-
+	// affinity column keeps typeof = blob.)
 	blob := BlobValue([]byte("hello"))
-	result := ApplyAffinity(blob, AffinityText)
-	if result.Type != DataTypeText || result.TextVal != "hello" {
-		t.Errorf("ApplyAffinity(BlobValue(hello), TEXT) = %v, want text 'hello'", result)
+	result = ApplyAffinity(blob, AffinityText)
+	if result.Type != DataTypeBlob {
+		t.Errorf("ApplyAffinity(BlobValue(hello), TEXT) = %v, want blob (TEXT affinity leaves blobs intact)", result)
 	}
 }
 

--- a/sqlite/schema_test.go
+++ b/sqlite/schema_test.go
@@ -347,10 +347,18 @@ func TestApplyAffinityInteger(t *testing.T) {
 		t.Errorf("ApplyAffinity(TextValue(42), INTEGER) = %v, want integer 42", result)
 	}
 
-	// Float → integer
+	// Float with fractional component stays REAL — SQLite's INTEGER
+	// affinity converts REAL to INTEGER only when lossless.
+	// https://www.sqlite.org/datatype3.html#type_affinity
 	result = ApplyAffinity(FloatValue(3.7), AffinityInteger)
-	if result.Type != DataTypeInteger || result.IntVal != 3 {
-		t.Errorf("ApplyAffinity(FloatValue(3.7), INTEGER) = %v, want integer 3", result)
+	if result.Type != DataTypeFloat || result.FloatVal != 3.7 {
+		t.Errorf("ApplyAffinity(FloatValue(3.7), INTEGER) = %v, want float 3.7", result)
+	}
+
+	// Lossless float → integer (no fractional component)
+	result = ApplyAffinity(FloatValue(4.0), AffinityInteger)
+	if result.Type != DataTypeInteger || result.IntVal != 4 {
+		t.Errorf("ApplyAffinity(FloatValue(4.0), INTEGER) = %v, want integer 4", result)
 	}
 
 	// Non-numeric text stays text

--- a/sqlite/statement_atomic.go
+++ b/sqlite/statement_atomic.go
@@ -19,16 +19,18 @@ func (e *Engine) executeMutationAtomic(stmt Statement, parsed Statement, params 
 	}
 
 	// An explicit transaction already owns the pager's COW journal. Snapshot
-	// its current state so a failed statement rolls back to the statement
+	// the in-memory pager state (page cache + dirty bits + the transaction's
+	// pre-BEGIN originals) so a failed statement rolls back to the statement
 	// boundary without discarding earlier successful work in the transaction.
-	pagerSnapshot := e.pager.Snapshot()
+	// StatementSnapshot must NOT touch the on-disk file: the outer
+	// transaction's eventual RollbackTxn assumes the file still reflects the
+	// pre-BEGIN state.
+	pagerSnapshot := e.pager.StatementSnapshot()
 	result, err := e.executeMutation(stmt, parsed, params)
 	if err == nil {
 		return result, nil
 	}
-	if restoreErr := e.pager.Restore(pagerSnapshot); restoreErr != nil {
-		return nil, fmt.Errorf("%w (statement rollback failed: %v)", err, restoreErr)
-	}
+	e.pager.StatementRestore(pagerSnapshot)
 	e.schema = schemaSnapshot
 	return nil, err
 }

--- a/sqlite/types.go
+++ b/sqlite/types.go
@@ -3,6 +3,8 @@
 // compatible with the standard SQLite library, and provides a database/sql driver.
 package sqlite
 
+import "strings"
+
 // SQLite magic header string
 const magicHeader = "SQLite format 3\x00"
 
@@ -343,7 +345,10 @@ func parseInt64(s string) (int64, error) {
 }
 
 func parseFloat64(s string) (float64, error) {
-	// Simple float parser - handles basic decimal notation
+	// Trim surrounding whitespace — SQLite accepts numeric literals and
+	// column values with leading/trailing spaces under REAL/NUMERIC
+	// affinity (e.g. ' 3.5 ', '+4.25').
+	s = strings.TrimSpace(s)
 	if len(s) == 0 {
 		return 0, errEmptyString
 	}
@@ -353,6 +358,11 @@ func parseFloat64(s string) (float64, error) {
 	if s[0] == '-' {
 		neg = true
 		i = 1
+	} else if s[0] == '+' {
+		i = 1
+	}
+	if i >= len(s) {
+		return 0, errBadNumber
 	}
 
 	var result float64

--- a/sqlite/unique_index.go
+++ b/sqlite/unique_index.go
@@ -2,7 +2,7 @@ package sqlite
 
 import "sort"
 
-func (e *Engine) validateUniqueIndex(table *TableInfo, columns []string) error {
+func (e *Engine) validateUniqueIndex(table *TableInfo, columns []string, predicate Expr) error {
 	cursor, err := e.btree.Scan(table.RootPage)
 	if err != nil {
 		return err
@@ -16,6 +16,13 @@ func (e *Engine) validateUniqueIndex(table *TableInfo, columns []string) error {
 			return err
 		}
 		row := recordToValues(record, table)
+		// A partial unique index only constrains rows the predicate
+		// selects. Skip rows outside the predicate entirely so a table
+		// that already has duplicates in un-indexed rows can still
+		// receive a partial unique index, mirroring SQLite.
+		if predicate != nil && !rowMatchesPredicate(table, row, predicate) {
+			continue
+		}
 		key := make([]Value, len(columns))
 		hasNull := false
 		for i, column := range columns {

--- a/sqlite/update_rollback_regress_test.go
+++ b/sqlite/update_rollback_regress_test.go
@@ -1,0 +1,177 @@
+package sqlite_test
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gosqlite "github.com/DonaldMurillo/gofastr/sqlite"
+)
+
+func openTest(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := gosqlite.Open()
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	return db
+}
+
+func mustExec(t *testing.T, db *sql.DB, q string, args ...any) {
+	t.Helper()
+	if _, err := db.Exec(q, args...); err != nil {
+		t.Fatalf("%s: %v", q, err)
+	}
+}
+
+// A statement that fails inside an explicit transaction must not destroy
+// the transaction's rollback state: ROLLBACK undoes every prior write.
+func TestRollbackAfterFailedStatement(t *testing.T) {
+	db := openTest(t)
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, u TEXT UNIQUE)`)
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO t (id, u) VALUES (1, 'prior')`); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	if _, err := tx.Exec(`INSERT INTO t (id, u) VALUES (2, 'temp'), (3, 'prior')`); err == nil {
+		t.Fatal("second insert succeeded, want UNIQUE failure")
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM t`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("%d row(s) survived ROLLBACK, want 0", n)
+	}
+}
+
+// A multi-row UPDATE whose pending rows collide with each other must fail
+// and leave the table unchanged, like real SQLite.
+func TestMultiRowUpdateUniqueRejected(t *testing.T) {
+	db := openTest(t)
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, u INTEGER UNIQUE)`)
+	mustExec(t, db, `INSERT INTO t (id, u) VALUES (1, 1), (2, 2)`)
+
+	if _, err := db.Exec(`UPDATE t SET u = 3`); err == nil {
+		t.Fatal("UPDATE succeeded, want UNIQUE constraint failure")
+	}
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM t WHERE u = 3`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("%d row(s) committed with u=3 after failed UPDATE, want 0", n)
+	}
+	for id, want := range map[int]int{1: 1, 2: 2} {
+		var u int
+		if err := db.QueryRow(`SELECT u FROM t WHERE id = $1`, id).Scan(&u); err != nil {
+			t.Fatalf("select id=%d: %v", id, err)
+		}
+		if u != want {
+			t.Fatalf("row %d: u=%d, want %d (original value)", id, u, want)
+		}
+	}
+}
+
+// UPDATE must maintain secondary indexes: the old key stops matching, the
+// new key starts matching.
+func TestUpdateRefreshesIndex(t *testing.T) {
+	db := openTest(t)
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`)
+	mustExec(t, db, `CREATE INDEX t_v ON t(v)`)
+	mustExec(t, db, `INSERT INTO t (id, v) VALUES (1, 'old')`)
+	mustExec(t, db, `UPDATE t SET v = 'new' WHERE id = 1`)
+
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM t WHERE v = 'old'`).Scan(&n); err != nil {
+		t.Fatalf("count old: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("index still matches v='old' after UPDATE (%d rows), want 0", n)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM t WHERE v = 'new'`).Scan(&n); err != nil {
+		t.Fatalf("count new: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("index matches v='new' %d times after UPDATE, want 1", n)
+	}
+}
+
+// Dynamic column defaults (CURRENT_TIMESTAMP) must survive close/reopen of
+// a file-backed database.
+func TestDynamicDefaultSurvivesReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reopen.db")
+	db, err := gosqlite.OpenFile(path)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)`)
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	db, err = gosqlite.OpenFile(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`INSERT INTO t (id) VALUES (1)`); err != nil {
+		t.Fatalf("insert after reopen: %v", err)
+	}
+	var created string
+	if err := db.QueryRow(`SELECT created_at FROM t WHERE id = 1`).Scan(&created); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if created == "" {
+		t.Fatal("created_at is empty, want CURRENT_TIMESTAMP value")
+	}
+	_ = os.Remove(path)
+}
+
+// Integer affinity converts a REAL only when the conversion is lossless;
+// DEFAULT 1.5 on an INTEGER column stays 1.5, like real SQLite.
+func TestFractionalDefaultKeepsReal(t *testing.T) {
+	db := openTest(t)
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, x INTEGER DEFAULT 1.5)`)
+	mustExec(t, db, `INSERT INTO t (id) VALUES (1)`)
+
+	var x any
+	if err := db.QueryRow(`SELECT x FROM t WHERE id = 1`).Scan(&x); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	f, ok := x.(float64)
+	if !ok || f != 1.5 {
+		t.Fatalf("x = %T %v, want float64 1.5", x, x)
+	}
+}
+
+// A partial unique index only constrains rows matching its WHERE predicate:
+// creation must skip non-matching duplicates, and enforcement must apply
+// only to rows the predicate selects.
+func TestPartialUniqueIndexPredicate(t *testing.T) {
+	db := openTest(t)
+	mustExec(t, db, `CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT, active INTEGER)`)
+	mustExec(t, db, `INSERT INTO t VALUES (1, 'dup', 0), (2, 'dup', 0)`)
+
+	if _, err := db.Exec(`CREATE UNIQUE INDEX active_v ON t(v) WHERE active = 1`); err != nil {
+		t.Fatalf("partial unique index rejected over non-matching duplicates: %v", err)
+	}
+	// Inactive duplicates remain insertable.
+	mustExec(t, db, `INSERT INTO t VALUES (3, 'dup', 0)`)
+	// Active values are constrained.
+	mustExec(t, db, `INSERT INTO t VALUES (4, 'live', 1)`)
+	if _, err := db.Exec(`INSERT INTO t VALUES (5, 'live', 1)`); err == nil {
+		t.Fatal("duplicate active row accepted, want UNIQUE failure")
+	}
+}


### PR DESCRIPTION
A multi-model post-merge review (Claude + GLM + Sol via omp) of everything merged 2026-07-18/19 (`a1eb9c51..610bebbe`) found ten confirmed bugs — every one reproduced in isolation before fixing, and every fix landed test-first with the failing test in the same commit.

## Commits → findings

- **8f06a042 fix(sqlite)** — six engine bugs, all in the pure-Go SQLite work from #106/#117:
  1. failed statement inside an explicit transaction destroyed ROLLBACK state (pre-BEGIN rows survived);
  2. multi-row `UPDATE` committed duplicate `UNIQUE` values;
  3. `UPDATE` never refreshed secondary indexes (index write sat in an error branch; stale entries matched old values);
  4. `DEFAULT CURRENT_TIMESTAMP` lost on file reopen → `NOT NULL` failures (plus legacy-file default loading hardened: empty-string and raw-text defaults survive);
  5. INTEGER affinity truncated `DEFAULT 1.5` → `1` (now lossless-only, per sqlite.org);
  6. partial unique index `WHERE` predicates ignored (now honored at create/insert/update; partial indexes excluded from scan planning).
- **609fcae1 fix(queue)** — two scheduler-fatal bugs from #95: non-UTC cron schedules errored on their first tick and killed `Start` for every schedule (cron now evaluates in the registration IANA zone, persisted via an idempotent `tz` column; `Register()` stays UTC so existing schedules keep their fire times and no replica-dependent `"Local"` is ever stored); cadence changes stranded the watermark with the same fatal error (now self-heals through the fenced CAS). A genuinely-corrupt schedule is logged and skipped, not fatal. Postgres path covered against a real container.
- **84b0e167 fix(outbox)** — legacy mattn space-separated timestamps vs pure-driver RFC3339 compared lexicographically in SQL, so active future leases were reclaimed (double delivery, reproduced live). The relay normalizes legacy values at start (idempotent, sqlite-only); the atomic claim UPDATE is unchanged.
- **389b314b fix(auth)** — `RequireAPIScopes`/`RequireScope` 403s were nested-JSON-in-text/plain, rendering as `api: 403: [object Object]` in the generated JS SDK; both now emit the canonical flat `{"error","success","code"}` envelope (the `code` field is additive on all battery/auth errors).
- **20b592f3 chore** — CHANGELOG (Unreleased) + two nits from the review (split comment in `build.go`, blueprint-centric lede in the site docs catalog).

## Verification

- `./scripts/test-all.sh` exit 0 (Docker up: Postgres testcontainers ran; includes chromedp + kiln/integration).
- `go test -race` on sqlite, battery/queue, framework/outbox — pass.
- `gofmt -l` clean repo-wide; `go vet` clean on all touched packages; `scripts/coverage-floors.sh` holds.
- All nine original isolated repros re-run against the fixed tree: none reproduce.

Clean areas from the same review (no changes needed): #114 v0.36.0 auth/crud (0 findings), #107 strict filters, #110 presence authz, #105 MCP nav, and the #113/#109/#111 docs merges (0 findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)