### PR TITLE
ci: pre-push gate skips pushes that only delete branches

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -22,6 +22,28 @@ pass() { printf "  ${GREEN}✓${NC} %s\n" "$1"; }
 warn() { printf "  ${YELLOW}!${NC} %s\n" "$1"; }
 fail() { printf "  ${RED}✗${NC} %s\n" "$1"; }
 
+# Git feeds ref updates on stdin: "<local ref> <local sha> <remote ref>
+# <remote sha>" per line, with an all-zero local sha for a deletion. A
+# push that ONLY deletes remote branches ships no code, so there is
+# nothing for the gate to test — skip it. Any line with a real local
+# sha keeps the full gate.
+ZERO=0000000000000000000000000000000000000000
+only_deletions=""
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
+  [ -z "$local_sha" ] && continue
+  if [ "$local_sha" = "$ZERO" ]; then
+    only_deletions="${only_deletions:-yes}"
+  else
+    only_deletions="no"
+  fi
+done
+if [ "$only_deletions" = "yes" ]; then
+  echo ""
+  echo "  Pre-push gate: branch deletion only — nothing to test, skipping."
+  echo ""
+  exit 0
+fi
+
 # Git runs hooks with GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE (etc.)
 # pointing at THIS repo; they inherit into the test sweep, whose tests
 # shell out to `git init` / `git status` in temp fixtures and would then


### PR DESCRIPTION
A deletion push ships no code, but the pre-push hook ran the full 10–20 min test sweep anyway — it never read the ref list git feeds on stdin, so post-merge branch cleanup paid the whole gate for nothing (and tempted hook bypasses, which are banned).

Now the hook reads stdin first: if every ref update has the all-zero local sha (pure deletions), it prints a skip notice and exits 0; any line with a real sha runs the unchanged full gate. Mixed pushes (code + deletion) still gate.

Verified: stdin logic unit-tested for deletion-only / mixed / real-sha cases, `sh -n` clean, and this branch itself was committed and pushed with all hooks live (full sweep + floors + govulncheck green, Docker up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)