### PR TITLE
Close the audit backlog (#135), fix #138/#139/#141, first pass at #136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,128 @@ All notable changes to GoFastr. Follows
 calendar versions (`YYYY-MM-DD` per substantive release until the API
 stabilises). Breaking changes are clearly marked with **BREAKING**.
 
+## [0.46.0] - 2026-07-26
+
+The v0.43.0 audit backlog (#135) closed, four filed issues fixed (#136,
+#138, #139, #141), and the first audit of surfaces the previous passes had
+never opened.
+
+Same shape as 0.45.0: **guard drift** — a check one path has and its
+sibling skips. Three of the findings below are the *same* property
+(a schema is a disclosure even when the data behind it is refused) showing
+up on three different surfaces.
+
+### Security
+
+- **`tools/list` no longer hands the schema to callers who cannot call
+  the tool.** `mcp.Gated` wraps a *handler*, so it only ever reached
+  `tools/call` — an unauthenticated POST came back with every tool's
+  `inputSchema`, and for entity CRUD tools those are built from live
+  entity definitions: every entity name, every non-`Hidden` field, its
+  type and full enum set. New `mcp.WithToolGate` registration option runs
+  the gate on both `tools/call` and `tools/list`; the MCP control tools
+  and `log_set_level` use it. **BREAKING** for anyone reading a gated
+  tool's schema anonymously.
+- **`framework.WithMCPGate` + `framework.MCPRequireUser`** close the whole
+  `/mcp` data surface (`tools/list`, `tools/call`, `resources/list`,
+  `resources/read`) in one call. `initialize` and `ping` stay open by
+  design — they carry only the protocol version, capability booleans and
+  the server name.
+- **`Endpoint.MCPHandler` twins require an authenticated caller by
+  default. BREAKING.** An `Endpoint` has two front doors for one
+  operation: `Handler` inherits the route's middleware chain, `MCPHandler`
+  does not — so an endpoint behind `auth.RequireRole("editor")` was
+  role-checked over HTTP and ungated over MCP. New `Endpoint.MCPGate` for
+  something stricter, `Endpoint.MCPPublic: true` to opt out.
+- **`log_set_level` is gated.** It mutates the running app's
+  observability — an anonymous caller could flip it to DEBUG, or to ERROR
+  to go quiet before doing something else. Dev-implied registration stays
+  ungated (the dev loop has no auth to satisfy; its exposure is bounded by
+  the loopback bind instead), but an app that set `AllowMCPMutation`
+  itself keeps the gate even under `gofastr dev`.
+- **`/{table}/llm.md` runs the entity's full scope chain.** It checked for
+  a session but not for the entity's declared permission, so an
+  authenticated caller with no `orders:read` grant got 403 on the rows and
+  200 on the schema. **BREAKING** for a caller that has a session but not
+  the read permission.
+- **The plugin iframe sandbox sanitizer is an allow-list on both sides.**
+  v0.45.0 flipped the Go half; `host/pluginhost.js` — the sink that
+  actually sets the attribute — was still a one-token deny-list, so
+  `allow-popups-to-escape-sandbox`, `allow-top-navigation` and
+  `allow-downloads` all passed it. **BREAKING** for a manifest asking for
+  those.
+- **`Manifest.Entry` must be a same-origin absolute path.** It was an
+  unvalidated arbitrary URL, and the opaque-origin guarantee has two
+  carriers — the sandbox attribute and the `CSP: sandbox` header
+  `AssetServer` emits for assets *it* serves. A cross-origin entry escapes
+  the second entirely. Dual-enforced in Go and in the JS broker.
+- **A blueprint entity `table:` must be an identifier.** It reaches two
+  sinks that neither re-escape nor re-validate it: the generated typed
+  client emits it into Go string literals, and the runtime interpolates it
+  into DDL. `name:` was already constrained to a Go identifier; `table:`
+  was the way around that. Found by a property sweep over every IR field
+  the emitters read — the tail of the injection class from #134.
+- **Kiln enforces its semantic guards during replay, not only at the tool
+  call. BREAKING journal format.** The journal is replayed at boot and by
+  `kiln freeze`; it recorded *what* was deleted but not that anyone
+  approved it, so a hand-authored `.kiln.session.jsonl` installed world
+  state the API refuses. Destructive entries now carry the authorizing
+  `plan_id` and replay re-checks approval, target match and single-use.
+  Plan consumption moved from a per-process map — which replay never
+  rebuilt, so a restart re-armed every spent approval — onto the session.
+- **CORS's wildcard writer forwards `Flush` and `Hijack`.** Every other
+  wrapper in `core/middleware` does, with a test pinning it;
+  `stripCredsWriter` did not, so behind `AllowedOrigins: ["*"]` the SSE
+  bus lost its `Flusher` (a hard failure — the SSE constructor
+  type-asserts it) and WebSocket upgrade lost its `Hijacker`. `Flush` now
+  strips the credentials header too, and `Vary` is appended rather than
+  clobbering an upstream `Vary: Accept-Encoding`.
+- **`core-ui/urlsafe` is now genuinely the single URL guard.** v0.45.0
+  claimed this and delivered one call site. The remaining six —
+  `framework/ui`, `framework/uihost`, `framework/crud`,
+  `framework/experimental/apiversions`, and the `tree` / `nestedlist` /
+  `breadcrumbs` pattern builders — now call it, `framework/ui` splits
+  anchor vs subresource policy (`mailto:` on an `<img src>` is dropped),
+  and a `repolint` rule fails the build if a seventh copy appears.
+
+### Fixed
+
+- **`WithAPIPrefix` applies to `EntityConfig.Endpoints`** (#139). A
+  relative `Endpoint.Path` is documented as resolving against the entity
+  table path, but the prefix was applied only to the generated CRUD
+  routes — so an app using both had its API split across two prefixes with
+  no warning. Absolute paths still bypass the prefix. **BREAKING** for an
+  app relying on the unprefixed mount.
+- **`webhook.NewSQLStore` works on Postgres** (#141). Both stores
+  dialect-switched their timestamp columns but hardcoded `payload BLOB`,
+  and Postgres has no `BLOB` type — so the outbound webhook battery could
+  not be constructed against the dialect it is most likely deployed on.
+- **`queue.DBQueue.Close()` returns when `Start` was never called**
+  (#141). It waited on a channel only `Start`'s goroutine closes, so a
+  failed startup sequence hung on shutdown. `Start` is now idempotent and
+  refuses to spawn workers after `Close`.
+- **Grouped entities' MCP tools reach their routes** (#136). `App.Entity`
+  sets `crudHandler.BasePath` from the API prefix; `GroupEntity` never
+  did, so a grouped entity's tools dispatched to `/widgets` while the
+  routes lived at `/api/widgets`. Fail-closed (a 404), but the tools were
+  simply broken for every grouped entity.
+- **`RouteGroup.Prefix()` composes nested prefixes.** It returned only its
+  own segment, so `app.Group("/api").Group("/v2")` reported `/v2` — and
+  both the route-collision pre-flight and the MCP dispatch above were
+  checking a path that does not exist.
+
+### Added
+
+- **`upload.RangeGetter`** (#138) — an optional capability a `Storage`
+  backend implements to expose seekable reads, so `upload.ServeHandler`
+  answers `Range:` requests with a 206 instead of the whole body. Local
+  and memory backends implement it; S3 declines (a network backend would
+  have to buffer the whole object to `Seek` — use `WithPresigner`).
+  `Storage.Get` keeps its narrow `io.ReadCloser` contract.
+- **`mcp.Server.ListToolsFor(ctx)`** — the caller-filtered listing.
+  `ListTools()` stays unfiltered for in-process introspection and is
+  documented as never safe to serve to a remote caller.
+
 ## [0.45.0] - 2026-07-25
 
 A full security pass — two-profile audit, 30 findings, every one fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ Honest expectations:
 
 ## Supported versions
 
-GoFastr is pre-1.0. Only the **latest minor release** (currently `0.40.x`)
+GoFastr is pre-1.0. Only the **latest minor release** (currently `0.46.x`)
 receives security fixes. Older `0.x` lines are not patched — upgrade to the
 latest release to stay supported.
 

--- a/battery/log/log.go
+++ b/battery/log/log.go
@@ -107,6 +107,14 @@ type Plugin struct {
 	// auto-installed. Populated during Init so the log_filter tool can
 	// tail the file for historical entries beyond the ring window.
 	resolvedFilePath string
+
+	// mutationDevImplied records that log_set_level exists only because
+	// `gofastr dev` turned mutation on, not because the host asked. Those
+	// tools are NOT auth-gated: the dev loop has no auth configured at all,
+	// so a gate would only lock the developer's agent out of its own app.
+	// Dev exposure is bounded on the other axis instead — the listener must
+	// be loopback (framework's guardDevMCPBind).
+	mutationDevImplied bool
 }
 
 // New constructs an unregistered plugin. Call App.RegisterPlugin to wire.
@@ -179,6 +187,7 @@ func (p *Plugin) Init(app *framework.App) error {
 	// explicit Config fields stay the only path there.
 	if dev.DevMCPEnabled() {
 		cfg.EnableMCP = true
+		p.mutationDevImplied = !cfg.AllowMCPMutation
 		cfg.AllowMCPMutation = true
 	}
 

--- a/battery/log/mcp.go
+++ b/battery/log/mcp.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DonaldMurillo/gofastr/core/mcp"
 	"github.com/DonaldMurillo/gofastr/framework"
 )
 
@@ -21,6 +22,10 @@ func (p *Plugin) registerMCPTools(app *framework.App) error {
 		description string
 		schema      map[string]any
 		handler     func(ctx context.Context, params map[string]any) (any, error)
+		// gate, when set, is a per-caller precondition. It also decides
+		// whether the tool is visible in tools/list, so a caller who cannot
+		// invoke it does not learn it exists.
+		gate func(ctx context.Context) error
 	}{
 		{
 			name:        "log_recent",
@@ -65,6 +70,7 @@ func (p *Plugin) registerMCPTools(app *framework.App) error {
 			description string
 			schema      map[string]any
 			handler     func(ctx context.Context, params map[string]any) (any, error)
+			gate        func(ctx context.Context) error
 		}{
 			name:        "log_set_level",
 			description: "Change the minimum log level emitted by the fan-out handler. Useful for temporarily switching to DEBUG during an investigation, then restoring the previous level (returned in `.previous_level`). Returns the previous level. Only registered when log.Config.AllowMCPMutation is true.",
@@ -76,10 +82,20 @@ func (p *Plugin) registerMCPTools(app *framework.App) error {
 				},
 			},
 			handler: p.toolSetLevel,
+			// This tool mutates the running app's observability: an
+			// unauthenticated caller could flip the app to DEBUG (log
+			// volume, and whatever DEBUG lines carry) or to ERROR to go
+			// quiet before doing something else. It registers directly on
+			// the MCP server, so no route middleware ever runs for it.
+			gate: p.setLevelGate(),
 		})
 	}
 	for _, t := range tools {
-		if err := app.MCP.RegisterTool(t.name, t.description, t.schema, t.handler); err != nil {
+		var opts []mcp.ToolOption
+		if t.gate != nil {
+			opts = append(opts, mcp.WithToolGate(t.gate))
+		}
+		if err := app.MCP.RegisterTool(t.name, t.description, t.schema, t.handler, opts...); err != nil {
 			return fmt.Errorf("register %s: %w", t.name, err)
 		}
 	}
@@ -336,4 +352,22 @@ func levelAtLeast(entry map[string]any, min slog.Level) bool {
 		return false
 	}
 	return lv >= min
+}
+
+// setLevelGate returns the precondition log_set_level runs behind, or nil
+// when the tool is dev-implied.
+//
+// The tool mutates the running app's observability: an unauthenticated caller
+// could flip it to DEBUG (log volume, and whatever DEBUG lines carry) or to
+// ERROR to go quiet before doing something else. It registers directly on the
+// MCP server, so no route middleware ever runs for it.
+//
+// Under `gofastr dev` there is no auth to satisfy, so a gate would only lock
+// the developer's own agent out — the same call framework's control tools
+// make. Dev exposure is bounded by the loopback bind instead.
+func (p *Plugin) setLevelGate() func(ctx context.Context) error {
+	if p.mutationDevImplied {
+		return nil
+	}
+	return framework.MCPRequireUser()
 }

--- a/battery/log/mcp_gate_security_test.go
+++ b/battery/log/mcp_gate_security_test.go
@@ -1,0 +1,110 @@
+package log
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/mcp"
+	"github.com/DonaldMurillo/gofastr/framework"
+)
+
+// log_set_level registers straight onto the MCP server, so no route
+// middleware ever runs for it. An unauthenticated caller could flip the app to
+// DEBUG — raising log volume and whatever DEBUG lines carry — or to ERROR to
+// go quiet before doing something else.
+func TestSetLevelRefusesUnauthenticatedCaller(t *testing.T) {
+	app, p := newLogMCPApp(t)
+	before := p.level.Level()
+
+	resp := app.MCP.HandleRequest(context.Background(), mcp.Request{
+		JSONRPC: "2.0", ID: 1, Method: "tools/call",
+		Params: json.RawMessage(`{"name":"log_set_level","arguments":{"level":"DEBUG"}}`),
+	})
+	if resp.Error == nil {
+		t.Fatal("SECURITY: [authz] log_set_level ran for an unauthenticated caller")
+	}
+	// The refusal must be the gate, not an incidental handler error — and
+	// the level must be untouched.
+	if !strings.Contains(resp.Error.Message, "authenticated caller") {
+		t.Errorf("refused for the wrong reason: %q", resp.Error.Message)
+	}
+	if got := p.level.Level(); got != before {
+		t.Errorf("SECURITY: [authz] level changed to %v despite the refusal", got)
+	}
+}
+
+// The schema is the disclosure, not just the call — a stranger should not
+// learn the app's log level is remotely settable.
+func TestSetLevelHiddenFromUnauthenticatedList(t *testing.T) {
+	app, _ := newLogMCPApp(t)
+
+	resp := app.MCP.HandleRequest(context.Background(), mcp.Request{
+		JSONRPC: "2.0", ID: 1, Method: "tools/list",
+	})
+	blob, _ := json.Marshal(resp.Result)
+	if strings.Contains(string(blob), "log_set_level") {
+		t.Error("SECURITY: [disclosure] log_set_level listed to an anonymous caller")
+	}
+	// The read-only tools stay listed: gating discovery must not blank the
+	// whole surface.
+	if !strings.Contains(string(blob), "log_recent") {
+		t.Error("read-only log tools vanished from the listing")
+	}
+}
+
+// `gofastr dev` turns mutation on with no auth configured at all, so gating
+// the dev-implied tool would only lock the developer's own agent out of its
+// own app. Dev exposure is bounded by the loopback bind instead.
+func TestDevImpliedSetLevelStaysUngated(t *testing.T) {
+	t.Setenv("GOFASTR_DEV", "1")
+	t.Setenv("GOFASTR_ENV", "")
+	app := framework.NewApp(framework.WithConfig(framework.AppConfig{Name: "test"}))
+	app.RegisterPlugin(New(Config{Sinks: []Sink{discardSink{}}}))
+	if err := app.InitPlugins(); err != nil {
+		t.Fatalf("InitPlugins: %v", err)
+	}
+
+	resp := app.MCP.HandleRequest(context.Background(), mcp.Request{
+		JSONRPC: "2.0", ID: 1, Method: "tools/call",
+		Params: json.RawMessage(`{"name":"log_set_level","arguments":{"level":"DEBUG"}}`),
+	})
+	if resp.Error != nil {
+		t.Fatalf("dev-implied log_set_level refused the local agent: %v", resp.Error)
+	}
+}
+
+// An app that asked for mutation explicitly keeps the gate even under dev —
+// the opt-out is "dev turned this on for me", not "dev is running".
+func TestExplicitMutationStaysGatedUnderDev(t *testing.T) {
+	t.Setenv("GOFASTR_DEV", "1")
+	t.Setenv("GOFASTR_ENV", "")
+	app := framework.NewApp(framework.WithConfig(framework.AppConfig{Name: "test"}))
+	app.RegisterPlugin(New(Config{Sinks: []Sink{discardSink{}}, EnableMCP: true, AllowMCPMutation: true}))
+	if err := app.InitPlugins(); err != nil {
+		t.Fatalf("InitPlugins: %v", err)
+	}
+
+	resp := app.MCP.HandleRequest(context.Background(), mcp.Request{
+		JSONRPC: "2.0", ID: 1, Method: "tools/call",
+		Params: json.RawMessage(`{"name":"log_set_level","arguments":{"level":"DEBUG"}}`),
+	})
+	if resp.Error == nil {
+		t.Fatal("SECURITY: [authz] explicitly-enabled log_set_level ran unauthenticated under dev")
+	}
+}
+
+func newLogMCPApp(t *testing.T) (*framework.App, *Plugin) {
+	t.Helper()
+	t.Setenv("GOFASTR_DEV", "")
+	t.Setenv("GOFASTR_DEV_MCP", "0")
+	app := framework.NewApp(framework.WithConfig(framework.AppConfig{Name: "test"}))
+	p := New(Config{Sinks: []Sink{discardSink{}}, EnableMCP: true, AllowMCPMutation: true, Level: slog.LevelInfo})
+	app.RegisterPlugin(p)
+	if err := app.InitPlugins(); err != nil {
+		t.Fatalf("InitPlugins: %v", err)
+	}
+	return app, p
+}

--- a/battery/log/mcp_test.go
+++ b/battery/log/mcp_test.go
@@ -2,6 +2,7 @@ package log_test
 
 import (
 	"context"
+	"github.com/DonaldMurillo/gofastr/core/handler"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -164,8 +165,11 @@ func TestMCPSetLevelMutatesThreshold(t *testing.T) {
 	// At default Level=INFO, a DEBUG line is suppressed.
 	app.Logger().Debug("invisible-at-info")
 
-	// Switch to DEBUG via the tool.
-	result, err := app.MCP.CallTool(context.Background(), "log_set_level", map[string]any{"level": "DEBUG"})
+	// Switch to DEBUG via the tool. log_set_level mutates the running app,
+	// so it runs behind an authenticated-caller gate — the tool call carries
+	// the identity the route middleware would have resolved.
+	ctx := handler.SetUser(context.Background(), "u1")
+	result, err := app.MCP.CallTool(ctx, "log_set_level", map[string]any{"level": "DEBUG"})
 	if err != nil {
 		t.Fatalf("CallTool: %v", err)
 	}

--- a/battery/queue/close_test.go
+++ b/battery/queue/close_test.go
@@ -1,0 +1,67 @@
+package queue
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Close waits on q.stopped, and only Start's goroutine ever closes it. A queue
+// that was constructed and abandoned — a startup sequence that failed after
+// NewDBQueue, a test that only exercised Enqueue — therefore hung forever on
+// shutdown instead of exiting.
+func TestCloseWithoutStartReturns(t *testing.T) {
+	_, q := openDBQueue(t, 1)
+	done := make(chan error, 1)
+	go func() { done <- q.Close() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close blocked forever on a queue that was never started")
+	}
+}
+
+// Close is documented as safe to call twice; the never-started path must keep
+// that promise rather than closing an already-closed channel.
+func TestCloseWithoutStartIsIdempotent(t *testing.T) {
+	_, q := openDBQueue(t, 1)
+	for i := 0; i < 2; i++ {
+		done := make(chan error, 1)
+		go func() { done <- q.Close() }()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("Close #%d: %v", i+1, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Close #%d blocked", i+1)
+		}
+	}
+}
+
+// Close must still join the workers when Start did run — otherwise fixing the
+// never-started hang would turn shutdown into a goroutine leak.
+func TestCloseAfterStartStillJoinsWorkers(t *testing.T) {
+	_, q := openDBQueue(t, 1)
+	q.Start(context.Background())
+	// Let the pool actually come up so Close has something to join.
+	time.Sleep(50 * time.Millisecond)
+	done := make(chan error, 1)
+	go func() { done <- q.Close() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close did not join a started worker pool")
+	}
+	select {
+	case <-q.stopped:
+	default:
+		t.Fatal("Close returned before the worker pool finished")
+	}
+}

--- a/battery/queue/db.go
+++ b/battery/queue/db.go
@@ -34,6 +34,13 @@ type DBQueue struct {
 	stop           chan struct{}
 	stopped        chan struct{}
 
+	// started records whether Start launched the supervisor goroutine — the
+	// only thing that ever closes stopped. Close waits on stopped, so without
+	// this flag a queue that was constructed and abandoned (a startup sequence
+	// that failed after NewDBQueue, a test that only enqueued) blocked forever
+	// on shutdown. Guarded by mu.
+	started bool
+
 	// mu guards post-construction mutation of handlers, lease, and gate so
 	// that RegisterHandler/SetLeaseTimeout/SetGate can race safely against
 	// the worker loop's reads (workerLoop, eligibleWhere).
@@ -670,11 +677,20 @@ var (
 
 // Close stops worker goroutines started by Start. Idempotent.
 func (q *DBQueue) Close() error {
+	q.mu.Lock()
 	select {
 	case <-q.stop:
+		q.mu.Unlock()
 		return nil
 	default:
 		close(q.stop)
+	}
+	started := q.started
+	q.mu.Unlock()
+	if !started {
+		// Nothing will ever close q.stopped. Signalling stop is the whole
+		// contract for a queue that never ran.
+		return nil
 	}
 	<-q.stopped
 	return nil
@@ -687,6 +703,23 @@ func (q *DBQueue) Close() error {
 // handler-recover guard) is respawned so the pool can never be permanently
 // drained by a poison message.
 func (q *DBQueue) Start(ctx context.Context) {
+	q.mu.Lock()
+	if q.started {
+		// A second pool would race to close q.stopped and panic.
+		q.mu.Unlock()
+		return
+	}
+	select {
+	case <-q.stop:
+		// Close already ran and has already returned. Spawning workers now
+		// would leak goroutines nobody joins.
+		q.mu.Unlock()
+		return
+	default:
+	}
+	q.started = true
+	q.mu.Unlock()
+
 	// Count total workers so the done channel and join loop match.
 	laneCount := 0
 	for _, n := range q.laneWorkers {

--- a/battery/storage/local.go
+++ b/battery/storage/local.go
@@ -164,6 +164,20 @@ func (ls *LocalStorage) Delete(ctx context.Context, key string) error {
 
 // Get opens the file identified by key and returns a ReadCloser for its contents.
 func (ls *LocalStorage) Get(ctx context.Context, key string) (io.ReadCloser, error) {
+	return ls.open(ctx, key)
+}
+
+// GetRange implements [upload.RangeGetter], exposing the seekability the
+// local backend already has: Get opens an *os.File and then discards Seek
+// through the io.ReadCloser return type. Key validation runs through the same
+// fullPath call, not a parallel one.
+func (ls *LocalStorage) GetRange(ctx context.Context, key string) (io.ReadSeekCloser, error) {
+	return ls.open(ctx, key)
+}
+
+// open is the single enforcement point shared by Get and GetRange, so the two
+// cannot drift on key validation.
+func (ls *LocalStorage) open(ctx context.Context, key string) (*os.File, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/battery/storage/memory.go
+++ b/battery/storage/memory.go
@@ -83,6 +83,27 @@ func (ms *MemoryStorage) Get(_ context.Context, key string) (io.ReadCloser, erro
 	return io.NopCloser(bytes.NewReader(data)), nil
 }
 
+// GetRange implements [upload.RangeGetter]. The bytes are already in memory,
+// so a *bytes.Reader satisfies Seek for free — the wrapper only supplies the
+// no-op Close.
+func (ms *MemoryStorage) GetRange(_ context.Context, key string) (io.ReadSeekCloser, error) {
+	ms.mu.RLock()
+	data, ok := ms.files[key]
+	ms.mu.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("storage: key %q not found", key)
+	}
+
+	return nopSeekCloser{bytes.NewReader(data)}, nil
+}
+
+// nopSeekCloser adds a no-op Close to a *bytes.Reader, the in-memory analogue
+// of [io.NopCloser] for a seekable source.
+type nopSeekCloser struct{ *bytes.Reader }
+
+func (nopSeekCloser) Close() error { return nil }
+
 // Exists reports whether a file exists for the given key.
 func (ms *MemoryStorage) Exists(_ context.Context, key string) (bool, error) {
 	ms.mu.RLock()

--- a/battery/storage/range_test.go
+++ b/battery/storage/range_test.go
@@ -1,0 +1,92 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Backends that hold their bytes locally can seek; Storage.Get just erased it
+// behind io.ReadCloser, which is what blocked HTTP range requests.
+func TestLocalAndMemoryServeRanges(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.bin"), []byte("0123456789"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mem := NewMemoryStorage()
+	if err := mem.Save(context.Background(), "f.bin", strings.NewReader("0123456789")); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, s := range map[string]Storage{
+		"local":  NewLocalStorage(dir),
+		"memory": mem,
+	} {
+		t.Run(name, func(t *testing.T) {
+			rg, ok := s.(RangeGetter)
+			if !ok {
+				t.Fatalf("%s does not implement RangeGetter", name)
+			}
+			rs, err := rg.GetRange(context.Background(), "f.bin")
+			if err != nil {
+				t.Fatalf("GetRange: %v", err)
+			}
+			defer rs.Close()
+			if _, err := rs.Seek(3, io.SeekStart); err != nil {
+				t.Fatalf("Seek: %v", err)
+			}
+			got, err := io.ReadAll(rs)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			if string(got) != "3456789" {
+				t.Errorf("after Seek(3) read %q, want %q", got, "3456789")
+			}
+		})
+	}
+}
+
+// GetRange must run the same key validation as Get. A capability that skipped
+// it would be a path-traversal hole with a performance justification.
+func TestGetRangeRejectsTraversal(t *testing.T) {
+	ls := NewLocalStorage(t.TempDir())
+	if _, err := ls.GetRange(context.Background(), "../../etc/passwd"); err == nil {
+		t.Fatal("SECURITY: LocalStorage.GetRange accepted a traversal key")
+	}
+	mem := NewMemoryStorage()
+	if _, err := mem.GetRange(context.Background(), "nope"); err == nil {
+		t.Fatal("MemoryStorage.GetRange returned no error for a missing key")
+	}
+}
+
+// A backend that declines the capability must stay a valid Storage — the
+// point of a capability interface is that not implementing it is legal.
+func TestS3DeclinesRangeGetter(t *testing.T) {
+	var s Storage = NewS3Storage("bucket", "us-east-1")
+	if _, ok := s.(RangeGetter); ok {
+		t.Error("S3Storage claims RangeGetter; a network backend must buffer to seek, so it should decline and let callers presign")
+	}
+}
+
+// The seekable reader must still return the whole object when read from the
+// start — the capability adds resumability, it does not change the bytes.
+func TestGetRangeWholeObjectMatchesGet(t *testing.T) {
+	mem := NewMemoryStorage()
+	want := []byte("the quick brown fox")
+	if err := mem.Save(context.Background(), "k", bytes.NewReader(want)); err != nil {
+		t.Fatal(err)
+	}
+	rs, err := mem.GetRange(context.Background(), "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rs.Close()
+	got, _ := io.ReadAll(rs)
+	if !bytes.Equal(got, want) {
+		t.Errorf("GetRange full read = %q, want %q", got, want)
+	}
+}

--- a/battery/storage/storage.go
+++ b/battery/storage/storage.go
@@ -11,6 +11,13 @@ import (
 // Storage is a re-export of the upload.Storage interface for convenience.
 type Storage = upload.Storage
 
+// RangeGetter is a re-export of [upload.RangeGetter], the optional capability
+// a backend implements to expose seekable reads so HTTP range requests can be
+// answered. LocalStorage and MemoryStorage implement it; S3Storage declines —
+// a network-backed store would have to buffer the whole object to satisfy
+// Seek, and [WithPresigner] lets the transfer bypass the app entirely.
+type RangeGetter = upload.RangeGetter
+
 // StorageType enumerates available storage backend types.
 type StorageType int
 
@@ -78,6 +85,10 @@ var (
 	_ Storage = (*LocalStorage)(nil)
 	_ Storage = (*MemoryStorage)(nil)
 	_ Storage = (*S3Storage)(nil)
+
+	// Backends that can serve byte ranges. S3Storage is deliberately absent.
+	_ RangeGetter = (*LocalStorage)(nil)
+	_ RangeGetter = (*MemoryStorage)(nil)
 )
 
 // KeyValidator validates storage keys to prevent path traversal and other attacks.

--- a/battery/webhook/inbound_sql.go
+++ b/battery/webhook/inbound_sql.go
@@ -20,7 +20,7 @@ import (
 //	    source      TEXT NOT NULL,
 //	    dedupe_key  TEXT NOT NULL DEFAULT '',  -- '' means no dedupe
 //	    headers     TEXT NOT NULL DEFAULT '{}', -- JSON object, allowlisted subset
-//	    payload     BLOB NOT NULL,
+//	    payload     BLOB NOT NULL,       -- BYTEA on postgres
 //	    status      TEXT NOT NULL,
 //	    attempts    INTEGER NOT NULL DEFAULT 0,
 //	    last_error  TEXT NOT NULL DEFAULT '',
@@ -80,9 +80,10 @@ func NewSQLInboundStore(db *sql.DB, opts ...InboundSQLOption) (*SQLInboundStore,
 }
 
 func (s *SQLInboundStore) ensureTable() error {
-	ts := "DATETIME"
+	ts, blob := "DATETIME", "BLOB"
 	if s.dialect == "postgres" {
-		ts = "TIMESTAMPTZ"
+		// See SQLStore.ensureTables: Postgres spells a byte array BYTEA.
+		ts, blob = "TIMESTAMPTZ", "BYTEA"
 	}
 	stmts := []string{
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
@@ -90,13 +91,13 @@ func (s *SQLInboundStore) ensureTable() error {
 			source      TEXT NOT NULL,
 			dedupe_key  TEXT NOT NULL DEFAULT '',
 			headers     TEXT NOT NULL DEFAULT '{}',
-			payload     BLOB NOT NULL,
+			payload     %s NOT NULL,
 			status      TEXT NOT NULL,
 			attempts    INTEGER NOT NULL DEFAULT 0,
 			last_error  TEXT NOT NULL DEFAULT '',
 			received_at %s NOT NULL,
 			updated_at  %s NOT NULL
-		)`, s.table, ts, ts),
+		)`, s.table, blob, ts, ts),
 		// Lookup indexes — no unique constraint (see type doc).
 		fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s_dedupe_idx ON %s (source, dedupe_key)",
 			s.table, s.table),

--- a/battery/webhook/postgres_ddl_test.go
+++ b/battery/webhook/postgres_ddl_test.go
@@ -1,0 +1,73 @@
+package webhook
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DonaldMurillo/gofastr/internal/pgtest"
+)
+
+// The outbound and inbound stores dialect-switch their timestamp columns but
+// hardcoded the payload column as BLOB. Postgres has no BLOB type, so
+// NewSQLStore/NewSQLInboundStore failed at ensureTables against every Postgres
+// app — the battery was unusable on the dialect it is most likely deployed on.
+//
+// These construct against a real server rather than asserting on the DDL
+// string: the property is "the emitted schema is one Postgres accepts", and
+// only Postgres can decide that.
+
+func TestSQLStoreConstructsOnPostgres(t *testing.T) {
+	db := pgtest.DB(t)
+	codec, err := NewAESGCMSecretCodec(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("codec: %v", err)
+	}
+	store, err := NewSQLStore(db, WithSQLSecretCodec(codec))
+	if err != nil {
+		t.Fatalf("NewSQLStore on Postgres: %v", err)
+	}
+
+	ctx := context.Background()
+	sub := Subscriber{ID: "s1", URL: "https://example.com/hook", Secret: "shh", Events: []string{"a"}, Active: true, Created: time.Now().UTC()}
+	if err := store.AddSubscriber(ctx, sub); err != nil {
+		t.Fatalf("AddSubscriber: %v", err)
+	}
+	// The payload column is the one that was mistyped — prove bytes survive a
+	// round-trip, not just that the CREATE TABLE parsed.
+	del := Delivery{ID: "d1", SubscriberID: "s1", Event: "a", Payload: []byte(`{"k":"v"}`), Status: "pending", CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}
+	if err := store.AddDelivery(ctx, del); err != nil {
+		t.Fatalf("AddDelivery: %v", err)
+	}
+	got, err := store.ListDeliveries(ctx, "s1", 10)
+	if err != nil {
+		t.Fatalf("ListDeliveries: %v", err)
+	}
+	if len(got) != 1 || string(got[0].Payload) != `{"k":"v"}` {
+		t.Fatalf("payload did not round-trip: %+v", got)
+	}
+}
+
+func TestSQLInboundStoreConstructsOnPostgres(t *testing.T) {
+	db := pgtest.DB(t)
+	store, err := NewSQLInboundStore(db)
+	if err != nil {
+		t.Fatalf("NewSQLInboundStore on Postgres: %v", err)
+	}
+	ctx := context.Background()
+	env := InboundEnvelope{
+		ID: "e1", Source: "stripe", DedupeKey: "evt_1",
+		Payload: []byte(`{"id":"evt_1"}`), Status: "pending",
+		ReceivedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	}
+	if err := store.AddEnvelope(ctx, env); err != nil {
+		t.Fatalf("AddEnvelope: %v", err)
+	}
+	got, err := store.GetEnvelope(ctx, "e1")
+	if err != nil {
+		t.Fatalf("GetEnvelope: %v", err)
+	}
+	if got == nil || string(got.Payload) != `{"id":"evt_1"}` {
+		t.Fatalf("payload did not round-trip: %+v", got)
+	}
+}

--- a/battery/webhook/sql.go
+++ b/battery/webhook/sql.go
@@ -32,7 +32,7 @@ import (
 //	    id              TEXT PRIMARY KEY,
 //	    subscriber_id   TEXT NOT NULL,
 //	    event           TEXT NOT NULL,
-//	    payload         BLOB NOT NULL,
+//	    payload         BLOB NOT NULL,           -- BYTEA on postgres
 //	    attempts        INTEGER NOT NULL,
 //	    status          TEXT NOT NULL,
 //	    last_error      TEXT NOT NULL,
@@ -122,9 +122,13 @@ func NewSQLStore(db *sql.DB, opts ...SQLOption) (*SQLStore, error) {
 }
 
 func (s *SQLStore) ensureTables() error {
-	ts := "DATETIME"
+	ts, blob := "DATETIME", "BLOB"
 	if s.dialect == "postgres" {
-		ts = "TIMESTAMPTZ"
+		// Postgres has no BLOB type; the byte-array spelling is BYTEA. The
+		// timestamp column was already switched here, which is what made
+		// leaving the payload column behind a construction-time failure on
+		// every Postgres app rather than a subtle storage difference.
+		ts, blob = "TIMESTAMPTZ", "BYTEA"
 	}
 	stmts := []string{
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
@@ -139,14 +143,14 @@ func (s *SQLStore) ensureTables() error {
 			id              TEXT PRIMARY KEY,
 			subscriber_id   TEXT NOT NULL,
 			event           TEXT NOT NULL,
-			payload         BLOB NOT NULL,
+			payload         %s NOT NULL,
 			attempts        INTEGER NOT NULL,
 			status          TEXT NOT NULL,
 			last_error      TEXT NOT NULL,
 			next_attempt_at %s,
 			created_at      %s NOT NULL,
 			updated_at      %s NOT NULL
-		)`, s.delTable, ts, ts, ts),
+		)`, s.delTable, blob, ts, ts, ts),
 		fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s_due_idx ON %s (status, next_attempt_at)",
 			s.delTable, s.delTable),
 	}

--- a/cmd/gofastr/blueprint.go
+++ b/cmd/gofastr/blueprint.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DonaldMurillo/gofastr/core/query"
 	coreyaml "github.com/DonaldMurillo/gofastr/core/yaml"
 	"github.com/DonaldMurillo/gofastr/framework"
 	fwentity "github.com/DonaldMurillo/gofastr/framework/entity"
@@ -1588,6 +1589,16 @@ func validateBlueprint(bp Blueprint) error {
 		}
 		if !isGoIdentifier(toCamelCase(decl.Name)) {
 			return fmt.Errorf("blueprint: entity %q does not produce a valid Go identifier — the generated code would not compile; rename it to start with a letter (e.g. \"two_fa_tokens\" instead of \"2fa_tokens\")", decl.Name)
+		}
+		// The table name reaches two sinks that neither re-escape nor
+		// re-validate it: the generated typed client emits it into Go string
+		// literals, and the runtime interpolates it into DDL/queries as a
+		// bare SQL identifier. An entity name is already constrained to a Go
+		// identifier above; `table:` was the way around that.
+		if decl.Table != "" {
+			if _, err := query.SafeIdent(decl.Table); err != nil {
+				return fmt.Errorf("blueprint: entity %q table %q must be letters, digits and underscores (it becomes a SQL identifier and is emitted into generated Go)", decl.Name, decl.Table)
+			}
 		}
 		if entityNames[decl.Name] {
 			return fmt.Errorf("blueprint: duplicate entity %q", decl.Name)

--- a/cmd/gofastr/blueprint_emitter_injection_test.go
+++ b/cmd/gofastr/blueprint_emitter_injection_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/framework"
+)
+
+// PR #134 fixed the e2e-test emitters; the entity and screen emitters were
+// never audited for the same class. The property is one sentence:
+//
+//	No blueprint-derived string may terminate the Go literal it is emitted
+//	into.
+//
+// This is not hypothetical developer input. The documented workflow has an
+// AGENT authoring gofastr.yml from natural-language requirements, so every
+// label, title and route in the spec is transcribed text — and `gofastr
+// generate` writes Go the developer then builds and runs.
+//
+// The sweep drives real payloads through every IR field the emitters read and
+// requires each to be either REJECTED at validate time or emitted inertly.
+// Silent acceptance that lands executable Go is the finding.
+
+// goLiteralBreakers are the byte sequences that end a Go string literal. A raw
+// (backtick) literal has no escape mechanism at all, so one backtick closes
+// it; an interpreted literal ends at an unescaped quote and never spans a
+// newline.
+var goLiteralBreakers = []string{
+	"x`+PWN()+`y",
+	`x"+PWN()+"y`,
+	"x\nfunc PWN() {}\nvar y = \"",
+	"x\r\nPWN()",
+}
+
+func TestBlueprintEmittersRejectOrNeutralizeLiteralBreakers(t *testing.T) {
+	for _, payload := range goLiteralBreakers {
+		label := strings.NewReplacer("\n", "N", "\r", "R", "`", "BT", `"`, "Q").Replace(payload)
+		for _, tc := range blueprintPayloadSites(payload) {
+			t.Run(tc.site+"/"+label, func(t *testing.T) {
+				if err := validateBlueprint(tc.bp); err != nil {
+					return // rejected at the boundary — the documented fix
+				}
+				files, err := renderBlueprintFiles(tc.bp)
+				if err != nil {
+					return // the emitter refused; also fine
+				}
+				for _, f := range files {
+					if strings.HasSuffix(f.name, ".go") {
+						assertPayloadStayedData(t, tc.site, f.name, f.content)
+					}
+				}
+			})
+		}
+	}
+}
+
+// assertPayloadStayedData parses the emitted file and fails if the marker
+// became syntax rather than data.
+//
+// Parsing is the decisive check: an injected `func PWN()` is perfectly valid
+// Go, so "does it compile" would pass it. The question is whether the marker
+// appears as an IDENTIFIER — inside a string literal it is just the label the
+// spec asked for.
+func assertPayloadStayedData(t *testing.T, site, name, src string) {
+	t.Helper()
+	if !strings.Contains(src, "PWN") {
+		return
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, name, src, parser.AllErrors)
+	if err != nil {
+		// Output that does not parse is a bug too: a spec string must not be
+		// able to make the generator emit broken source.
+		t.Fatalf("SECURITY: [injection] %s: emitted %s does not parse: %v", site, name, err)
+	}
+	var escaped bool
+	ast.Inspect(file, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok && strings.Contains(id.Name, "PWN") {
+			escaped = true
+			return false
+		}
+		return true
+	})
+	if escaped {
+		t.Fatalf("SECURITY: [injection] %s: the payload left its literal and became an identifier in %s", site, name)
+	}
+}
+
+type payloadSite struct {
+	site string
+	bp   Blueprint
+}
+
+func blueprintPayloadSites(payload string) []payloadSite {
+	base := func() Blueprint {
+		return Blueprint{
+			App: BlueprintApp{Name: "app"},
+			Entities: []framework.EntityDeclaration{{
+				Name:   "tickets",
+				Fields: []framework.FieldDeclaration{{Name: "title", Type: "string"}},
+			}},
+			Screens: []BlueprintScreen{{Name: "home", Route: "/", Type: "page"}},
+		}
+	}
+	var out []payloadSite
+	add := func(site string, mut func(*Blueprint)) {
+		bp := base()
+		mut(&bp)
+		out = append(out, payloadSite{site, bp})
+	}
+
+	add("app.name", func(b *Blueprint) { b.App.Name = payload })
+	add("app.description", func(b *Blueprint) { b.App.Description = payload })
+	add("entity.table", func(b *Blueprint) { b.Entities[0].Table = payload })
+	add("field.enum", func(b *Blueprint) { b.Entities[0].Fields[0].Values = []string{payload} })
+	add("screen.route", func(b *Blueprint) { b.Screens[0].Route = "/" + payload })
+	add("screen.title", func(b *Blueprint) { b.Screens[0].Title = payload })
+	add("screen.description", func(b *Blueprint) { b.Screens[0].Description = payload })
+	add("block.text", func(b *Blueprint) {
+		b.Screens[0].Body = []BlueprintBlock{{Kind: "text", Text: payload}}
+	})
+	add("block.heading", func(b *Blueprint) {
+		b.Screens[0].Body = []BlueprintBlock{{Kind: "heading", Level: 1, Text: payload}}
+	})
+	add("block.class", func(b *Blueprint) {
+		b.Screens[0].Body = []BlueprintBlock{{Kind: "text", Text: "hi", Class: payload}}
+	})
+	add("block.href", func(b *Blueprint) {
+		b.Screens[0].Body = []BlueprintBlock{{Kind: "text", Text: "hi", Href: payload}}
+	})
+	add("block.empty_text", func(b *Blueprint) {
+		b.Screens[0].Body = []BlueprintBlock{{Kind: "entity_list", Entity: "tickets", EmptyText: payload}}
+	})
+	return out
+}

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.45.0
+through: v0.46.0
 
 releases:
   - version: v0.3.0
@@ -311,3 +311,40 @@ releases:
       - change: Plugin iframe sandbox tokens are an allow-list
         breaking: true
         guidance: "framework/pluginhost drops any sandbox token outside allow-scripts/forms/modals/popups/pointer-lock/orientation-lock/presentation. A manifest asking for allow-popups-to-escape-sandbox, allow-top-navigation or allow-downloads no longer gets them."
+  - version: v0.46.0
+    title: Audit backlog closed + never-looked surfaces
+    notes:
+      - change: A gated MCP tool is hidden from tools/list
+        breaking: true
+        guidance: "mcp.Gated wraps a handler, so it only reached tools/call — an anonymous tools/list returned every gated tool's inputSchema. Register with mcp.WithToolGate(gate) instead of wrapping with mcp.Gated to gate the listing too."
+        detect: "mcp\\.Gated\\("
+      - change: Endpoint.MCPHandler twins require an authenticated caller
+        breaking: true
+        guidance: "The HTTP Handler inherits route middleware; the MCP twin never did. Set Endpoint.MCPGate for a stricter predicate, or Endpoint.MCPPublic: true for an endpoint that really is anonymous over HTTP too."
+        detect: "MCPHandler:"
+      - change: "/{table}/llm.md runs the entity's full access chain"
+        breaking: true
+        guidance: "It checked for a session but not the entity's declared permission, so a caller without orders:read got 403 on rows and 200 on the schema. Grant the entity's read permission to callers that should read its docs."
+      - change: log_set_level requires an authenticated caller
+        breaking: true
+        guidance: "Only when the host set AllowMCPMutation itself; dev-implied registration stays ungated. Make sure the app's session middleware runs on the /mcp route."
+        detect: "AllowMCPMutation"
+      - change: WithAPIPrefix now applies to EntityConfig.Endpoints
+        breaking: true
+        guidance: "A relative Endpoint.Path resolves under the prefixed table path — {id}/revoke on entity licenses with WithAPIPrefix(\"/api\") mounts at /api/licenses/{id}/revoke. Drop any hand-rolled prefix from relative paths; absolute paths still bypass the prefix."
+        detect: "WithAPIPrefix\\("
+      - change: The plugin host JS sandbox sanitizer is an allow-list
+        breaking: true
+        guidance: "host/pluginhost.js was still a one-token deny-list after the Go half flipped in v0.45.0. A manifest asking for allow-popups-to-escape-sandbox, allow-top-navigation or allow-downloads no longer gets them from either side."
+      - change: Manifest.Entry must be a same-origin absolute path
+        breaking: true
+        guidance: "An off-origin or scheme-bearing entry escapes the CSP sandbox header AssetServer emits, so it is refused by both Manifest.Validate and the JS broker. Serve the frame document from your own origin."
+        detect: "Entry:"
+      - change: A blueprint entity table must be letters, digits and underscores
+        breaking: true
+        guidance: "The table name is emitted into generated Go string literals and interpolated into DDL as a bare SQL identifier. Rename the table; entity name: was already constrained this way."
+        detect: "table:"
+      - change: Kiln journal destructive entries carry their authorizing plan_id
+        breaking: true
+        guidance: "Replay now re-checks that a delete was covered by an approved, unspent plan naming that target. A .kiln.session.jsonl written before v0.46.0 that contains deletes will fail replay — run `kiln freeze` with the old binary first, or start a fresh session."
+        detect: "\\.kiln\\.session\\.jsonl"

--- a/cmd/repolint/main.go
+++ b/cmd/repolint/main.go
@@ -158,6 +158,14 @@ func lintBytes(rel string, body []byte) []finding {
 			Message: "file uses CRLF line endings",
 		})
 	}
+	if line := duplicateURLGuardLine(rel, body); line > 0 {
+		out = append(out, finding{
+			File:    rel,
+			Line:    line,
+			Rule:    "duplicate-url-guard",
+			Message: "re-derived URL-scheme allow-list — call core-ui/urlsafe (urlsafe.OK / urlsafe.Clean) instead of growing another copy",
+		})
+	}
 	lines := strings.Split(string(body), "\n")
 	for i, line := range lines {
 		if isConflictMarker(line) {
@@ -381,6 +389,37 @@ func isUntypedFUIWiringScope(rel string) bool {
 		return false
 	}
 	return strings.HasPrefix(rel, "cmd/gofastr/") || strings.HasPrefix(rel, "battery/")
+}
+
+// duplicateURLGuardLine reports the line of a re-derived URL-scheme
+// allow-list, or 0 when the file has none.
+//
+// The fingerprint is the percent-encoded CR/LF rejection, which every copy of
+// this guard carries and almost nothing else does. The guard had been written
+// five times — framework/ui, framework/uihost, framework/crud,
+// framework/experimental/apiversions and three core-ui/patterns builders —
+// each copy byte-identical on the day it was written and free to drift the
+// day after. core-ui/urlsafe is the one definition; this rule is what keeps
+// it the only one.
+func duplicateURLGuardLine(rel string, body []byte) int {
+	if !strings.HasSuffix(rel, ".go") || strings.HasSuffix(rel, "_test.go") {
+		return 0
+	}
+	if strings.HasPrefix(rel, "core-ui/urlsafe/") {
+		return 0 // the definition itself
+	}
+	if strings.HasPrefix(rel, "cmd/repolint/") {
+		return 0 // this rule naming the pattern is not a copy of it
+	}
+	if !bytes.Contains(body, []byte(`"%0d"`)) || !bytes.Contains(body, []byte(`"%0a"`)) {
+		return 0
+	}
+	for i, line := range strings.Split(string(body), "\n") {
+		if strings.Contains(line, `"%0d"`) {
+			return i + 1
+		}
+	}
+	return 1
 }
 
 func mentionsExternalLintTool(line string) bool {

--- a/core-ui/patterns/breadcrumbs/breadcrumbs.go
+++ b/core-ui/patterns/breadcrumbs/breadcrumbs.go
@@ -15,10 +15,9 @@
 package breadcrumbs
 
 import (
-	"strings"
-
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
+	"github.com/DonaldMurillo/gofastr/core-ui/urlsafe"
 	"github.com/DonaldMurillo/gofastr/core/render"
 )
 
@@ -99,54 +98,12 @@ func renderCrumb(c Crumb) render.HTML {
 	)
 }
 
-// safeURL returns u if it is safe to render as an href, and "" if it
-// carries a script-executing or origin-ambiguous scheme. Permitted:
-// http(s), mailto, tel, relative paths, fragment- and query-only
-// references. Dropped: javascript:/vbscript:/data:/file:/blob: and any
-// other non-allow-listed scheme, protocol-relative "//host", and any
-// value containing control bytes or percent-encoded CR/LF. Mirrors
-// framework/ui/safety.go::safeURL and the sibling tree/nestedlist
-// builders — the patterns layer bypasses that helper, so the allow-list
-// is enforced here.
+// safeURL returns u if it is safe to render as an href, and "" otherwise.
+// The rule set lives in core-ui/urlsafe — this builder renders below
+// framework/ui, so the allow-list has to be enforced here too, but it is
+// the same allow-list, not another copy of it.
 func safeURL(u string) string {
-	if u == "" {
-		return ""
-	}
-	for i := 0; i < len(u); i++ {
-		if c := u[i]; c < 0x20 || c == 0x7f {
-			return ""
-		}
-	}
-	trimmed := strings.TrimLeft(u, " \t")
-	low := strings.ToLower(trimmed)
-	if strings.Contains(low, "%0d") || strings.Contains(low, "%0a") {
-		return ""
-	}
-	// Protocol-relative URLs are ambiguous about origin trust.
-	if strings.HasPrefix(trimmed, "//") {
-		return ""
-	}
-	// Fragment-only, query-only, or relative paths pass.
-	if strings.HasPrefix(trimmed, "/") || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "?") || strings.HasPrefix(trimmed, "./") || strings.HasPrefix(trimmed, "../") {
-		return u
-	}
-	for i := 0; i < len(trimmed); i++ {
-		switch c := trimmed[i]; c {
-		case ':':
-			switch strings.ToLower(trimmed[:i]) {
-			case "http", "https", "mailto", "tel":
-				return u
-			default:
-				return ""
-			}
-		case '/', '?', '#':
-			// No scheme before the first path/query/fragment delimiter
-			// — relative reference, allowed.
-			return u
-		}
-	}
-	// No colon — bare relative reference.
-	return u
+	return urlsafe.Clean(u, urlsafe.Anchor)
 }
 
 // baseCSS is the stylesheet for breadcrumbs. Tokens: --color-text-muted,

--- a/core-ui/patterns/nestedlist/nestedlist.go
+++ b/core-ui/patterns/nestedlist/nestedlist.go
@@ -6,10 +6,9 @@
 package nestedlist
 
 import (
-	"strings"
-
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
+	"github.com/DonaldMurillo/gofastr/core-ui/urlsafe"
 	"github.com/DonaldMurillo/gofastr/core/render"
 )
 
@@ -115,53 +114,12 @@ func renderItem(ordered bool, it Item) render.HTML {
 	)
 }
 
-// safeURL returns u if it is safe to render as an href, and "" if it
-// carries a script-executing or origin-ambiguous scheme. Permitted:
-// http(s), mailto, tel, relative paths, fragment- and query-only
-// references. Dropped: javascript:/vbscript:/data:/file:/blob: and any
-// other non-allow-listed scheme, protocol-relative "//host", and any
-// value containing control bytes or percent-encoded CR/LF. Mirrors
-// framework/ui/safety.go::safeURL — the patterns builders bypass that
-// layer, so the allow-list is enforced here.
+// safeURL returns u if it is safe to render as an href, and "" otherwise.
+// The rule set lives in core-ui/urlsafe — this builder renders below
+// framework/ui, so the allow-list has to be enforced here too, but it is
+// the same allow-list, not another copy of it.
 func safeURL(u string) string {
-	if u == "" {
-		return ""
-	}
-	for i := 0; i < len(u); i++ {
-		if c := u[i]; c < 0x20 || c == 0x7f {
-			return ""
-		}
-	}
-	trimmed := strings.TrimLeft(u, " \t")
-	low := strings.ToLower(trimmed)
-	if strings.Contains(low, "%0d") || strings.Contains(low, "%0a") {
-		return ""
-	}
-	// Protocol-relative URLs are ambiguous about origin trust.
-	if strings.HasPrefix(trimmed, "//") {
-		return ""
-	}
-	// Fragment-only, query-only, or relative paths pass.
-	if strings.HasPrefix(trimmed, "/") || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "?") || strings.HasPrefix(trimmed, "./") || strings.HasPrefix(trimmed, "../") {
-		return u
-	}
-	for i := 0; i < len(trimmed); i++ {
-		switch c := trimmed[i]; c {
-		case ':':
-			switch strings.ToLower(trimmed[:i]) {
-			case "http", "https", "mailto", "tel":
-				return u
-			default:
-				return ""
-			}
-		case '/', '?', '#':
-			// No scheme before the first path/query/fragment delimiter
-			// — relative reference, allowed.
-			return u
-		}
-	}
-	// No colon — bare relative reference.
-	return u
+	return urlsafe.Clean(u, urlsafe.Anchor)
 }
 
 // styleFn returns the stylesheet for nested-list. Tokens used:

--- a/core-ui/patterns/tree/tree.go
+++ b/core-ui/patterns/tree/tree.go
@@ -2,9 +2,9 @@ package tree
 
 import (
 	"strconv"
-	"strings"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
+	"github.com/DonaldMurillo/gofastr/core-ui/urlsafe"
 	"github.com/DonaldMurillo/gofastr/core/render"
 )
 
@@ -160,51 +160,10 @@ func renderNode(n Node, level, pos, setSize int, signalPrefix string, isFirstFoc
 	return render.Tag("li", liAttrs, liBody...)
 }
 
-// safeURL returns u if it is safe to render as an href, and "" if it
-// carries a script-executing or origin-ambiguous scheme. Permitted:
-// http(s), mailto, tel, relative paths, fragment- and query-only
-// references. Dropped: javascript:/vbscript:/data:/file:/blob: and any
-// other non-allow-listed scheme, protocol-relative "//host", and any
-// value containing control bytes or percent-encoded CR/LF. Mirrors
-// framework/ui/safety.go::safeURL — the patterns builders bypass that
-// layer, so the allow-list is enforced here.
+// safeURL returns u if it is safe to render as an href, and "" otherwise.
+// The rule set lives in core-ui/urlsafe — this builder renders below
+// framework/ui, so the allow-list has to be enforced here too, but it is
+// the same allow-list, not another copy of it.
 func safeURL(u string) string {
-	if u == "" {
-		return ""
-	}
-	for i := 0; i < len(u); i++ {
-		if c := u[i]; c < 0x20 || c == 0x7f {
-			return ""
-		}
-	}
-	trimmed := strings.TrimLeft(u, " \t")
-	low := strings.ToLower(trimmed)
-	if strings.Contains(low, "%0d") || strings.Contains(low, "%0a") {
-		return ""
-	}
-	// Protocol-relative URLs are ambiguous about origin trust.
-	if strings.HasPrefix(trimmed, "//") {
-		return ""
-	}
-	// Fragment-only, query-only, or relative paths pass.
-	if strings.HasPrefix(trimmed, "/") || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "?") || strings.HasPrefix(trimmed, "./") || strings.HasPrefix(trimmed, "../") {
-		return u
-	}
-	for i := 0; i < len(trimmed); i++ {
-		switch c := trimmed[i]; c {
-		case ':':
-			switch strings.ToLower(trimmed[:i]) {
-			case "http", "https", "mailto", "tel":
-				return u
-			default:
-				return ""
-			}
-		case '/', '?', '#':
-			// No scheme before the first path/query/fragment delimiter
-			// — relative reference, allowed.
-			return u
-		}
-	}
-	// No colon — bare relative reference.
-	return u
+	return urlsafe.Clean(u, urlsafe.Anchor)
 }

--- a/core-ui/urlsafe/urlsafe_test.go
+++ b/core-ui/urlsafe/urlsafe_test.go
@@ -1,0 +1,98 @@
+package urlsafe
+
+import "testing"
+
+// This package is the single enforcement point for every surface that renders
+// a caller-supplied URL — framework/ui's anchors and images, uihost's head
+// tags, crud's stored media paths, apiversions' deprecation hints, and three
+// core-ui/patterns builders. A hole here is a hole in all of them, so the
+// table is deliberately exhaustive rather than illustrative.
+
+func TestRejectedUnderEveryPolicy(t *testing.T) {
+	bad := []struct{ url, why string }{
+		{"", "empty is not a URL"},
+		{"javascript:alert(1)", "script-executing scheme"},
+		{"JavaScript:alert(1)", "scheme match is case-insensitive"},
+		{"  javascript:alert(1)", "leading whitespace does not hide the scheme"},
+		{"\tjavascript:alert(1)", "leading tab does not hide the scheme"},
+		{"vbscript:msgbox(1)", "script-executing scheme"},
+		{"data:text/html,<script>alert(1)</script>", "data: renders attacker HTML"},
+		{"file:///etc/passwd", "local file scheme"},
+		{"blob:https://x/y", "blob scheme"},
+		{"filesystem:https://x/y", "filesystem scheme"},
+		{"view-source:https://x", "view-source scheme"},
+		{"chrome://settings", "browser-internal scheme"},
+		{"//evil.example/x", "protocol-relative inherits the page scheme"},
+		{"/x\x00y", "NUL byte"},
+		{"/x\ny", "raw LF splits the attribute"},
+		{"/x\ry", "raw CR splits the attribute"},
+		{"/x\x7fy", "DEL byte"},
+		{"/x%0dSet-Cookie:%20a=b", "percent-encoded CR smuggles a header"},
+		{"/x%0aSet-Cookie:%20a=b", "percent-encoded LF smuggles a header"},
+		{"/x%0D%0Ay", "percent-encoded CRLF, uppercase"},
+	}
+	for _, tc := range bad {
+		for _, p := range []Policy{Anchor, Resource} {
+			if OK(tc.url, p) {
+				t.Errorf("SECURITY: OK(%q, %v) = true — %s", tc.url, p, tc.why)
+			}
+			if Clean(tc.url, p) != "" {
+				t.Errorf("SECURITY: Clean(%q, %v) returned it — %s", tc.url, p, tc.why)
+			}
+		}
+	}
+}
+
+func TestAcceptedUnderEveryPolicy(t *testing.T) {
+	good := []string{
+		"https://example.com/x",
+		"HTTPS://example.com/x",
+		"http://example.com/x",
+		"/absolute/path",
+		"relative/path",
+		"logo.png",
+		"./sibling",
+		"../parent",
+		"#fragment",
+		"?query=1",
+		"/path?q=1#frag",
+		"/path/with:colon/after/slash",
+		"?a=b:c",
+		"#a:b",
+	}
+	for _, u := range good {
+		for _, p := range []Policy{Anchor, Resource} {
+			if !OK(u, p) {
+				t.Errorf("OK(%q, %v) = false, want true", u, p)
+			}
+			if Clean(u, p) != u {
+				t.Errorf("Clean(%q, %v) = %q, want the input back", u, p, Clean(u, p))
+			}
+		}
+	}
+}
+
+// The policy split is the whole reason there are two constants: mailto: on an
+// <a href> is a feature, and mailto: on an <img src> is a caller mistake at
+// best. A single policy would have to pick one and be wrong somewhere.
+func TestPolicySplit(t *testing.T) {
+	for _, u := range []string{"mailto:a@b.com", "tel:+15551234", "MAILTO:a@b.com"} {
+		if !OK(u, Anchor) {
+			t.Errorf("OK(%q, Anchor) = false; navigational schemes belong on anchors", u)
+		}
+		if OK(u, Resource) {
+			t.Errorf("OK(%q, Resource) = true; the browser must not fetch this as a subresource", u)
+		}
+	}
+}
+
+// A colon that appears after a path delimiter is not a scheme. Treating it as
+// one would drop legitimate URLs, and the failure mode of an over-strict guard
+// is a silently missing link rather than a visible error.
+func TestColonAfterDelimiterIsNotAScheme(t *testing.T) {
+	for _, u := range []string{"/a/b:c", "a/b:c", "?x=1:2", "#x:y"} {
+		if !OK(u, Resource) {
+			t.Errorf("OK(%q) = false; the colon is inside the path, not a scheme", u)
+		}
+	}
+}

--- a/core/mcp/listgate_security_test.go
+++ b/core/mcp/listgate_security_test.go
@@ -1,0 +1,165 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type ctxKey string
+
+const principalKey ctxKey = "principal"
+
+func authed(ctx context.Context) context.Context {
+	return context.WithValue(ctx, principalKey, "u1")
+}
+
+func requireUser(ctx context.Context) error {
+	if ctx.Value(principalKey) == nil {
+		return errors.New("authentication required")
+	}
+	return nil
+}
+
+// tools/list ran with no gate at all: mcp.Gated wraps HANDLERS, so it only
+// ever affected tools/call. An unauthenticated POST therefore returned every
+// tool's inputSchema — which framework/crud builds from live entity
+// definitions, i.e. every entity name, every non-Hidden field, its type and
+// full enum set. The call 401s; the schema was already out.
+func TestGatedToolIsHiddenFromUnauthenticatedList(t *testing.T) {
+	s := NewServer()
+	mustRegisterGated(t, s, "secret_tool", requireUser)
+	mustRegisterOpen(t, s, "public_tool")
+
+	names := listToolNames(t, s, context.Background())
+	if contains(names, "secret_tool") {
+		t.Errorf("SECURITY: [disclosure] unauthenticated tools/list exposed a gated tool's schema; got %v", names)
+	}
+	if !contains(names, "public_tool") {
+		t.Errorf("ungated tool vanished from the listing; got %v", names)
+	}
+}
+
+// The caller who can actually call it must still see it, or the gate has
+// merely broken discovery.
+func TestGatedToolIsVisibleToAuthenticatedList(t *testing.T) {
+	s := NewServer()
+	mustRegisterGated(t, s, "secret_tool", requireUser)
+
+	names := listToolNames(t, s, authed(context.Background()))
+	if !contains(names, "secret_tool") {
+		t.Errorf("authenticated tools/list hid a callable tool; got %v", names)
+	}
+}
+
+// Hiding it from the listing is disclosure control, not access control — the
+// gate must also refuse the call.
+func TestGatedToolRefusesUnauthenticatedCall(t *testing.T) {
+	s := NewServer()
+	mustRegisterGated(t, s, "secret_tool", requireUser)
+
+	resp := s.HandleRequest(context.Background(), Request{
+		JSONRPC: "2.0", ID: 1, Method: "tools/call",
+		Params: json.RawMessage(`{"name":"secret_tool","arguments":{}}`),
+	})
+	if resp.Error == nil {
+		t.Fatal("SECURITY: [authz] gated tool ran for an unauthenticated caller")
+	}
+}
+
+// A server-wide gate closes the whole JSON-RPC data surface for hosts whose
+// /mcp is private, without per-tool wiring.
+func TestServerGateClosesListAndCall(t *testing.T) {
+	s := NewServer()
+	mustRegisterOpen(t, s, "public_tool")
+	s.SetGate(requireUser)
+
+	if names := listToolNames(t, s, context.Background()); len(names) != 0 {
+		t.Errorf("SECURITY: [disclosure] server gate did not cover tools/list; got %v", names)
+	}
+	resp := s.HandleRequest(context.Background(), Request{
+		JSONRPC: "2.0", ID: 1, Method: "tools/call",
+		Params: json.RawMessage(`{"name":"public_tool","arguments":{}}`),
+	})
+	if resp.Error == nil {
+		t.Error("SECURITY: [authz] server gate did not cover tools/call")
+	}
+
+	// resources/list is the same disclosure surface by another name.
+	rl := s.HandleRequest(context.Background(), Request{JSONRPC: "2.0", ID: 2, Method: "resources/list"})
+	if rl.Error == nil {
+		t.Error("SECURITY: [disclosure] server gate did not cover resources/list")
+	}
+
+	if names := listToolNames(t, s, authed(context.Background())); !contains(names, "public_tool") {
+		t.Errorf("server gate refused an authenticated caller; got %v", names)
+	}
+}
+
+// The handshake stays open on purpose: it carries only the protocol version,
+// capability booleans and the server name, and a client that cannot handshake
+// cannot present credentials in a way any MCP client implements. Pin the
+// decision so a future change is deliberate.
+func TestInitializeAndPingStayOpenUnderServerGate(t *testing.T) {
+	s := NewServer()
+	s.SetGate(requireUser)
+	for _, method := range []string{"initialize", "ping"} {
+		resp := s.HandleRequest(context.Background(), Request{JSONRPC: "2.0", ID: 1, Method: method})
+		if resp.Error != nil {
+			t.Errorf("%s refused under the server gate: %v", method, resp.Error)
+		}
+	}
+	// …and it must not carry anything but the handshake.
+	resp := s.HandleRequest(context.Background(), Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	blob, _ := json.Marshal(resp.Result)
+	if strings.Contains(string(blob), "inputSchema") {
+		t.Error("SECURITY: [disclosure] initialize leaked tool schemas")
+	}
+}
+
+func mustRegisterGated(t *testing.T, s *Server, name string, gate func(context.Context) error) {
+	t.Helper()
+	err := s.RegisterTool(name, "d", map[string]any{"type": "object"},
+		func(context.Context, map[string]any) (any, error) { return "ok", nil },
+		WithToolGate(gate))
+	if err != nil {
+		t.Fatalf("register %s: %v", name, err)
+	}
+}
+
+func mustRegisterOpen(t *testing.T, s *Server, name string) {
+	t.Helper()
+	err := s.RegisterTool(name, "d", map[string]any{"type": "object"},
+		func(context.Context, map[string]any) (any, error) { return "ok", nil })
+	if err != nil {
+		t.Fatalf("register %s: %v", name, err)
+	}
+}
+
+func listToolNames(t *testing.T, s *Server, ctx context.Context) []string {
+	t.Helper()
+	resp := s.HandleRequest(ctx, Request{JSONRPC: "2.0", ID: 1, Method: "tools/list"})
+	if resp.Error != nil {
+		return nil
+	}
+	res, ok := resp.Result.(toolsListResult)
+	if !ok {
+		t.Fatalf("tools/list result type %T", resp.Result)
+	}
+	names := make([]string, 0, len(res.Tools))
+	for _, tool := range res.Tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/core/mcp/protocol.go
+++ b/core/mcp/protocol.go
@@ -58,6 +58,15 @@ func (s *Server) HandleRequest(ctx context.Context, req Request) Response {
 	ctx = enrichContext(ctx)
 
 	switch req.Method {
+	case "tools/list", "tools/call", "resources/list", "resources/read":
+		// Server-wide gate over the DATA surface. initialize and ping fall
+		// through uncovered on purpose — see Server.serverGate.
+		if err := s.checkServerGate(ctx); err != nil {
+			return newErrorResponse(req.ID, ErrInvalidParams, err.Error())
+		}
+	}
+
+	switch req.Method {
 	case "tools/list":
 		return s.handleToolsList(ctx, req)
 	case "tools/call":

--- a/core/mcp/server.go
+++ b/core/mcp/server.go
@@ -40,6 +40,11 @@ type Tool struct {
 	// compat alias "openai/outputTemplate").
 	Meta    map[string]any `json:"_meta,omitempty"`
 	Handler ToolHandler    `json:"-"`
+
+	// Gate, when set, is a per-caller precondition evaluated BEFORE the
+	// handler on tools/call, and again in tools/list to decide whether this
+	// tool is visible to the caller at all. See WithToolGate.
+	Gate func(ctx context.Context) error `json:"-"`
 }
 
 // ToolOption customizes a tool at registration time.
@@ -55,6 +60,25 @@ func WithOutputSchema(schema map[string]any) ToolOption {
 // WithResourceMeta on the resource side.
 func WithToolMeta(meta map[string]any) ToolOption {
 	return func(t *Tool) { t.Meta = meta }
+}
+
+// WithToolGate attaches a per-caller precondition to a tool. The gate runs on
+// every tools/call before the handler, and is also evaluated during tools/list
+// so a caller who cannot invoke the tool does not see it.
+//
+// That second half is the point. [Gated] wraps a HANDLER, so it only ever
+// affected tools/call: an unauthenticated tools/list still returned the tool's
+// full inputSchema, which for entity CRUD tools is built from live entity
+// definitions — every entity name, every non-Hidden field, its type and its
+// enum set. The call refused; the schema was already out.
+//
+// Prefer this over [Gated] for anything registered directly on the server.
+// battery/auth's MCPUser() / MCPRole("admin") are ready-made gates.
+func WithToolGate(gate func(ctx context.Context) error) ToolOption {
+	if gate == nil {
+		panic("mcp.WithToolGate: nil gate — a nil precondition would silently allow every caller")
+	}
+	return func(t *Tool) { t.Gate = gate }
 }
 
 // Server is an MCP server with a tool registry.
@@ -82,6 +106,17 @@ type Server struct {
 	// result without invoking the tool. Framework code uses it to gate
 	// tools owned by a disabled module.
 	callGate func(toolName string) error
+
+	// serverGate, when set, is a per-caller precondition covering the whole
+	// JSON-RPC DATA surface: tools/list, tools/call, resources/list and
+	// resources/read. It is the switch for a host whose /mcp is private
+	// wholesale, as opposed to per-tool WithToolGate.
+	//
+	// initialize and ping are deliberately NOT covered — they carry only the
+	// protocol version, capability booleans and the server name, and a client
+	// that cannot complete the handshake cannot present credentials in a way
+	// any MCP client implements.
+	serverGate func(ctx context.Context) error
 
 	// allowedHosts pins the Host authorities this server answers on
 	// (the DNS-rebinding control). Empty = unpinned. See originOK.
@@ -197,15 +232,31 @@ func (s *Server) getTool(name string) (Tool, bool) {
 
 // ListTools returns all registered tools whose call gate (if set)
 // allows them. Tools owned by a disabled module are excluded. Handlers
-// are nilled out for safety. This is the exported version of listTools.
+// are nilled out for safety.
+//
+// It does NOT apply per-tool caller gates ([WithToolGate]) — there is no
+// caller to evaluate them against. It is a Go-API introspection call for
+// in-process code that already holds the server. Never serve its output to a
+// remote caller: use [Server.ListToolsFor] with the request context, which is
+// what the JSON-RPC tools/list path does.
 func (s *Server) ListTools() []Tool {
-	return s.listTools()
+	return s.listToolsUnfiltered()
+}
+
+// ListToolsFor returns the tools visible to the caller ctx identifies:
+// per-tool gates and the server-wide gate are both applied. This is the
+// listing tools/list serves.
+func (s *Server) ListToolsFor(ctx context.Context) ([]Tool, error) {
+	if err := s.checkServerGate(ctx); err != nil {
+		return nil, err
+	}
+	return s.listTools(ctx), nil
 }
 
 // listTools returns all registered tools (without handlers), excluding
 // any whose call gate refuses them (e.g. tools owned by a disabled
 // module).
-func (s *Server) listTools() []Tool {
+func (s *Server) listTools(ctx context.Context) []Tool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -215,15 +266,67 @@ func (s *Server) listTools() []Tool {
 		if gate != nil && gate(t.Name) != nil {
 			continue // gated tool excluded from listing
 		}
+		// A tool the caller cannot invoke is not listed to them: the
+		// inputSchema is the disclosure, not the call.
+		if t.Gate != nil && t.Gate(ctx) != nil {
+			continue
+		}
 		tools = append(tools, t)
 	}
 	return tools
+}
+
+// listToolsUnfiltered applies only the name-based call gate (disabled
+// modules), not per-caller gates. See ListTools.
+func (s *Server) listToolsUnfiltered() []Tool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	gate := s.callGate
+	tools := make([]Tool, 0, len(s.tools))
+	for _, t := range s.tools {
+		if gate != nil && gate(t.Name) != nil {
+			continue
+		}
+		tools = append(tools, t)
+	}
+	return tools
+}
+
+// SetGate installs a server-wide precondition over the JSON-RPC data surface
+// (tools/list, tools/call, resources/list, resources/read). Pass nil to clear
+// it. See the serverGate field for why initialize and ping stay open.
+//
+// Use it when the whole /mcp endpoint is private. For a mixed surface —
+// public read tools, gated mutating ones — attach per-tool gates with
+// [WithToolGate] instead, which also filters the listing per caller.
+func (s *Server) SetGate(gate func(ctx context.Context) error) {
+	s.mu.Lock()
+	s.serverGate = gate
+	s.mu.Unlock()
+}
+
+// checkServerGate evaluates the server-wide gate, if any.
+func (s *Server) checkServerGate(ctx context.Context) error {
+	s.mu.RLock()
+	gate := s.serverGate
+	s.mu.RUnlock()
+	if gate == nil {
+		return nil
+	}
+	return gate(ctx)
 }
 
 // CallTool is the exported form of callTool: invokes a registered tool
 // by name with the given params. Use this when calling MCP tools
 // in-process (tests, server-side integrations) without going through
 // the JSON-RPC transport layer.
+//
+// It runs the tool's own gate ([WithToolGate]) against ctx, so an in-process
+// caller must carry the identity the gate expects. It does NOT run the
+// server-wide gate ([Server.SetGate]) — that one describes who may reach the
+// /mcp ENDPOINT, and an in-process caller is not coming through it. Every
+// remote transport dispatches via HandleRequest, which does apply it.
 func (s *Server) CallTool(ctx context.Context, name string, params map[string]any) (any, error) {
 	return s.callTool(ctx, name, params)
 }
@@ -251,6 +354,14 @@ func (s *Server) callTool(ctx context.Context, name string, params map[string]an
 				Code:    ErrInternalError,
 				Message: "tool unavailable",
 			}
+		}
+	}
+
+	// Per-tool caller gate (WithToolGate). Runs before the handler; the
+	// same predicate decided whether this tool appeared in tools/list.
+	if t.Gate != nil {
+		if err := t.Gate(ctx); err != nil {
+			return nil, &RPCError{Code: ErrInvalidParams, Message: err.Error()}
 		}
 	}
 

--- a/core/mcp/tools.go
+++ b/core/mcp/tools.go
@@ -25,8 +25,8 @@ type toolsCallResult struct {
 }
 
 // handleToolsList returns all registered tools.
-func (s *Server) handleToolsList(_ context.Context, req Request) Response {
-	tools := s.listTools()
+func (s *Server) handleToolsList(ctx context.Context, req Request) Response {
+	tools := s.listTools(ctx)
 	return newSuccessResponse(req.ID, toolsListResult{Tools: tools})
 }
 

--- a/core/middleware/cors.go
+++ b/core/middleware/cors.go
@@ -1,6 +1,9 @@
 package middleware
 
 import (
+	"bufio"
+	"errors"
+	"net"
 	"net/http"
 	"strings"
 )
@@ -57,7 +60,11 @@ func CORS(cfg CORSConfig) Middleware {
 				allowed = true
 			} else if origin != "" && originSet[origin] {
 				w.Header().Set("Access-Control-Allow-Origin", origin)
-				w.Header().Set("Vary", "Origin")
+				// Add, not Set: an upstream middleware may already have
+				// written Vary (compression writes Accept-Encoding), and
+				// clobbering it makes a shared cache serve one variant to
+				// clients that cannot read it.
+				w.Header().Add("Vary", "Origin")
 				allowed = true
 			}
 
@@ -94,7 +101,15 @@ func CORS(cfg CORSConfig) Middleware {
 }
 
 // stripCredsWriter prevents Access-Control-Allow-Credentials from being
-// emitted by a downstream handler when the configured ACAO is "*".
+// emitted by a downstream handler when the configured ACAO is "*". Browsers
+// reject that combination, and a handler that sets it is asking for a
+// credentialed cross-origin read.
+//
+// It forwards Flush and Hijack like every other wrapper in this package
+// (metrics, logging, tracing, timeout). It did not, so behind a wildcard CORS
+// policy the SSE bus lost its Flusher — and the framework's SSE constructor
+// type-asserts http.Flusher, making that a hard failure rather than degraded
+// buffering — while a WebSocket upgrade lost its Hijacker.
 type stripCredsWriter struct {
 	http.ResponseWriter
 }
@@ -108,6 +123,30 @@ func (s stripCredsWriter) Write(b []byte) (int, error) {
 	s.ResponseWriter.Header().Del("Access-Control-Allow-Credentials")
 	return s.ResponseWriter.Write(b)
 }
+
+// Flush strips before flushing: a streaming handler that sets the header and
+// flushes before its first Write would otherwise commit it to the wire.
+func (s stripCredsWriter) Flush() {
+	s.ResponseWriter.Header().Del("Access-Control-Allow-Credentials")
+	if f, ok := s.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack forwards to the underlying writer so a WebSocket upgrade behind a
+// wildcard CORS policy still works. Once hijacked the connection is raw and
+// this wrapper no longer mediates it — which is correct: there are no HTTP
+// response headers left to strip.
+func (s stripCredsWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := s.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, errors.New("middleware: underlying ResponseWriter does not implement http.Hijacker")
+}
+
+// Unwrap lets http.ResponseController reach the original writer for
+// capabilities this wrapper does not name explicitly.
+func (s stripCredsWriter) Unwrap() http.ResponseWriter { return s.ResponseWriter }
 
 // sanitizeCORSTokens strips bytes that could terminate the Allow-Methods
 // or Allow-Headers value and smuggle a second header line. The CORS

--- a/core/middleware/cors_security_test.go
+++ b/core/middleware/cors_security_test.go
@@ -106,3 +106,100 @@ func TestCORS_WildcardStripsCredentialsHeader(t *testing.T) {
 		t.Fatalf("SECURITY: [cors] wildcard ACAO response kept Access-Control-Allow-Credentials=%q. Attack: invalid wildcard+credentials CORS config survives.", got)
 	}
 }
+
+// Every other ResponseWriter wrapper in this package forwards Flusher and
+// Hijacker (metrics, logging, tracing and timeout each have a test pinning
+// it). CORS's stripCredsWriter — installed on every non-preflight request
+// when AllowedOrigins is ["*"] — did not, so behind a wildcard CORS policy
+// the SSE bus lost its Flusher and the WebSocket upgrade lost its Hijacker.
+// The framework's SSE constructor type-asserts http.Flusher, so this is a
+// hard failure, not degraded buffering.
+func TestCORS_PreservesFlusherAndHijacker(t *testing.T) {
+	var sawFlusher, sawHijacker bool
+	h := CORS(CORSConfig{AllowedOrigins: []string{"*"}})(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, sawFlusher = w.(http.Flusher)
+			_, sawHijacker = w.(http.Hijacker)
+		}))
+
+	rec := &hijackableRecorder{ResponseRecorder: httptest.NewRecorder()}
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	if !sawFlusher {
+		t.Error("Flusher not preserved through the wildcard-CORS wrapper — SSE cannot stream behind it")
+	}
+	if !sawHijacker {
+		t.Error("Hijacker not preserved through the wildcard-CORS wrapper — WebSocket upgrade fails behind it")
+	}
+}
+
+// The wrapper exists to stop a downstream handler pairing ACAO:* with
+// credentials, which is the actual vulnerability. Preserving the interfaces
+// must not weaken that.
+func TestCORS_WildcardStillStripsCredentials(t *testing.T) {
+	h := CORS(CORSConfig{AllowedOrigins: []string{"*"}})(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+			w.WriteHeader(200)
+		}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	if got := rec.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Errorf("SECURITY: [cors] credentials header survived alongside ACAO:* (got %q)", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("ACAO = %q, want *", got)
+	}
+}
+
+// Flush must strip too, or a streaming handler that sets the header and
+// flushes before WriteHeader slips it out.
+func TestCORS_WildcardStripsCredentialsOnFlush(t *testing.T) {
+	h := CORS(CORSConfig{AllowedOrigins: []string{"*"}})(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	if got := rec.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Errorf("SECURITY: [cors] credentials header survived a pre-write Flush (got %q)", got)
+	}
+}
+
+// Vary must be APPENDED. Set() clobbers a Vary an upstream middleware
+// already wrote (compression sets Vary: Accept-Encoding), which makes a
+// shared cache serve one encoding to clients that cannot read it.
+func TestCORS_AppendsVaryInsteadOfClobbering(t *testing.T) {
+	h := CORS(CORSConfig{AllowedOrigins: []string{"https://ok.example"}})(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) }))
+
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Vary", "Accept-Encoding")
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Origin", "https://ok.example")
+	h.ServeHTTP(rec, req)
+
+	vary := rec.Header().Values("Vary")
+	var sawEncoding, sawOrigin bool
+	for _, v := range vary {
+		if strings.Contains(v, "Accept-Encoding") {
+			sawEncoding = true
+		}
+		if strings.Contains(v, "Origin") {
+			sawOrigin = true
+		}
+	}
+	if !sawEncoding {
+		t.Errorf("CORS clobbered an existing Vary header; got %v", vary)
+	}
+	if !sawOrigin {
+		t.Errorf("CORS did not vary on Origin; got %v", vary)
+	}
+}

--- a/core/router/router.go
+++ b/core/router/router.go
@@ -332,6 +332,12 @@ func (c *cachedRoute) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	composed.ServeHTTP(w, req)
 }
 
+// Prefix returns the router's full path prefix — the composition of every
+// enclosing Group's prefix. Registrars that need to address a sub-router's
+// routes by URL (the entity MCP tools re-dispatch through the router) must
+// use this, not the innermost segment.
+func (r *Router) Prefix() string { return r.prefix }
+
 // Group creates a sub-router with the given path prefix and optional middleware.
 // The sub-router inherits its parent's middleware chain — resolved at
 // request time, so middleware added to the parent after Group still

--- a/core/upload/local.go
+++ b/core/upload/local.go
@@ -139,6 +139,21 @@ func (s *LocalStorage) Delete(_ context.Context, key string) error {
 // absolute filesystem path stripped, so a 500 propagated to an end
 // user doesn't disclose where the data lives.
 func (s *LocalStorage) Get(_ context.Context, key string) (io.ReadCloser, error) {
+	return s.open(key)
+}
+
+// GetRange implements [RangeGetter]. The local backend already opens an
+// *os.File, so seekability costs nothing here — Get simply discarded it
+// through the io.ReadCloser return type. Key validation is the same code
+// path, not a parallel one.
+func (s *LocalStorage) GetRange(_ context.Context, key string) (io.ReadSeekCloser, error) {
+	return s.open(key)
+}
+
+// open resolves key against baseDir and opens it. It is the single
+// enforcement point for sanitization and the base-dir containment check, so
+// Get and GetRange cannot drift apart.
+func (s *LocalStorage) open(key string) (*os.File, error) {
 	safeKey, err := sanitizeKey(key)
 	if err != nil {
 		return nil, err

--- a/core/upload/range.go
+++ b/core/upload/range.go
@@ -1,0 +1,27 @@
+package upload
+
+import (
+	"context"
+	"io"
+)
+
+// RangeGetter is an optional capability a [Storage] backend may implement to
+// expose seekable reads.
+//
+// [Storage.Get] returns an io.ReadCloser, which erases seekability, and
+// [http.ServeContent] needs an io.ReadSeeker to answer a `Range:` request.
+// Without this, a client that loses its connection 1.8 GB into a 2 GB download
+// restarts from zero, and browsers/CDNs that probe with a range request get a
+// 200 with the whole body instead of a 206.
+//
+// It is a capability interface rather than a widening of Storage on purpose:
+// a network-backed store would have to buffer the whole object to satisfy
+// Seek, which is worse than declining. Callers type-assert and fall back —
+// [ServeHandler] is the reference consumer.
+//
+// An implementation MUST apply the same key validation as its Get: a
+// capability that skipped the traversal check would be a path-traversal hole
+// with a performance justification.
+type RangeGetter interface {
+	GetRange(ctx context.Context, key string) (io.ReadSeekCloser, error)
+}

--- a/core/upload/range_test.go
+++ b/core/upload/range_test.go
@@ -1,0 +1,154 @@
+package upload
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Storage.Get returns io.ReadCloser, which erases seekability, so ServeHandler
+// could not answer a Range request: a client that dropped 1.8 GB into a 2 GB
+// download restarted from zero, and a CDN probing with a range got a 200 with
+// the whole body instead of a 206.
+//
+// The capability exists — LocalStorage.Get already hands back an *os.File —
+// the interface just hid it. RangeGetter is the declared way to ask for it.
+
+func TestServeHandlerAnswersRangeRequest(t *testing.T) {
+	h, body := localServeHandler(t)
+
+	req := httptest.NewRequest("GET", "/big.bin", nil)
+	req.Header.Set("Range", "bytes=10-19")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("Range request = %d, want 206 (whole body returned instead of a range)", rec.Code)
+	}
+	if got, want := rec.Body.String(), body[10:20]; got != want {
+		t.Errorf("range body = %q, want %q", got, want)
+	}
+	if cr := rec.Header().Get("Content-Range"); cr != "bytes 10-19/"+itoa(len(body)) {
+		t.Errorf("Content-Range = %q", cr)
+	}
+}
+
+// A backend that can serve ranges must say so, or clients never ask.
+func TestServeHandlerAdvertisesAcceptRanges(t *testing.T) {
+	h, _ := localServeHandler(t)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/big.bin", nil))
+	if rec.Header().Get("Accept-Ranges") != "bytes" {
+		t.Errorf("Accept-Ranges = %q, want %q", rec.Header().Get("Accept-Ranges"), "bytes")
+	}
+}
+
+// The stored-XSS guard is the reason this handler exists rather than
+// http.FileServer. Adding range support must not drop it.
+func TestRangeServingKeepsScriptableGuard(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.svg"), []byte("<svg onload=alert(1)>"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h := ServeHandler(NewLocalStorage(dir))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/x.svg", nil))
+
+	if ct := rec.Header().Get("Content-Type"); ct != "application/octet-stream" {
+		t.Errorf("Content-Type = %q, want application/octet-stream", ct)
+	}
+	if cd := rec.Header().Get("Content-Disposition"); cd != "attachment" {
+		t.Errorf("Content-Disposition = %q, want attachment", cd)
+	}
+	if rec.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Error("nosniff header dropped")
+	}
+}
+
+// A backend that declines the capability must still serve whole bodies —
+// the fallback is the contract, not an error path.
+func TestServeHandlerFallsBackWithoutRangeGetter(t *testing.T) {
+	h := ServeHandler(nonSeekableStorage{data: "hello world"})
+	req := httptest.NewRequest("GET", "/k", nil)
+	req.Header.Set("Range", "bytes=0-3")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("non-seekable backend = %d, want 200", rec.Code)
+	}
+	if rec.Body.String() != "hello world" {
+		t.Errorf("body = %q, want the whole object", rec.Body.String())
+	}
+}
+
+func TestLocalStorageImplementsRangeGetter(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.bin"), []byte("0123456789"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var s Storage = NewLocalStorage(dir)
+	rg, ok := s.(RangeGetter)
+	if !ok {
+		t.Fatal("LocalStorage does not implement RangeGetter")
+	}
+	rs, err := rg.GetRange(context.Background(), "f.bin")
+	if err != nil {
+		t.Fatalf("GetRange: %v", err)
+	}
+	defer rs.Close()
+	if _, err := rs.Seek(4, io.SeekStart); err != nil {
+		t.Fatalf("Seek: %v", err)
+	}
+	got, _ := io.ReadAll(rs)
+	if string(got) != "456789" {
+		t.Errorf("after Seek(4) read %q, want %q", got, "456789")
+	}
+}
+
+// GetRange must apply the same key sanitization as Get — a capability that
+// skipped the traversal check would be a path-traversal hole wearing a
+// performance hat.
+func TestGetRangeRejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+	rg := NewLocalStorage(dir)
+	if _, err := rg.GetRange(context.Background(), "../../etc/passwd"); err == nil {
+		t.Fatal("SECURITY: GetRange accepted a traversal key")
+	}
+}
+
+func localServeHandler(t *testing.T) (http.Handler, string) {
+	t.Helper()
+	dir := t.TempDir()
+	body := strings.Repeat("abcdefghij", 10)
+	if err := os.WriteFile(filepath.Join(dir, "big.bin"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return ServeHandler(NewLocalStorage(dir)), body
+}
+
+type nonSeekableStorage struct{ data string }
+
+func (n nonSeekableStorage) Save(context.Context, string, io.Reader) error { return nil }
+func (n nonSeekableStorage) Delete(context.Context, string) error          { return nil }
+func (n nonSeekableStorage) Exists(context.Context, string) (bool, error)  { return true, nil }
+func (n nonSeekableStorage) Get(context.Context, string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(n.data)), nil
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/core/upload/serve.go
+++ b/core/upload/serve.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // scriptableHead reports whether a sniffed content type is one a
@@ -52,6 +53,10 @@ func scriptableExt(key string) bool {
 //     backend ([LocalStorage]'s sanitizeKey is the single enforcement
 //     point); the handler performs no path manipulation of its own and
 //     echoes no filesystem path on any error.
+//   - When the backend implements [RangeGetter], `Range:` requests are
+//     answered with 206 and Accept-Ranges is advertised, so an interrupted
+//     download of a large object resumes instead of restarting. Backends
+//     that decline the capability serve whole bodies exactly as before.
 func ServeHandler(storage Storage) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet && r.Method != http.MethodHead {
@@ -63,6 +68,21 @@ func ServeHandler(storage Storage) http.HandlerFunc {
 		key := r.PathValue("key")
 		if key == "" {
 			key = strings.TrimPrefix(r.URL.Path, "/")
+		}
+
+		// A backend that implements RangeGetter hands back a seekable
+		// reader, which is what http.ServeContent needs to answer a Range
+		// request. Backends that decline fall through to the whole-body
+		// path below.
+		if rg, ok := storage.(RangeGetter); ok {
+			rs, err := rg.GetRange(r.Context(), key)
+			if err != nil {
+				serveStoreError(w, err)
+				return
+			}
+			defer rs.Close()
+			serveSeekable(w, r, key, rs)
+			return
 		}
 
 		rc, err := storage.Get(r.Context(), key)
@@ -82,18 +102,8 @@ func ServeHandler(storage Storage) http.HandlerFunc {
 			return
 		}
 		head = head[:n]
-		contentType := http.DetectContentType(head)
 
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-		if scriptableHead(contentType) || scriptableExt(key) {
-			// Stored-XSS guard: never let a browser render uploaded
-			// HTML/SVG. Force a neutral, downloadable representation.
-			// SVG sniffs as text/plain, so the key's extension is the
-			// reliable "derived" signal for it.
-			contentType = "application/octet-stream"
-			w.Header().Set("Content-Disposition", "attachment")
-		}
-		w.Header().Set("Content-Type", contentType)
+		setServeHeaders(w, key, http.DetectContentType(head))
 
 		if r.Method == http.MethodHead {
 			w.WriteHeader(http.StatusOK)
@@ -103,6 +113,46 @@ func ServeHandler(storage Storage) http.HandlerFunc {
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.Copy(w, io.MultiReader(bytes.NewReader(head), rc))
 	}
+}
+
+// serveSeekable sniffs the head, rewinds, and hands the reader to
+// http.ServeContent, which owns Range/If-Range/206/Accept-Ranges. The
+// content-type headers are set first: ServeContent only guesses a type when
+// the header is unset, so the sniffed value and the stored-XSS guard both
+// survive.
+func serveSeekable(w http.ResponseWriter, r *http.Request, key string, rs io.ReadSeeker) {
+	head := make([]byte, 512)
+	n, readErr := io.ReadFull(rs, head)
+	if readErr != nil && readErr != io.EOF && readErr != io.ErrUnexpectedEOF {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	if _, err := rs.Seek(0, io.SeekStart); err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	setServeHeaders(w, key, http.DetectContentType(head[:n]))
+
+	// An empty name keeps ServeContent from re-deriving a content type from
+	// the extension — the sniffed value above is authoritative. A zero modtime
+	// suppresses Last-Modified; the Storage contract exposes no mtime.
+	http.ServeContent(w, r, "", time.Time{}, rs)
+}
+
+// setServeHeaders applies the content-type decision shared by both serving
+// paths, including the stored-XSS guard.
+func setServeHeaders(w http.ResponseWriter, key, contentType string) {
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	if scriptableHead(contentType) || scriptableExt(key) {
+		// Stored-XSS guard: never let a browser render uploaded HTML/SVG.
+		// Force a neutral, downloadable representation. SVG sniffs as
+		// text/plain, so the key's extension is the reliable "derived"
+		// signal for it.
+		contentType = "application/octet-stream"
+		w.Header().Set("Content-Disposition", "attachment")
+	}
+	w.Header().Set("Content-Type", contentType)
 }
 
 // serveStoreError maps a Storage.Get error to an HTTP status without

--- a/framework/api_prefix_endpoints_test.go
+++ b/framework/api_prefix_endpoints_test.go
@@ -1,0 +1,78 @@
+package framework
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// WithAPIPrefix was applied to an entity's generated CRUD routes but not to
+// its EntityConfig.Endpoints, so an app using both had its API silently split
+// across two prefixes: /api/licenses for CRUD, /licenses/{id}/revoke for the
+// custom endpoint. Endpoint.Path is documented as "relative to the entity
+// table path", and under a prefix that table path is prefixed.
+//
+// Nothing reported the split — the route registered fine, just somewhere the
+// author had no reason to look.
+func TestAPIPrefixAppliesToRelativeEntityEndpoints(t *testing.T) {
+	app := newPrefixEndpointApp(t, "/api")
+
+	rec := httptest.NewRecorder()
+	app.Router().ServeHTTP(rec, httptest.NewRequest("POST", "/api/licenses/abc/revoke", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("POST /api/licenses/abc/revoke = %d, want %d (relative endpoint did not inherit the API prefix)", rec.Code, http.StatusNoContent)
+	}
+
+	// The unprefixed path must NOT also answer — a route at both places is
+	// the same split bug wearing a friendlier face.
+	rec = httptest.NewRecorder()
+	app.Router().ServeHTTP(rec, httptest.NewRequest("POST", "/licenses/abc/revoke", nil))
+	if rec.Code == http.StatusNoContent {
+		t.Errorf("POST /licenses/abc/revoke still answers; the endpoint should live only under the API prefix")
+	}
+}
+
+// An absolute Endpoint.Path is the documented escape hatch for mounting
+// outside the entity namespace. It must keep bypassing the prefix.
+func TestAPIPrefixSkipsAbsoluteEntityEndpoints(t *testing.T) {
+	app := newPrefixEndpointApp(t, "/api")
+
+	rec := httptest.NewRecorder()
+	app.Router().ServeHTTP(rec, httptest.NewRequest("GET", "/health/licenses", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("GET /health/licenses = %d, want %d (absolute endpoint path must bypass the prefix)", rec.Code, http.StatusNoContent)
+	}
+}
+
+// With no prefix configured, relative endpoints mount exactly where they
+// always did.
+func TestNoAPIPrefixLeavesEntityEndpointsAtRoot(t *testing.T) {
+	app := newPrefixEndpointApp(t, "")
+
+	rec := httptest.NewRecorder()
+	app.Router().ServeHTTP(rec, httptest.NewRequest("POST", "/licenses/abc/revoke", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("POST /licenses/abc/revoke = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+}
+
+func newPrefixEndpointApp(t *testing.T, prefix string) *App {
+	t.Helper()
+	opts := []AppOption{}
+	if prefix != "" {
+		opts = append(opts, WithAPIPrefix(prefix))
+	}
+	app := NewApp(opts...)
+	ok := func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusNoContent) }
+	app.Entity("licenses", entity.EntityConfig{
+		Fields: []schema.Field{{Name: "name", Type: schema.String}},
+		Endpoints: []entity.Endpoint{
+			{Method: "POST", Path: "{id}/revoke", Name: "licenses_revoke", Handler: http.HandlerFunc(ok)},
+			{Method: "GET", Path: "/health/licenses", Name: "licenses_health", Handler: http.HandlerFunc(ok)},
+		},
+	})
+	return app
+}

--- a/framework/app.go
+++ b/framework/app.go
@@ -1040,7 +1040,7 @@ func (a *App) registerGroupEndpoints(g *routegroup.RouteGroup, ent *entity.Entit
 			if description == "" {
 				description = method + " " + g.Prefix() + path
 			}
-			if err := a.MCP.RegisterTool(toolName, description, openapi.EndpointInputSchema(endpoint), endpoint.MCPHandler); err != nil {
+			if err := a.MCP.RegisterTool(toolName, description, openapi.EndpointInputSchema(endpoint), endpoint.MCPHandler, endpointMCPOptions(endpoint)...); err != nil {
 				return err
 			}
 		}
@@ -1603,12 +1603,29 @@ func (a *App) registerEntityEndpoints(ent *entity.Entity, endpoints []entity.End
 			if description == "" {
 				description = method + " " + path
 			}
-			if err := a.MCP.RegisterTool(name, description, openapi.EndpointInputSchema(endpoint), endpoint.MCPHandler); err != nil {
+			if err := a.MCP.RegisterTool(name, description, openapi.EndpointInputSchema(endpoint), endpoint.MCPHandler, endpointMCPOptions(endpoint)...); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+// endpointMCPOptions returns the registration options for an Endpoint's MCP
+// twin. An Endpoint's two front doors do not get the same protection for
+// free: Handler inherits the route's middleware chain, MCPHandler is
+// registered straight onto the MCP server and sees none of it. So the twin
+// defaults to requiring an authenticated caller, and an endpoint that really
+// is anonymous says so with MCPPublic.
+func endpointMCPOptions(ep entity.Endpoint) []mcp.ToolOption {
+	switch {
+	case ep.MCPGate != nil:
+		return []mcp.ToolOption{mcp.WithToolGate(ep.MCPGate)}
+	case ep.MCPPublic:
+		return nil
+	default:
+		return []mcp.ToolOption{mcp.WithToolGate(MCPRequireUser())}
+	}
 }
 
 // openapi.EntityEndpointPath, convertColonParams, openapi.DefaultEndpointToolName moved to

--- a/framework/app.go
+++ b/framework/app.go
@@ -1581,7 +1581,13 @@ func (a *App) registerEntityEndpoints(ent *entity.Entity, endpoints []entity.End
 		if method == "" {
 			return fmt.Errorf("endpoint %q: method is required", endpoint.Path)
 		}
-		path := openapi.EntityEndpointPath(ent, endpoint.Path)
+		// path is where the endpoint is mounted (prefix applied for relative
+		// paths); specPath is the prefix-relative form the OpenAPI spec uses.
+		// The auto-generated tool name is derived from specPath so it keeps
+		// matching the spec's operationId — the prefix moves the route, not
+		// the endpoint's identity.
+		path := openapi.EntityEndpointRoutePath(ent, endpoint.Path, a.apiPrefix())
+		specPath := openapi.EntityEndpointPath(ent, endpoint.Path)
 		if endpoint.Handler != nil {
 			a.router.Handle(method, path, endpoint.Handler)
 		}
@@ -1591,7 +1597,7 @@ func (a *App) registerEntityEndpoints(ent *entity.Entity, endpoints []entity.End
 			}
 			name := endpoint.Name
 			if name == "" {
-				name = openapi.DefaultEndpointToolName(ent.GetName(), method, path)
+				name = openapi.DefaultEndpointToolName(ent.GetName(), method, specPath)
 			}
 			description := endpoint.Description
 			if description == "" {

--- a/framework/app.go
+++ b/framework/app.go
@@ -988,6 +988,14 @@ func (a *App) GroupEntity(g *routegroup.RouteGroup, name string, config entity.E
 			crudHandler.Outbox = a.outbox
 		}
 		crudHandler.Registry = a.Registry
+		// The MCP tools re-dispatch through the router — that is what makes
+		// them inherit auth, owner and tenant scoping rather than
+		// re-implementing it — so they must address the path the routes are
+		// actually mounted at. A group's sub-router shares the parent mux and
+		// registers PREFIXED patterns, so dispatching to the bare "/table"
+		// 404s. App.Entity sets this from the API prefix; the grouped path
+		// left it empty.
+		crudHandler.BasePath = g.Prefix()
 
 		// Register CRUD routes on the group's sub-router.
 		// The group's prefix is already baked into the sub-router,

--- a/framework/crud/crud_routes.go
+++ b/framework/crud/crud_routes.go
@@ -7,9 +7,15 @@ import (
 
 // registerLLMMDRoutes registers the /{path}/llm.md documentation endpoint for
 // a single entity. Called automatically by RegisterCrudRoutes.
-func registerLLMMDRoutes(r *router.Router, ent *entity.Entity, path string) {
+//
+// It mounts the SCOPE-AWARE handler: the docs describe exactly the entity the
+// sibling List route serves, so they answer to the same gate. Mounting the
+// bare LLMMDHandler here checked only for a session, which let an
+// authenticated caller with no read permission fetch the schema of an entity
+// whose rows they get a 403 on.
+func registerLLMMDRoutes(r *router.Router, ch *CrudHandler, path string) {
 	path = NormalizePath(path)
-	r.Get(path+"/llm.md", LLMMDHandler(ent))
+	r.Get(path+"/llm.md", LLMMDHandlerFor(ch))
 }
 
 // CrudRouteOptions controls which routes are registered by RegisterCrudRoutes.
@@ -60,7 +66,7 @@ func RegisterCrudRoutes(r *router.Router, handler *CrudHandler, path string, opt
 
 	// LLM-friendly documentation endpoint
 	if !opt.NoLLMMD {
-		registerLLMMDRoutes(r, handler.Entity, path)
+		registerLLMMDRoutes(r, handler, path)
 	}
 }
 

--- a/framework/crud/crud_upload.go
+++ b/framework/crud/crud_upload.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/urlsafe"
 	"github.com/DonaldMurillo/gofastr/core/schema"
 	"github.com/DonaldMurillo/gofastr/framework/entity"
 	"github.com/DonaldMurillo/gofastr/framework/file"
@@ -248,44 +249,14 @@ func (ch *CrudHandler) validateMediaURLs(body map[string]any) error {
 // stored value flows into HTML attributes and HTTP redirects later —
 // any scheme not on this list becomes a phishing / XSS / SSRF vector
 // when rendered.
+//
+// The scheme allow-list is core-ui/urlsafe's Resource policy (http(s) plus
+// relative references), not a local copy of it. The traversal check on top is
+// storage-specific: a stored key must not climb out of the storage root, and
+// urlsafe deliberately allows "../" because a relative href legitimately may.
 func isSafeMediaURL(s string) bool {
-	for i := 0; i < len(s); i++ {
-		if s[i] < 0x20 || s[i] == 0x7f {
-			return false
-		}
-	}
-	low := strings.ToLower(s)
-	// Percent-encoded CR/LF tries to smuggle a header line through
-	// downstream consumers that re-encode the URL.
-	if strings.Contains(low, "%0d") || strings.Contains(low, "%0a") {
-		return false
-	}
-	// Path traversal escapes the storage root.
 	if strings.Contains(s, "..") {
 		return false
 	}
-	// Protocol-relative URLs are ambiguous about origin trust.
-	if strings.HasPrefix(s, "//") {
-		return false
-	}
-	// Relative paths (no scheme) are fine — they live under the storage
-	// prefix.
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c == ':' {
-			scheme := strings.ToLower(s[:i])
-			switch scheme {
-			case "http", "https":
-				return true
-			default:
-				return false
-			}
-		}
-		if c == '/' || c == '?' || c == '#' || c == '.' {
-			// Hit a non-scheme delimiter first — relative path.
-			return true
-		}
-	}
-	// No colon at all — bare filename.
-	return true
+	return urlsafe.OK(s, urlsafe.Resource)
 }

--- a/framework/crud/llmmd.go
+++ b/framework/crud/llmmd.go
@@ -342,6 +342,27 @@ func LLMMDHandler(ent *entity.Entity) http.Handler {
 	})
 }
 
+// LLMMDHandlerFor is [LLMMDHandler] with the entity's own access gate
+// applied — the form the CRUD routes register.
+//
+// LLMMDHandler checks only for a session, while List runs the full scope
+// chain, so an authenticated caller with no `orders:read` grant got 403 on the
+// rows and 200 on the schema: every field name, type and enum of an entity
+// they cannot read. The schema is the disclosure, not the row.
+//
+// It reuses requireScope, so owner, tenant, baseline-session and RBAC all move
+// together with the read path instead of being restated here.
+func LLMMDHandlerFor(ch *CrudHandler) http.Handler {
+	docs := LLMMDHandler(ch.Entity)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		if !ch.requireScope(w, r, opRead) {
+			return
+		}
+		docs.ServeHTTP(w, r)
+	})
+}
+
 // RegistryLLMMDHandler returns an http.Handler that serves the top-level
 // LLM-friendly markdown index for all registered entities. Auth-required
 // for the same reason as [LLMMDHandler].

--- a/framework/crud/llmmd_authz_security_test.go
+++ b/framework/crud/llmmd_authz_security_test.go
@@ -1,0 +1,70 @@
+package crud
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// /{table}/llm.md checked for a session but not for the entity's declared
+// permission, while List checks both. An authenticated user with no
+// `orders:read` grant got 403 on the data and 200 on the schema — every field
+// name, type and enum of an entity they cannot read.
+//
+// This is the REST twin of the MCP tools/list disclosure: the schema is the
+// disclosure, not the row.
+func TestLLMMDRequiresTheSamePermissionAsList(t *testing.T) {
+	ch := ordersHandlerWithReadPermission(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/orders/llm.md", nil)
+	req = reqWithRolesOnly(req, "u1") // signed in, no orders:read grant
+	LLMMDHandlerFor(ch).ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusOK {
+		t.Fatalf("SECURITY: [disclosure] llm.md served the schema of an entity the caller cannot read (status %d)", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "internal_note") {
+		t.Error("SECURITY: [disclosure] refused response still carried field names")
+	}
+}
+
+// An anonymous caller was already refused; keep it that way.
+func TestLLMMDStillRefusesAnonymous(t *testing.T) {
+	ch := ordersHandlerWithReadPermission(t)
+	rec := httptest.NewRecorder()
+	LLMMDHandlerFor(ch).ServeHTTP(rec, httptest.NewRequest("GET", "/orders/llm.md", nil))
+	if rec.Code == http.StatusOK {
+		t.Fatal("SECURITY: [disclosure] llm.md served an anonymous caller")
+	}
+}
+
+// A caller who holds the permission must still get the docs — the whole point
+// of the endpoint is that an agent with access can read it.
+func TestLLMMDServesPermittedCaller(t *testing.T) {
+	ch := ordersHandlerWithReadPermission(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/orders/llm.md", nil)
+	LLMMDHandlerFor(ch).ServeHTTP(rec, reqWithGrant(req, "u1", "orders:read"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("llm.md refused a permitted caller: %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func ordersHandlerWithReadPermission(t *testing.T) *CrudHandler {
+	t.Helper()
+	ent := entity.Define("orders", entity.EntityConfig{
+		Fields: []schema.Field{
+			{Name: "total", Type: schema.Int},
+			{Name: "internal_note", Type: schema.String},
+		},
+		Access: entity.AccessControl{Read: "orders:read"},
+	})
+	return &CrudHandler{Entity: ent}
+}

--- a/framework/docs/content/agent-ready.md
+++ b/framework/docs/content/agent-ready.md
@@ -198,12 +198,42 @@ running app (persisted through the module store, dependency-checked). Keep
 it off any `/mcp` reachable by untrusted callers.
 
 When you opt in explicitly, both control tools require an
-**authenticated caller**: they run behind an `mcp.Gated` precondition
-that refuses a request with no identity on its context. Make sure the
-app's session/JWT middleware runs on the `/mcp` route, or every call
-comes back asking for a caller. The gate asks only for an identity —
-the framework layer cannot know your role vocabulary — so wrap your own
-handlers with `mcp.Gated(auth.MCPRole("admin"), …)` when you want more.
+**authenticated caller**: they run behind an `mcp.WithToolGate`
+precondition that refuses a request with no identity on its context. Make
+sure the app's session/JWT middleware runs on the `/mcp` route, or every
+call comes back asking for a caller. The gate asks only for an identity —
+the framework layer cannot know your role vocabulary — so pass
+`auth.MCPRole("admin")` when you want more.
+
+A gated tool is also **hidden from `tools/list`** for callers who cannot
+invoke it. That matters more than it sounds: `tools/list` used to run with
+no gate at all, so an anonymous POST came back with every tool's
+`inputSchema` — and for entity CRUD tools those schemas are built from live
+entity definitions, naming every entity and every non-`Hidden` field with
+its type and enum set. The call refused; the schema was already out.
+
+Prefer `mcp.WithToolGate(gate)` as a `RegisterTool` option over the older
+`mcp.Gated(gate, handler)` wrapper. `Gated` wraps the handler, so it only
+ever reached `tools/call` — the listing never consulted it.
+
+```go
+app.MCP.RegisterTool("orders_refund", "…", schema, refundHandler,
+    mcp.WithToolGate(auth.MCPRole("support")))
+```
+
+When the whole endpoint is private, close it in one place instead:
+
+```go
+framework.NewApp(
+    framework.WithMCP(),
+    framework.WithMCPGate(framework.MCPRequireUser()),
+)
+```
+
+`WithMCPGate` covers `tools/list`, `tools/call`, `resources/list` and
+`resources/read`. The `initialize` handshake and `ping` stay open by
+design — they carry only the protocol version, capability booleans and the
+server name, and a client that cannot handshake cannot present credentials.
 
 The `gofastr dev` loop is exempt: it turns these tools on with no auth
 configured at all, so a gate would only lock the dev loop out of its own
@@ -219,9 +249,28 @@ through the router, so session/JWT auth, owner scoping, and RBAC apply
 exactly as they do over HTTP (the caller's Cookie/Authorization from the `/mcp`
 request carries through). Directly registered tools — custom
 `app.MCP.RegisterTool` handlers and `Endpoint.MCPHandler` twins — run
-without route middleware; gate them per-caller with `mcp.Gated` +
-battery/auth's `auth.MCPUser()` / `auth.MCPRole(...)` (see
-[plugins](plugins.md)).
+without route middleware, so they carry their own gate.
+
+**`Endpoint.MCPHandler` twins default to requiring an authenticated
+caller.** An `Endpoint` has two front doors for one operation: `Handler`
+inherits the route's middleware chain, `MCPHandler` does not. An endpoint
+behind `auth.RequireRole("editor")` was therefore role-checked over HTTP
+and ungated over MCP. Declare something stricter with
+`Endpoint.MCPGate`, or opt out with `Endpoint.MCPPublic: true` for an
+endpoint that really is anonymous over HTTP too:
+
+```go
+entity.Endpoint{
+    Method: "POST", Path: "{id}/publish", MCP: true,
+    Handler:    publishHTTP,
+    MCPHandler: publishTool,
+    MCPGate:    auth.MCPRole("editor"),   // else: any authenticated caller
+}
+```
+
+For your own `RegisterTool` calls, gate them per-caller with
+`mcp.WithToolGate` + battery/auth's `auth.MCPUser()` / `auth.MCPRole(...)`
+(see [plugins](plugins.md)).
 
 Process modules (issue `#37`) add a third tool kind alongside the entity
 CRUD tools and directly-registered handlers. Each tool a process module

--- a/framework/docs/content/api-versioning.md
+++ b/framework/docs/content/api-versioning.md
@@ -44,6 +44,7 @@ Input is normalised: `"api"`, `"/api"`, and `"/api/"` all become
 | Where | Behaviour under `WithAPIPrefix("/api/v1")` |
 | --- | --- |
 | **REST routes** | mounted at `/api/v1/<table>` (list/get/create/update/delete, `_batch`, `_events`, …). |
+| **Custom `Endpoints`** | a **relative** `Endpoint.Path` (`"{id}/publish"`) resolves under the prefixed table path → `/api/v1/posts/{id}/publish`. An **absolute** path (`"/health/posts"`) bypasses the prefix — the escape hatch for mounting outside the API namespace. |
 | **OpenAPI** (`/openapi.json`) | the prefix is expressed as the spec's **server URL** (`servers: [{ url: "/api/v1" }]`); operation paths stay bare (`/posts`). Generated SDKs prepend the server URL, so they call `/api/v1/posts`. |
 | **MCP tools** | `posts_list` / `posts_get` / `posts_create` / … dispatch against the prefixed path, so an agent driving the app over MCP reaches the same routes as REST. |
 

--- a/framework/docs/content/blueprints.md
+++ b/framework/docs/content/blueprints.md
@@ -1006,6 +1006,11 @@ The generator rejects:
 
 - unknown top-level or section keys, except `x_` / `x-` extension keys
 - duplicate entity names, routes, endpoints, middleware, plugins, or helpers
+- an entity `table:` that is not letters, digits and underscores — the table
+  name reaches two sinks that neither re-escape nor re-validate it: the
+  generated typed client emits it into Go string literals, and the runtime
+  interpolates it into DDL as a bare SQL identifier. The entity `name:` is
+  already constrained to a Go identifier; `table:` was the way around that.
 - relation-typed fields (`type: relation`) without a `to:` target, or whose
   `to:` names an entity the blueprint does not declare — without this check
   the built app would crash at startup with "auto-migrate: entity has

--- a/framework/docs/content/entity-declarations.md
+++ b/framework/docs/content/entity-declarations.md
@@ -869,12 +869,29 @@ Endpoint paths can be absolute (`/posts/{id}/publish`) or relative to the
 entity table path (`{id}/publish`). Both `{id}` and `:id` parameter syntax are
 accepted.
 
+Under `WithAPIPrefix` a **relative** path resolves under the prefixed table
+path — `WithAPIPrefix("/api")` mounts `{id}/publish` on entity `posts` at
+`POST /api/posts/{id}/publish`, alongside that entity's CRUD routes. An
+absolute path bypasses the prefix; use it to mount outside the entity's API
+namespace.
+
 Note the auth asymmetry: the HTTP `Handler` runs behind the route
-middleware chain, but the `MCPHandler` twin is invoked directly — no
-route middleware, so no per-caller auth of its own. If the HTTP side is
-protected, gate the MCP side to match by wrapping it:
-`MCPHandler: mcp.Gated(auth.MCPRole("admin"), publishTool)` — see
-[plugins](plugins.md) → MCP tool gating.
+middleware chain, but the `MCPHandler` twin is invoked directly — no route
+middleware, so no per-caller auth of its own. **The twin therefore defaults
+to requiring an authenticated caller.** Declare something stricter with
+`MCPGate`, or opt out with `MCPPublic` for an endpoint that really is
+anonymous over HTTP too:
+
+```go
+entity.Endpoint{
+    Method: "POST", Path: "{id}/publish", MCP: true,
+    Handler:    publishHTTP,
+    MCPHandler: publishTool,
+    MCPGate:    auth.MCPRole("admin"), // default: any authenticated caller
+}
+```
+
+See [plugins](plugins.md) → MCP tool gating.
 
 ### Typed input/output schemas
 

--- a/framework/docs/content/kiln.md
+++ b/framework/docs/content/kiln.md
@@ -92,6 +92,20 @@ approved plan naming the exact operation and target. An approval is
 single-use. `undo` truncates one journal entry and deterministically rebuilds;
 `reset_session` clears the journal and ephemeral schema.
 
+Those rules are enforced during **replay**, not only at the tool call. The
+journal is the authorization record, so a destructive entry carries the
+`plan_id` that authorized it and replay re-checks that the plan exists, was
+approved, lists that exact target, and has not already been spent on it.
+Consumption is derived from the log too — it used to live in a per-process
+map that replay never rebuilt, so a restart re-armed every spent approval.
+The `multi_tenant` refusal runs on the same path.
+
+This matters because the journal is replayed at boot and by `kiln freeze`,
+which turns the replayed world into a blueprint. A hand-authored
+`.kiln.session.jsonl` used to install world state the tool API refuses. It
+needs a local filesystem write, so it is an integrity property rather than a
+remote one — but a guard only one of two readers applies is not a guard.
+
 ## Current world contract
 
 The world mirrors the current blueprint where a live representation is safe:

--- a/framework/docs/content/plugins.md
+++ b/framework/docs/content/plugins.md
@@ -39,15 +39,20 @@ dodge.
 
 Directly registered MCP tools do NOT pass through route middleware —
 the handler runs as-is for any caller who can reach `/mcp`. To
-auth-gate one, wrap it with `mcp.Gated` and a precondition; battery/auth
-ships ready-made gates that read the identity the app's global
-session/JWT middleware resolved onto the request context:
+auth-gate one, register it with `mcp.WithToolGate` and a precondition;
+battery/auth ships ready-made gates that read the identity the app's
+global session/JWT middleware resolved onto the request context:
 
 ```go
 app.MCP.RegisterTool("reports_rebuild", "Rebuild the reports cache", schema,
-    mcp.Gated(auth.MCPRole("admin"), rebuildHandler))
+    rebuildHandler, mcp.WithToolGate(auth.MCPRole("admin")))
 // auth.MCPUser() = any signed-in caller; auth.MCPRole("a", "b") = any of the roles.
 ```
+
+`WithToolGate` also **hides the tool from `tools/list`** for callers who
+cannot invoke it — the `inputSchema` is a disclosure in its own right. The
+older `mcp.Gated(gate, handler)` wrapper still works but only reaches
+`tools/call`, so the schema stayed visible to everyone; prefer the option.
 
 (Entity CRUD tools don't need this — they re-dispatch through the
 router and inherit HTTP auth, owner scoping, and RBAC wholesale.)

--- a/framework/docs/content/security.md
+++ b/framework/docs/content/security.md
@@ -325,11 +325,18 @@ for every operation on an entity that declares none of `OwnerField`,
    `Read` + a real `Create` permission).
 
 Because entity MCP tools dispatch through the router, this gate governs
-them automatically — no separate `mcp.Gated`/`auth.MCPUser` wiring is
-needed for generated CRUD tools (that machinery remains for *custom*
-tools registered directly via `app.MCP.RegisterTool` or
-`Endpoint.MCPHandler`, which bypass route middleware; see
+them automatically — no separate `mcp.WithToolGate`/`auth.MCPUser` wiring
+is needed for generated CRUD tools (that machinery remains for *custom*
+tools registered directly via `app.MCP.RegisterTool`; `Endpoint.MCPHandler`
+twins default to requiring an authenticated caller — see
 [agent-ready](agent-ready.md)).
+
+The entity's auto-generated `/{table}/llm.md` runs the **same** `requireScope`
+chain as `List`. It documents exactly the entity `List` serves, so it answers
+to the same gate: an authenticated caller without the entity's read permission
+gets a 403 on the schema, not just on the rows. The field list is a disclosure
+in its own right — it names every non-`Hidden` column, its type and its enum
+set.
 
 `gofastr generate` prints a warning listing every entity left publicly
 readable/writable (`public: true`), so a generated app never has open

--- a/framework/docs/content/uploads.md
+++ b/framework/docs/content/uploads.md
@@ -138,6 +138,34 @@ as script in a victim's browser (stored-XSS guard). Path-traversal
 defense is delegated to the backend's key sanitization; the handler
 echoes no filesystem path on any error.
 
+### Range requests and resumable downloads
+
+`Storage.Get` returns an `io.ReadCloser`, which erases seekability — and
+`http.ServeContent` needs an `io.ReadSeeker` to answer a `Range:` header.
+Backends that hold their bytes locally declare the capability instead:
+
+```go
+type RangeGetter interface {
+    GetRange(ctx context.Context, key string) (io.ReadSeekCloser, error)
+}
+```
+
+`ServeHandler` type-asserts for it. When the backend implements it, range
+requests get a `206` with `Accept-Ranges: bytes`, so a download interrupted
+1.8 GB into a 2 GB file resumes instead of restarting. When it doesn't, the
+handler serves whole bodies exactly as before — declining is legal.
+
+| Backend | `RangeGetter` |
+| --- | --- |
+| `upload.LocalStorage`, `storage.LocalStorage` | yes — already opens an `*os.File` |
+| `storage.MemoryStorage` | yes — the bytes are already resident |
+| `storage.S3Storage` | no — a network backend would have to buffer the whole object to satisfy `Seek`. Use `WithPresigner` so the transfer bypasses the app entirely. |
+
+Implement it on your own backend only if seeking is genuinely cheap there,
+and route key validation through the same code path as `Get` — a capability
+that skipped the traversal check would be a path-traversal hole with a
+performance justification.
+
 ## Content checksums
 
 The `battery/storage` package provides opt-in SHA-256 helpers that wrap

--- a/framework/endpoint_mcp_gate_test.go
+++ b/framework/endpoint_mcp_gate_test.go
@@ -1,0 +1,101 @@
+package framework
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/mcp"
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// An entity Endpoint declares one operation with two front doors: an HTTP
+// handler that inherits the route's middleware chain, and an MCPHandler
+// registered straight onto the MCP server. The MCP twin saw no middleware, so
+// an endpoint behind auth.RequireRole("editor") was role-checked over HTTP and
+// wide open over MCP.
+//
+// The twin now defaults to requiring an authenticated caller. An endpoint that
+// really is public says so with MCPPublic.
+func TestEndpointMCPTwinRequiresUserByDefault(t *testing.T) {
+	app := newEndpointMCPApp(t, entity.Endpoint{
+		Method: "POST", Path: "{id}/publish", Name: "posts_publish", MCP: true,
+		Handler:    http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(204) }),
+		MCPHandler: func(context.Context, map[string]any) (any, error) { return "published", nil },
+	})
+
+	resp := app.MCP.HandleRequest(context.Background(), mcp.Request{
+		JSONRPC: "2.0", ID: 1, Method: "tools/call",
+		Params: json.RawMessage(`{"name":"posts_publish","arguments":{}}`),
+	})
+	if resp.Error == nil {
+		t.Fatal("SECURITY: [authz] endpoint MCP twin ran for an unauthenticated caller")
+	}
+	if names := toolNames(t, app, context.Background()); hasTool(names, "posts_publish") {
+		t.Errorf("SECURITY: [disclosure] gated endpoint twin still listed to an anonymous caller: %v", names)
+	}
+}
+
+// The opt-out has to actually work, or hosts will reach for something worse.
+func TestEndpointMCPPublicOptsOut(t *testing.T) {
+	app := newEndpointMCPApp(t, entity.Endpoint{
+		Method: "GET", Path: "{id}/preview", Name: "posts_preview", MCP: true, MCPPublic: true,
+		Handler:    http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(204) }),
+		MCPHandler: func(context.Context, map[string]any) (any, error) { return "preview", nil },
+	})
+
+	resp := app.MCP.HandleRequest(context.Background(), mcp.Request{
+		JSONRPC: "2.0", ID: 1, Method: "tools/call",
+		Params: json.RawMessage(`{"name":"posts_preview","arguments":{}}`),
+	})
+	if resp.Error != nil {
+		t.Fatalf("MCPPublic endpoint refused an anonymous caller: %v", resp.Error)
+	}
+	if names := toolNames(t, app, context.Background()); !hasTool(names, "posts_preview") {
+		t.Errorf("MCPPublic endpoint missing from the listing: %v", names)
+	}
+}
+
+// A host that wants a stricter predicate than "any authenticated caller"
+// supplies one, and it must win over the default.
+func TestEndpointMCPGateOverridesDefault(t *testing.T) {
+	var called bool
+	app := newEndpointMCPApp(t, entity.Endpoint{
+		Method: "POST", Path: "{id}/archive", Name: "posts_archive", MCP: true,
+		MCPGate:    func(context.Context) error { called = true; return errAuthRequired },
+		Handler:    http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(204) }),
+		MCPHandler: func(context.Context, map[string]any) (any, error) { return "archived", nil },
+	})
+
+	resp := app.MCP.HandleRequest(context.Background(), mcp.Request{
+		JSONRPC: "2.0", ID: 1, Method: "tools/call",
+		Params: json.RawMessage(`{"name":"posts_archive","arguments":{}}`),
+	})
+	if resp.Error == nil {
+		t.Fatal("custom MCPGate did not refuse")
+	}
+	if !called {
+		t.Error("custom MCPGate never ran; the default gate shadowed it")
+	}
+}
+
+func newEndpointMCPApp(t *testing.T, ep entity.Endpoint) *App {
+	t.Helper()
+	app := NewApp()
+	app.Entity("posts", entity.EntityConfig{
+		Fields:    []schema.Field{{Name: "title", Type: schema.String}},
+		Endpoints: []entity.Endpoint{ep},
+	})
+	return app
+}
+
+func hasTool(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/framework/entity/entity.go
+++ b/framework/entity/entity.go
@@ -240,6 +240,12 @@ type Index struct {
 // are accepted. Handler is used for HTTP. MCPHandler is optional and is only
 // registered when MCP is true.
 //
+// Under framework.WithAPIPrefix a relative path resolves under the prefixed
+// table path — WithAPIPrefix("/api") mounts "{id}/publish" on entity "posts"
+// at POST /api/posts/{id}/publish, alongside that entity's CRUD routes. An
+// absolute path bypasses the prefix entirely; use it to mount outside the
+// entity's API namespace.
+//
 // InputSchema and OutputSchema are OPTIONAL typed descriptions of the request
 // body and the success (200) response, expressed as []schema.Field — the same
 // representation the entity's own CRUD schema is built from, so OpenAPI and the

--- a/framework/entity/entity.go
+++ b/framework/entity/entity.go
@@ -263,6 +263,26 @@ type Endpoint struct {
 	OutputSchema []schema.Field  `json:"outputSchema,omitempty"`
 	Handler      http.Handler    `json:"-"`
 	MCPHandler   mcp.ToolHandler `json:"-"`
+
+	// MCPGate is an optional per-caller precondition for the MCP twin. It
+	// runs before MCPHandler on every tools/call, and decides whether the
+	// tool is visible to that caller in tools/list.
+	//
+	// It exists because the two front doors of one Endpoint do not get the
+	// same protection for free: Handler inherits the route's middleware
+	// chain, while MCPHandler is registered straight onto the MCP server and
+	// sees none of it. An endpoint behind auth.RequireRole("editor") was
+	// therefore role-checked over HTTP and ungated over MCP.
+	//
+	// When unset, the twin defaults to requiring an authenticated caller
+	// (framework.MCPRequireUser). Set MCPPublic to opt out of that default;
+	// set this to something stricter, e.g. auth.MCPRole("editor").
+	MCPGate func(ctx context.Context) error `json:"-"`
+
+	// MCPPublic opts the MCP twin out of the default authenticated-caller
+	// gate, for an endpoint that really is anonymous over HTTP too. Ignored
+	// when MCPGate is set.
+	MCPPublic bool `json:"mcpPublic,omitempty"`
 }
 
 // TenantColumn returns the tenant-scoping column name for this entity:

--- a/framework/experimental/apiversions/version.go
+++ b/framework/experimental/apiversions/version.go
@@ -17,6 +17,7 @@ package apiversions
 
 import (
 	"fmt"
+	"github.com/DonaldMurillo/gofastr/core-ui/urlsafe"
 	"net/http"
 	"regexp"
 	"strings"
@@ -170,41 +171,8 @@ func DeprecationHeaders(w http.ResponseWriter, sunset time.Time, replacement str
 // deprecation hint into a phishing vector. Protocol-relative URLs
 // ("//other.example") are dropped as ambiguous about origin trust.
 func safeReplacementURL(u string) (string, bool) {
-	if u == "" {
+	if !urlsafe.OK(u, urlsafe.Resource) {
 		return "", false
-	}
-	for i := 0; i < len(u); i++ {
-		c := u[i]
-		if c < 0x20 || c == 0x7f {
-			return "", false
-		}
-	}
-	if strings.HasPrefix(u, "//") {
-		return "", false
-	}
-	// Percent-encoded CR/LF still smuggles a line when consumers decode.
-	low := strings.ToLower(u)
-	if strings.Contains(low, "%0d") || strings.Contains(low, "%0a") {
-		return "", false
-	}
-	if strings.HasPrefix(u, "/") || strings.HasPrefix(u, "./") || strings.HasPrefix(u, "../") {
-		return u, true
-	}
-	for i := 0; i < len(u); i++ {
-		c := u[i]
-		if c == ':' {
-			scheme := strings.ToLower(u[:i])
-			switch scheme {
-			case "http", "https":
-				return u, true
-			default:
-				return "", false
-			}
-		}
-		if c == '/' || c == '?' || c == '#' {
-			// No scheme delimiter before path-ish char — relative path.
-			return u, true
-		}
 	}
 	return u, true
 }

--- a/framework/group_mcp_dispatch_test.go
+++ b/framework/group_mcp_dispatch_test.go
@@ -1,0 +1,69 @@
+package framework
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// The entity CRUD MCP tools work by re-dispatching through the router, which
+// is what makes them inherit auth, owner scoping and tenant scoping instead of
+// re-implementing them. That only holds if they dispatch to the path the
+// routes are actually mounted at.
+//
+// App.Entity sets crudHandler.BasePath from the API prefix; GroupEntity never
+// set it, so a grouped entity's tools dispatched to "/widgets" while the
+// routes lived at "/api/widgets". Fail-closed (a 404, not a data leak) but the
+// tools were simply broken for every grouped entity.
+func TestGroupEntityMCPToolsReachGroupedRoutes(t *testing.T) {
+	db := openMemDB(t)
+	app := NewApp(WithDB(db))
+	g := app.Group("/api")
+	app.GroupEntity(g, "widgets", entity.EntityConfig{
+		Exposure: &entity.ExposureConfig{MCP: true, Public: true},
+		Fields:   []schema.Field{{Name: "name", Type: schema.String}},
+	})
+	if err := AutoMigrate(db, app.Registry); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+
+	if _, err := app.MCP.CallTool(context.Background(), "widgets_list", map[string]any{}); err != nil {
+		t.Fatalf("widgets_list on a grouped entity: %v", err)
+	}
+}
+
+// The same bug on a nested group: the dispatch path must be the FULL composed
+// prefix, not just the innermost one.
+func TestNestedGroupEntityMCPToolsReachRoutes(t *testing.T) {
+	db := openMemDB(t)
+	app := NewApp(WithDB(db))
+	g := app.Group("/api").Group("/v2")
+	app.GroupEntity(g, "gadgets", entity.EntityConfig{
+		Exposure: &entity.ExposureConfig{MCP: true, Public: true},
+		Fields:   []schema.Field{{Name: "name", Type: schema.String}},
+	})
+	if err := AutoMigrate(db, app.Registry); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+
+	if _, err := app.MCP.CallTool(context.Background(), "gadgets_list", map[string]any{}); err != nil {
+		t.Fatalf("gadgets_list under /api/v2: %v", err)
+	}
+}
+
+func openMemDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	// ":memory:" with the default pool hands out a fresh empty database per
+	// connection — pin to one.
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+	return db
+}

--- a/framework/mcp_control.go
+++ b/framework/mcp_control.go
@@ -39,6 +39,33 @@ func WithMCPControl() AppOption {
 	}
 }
 
+// WithMCPGate installs a server-wide precondition over the /mcp data surface:
+// tools/list, tools/call, resources/list and resources/read all run it first.
+// Use it when the endpoint is private wholesale.
+//
+// Without it, /mcp discloses every registered tool's inputSchema to anyone who
+// can reach the route — and for entity CRUD tools those schemas are built from
+// live entity definitions, naming every entity and every non-Hidden field.
+// Individual tools can be gated instead with mcp.WithToolGate, which filters
+// the listing per caller rather than closing it for everyone.
+//
+// The `initialize` handshake and `ping` stay open by design: they carry only
+// the protocol version, capability booleans and the server name, and a client
+// that cannot handshake cannot present credentials.
+//
+//	app := framework.NewApp(
+//	    framework.WithMCP(),
+//	    framework.WithMCPGate(framework.MCPRequireUser()),
+//	)
+func WithMCPGate(gate func(ctx context.Context) error) AppOption {
+	if gate == nil {
+		panic("framework.WithMCPGate: nil gate — a nil precondition would silently allow every caller")
+	}
+	return func(a *App) {
+		a.MCP.SetGate(gate)
+	}
+}
+
 func (a *App) registerControlTools() error {
 	tools := []struct {
 		name        string
@@ -73,13 +100,47 @@ func (a *App) registerControlTools() error {
 	}
 	gate := controlToolGate(a.mcpControlDevImplied)
 	for _, t := range tools {
-		h := t.handler
+		var opts []mcp.ToolOption
 		if gate != nil {
-			h = mcp.Gated(gate, h)
+			// WithToolGate, not mcp.Gated: the wrapper only ever reached
+			// tools/call, so an anonymous tools/list still returned these
+			// tools' schemas — telling a stranger the app can be
+			// reconfigured over MCP, and exactly how.
+			opts = append(opts, mcp.WithToolGate(gate))
 		}
-		if err := a.MCP.RegisterTool(t.name, t.description, t.schema, h); err != nil {
+		if err := a.MCP.RegisterTool(t.name, t.description, t.schema, t.handler, opts...); err != nil {
 			return fmt.Errorf("framework: register MCP control tool %q: %w", t.name, err)
 		}
+	}
+	return nil
+}
+
+// MCPRequireUser is the precondition the framework ships for MCP tools that
+// register DIRECTLY on the server and so never see the router's middleware
+// chain: entity.Endpoint.MCPHandler twins, app.MCP.RegisterTool calls, and
+// battery-registered mutating tools.
+//
+// It asks only for an identity, not a role, because the framework layer
+// cannot know the host's role vocabulary (and cannot import battery/auth).
+// A host wanting more passes auth.MCPRole("admin") instead.
+//
+// Pair it with [mcp.WithToolGate] rather than [mcp.Gated] so the tool also
+// disappears from tools/list for callers who cannot invoke it — the
+// inputSchema is the disclosure, not the call.
+func MCPRequireUser() func(ctx context.Context) error {
+	return requireMCPUser
+}
+
+// errAuthRequired is the refusal MCPRequireUser returns. It names the fix
+// (send credentials, check the middleware runs on /mcp) without disclosing
+// anything about the tool or the app's state.
+var errAuthRequired = errors.New("this tool requires an authenticated caller — " +
+	"send the session cookie or Authorization header on the /mcp request, " +
+	"and make sure the app's session middleware runs on the /mcp route")
+
+func requireMCPUser(ctx context.Context) error {
+	if u, ok := handler.GetUser(ctx); !ok || u == nil {
+		return errAuthRequired
 	}
 	return nil
 }
@@ -107,14 +168,7 @@ func controlToolGate(devImplied bool) func(ctx context.Context) error {
 	if devImplied {
 		return nil
 	}
-	return func(ctx context.Context) error {
-		if u, ok := handler.GetUser(ctx); !ok || u == nil {
-			return errors.New("this tool mutates the running app and requires an authenticated caller — " +
-				"send the session cookie or Authorization header on the /mcp request, " +
-				"and make sure the app's session middleware runs on the /mcp route")
-		}
-		return nil
-	}
+	return requireMCPUser
 }
 
 // routerHasMCPRoute reports whether the host already mounted a POST

--- a/framework/mcp_gate_test.go
+++ b/framework/mcp_gate_test.go
@@ -1,0 +1,81 @@
+package framework
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/mcp"
+)
+
+// The mutating control tools already refused an unauthenticated CALL, but
+// they still appeared in tools/list with their full input schema — mcp.Gated
+// wraps handlers, and the listing never consulted it. An anonymous caller
+// learned that this app can be reconfigured over MCP and exactly how.
+func TestControlToolsHiddenFromUnauthenticatedList(t *testing.T) {
+	app := NewApp(WithMCPControl())
+	names := toolNames(t, app, context.Background())
+	for _, n := range names {
+		if strings.HasPrefix(n, "app_module_") {
+			t.Errorf("SECURITY: [disclosure] unauthenticated tools/list exposed %q; got %v", n, names)
+		}
+	}
+}
+
+// WithMCPGate closes the whole data surface for hosts whose /mcp is private.
+func TestWithMCPGateClosesDiscovery(t *testing.T) {
+	deny := func(context.Context) error { return errAuthRequired }
+	app := NewApp(WithMCPIntrospection(), WithMCPGate(deny))
+
+	resp := app.MCP.HandleRequest(context.Background(), mcp.Request{
+		JSONRPC: "2.0", ID: 1, Method: "tools/list",
+	})
+	if resp.Error == nil {
+		t.Fatal("SECURITY: [disclosure] WithMCPGate did not cover tools/list")
+	}
+
+	// The handshake stays reachable so a client can still connect and be
+	// told to authenticate.
+	init := app.MCP.HandleRequest(context.Background(), mcp.Request{
+		JSONRPC: "2.0", ID: 2, Method: "initialize",
+	})
+	if init.Error != nil {
+		t.Errorf("initialize refused: %v", init.Error)
+	}
+}
+
+// MCPRequireUser is the predicate the framework ships for direct-handler
+// tools. It must refuse a context with no resolved principal and accept one
+// that has one — a gate that accepted anonymous callers would be worse than
+// no gate, because it reads as protection.
+func TestMCPRequireUserRefusesAnonymous(t *testing.T) {
+	if err := MCPRequireUser()(context.Background()); err == nil {
+		t.Fatal("SECURITY: [authz] MCPRequireUser accepted a context with no user")
+	}
+}
+
+func toolNames(t *testing.T, app *App, ctx context.Context) []string {
+	t.Helper()
+	resp := app.MCP.HandleRequest(ctx, mcp.Request{JSONRPC: "2.0", ID: 1, Method: "tools/list"})
+	if resp.Error != nil {
+		return nil
+	}
+	blob, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatalf("marshal tools/list: %v", err)
+	}
+	var out struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(blob, &out); err != nil {
+		t.Fatalf("unmarshal tools/list: %v", err)
+	}
+	names := make([]string, 0, len(out.Tools))
+	for _, tl := range out.Tools {
+		names = append(names, tl.Name)
+	}
+	return names
+}

--- a/framework/openapi/endpoint.go
+++ b/framework/openapi/endpoint.go
@@ -22,6 +22,30 @@ func EntityEndpointPath(ent *entity.Entity, path string) string {
 	return crud.NormalizePath(convertColonParams(path))
 }
 
+// EntityEndpointRoutePath is EntityEndpointPath with the app's API prefix
+// applied — the path the endpoint is actually mounted at.
+//
+// A relative Endpoint.Path is documented as resolving against the entity's
+// table path. Under WithAPIPrefix that table path is prefixed, so the endpoint
+// must be too; without this an app using both ends up with its API split
+// across two prefixes (CRUD at /api/licenses, the custom endpoint at
+// /licenses/{id}/revoke) and nothing reports it.
+//
+// An absolute path keeps bypassing the prefix. That is the documented escape
+// hatch for mounting outside the entity's namespace.
+//
+// The OpenAPI spec deliberately keeps using EntityEndpointPath: it carries the
+// prefix in the `servers` entry, so its paths are prefix-relative by
+// construction.
+func EntityEndpointRoutePath(ent *entity.Entity, path, apiPrefix string) string {
+	relative := !strings.HasPrefix(strings.TrimSpace(path), "/")
+	out := EntityEndpointPath(ent, path)
+	if relative && apiPrefix != "" {
+		out = strings.TrimSuffix(apiPrefix, "/") + out
+	}
+	return out
+}
+
 func convertColonParams(path string) string {
 	parts := strings.Split(path, "/")
 	for i, part := range parts {

--- a/framework/pluginhost/clientcore_test.go
+++ b/framework/pluginhost/clientcore_test.go
@@ -30,20 +30,23 @@ func TestBrokerJS_ValidatesMessageSource(t *testing.T) {
 }
 
 // (2) The iframe sandbox attribute is set from the authoritative sandboxFor
-// (pinned separately in TestBrokerJS_SandboxForIsAuthoritative) and the
-// same-origin token must appear NOWHERE as a literal that could be emitted.
+// (pinned separately in TestBrokerJS_SandboxForIsAuthoritative), which filters
+// through an allow-list — so allow-same-origin must appear NOWHERE in a
+// grantable position. Under an allow-list "grantable" means a key in
+// ALLOWED_SANDBOX; prose mentioning the token is inert.
 func TestBrokerJS_NeverEmitsAllowSameOrigin(t *testing.T) {
 	js := string(brokerJSBytes)
-	// allow-same-origin may appear ONLY inside the SAME_ORIGIN_COLLAPSING
-	// filter (as a key to strip), never in an additive/emitting position.
 	for _, line := range strings.Split(js, "\n") {
-		if !strings.Contains(line, "allow-same-origin") {
-			continue
+		code := strings.TrimSpace(line)
+		if idx := strings.Index(code, "//"); idx >= 0 {
+			code = strings.TrimSpace(code[:idx]) // strip trailing comment
 		}
-		if strings.Contains(line, "SAME_ORIGIN_COLLAPSING") {
-			continue // the strip-filter declaration — allowed
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue // whole-line comment
 		}
-		t.Errorf("allow-same-origin referenced outside the strip filter: %q", strings.TrimSpace(line))
+		if strings.Contains(code, "allow-same-origin") {
+			t.Errorf("allow-same-origin referenced in executable code: %q", strings.TrimSpace(line))
+		}
 	}
 }
 

--- a/framework/pluginhost/entry_security_test.go
+++ b/framework/pluginhost/entry_security_test.go
@@ -1,0 +1,100 @@
+package pluginhost
+
+import (
+	"strings"
+	"testing"
+)
+
+// Manifest.Entry is the URL the broker loads into the plugin iframe, and it
+// arrives with the third-party plugin — attacker-influenced by construction.
+// It was unvalidated: an absolute "https://evil.example/x.html" or a
+// protocol-relative "//evil.example/x.html" made the frame a document the host
+// origin no longer controls, and the framed-CSP sandbox header that carries
+// the opaque-origin guarantee is only emitted by AssetServer for assets it
+// serves. A cross-origin Entry gets no such header.
+func TestManifestRejectsOffOriginEntry(t *testing.T) {
+	bad := []struct {
+		entry string
+		why   string
+	}{
+		{"https://evil.example/x.html", "absolute https URL"},
+		{"http://evil.example/x.html", "absolute http URL"},
+		{"//evil.example/x.html", "protocol-relative URL"},
+		{"javascript:alert(1)", "javascript: scheme"},
+		{"data:text/html,<script>alert(1)</script>", "data: URL"},
+		{"\\\\evil.example\\x.html", "backslash-authority form"},
+		{"/\\evil.example/x.html", "slash-backslash authority form"},
+		{"relative/path.html", "relative path (resolves against the mounting page)"},
+		{"/plugin/x.html\nX-Injected: 1", "control character"},
+	}
+	for _, tc := range bad {
+		m := Manifest{Entry: tc.entry, Schema: "v1"}
+		if err := m.Validate(); err == nil {
+			t.Errorf("SECURITY: [isolation] Validate accepted %s: %q", tc.why, tc.entry)
+		}
+	}
+}
+
+// The legitimate shape must keep working, or plugins can't ship.
+func TestManifestAcceptsSameOriginAbsolutePath(t *testing.T) {
+	for _, entry := range []string{
+		"/__gofastr/plugin/wysiwyg/editor.html",
+		"/__gofastr/plugin/wysiwyg/editor.html?v=2",
+		"/plugins/x/index.html",
+	} {
+		m := Manifest{Entry: entry, Schema: "v1"}
+		if err := m.Validate(); err != nil {
+			t.Errorf("Validate rejected a legitimate entry %q: %v", entry, err)
+		}
+	}
+}
+
+// The JS broker is the actual sink — it sets the iframe src. A Go-side
+// Validate a plugin author might skip cannot be the only check, exactly as
+// the sandbox invariant is dual-enforced.
+func TestBrokerJSValidatesEntry(t *testing.T) {
+	js := string(brokerJSBytes)
+	if !strings.Contains(js, "safeEntry") {
+		t.Fatal("pluginhost.js does not validate manifest.entry before setting iframe src")
+	}
+	// The frame src must be built from the validated value, never the raw
+	// manifest field.
+	for _, line := range strings.Split(js, "\n") {
+		if strings.Contains(line, `setAttribute("src"`) && !strings.Contains(line, "entry") {
+			t.Errorf("iframe src set from something other than the validated entry: %q", strings.TrimSpace(line))
+		}
+	}
+}
+
+// The Go sandbox sanitizer became an allow-list in v0.45.0; the JS one — the
+// authoritative sink — was still a one-token deny-list, so
+// allow-popups-to-escape-sandbox, allow-top-navigation and allow-downloads all
+// passed through it. Two sanitizers with different verdicts is one sanitizer.
+func TestBrokerJSSandboxIsAllowList(t *testing.T) {
+	js := string(brokerJSBytes)
+	if strings.Contains(js, "SAME_ORIGIN_COLLAPSING") {
+		t.Error("pluginhost.js still uses the same-origin-only deny-list; it must be an allow-list")
+	}
+	if !strings.Contains(js, "ALLOWED_SANDBOX") {
+		t.Fatal("pluginhost.js has no sandbox allow-list")
+	}
+	// Every token the Go allow-list grants must be grantable in JS too, or
+	// the two sanitizers disagree about what a legitimate plugin may do.
+	for tok := range allowedSandboxTokens {
+		if !strings.Contains(js, `"`+tok+`"`) {
+			t.Errorf("JS allow-list is missing %q, which Go grants", tok)
+		}
+	}
+	// And the escape tokens must appear nowhere.
+	for _, tok := range []string{
+		"allow-same-origin",
+		"allow-popups-to-escape-sandbox",
+		"allow-top-navigation",
+		"allow-top-navigation-by-user-activation",
+		"allow-downloads",
+	} {
+		if strings.Contains(js, `"`+tok+`": true`) {
+			t.Errorf("SECURITY: [isolation] JS allow-list grants escape token %q", tok)
+		}
+	}
+}

--- a/framework/pluginhost/host/pluginhost.js
+++ b/framework/pluginhost/host/pluginhost.js
@@ -167,10 +167,26 @@
     return DEFAULT_MIN_HEIGHT;
   }
 
-  // Same-origin-collapsing sandbox tokens: these hand the framed document
-  // access back to the host origin (DOM/cookies/storage) and are stripped
-  // UNCONDITIONALLY. Keep in sync with Go's sameOriginCollapsingTokens.
-  var SAME_ORIGIN_COLLAPSING = { "allow-same-origin": true };
+  // Sandbox capability ALLOW-LIST. Keep in sync with Go's
+  // allowedSandboxTokens (pinned by TestBrokerJSSandboxIsAllowList).
+  //
+  // It was a one-token deny-list that stripped only allow-same-origin, which
+  // let "allow-popups-to-escape-sandbox" through — a popup the plugin opens
+  // is then fully unsandboxed AND same-origin, so window.open('/admin/...')
+  // is an ordinary cookie-bearing document. "allow-top-navigation" (retarget
+  // the whole tab) and "allow-downloads" (write to the user's disk) passed
+  // too. A deny-list has to enumerate every way out of the box and loses the
+  // moment the HTML spec adds one; the manifest ships with the third-party
+  // plugin, so it is attacker-influenced by construction.
+  var ALLOWED_SANDBOX = {
+    "allow-scripts": true,
+    "allow-forms": true,
+    "allow-modals": true,
+    "allow-popups": true,          // a popup, still sandboxed — no escape token
+    "allow-pointer-lock": true,
+    "allow-orientation-lock": true,
+    "allow-presentation": true
+  };
 
   // sandboxFor is AUTHORITATIVE, not advisory: whatever the manifest carries,
   // the emitted sandbox always includes "allow-scripts" and never a
@@ -190,7 +206,7 @@
       var parts = String(tokens[i] || "").toLowerCase().split(/\s+/);
       for (var j = 0; j < parts.length; j++) {
         var tok = parts[j];
-        if (!tok || SAME_ORIGIN_COLLAPSING[tok] || seen[tok]) continue;
+        if (!tok || ALLOWED_SANDBOX[tok] !== true || seen[tok]) continue;
         seen[tok] = true;
         out.push(tok);
       }
@@ -203,9 +219,38 @@
     return (manifest && manifest.title) || DEFAULT_TITLE;
   }
 
+  // safeEntry requires the frame document URL to be a same-origin absolute
+  // path, returning "" for anything else. Mirrors Go's validateEntry.
+  //
+  // The opaque-origin guarantee has two carriers: this sandbox attribute, and
+  // the `Content-Security-Policy: sandbox allow-scripts` header AssetServer
+  // emits for the assets IT serves. A cross-origin or scheme-bearing entry
+  // escapes the second entirely — nothing the host controls emits headers for
+  // someone else's document. This is the sink that sets src, so the check
+  // lives HERE too, not only in a Go-side Validate() a plugin author may skip.
+  function safeEntry(raw) {
+    var entry = String(raw || "");
+    if (!entry) return "";
+    if (/[\u0000-\u001f\u007f]/.test(entry)) return "";
+    // Normalise backslashes the way a browser does before reading the
+    // authority: "/\\evil.example/x" is "//evil.example/x".
+    var norm = entry.replace(/\\/g, "/");
+    if (norm.charAt(0) !== "/") return "";   // scheme or relative path
+    if (norm.charAt(1) === "/") return "";   // protocol-relative
+    return entry;
+  }
+
   function createIframe(marker, manifest) {
-    var entry = (manifest && manifest.entry) || "";
+    var entry = safeEntry(manifest && manifest.entry);
     var frame = document.createElement("iframe");
+    if (!entry) {
+      // Fail closed: no src at all beats loading an off-origin document into
+      // a frame the host is about to hand a capability grant.
+      frame.setAttribute("sandbox", sandboxFor(manifest));
+      frame.setAttribute("title", titleFor(manifest));
+      marker.appendChild(frame);
+      return frame;
+    }
     frame.setAttribute("src", entry + (entry.indexOf("?") === -1 ? "?" : "&") + "v=" + cacheBust());
     // SECURITY: "allow-scripts" ONLY — the same-origin token is never added.
     frame.setAttribute("sandbox", sandboxFor(manifest));

--- a/framework/pluginhost/manifest.go
+++ b/framework/pluginhost/manifest.go
@@ -75,6 +75,9 @@ func (m Manifest) Validate() error {
 	if m.Entry == "" {
 		return errors.New("pluginhost: manifest entry is required")
 	}
+	if err := validateEntry(m.Entry); err != nil {
+		return err
+	}
 	if m.Isolation != "" && m.Isolation != IsolationSandboxOpaque {
 		return fmt.Errorf("pluginhost: unsupported isolation %q (v1 supports only %q)",
 			m.Isolation, IsolationSandboxOpaque)
@@ -107,6 +110,39 @@ func (m Manifest) Validate() error {
 // invariant does not depend on anyone having called [Manifest.Validate].
 func (m Manifest) SandboxString() string {
 	return sanitizeSandboxTokens(m.Sandbox)
+}
+
+// validateEntry requires the frame document URL to be a same-origin absolute
+// path.
+//
+// Entry ships with the third-party plugin, so it is attacker-influenced by
+// construction. The opaque-origin guarantee has two carriers: the iframe
+// sandbox attribute, and the `Content-Security-Policy: sandbox allow-scripts`
+// header [AssetServer] emits for the assets IT serves. A cross-origin or
+// scheme-bearing Entry escapes the second one entirely — nothing the host
+// controls is emitting headers for someone else's document.
+//
+// Rejected: any scheme (`https:`, `javascript:`, `data:`), protocol-relative
+// `//host/…`, the backslash forms browsers normalise to an authority
+// (`\\host\…`, `/\host/…`), relative paths (they resolve against whatever page
+// mounted the plugin, which is not knowable here), and control characters
+// (header/attribute smuggling).
+func validateEntry(entry string) error {
+	for _, r := range entry {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("pluginhost: manifest entry %q contains a control character", entry)
+		}
+	}
+	// Normalise backslashes the way a browser does before deciding what the
+	// authority component is: "/\evil.example/x" is //evil.example/x.
+	norm := strings.ReplaceAll(entry, "\\", "/")
+	if !strings.HasPrefix(norm, "/") {
+		return fmt.Errorf("pluginhost: manifest entry %q must be a same-origin absolute path beginning with \"/\" (a scheme or relative path escapes the host origin, and with it the framed-CSP sandbox header)", entry)
+	}
+	if strings.HasPrefix(norm, "//") {
+		return fmt.Errorf("pluginhost: manifest entry %q is protocol-relative, which resolves to another origin", entry)
+	}
+	return nil
 }
 
 // allowedSandboxTokens is the set of iframe sandbox capabilities a plugin

--- a/framework/pluginhost/manifest_test.go
+++ b/framework/pluginhost/manifest_test.go
@@ -155,8 +155,8 @@ func TestBrokerJS_SandboxForIsAuthoritative(t *testing.T) {
 	if strings.Contains(js, `manifest.sandbox.join(" ")`) {
 		t.Error("sandboxFor must not join manifest.sandbox verbatim — it must strip allow-same-origin and force allow-scripts")
 	}
-	if !strings.Contains(js, "SAME_ORIGIN_COLLAPSING") {
-		t.Error("sandboxFor must reference the same-origin-collapsing token filter")
+	if !strings.Contains(js, "ALLOWED_SANDBOX") {
+		t.Error("sandboxFor must filter through the sandbox capability allow-list")
 	}
 	if !strings.Contains(js, `unshift("allow-scripts")`) {
 		t.Error("sandboxFor must force-include allow-scripts")

--- a/framework/routegroup/group.go
+++ b/framework/routegroup/group.go
@@ -181,9 +181,16 @@ func (g *RouteGroup) Group(prefix string, opts ...GroupOption) *RouteGroup {
 	return child
 }
 
-// Prefix returns the full URL prefix for this group.
+// Prefix returns the full URL prefix for this group, composing every
+// enclosing group's prefix.
+//
+// It used to return only this group's own segment, so a nested
+// app.Group("/api").Group("/v2") reported "/v2". Callers that address the
+// group's routes by URL — the entity route-collision pre-flight, and the MCP
+// tools that re-dispatch through the router — were checking and dispatching
+// against a path that does not exist.
 func (g *RouteGroup) Prefix() string {
-	return g.prefix
+	return g.router_().Prefix()
 }
 
 // OpenAPITag returns the configured OpenAPI tag, or empty string.

--- a/framework/ui/gallery.go
+++ b/framework/ui/gallery.go
@@ -180,7 +180,7 @@ func Gallery(cfg GalleryConfig) render.HTML {
 		// Drop unsafe schemes on the thumbnail src (see safety.go). An
 		// unsafe value falls back to the framework's 1×1 placeholder so
 		// a javascript:/data: URL never reaches <img src>.
-		if safe := safeURL(thumb); safe != "" {
+		if safe := safeResourceURL(thumb); safe != "" {
 			thumb = safe
 		} else {
 			thumb = "/__gofastr/blank.png"

--- a/framework/ui/image.go
+++ b/framework/ui/image.go
@@ -105,7 +105,7 @@ func OptimizedImage(cfg OptimizedImageConfig) render.HTML {
 	// stub the runtime serves. The browser renders nothing, and the
 	// surrounding layout is preserved. Preferable to silently shipping
 	// a `javascript:`/`data:` URL into <img src>.
-	if safe := safeURL(cfg.Src); safe != "" {
+	if safe := safeResourceURL(cfg.Src); safe != "" {
 		cfg.Src = safe
 	} else {
 		cfg.Src = "/__gofastr/blank.png"
@@ -113,7 +113,7 @@ func OptimizedImage(cfg OptimizedImageConfig) render.HTML {
 	if len(cfg.Sources) > 0 {
 		filtered := cfg.Sources[:0]
 		for _, s := range cfg.Sources {
-			if safeURL(s.URL) != "" {
+			if safeResourceURL(s.URL) != "" {
 				filtered = append(filtered, s)
 			}
 		}

--- a/framework/ui/safety.go
+++ b/framework/ui/safety.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
+	"github.com/DonaldMurillo/gofastr/core-ui/urlsafe"
 )
 
 // safeURL returns u if it is safe to render as an href / src / action /
@@ -19,50 +20,22 @@ import (
 // architecture iterations expected callers to handle. Callers that
 // need a legitimate non-http(s) scheme can render the raw anchor via
 // core-ui/html directly — UI builders no longer make that decision.
+//
+// The rule set lives in core-ui/urlsafe, not here: it had been
+// re-derived six times across framework/ui, framework/uihost,
+// framework/crud, framework/experimental/apiversions and three
+// core-ui/patterns builders, each copy free to drift the day after it
+// was written.
 func safeURL(u string) string {
-	if u == "" {
-		return ""
-	}
-	// Reject control bytes outright.
-	for i := 0; i < len(u); i++ {
-		c := u[i]
-		if c < 0x20 || c == 0x7f {
-			return ""
-		}
-	}
-	trimmed := strings.TrimLeft(u, " \t")
-	low := strings.ToLower(trimmed)
-	// Reject percent-encoded CR/LF as a downstream header-smuggling
-	// primitive. Real content rarely contains those byte sequences.
-	if strings.Contains(low, "%0d") || strings.Contains(low, "%0a") {
-		return ""
-	}
-	// Protocol-relative URLs are ambiguous about origin trust.
-	if strings.HasPrefix(trimmed, "//") {
-		return ""
-	}
-	// Fragment-only or relative paths pass.
-	if strings.HasPrefix(trimmed, "/") || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "?") || strings.HasPrefix(trimmed, "./") || strings.HasPrefix(trimmed, "../") {
-		return u
-	}
-	for i := 0; i < len(trimmed); i++ {
-		c := trimmed[i]
-		if c == ':' {
-			scheme := strings.ToLower(trimmed[:i])
-			switch scheme {
-			case "http", "https", "mailto", "tel":
-				return u
-			default:
-				return ""
-			}
-		}
-		if c == '/' || c == '?' || c == '#' {
-			// No scheme — relative reference, allowed.
-			return u
-		}
-	}
-	// No colon — bare relative reference.
-	return u
+	return urlsafe.Clean(u, urlsafe.Anchor)
+}
+
+// safeResourceURL is safeURL for URLs the BROWSER fetches on its own —
+// <img src>, <source src>, <link href>. It drops mailto:/tel:, which are
+// meaningful on an anchor the user activates and a caller mistake on a
+// subresource.
+func safeResourceURL(u string) string {
+	return urlsafe.Clean(u, urlsafe.Resource)
 }
 
 // scrubAttrs filters an html.Attrs map, removing keys that look like

--- a/framework/uihost/uihost.go
+++ b/framework/uihost/uihost.go
@@ -35,6 +35,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/core-ui/seo"
 	"github.com/DonaldMurillo/gofastr/core-ui/store"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
+	"github.com/DonaldMurillo/gofastr/core-ui/urlsafe"
 	"github.com/DonaldMurillo/gofastr/core-ui/widget"
 	"github.com/DonaldMurillo/gofastr/core/fanout"
 	"github.com/DonaldMurillo/gofastr/core/middleware"
@@ -2840,44 +2841,14 @@ func extractAttrValue(tag, attr string) string {
 }
 
 // isSafeHeadURL is the allow-list for URLs that may appear in caller-
-// supplied head tags. Mirrors the framework/ui safety policy: relative,
-// http(s), or fragment.
+// supplied head tags. These are subresources the browser fetches on its own
+// (og:image, canonical, alternate), so the Resource policy applies: http(s)
+// and relative references, nothing else.
+//
+// The rule set is core-ui/urlsafe's, not a local copy — this guard had been
+// re-derived six times across the repo.
 func isSafeHeadURL(u string) bool {
-	if u == "" {
-		return false
-	}
-	for i := 0; i < len(u); i++ {
-		c := u[i]
-		if c < 0x20 || c == 0x7f {
-			return false
-		}
-	}
-	low := strings.ToLower(u)
-	if strings.Contains(low, "%0d") || strings.Contains(low, "%0a") {
-		return false
-	}
-	if strings.HasPrefix(u, "//") {
-		return false
-	}
-	if strings.HasPrefix(u, "/") || strings.HasPrefix(u, "#") || strings.HasPrefix(u, "?") || strings.HasPrefix(u, "./") || strings.HasPrefix(u, "../") {
-		return true
-	}
-	for i := 0; i < len(u); i++ {
-		c := u[i]
-		if c == ':' {
-			scheme := strings.ToLower(u[:i])
-			switch scheme {
-			case "http", "https":
-				return true
-			default:
-				return false
-			}
-		}
-		if c == '/' || c == '?' || c == '#' {
-			return true
-		}
-	}
-	return true
+	return urlsafe.OK(u, urlsafe.Resource)
 }
 
 // handleComponentCSS serves a single registered component's scoped

--- a/framework/unconfigured_handlers_test.go
+++ b/framework/unconfigured_handlers_test.go
@@ -1,0 +1,137 @@
+package framework
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/handler"
+)
+
+// Each of these discovery/manifest handlers guards on "the host never
+// configured me" and 404s. The guard was untested on every one of them — and
+// it is the branch that runs in the common case, since the surfaces are all
+// opt-in. A handler that fell through on nil config would nil-deref inside the
+// route rather than 404, taking the request down with it.
+func TestUnconfiguredDiscoveryHandlersReturn404(t *testing.T) {
+	app := NewApp()
+	cases := map[string]http.HandlerFunc{
+		"web-bot-auth directory":     app.handleWebBotAuthDirectory,
+		"ucp":                        app.handleUCP,
+		"acp":                        app.handleACP,
+		"auth.md":                    app.handleAuthMD,
+		"oauth-authorization-server": app.handleOAuthAuthorizationServer,
+	}
+	for name, h := range cases {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h(rec, httptest.NewRequest("GET", "/", nil))
+			if rec.Code != http.StatusNotFound {
+				t.Errorf("%s on an unconfigured app = %d, want 404", name, rec.Code)
+			}
+		})
+	}
+}
+
+// A nil gate would silently allow every caller, which is worse than no gate
+// because it reads as protection. The option panics at wiring time instead.
+func TestWithMCPGateRejectsNilGate(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("WithMCPGate(nil) did not panic — a nil precondition allows everyone")
+		}
+	}()
+	WithMCPGate(nil)
+}
+
+// MCPRequireUser must accept a context that carries a resolved principal, or
+// gating a tool with it would lock out the callers it is meant to admit.
+func TestMCPRequireUserAcceptsResolvedUser(t *testing.T) {
+	ctx := handler.SetUser(context.Background(), struct{ ID string }{ID: "u1"})
+	if err := MCPRequireUser()(ctx); err != nil {
+		t.Fatalf("MCPRequireUser refused an authenticated caller: %v", err)
+	}
+}
+
+// resolveWellKnownBase decides the scheme every advertised absolute URL
+// carries — including the Link: rel=service MCP endpoint. Its own doc comment
+// weighs the forged-header risk, so both branches deserve to be pinned rather
+// than inferred.
+func TestResolveWellKnownBaseScheme(t *testing.T) {
+	plain := httptest.NewRequest("GET", "http://app.example/x", nil)
+	if got := resolveWellKnownBase(plain); got != "http://app.example" {
+		t.Errorf("plain request base = %q", got)
+	}
+
+	tls := httptest.NewRequest("GET", "https://app.example/x", nil)
+	tls.TLS = &tlsConnState
+	if got := resolveWellKnownBase(tls); got != "https://app.example" {
+		t.Errorf("TLS request base = %q, want https", got)
+	}
+
+	// A terminating proxy speaks for the scheme; the host is NOT taken from a
+	// forwarded header (that was closed in v0.45.0).
+	fwd := httptest.NewRequest("GET", "http://app.example/x", nil)
+	fwd.Header.Set("X-Forwarded-Proto", "https")
+	fwd.Header.Set("X-Forwarded-Host", "evil.example")
+	if got := resolveWellKnownBase(fwd); got != "https://app.example" {
+		t.Errorf("forwarded-proto base = %q, want https on the real host", got)
+	}
+}
+
+// The RFC 8414 document emits each optional field only when configured. An
+// unconditional emit would advertise empty capability lists, which a strict
+// client reads as "supports nothing".
+func TestOAuthAuthorizationServerEmitsConfiguredFields(t *testing.T) {
+	app := NewApp(WithOAuthAuthorizationServer(OAuthAuthorizationServerConfig{
+		Issuer:                            "https://id.example",
+		AuthorizationEndpoint:             "https://id.example/authorize",
+		TokenEndpoint:                     "https://id.example/token",
+		IntrospectionEndpoint:             "https://id.example/introspect",
+		UserinfoEndpoint:                  "https://id.example/userinfo",
+		JwksURI:                           "https://id.example/jwks",
+		ScopesSupported:                   []string{"openid"},
+		ResponseTypesSupported:            []string{"code"},
+		GrantTypesSupported:               []string{"authorization_code"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic"},
+	}))
+
+	rec := httptest.NewRecorder()
+	app.handleOAuthAuthorizationServer(rec, httptest.NewRequest("GET", "/.well-known/oauth-authorization-server", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, k := range []string{
+		"issuer", "authorization_endpoint", "token_endpoint",
+		"introspection_endpoint", "userinfo_endpoint", "jwks_uri",
+		"scopes_supported", "response_types_supported",
+		"grant_types_supported", "token_endpoint_auth_methods_supported",
+	} {
+		if _, ok := doc[k]; !ok {
+			t.Errorf("configured field %q missing from the document", k)
+		}
+	}
+}
+
+// An issuer-only config must NOT advertise empty lists.
+func TestOAuthAuthorizationServerOmitsUnsetFields(t *testing.T) {
+	app := NewApp(WithOAuthAuthorizationServer(OAuthAuthorizationServerConfig{Issuer: "https://id.example"}))
+	rec := httptest.NewRecorder()
+	app.handleOAuthAuthorizationServer(rec, httptest.NewRequest("GET", "/", nil))
+	var doc map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(doc) != 1 {
+		t.Errorf("issuer-only config emitted %d fields: %v", len(doc), doc)
+	}
+}
+
+var tlsConnState = tls.ConnectionState{}

--- a/kiln/journal/entry.go
+++ b/kiln/journal/entry.go
@@ -96,6 +96,11 @@ type UpdateEntityPayload struct {
 type DeleteEntityPayload struct {
 	Name string        `json:"name"`
 	Prev *world.Entity `json:"prev,omitempty"`
+	// PlanID names the approved plan that authorized this deletion. The
+	// log is the authorization record, not just a state record: without
+	// this, replay could not tell an approved delete from one appended by
+	// hand, and reproduced both. See planGatedTarget.
+	PlanID string `json:"plan_id,omitempty"`
 }
 
 type AddFieldPayload struct {
@@ -107,6 +112,7 @@ type DeleteFieldPayload struct {
 	Entity string       `json:"entity"`
 	Field  string       `json:"field"`
 	Prev   *world.Field `json:"prev,omitempty"`
+	PlanID string       `json:"plan_id,omitempty"` // see DeleteEntityPayload.PlanID
 }
 
 type AddPagePayload struct {
@@ -114,8 +120,9 @@ type AddPagePayload struct {
 }
 
 type DeletePagePayload struct {
-	Path string      `json:"path"`
-	Prev *world.Page `json:"prev,omitempty"`
+	Path   string      `json:"path"`
+	Prev   *world.Page `json:"prev,omitempty"`
+	PlanID string      `json:"plan_id,omitempty"` // see DeleteEntityPayload.PlanID
 }
 
 // UpdatePageElementPayload carries the post-patch page snapshot. The
@@ -139,8 +146,9 @@ type AddHookPayload struct {
 }
 
 type DeleteHookPayload struct {
-	ID   string      `json:"id"`
-	Prev *world.Hook `json:"prev,omitempty"`
+	ID     string      `json:"id"`
+	Prev   *world.Hook `json:"prev,omitempty"`
+	PlanID string      `json:"plan_id,omitempty"` // see DeleteEntityPayload.PlanID
 }
 
 type AddRoutePayload struct {
@@ -151,6 +159,7 @@ type DeleteRoutePayload struct {
 	Method string       `json:"method"`
 	Path   string       `json:"path"`
 	Prev   *world.Route `json:"prev,omitempty"`
+	PlanID string       `json:"plan_id,omitempty"` // see DeleteEntityPayload.PlanID
 }
 
 type AddSeedPayload struct {

--- a/kiln/journal/replay.go
+++ b/kiln/journal/replay.go
@@ -2,8 +2,6 @@ package journal
 
 import (
 	"fmt"
-
-	"github.com/DonaldMurillo/gofastr/kiln/world"
 )
 
 // Replay reads every entry from j and applies it to a fresh Session.
@@ -33,7 +31,7 @@ func ReplayEntries(entries []Entry) (*Session, error) {
 func Apply(s *Session, e Entry) error {
 	switch e.Kind {
 	case KindWorldEdit:
-		return applyWorldEdit(s.World, e)
+		return applyWorldEdit(s, e)
 	case KindChatUser, KindChatAssistant:
 		var p ChatMessagePayload
 		if err := e.Decode(&p); err != nil {
@@ -121,7 +119,15 @@ func Apply(s *Session, e Entry) error {
 }
 
 // applyWorldEdit dispatches by Op.
-func applyWorldEdit(w *world.World, e Entry) error {
+//
+// It enforces the same semantic guards kiln/protocol enforces on the live
+// path — the multi-tenant refusal and plan-gating of destructive ops. Those
+// used to live only in protocol.go, so a hand-authored .kiln.session.jsonl
+// replayed at boot (kiln/live.New) or by `kiln freeze` installed world state
+// the HTTP API refuses. The log is the authorization record; a guard that
+// only one of the two readers applies is not a guard.
+func applyWorldEdit(s *Session, e Entry) error {
+	w := s.World
 	switch e.Op {
 	case OpSetAppConfig:
 		var p SetAppConfigPayload
@@ -154,6 +160,9 @@ func applyWorldEdit(w *world.World, e Entry) error {
 		if p.Entity.Name == "" {
 			return fmt.Errorf("add_entity: entity has empty name")
 		}
+		if p.Entity.MultiTenant {
+			return fmt.Errorf("add_entity: entity %q sets multi_tenant, which kiln cannot honour (it cannot choose the app-specific tenant resolver) — use owner_field, or add tenant middleware in owned Go after freeze", p.Entity.Name)
+		}
 		if _, exists := w.Entities[p.Entity.Name]; exists {
 			return fmt.Errorf("add_entity: %q already exists", p.Entity.Name)
 		}
@@ -168,6 +177,9 @@ func applyWorldEdit(w *world.World, e Entry) error {
 		if p.Entity == nil {
 			return fmt.Errorf("update_entity: nil entity")
 		}
+		if p.Entity.MultiTenant {
+			return fmt.Errorf("update_entity: entity %q sets multi_tenant, which kiln cannot honour (it cannot choose the app-specific tenant resolver) — use owner_field, or add tenant middleware in owned Go after freeze", p.Entity.Name)
+		}
 		if _, exists := w.Entities[p.Entity.Name]; !exists {
 			return fmt.Errorf("update_entity: %q not found", p.Entity.Name)
 		}
@@ -177,6 +189,10 @@ func applyWorldEdit(w *world.World, e Entry) error {
 	case OpDeleteEntity:
 		var p DeleteEntityPayload
 		if err := e.Decode(&p); err != nil {
+			return err
+		}
+		target := PlanTarget{Op: "delete_entity", Name: p.Name}
+		if err := s.spendPlan(p.PlanID, target); err != nil {
 			return err
 		}
 		if _, exists := w.Entities[p.Name]; !exists {
@@ -205,6 +221,10 @@ func applyWorldEdit(w *world.World, e Entry) error {
 	case OpDeleteField:
 		var p DeleteFieldPayload
 		if err := e.Decode(&p); err != nil {
+			return err
+		}
+		target := PlanTarget{Op: "delete_field", Name: p.Entity + "." + p.Field}
+		if err := s.spendPlan(p.PlanID, target); err != nil {
 			return err
 		}
 		ent, ok := w.Entities[p.Entity]
@@ -239,6 +259,10 @@ func applyWorldEdit(w *world.World, e Entry) error {
 	case OpDeletePage:
 		var p DeletePagePayload
 		if err := e.Decode(&p); err != nil {
+			return err
+		}
+		target := PlanTarget{Op: "delete_page", Name: p.Path}
+		if err := s.spendPlan(p.PlanID, target); err != nil {
 			return err
 		}
 		if _, exists := w.Pages[p.Path]; !exists {
@@ -282,6 +306,9 @@ func applyWorldEdit(w *world.World, e Entry) error {
 		if err := e.Decode(&p); err != nil {
 			return err
 		}
+		if err := s.spendPlan(p.PlanID, PlanTarget{Op: "delete_hook", Name: p.ID}); err != nil {
+			return err
+		}
 		for i, h := range w.Hooks {
 			if h.ID == p.ID {
 				w.Hooks = append(w.Hooks[:i], w.Hooks[i+1:]...)
@@ -309,6 +336,9 @@ func applyWorldEdit(w *world.World, e Entry) error {
 	case OpDeleteRoute:
 		var p DeleteRoutePayload
 		if err := e.Decode(&p); err != nil {
+			return err
+		}
+		if err := s.spendPlan(p.PlanID, PlanTarget{Op: "delete_route", Name: p.Method + " " + p.Path}); err != nil {
 			return err
 		}
 		for i, r := range w.Routes {
@@ -344,4 +374,50 @@ func applyWorldEdit(w *world.World, e Entry) error {
 	default:
 		return fmt.Errorf("unknown world edit op %q", e.Op)
 	}
+}
+
+// spendPlan is the single authorization check for a destructive world edit:
+// the named plan must exist, be approved, not be rejected, list this exact
+// target, and not already have been spent on it. On success the (plan,
+// target) pair is marked consumed so one approval authorizes one deletion.
+//
+// It mirrors kiln/protocol's requirePlan + consumeTarget, but derives
+// consumption from the log instead of a per-process map — that map was never
+// rebuilt on replay, so every restart re-armed every consumed plan.
+func (s *Session) spendPlan(planID string, target PlanTarget) error {
+	if planID == "" {
+		return fmt.Errorf("%s %q: no plan_id — destructive edits require an approved plan naming this target", target.Op, target.Name)
+	}
+	plan, ok := s.Plans[planID]
+	if !ok {
+		return fmt.Errorf("%s %q: plan %q not found", target.Op, target.Name, planID)
+	}
+	if plan.Rejected {
+		return fmt.Errorf("%s %q: plan %q was rejected", target.Op, target.Name, planID)
+	}
+	if !plan.Approved {
+		return fmt.Errorf("%s %q: plan %q is not approved", target.Op, target.Name, planID)
+	}
+	listed := false
+	for _, tg := range plan.Targets {
+		if tg == target {
+			listed = true
+			break
+		}
+	}
+	if !listed {
+		return fmt.Errorf("%s %q: plan %q does not list this target", target.Op, target.Name, planID)
+	}
+	key := string(target.Op) + ":" + target.Name
+	if s.Consumed[planID][key] {
+		return fmt.Errorf("%s %q: plan %q was already spent on this target", target.Op, target.Name, planID)
+	}
+	if s.Consumed == nil {
+		s.Consumed = map[string]map[string]bool{}
+	}
+	if s.Consumed[planID] == nil {
+		s.Consumed[planID] = map[string]bool{}
+	}
+	s.Consumed[planID][key] = true
+	return nil
 }

--- a/kiln/journal/replay_security_test.go
+++ b/kiln/journal/replay_security_test.go
@@ -1,0 +1,176 @@
+package journal
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DonaldMurillo/gofastr/kiln/world"
+)
+
+// The journal is replayed at boot (kiln/live.New) and by `kiln freeze`, which
+// turns the replayed world into a blueprint. Replay went straight to the world
+// mutators, skipping every semantic guard kiln/protocol enforces on the live
+// path — so a hand-authored .kiln.session.jsonl installed world state the API
+// refuses, and `kiln freeze` then generated an app from it.
+//
+// The precondition is a local filesystem write, so this is not a remote hole.
+// It is an integrity one: the log is supposed to be the authorization record,
+// and it was only ever a state record.
+
+// protocol.go refuses multi_tenant entities because Kiln cannot choose the
+// app's tenant resolver. Replay accepted them, so the refusal was one code
+// path deep.
+func TestReplayRefusesMultiTenantEntity(t *testing.T) {
+	for _, op := range []Op{OpAddEntity, OpUpdateEntity} {
+		s := NewSession()
+		if op == OpUpdateEntity {
+			// update needs something to update
+			mustApply(t, s, worldEdit(OpAddEntity, AddEntityPayload{
+				Entity: &world.Entity{Name: "orders"},
+			}))
+		}
+		var payload any = AddEntityPayload{Entity: &world.Entity{Name: "orders", MultiTenant: true}}
+		if op == OpUpdateEntity {
+			payload = UpdateEntityPayload{Entity: &world.Entity{Name: "orders", MultiTenant: true}}
+		}
+		err := Apply(s, worldEdit(op, payload))
+		if err == nil {
+			t.Errorf("SECURITY: [integrity] replay accepted a multi_tenant entity via %s, which the live API refuses", op)
+			continue
+		}
+		if !strings.Contains(err.Error(), "multi_tenant") {
+			t.Errorf("%s refused for the wrong reason: %v", op, err)
+		}
+	}
+}
+
+// A destructive op is plan-gated on the live path: it needs a plan the user
+// approved that names this exact target. The journal recorded the deletion but
+// not its authorization, so replay could not tell an approved delete from a
+// forged one — and reproduced both.
+func TestReplayRefusesUnauthorizedDelete(t *testing.T) {
+	s := NewSession()
+	mustApply(t, s, worldEdit(OpAddEntity, AddEntityPayload{Entity: &world.Entity{Name: "orders"}}))
+
+	err := Apply(s, worldEdit(OpDeleteEntity, DeleteEntityPayload{Name: "orders"}))
+	if err == nil {
+		t.Fatal("SECURITY: [integrity] replay applied a delete with no approved plan")
+	}
+	if _, still := s.World.Entities["orders"]; !still {
+		t.Error("SECURITY: [integrity] the refused delete still mutated the world")
+	}
+}
+
+// A plan that exists but was never approved must not authorize anything.
+func TestReplayRefusesUnapprovedPlan(t *testing.T) {
+	s := newSessionWithEntity(t)
+	mustApply(t, s, planEntry(KindPlanProposed, PlanProposedPayload{
+		PlanID:  "p1",
+		Steps:   []string{"drop orders"},
+		Targets: []PlanTarget{{Op: "delete_entity", Name: "orders"}},
+	}))
+	if err := Apply(s, worldEdit(OpDeleteEntity, DeleteEntityPayload{Name: "orders", PlanID: "p1"})); err == nil {
+		t.Fatal("SECURITY: [integrity] an unapproved plan authorized a delete")
+	}
+}
+
+// An approved plan must only authorize the targets it lists.
+func TestReplayRefusesPlanTargetMismatch(t *testing.T) {
+	s := newSessionWithEntity(t)
+	approvePlan(t, s, "p1", PlanTarget{Op: "delete_entity", Name: "invoices"})
+	if err := Apply(s, worldEdit(OpDeleteEntity, DeleteEntityPayload{Name: "orders", PlanID: "p1"})); err == nil {
+		t.Fatal("SECURITY: [integrity] a plan authorized a target it does not list")
+	}
+}
+
+// Single-use enforcement lived in a per-process map that replay never
+// rebuilt, so a restart re-armed every consumed plan. Consumption has to be
+// derived from the log like everything else.
+func TestReplayEnforcesPlanSingleUse(t *testing.T) {
+	s := newSessionWithEntity(t)
+	approvePlan(t, s, "p1", PlanTarget{Op: "delete_entity", Name: "orders"})
+
+	mustApply(t, s, worldEdit(OpDeleteEntity, DeleteEntityPayload{Name: "orders", PlanID: "p1"}))
+	// Re-create it and try to spend the same plan again.
+	mustApply(t, s, worldEdit(OpAddEntity, AddEntityPayload{Entity: &world.Entity{Name: "orders"}}))
+	if err := Apply(s, worldEdit(OpDeleteEntity, DeleteEntityPayload{Name: "orders", PlanID: "p1"})); err == nil {
+		t.Fatal("SECURITY: [integrity] a consumed plan authorized a second delete")
+	}
+}
+
+// The authorized path must still work, or the guard has just broken kiln.
+func TestReplayAppliesAuthorizedDelete(t *testing.T) {
+	s := newSessionWithEntity(t)
+	approvePlan(t, s, "p1", PlanTarget{Op: "delete_entity", Name: "orders"})
+	mustApply(t, s, worldEdit(OpDeleteEntity, DeleteEntityPayload{Name: "orders", PlanID: "p1"}))
+	if _, still := s.World.Entities["orders"]; still {
+		t.Error("authorized delete did not apply")
+	}
+}
+
+// Every destructive op protocol.go plan-gates must be gated on replay too —
+// a guard that covers four of five ops is a guard with a documented bypass.
+func TestReplayGatesEveryDestructiveOp(t *testing.T) {
+	cases := []struct {
+		op      Op
+		payload any
+	}{
+		{OpDeleteEntity, DeleteEntityPayload{Name: "orders"}},
+		{OpDeleteField, DeleteFieldPayload{Entity: "orders", Field: "total"}},
+		{OpDeletePage, DeletePagePayload{Path: "/orders"}},
+		{OpDeleteHook, DeleteHookPayload{ID: "h1"}},
+		{OpDeleteRoute, DeleteRoutePayload{Method: "GET", Path: "/x"}},
+	}
+	for _, tc := range cases {
+		s := NewSession()
+		err := Apply(s, worldEdit(tc.op, tc.payload))
+		if err == nil {
+			t.Errorf("SECURITY: [integrity] %s applied with no approved plan", tc.op)
+			continue
+		}
+		if !strings.Contains(err.Error(), "plan") {
+			t.Errorf("%s refused for the wrong reason (want a plan refusal): %v", tc.op, err)
+		}
+	}
+}
+
+// ---- helpers --------------------------------------------------------------
+
+func worldEdit(op Op, payload any) Entry {
+	e, err := NewEntry("e", time.Now(), KindWorldEdit, op, payload)
+	if err != nil {
+		panic(err)
+	}
+	return e
+}
+
+func planEntry(kind Kind, payload any) Entry {
+	e, err := NewEntry("p", time.Now(), kind, "", payload)
+	if err != nil {
+		panic(err)
+	}
+	return e
+}
+
+func mustApply(t *testing.T, s *Session, e Entry) {
+	t.Helper()
+	if err := Apply(s, e); err != nil {
+		t.Fatalf("Apply(%s/%s): %v", e.Kind, e.Op, err)
+	}
+}
+
+func newSessionWithEntity(t *testing.T) *Session {
+	t.Helper()
+	s := NewSession()
+	mustApply(t, s, worldEdit(OpAddEntity, AddEntityPayload{Entity: &world.Entity{Name: "orders"}}))
+	return s
+}
+
+func approvePlan(t *testing.T, s *Session, id string, targets ...PlanTarget) {
+	t.Helper()
+	mustApply(t, s, planEntry(KindPlanProposed, PlanProposedPayload{
+		PlanID: id, Steps: []string{"step"}, Targets: targets,
+	}))
+	mustApply(t, s, planEntry(KindPlanApproved, PlanApprovedPayload{PlanID: id}))
+}

--- a/kiln/journal/session.go
+++ b/kiln/journal/session.go
@@ -11,6 +11,14 @@ type Session struct {
 	World *world.World     `json:"world"`
 	Chat  []ChatEvent      `json:"chat"`
 	Plans map[string]*Plan `json:"plans"`
+
+	// Consumed records which (planID, op:name) authorizations have already
+	// been spent, so an approved plan authorizes its target exactly once.
+	//
+	// It is derived from the log during Apply rather than held per-process:
+	// the live path used to track this in a map that replay never rebuilt,
+	// so every restart re-armed every consumed plan.
+	Consumed map[string]map[string]bool `json:"consumed,omitempty"`
 }
 
 // ChatEvent is one entry on the conversation timeline. Exactly one of
@@ -48,7 +56,8 @@ type Plan struct {
 // NewSession returns an empty Session with an empty world.
 func NewSession() *Session {
 	return &Session{
-		World: world.New(),
-		Plans: map[string]*Plan{},
+		World:    world.New(),
+		Plans:    map[string]*Plan{},
+		Consumed: map[string]map[string]bool{},
 	}
 }

--- a/kiln/protocol/protocol.go
+++ b/kiln/protocol/protocol.go
@@ -29,20 +29,11 @@ type Tools struct {
 
 	mu      sync.Mutex
 	counter int64
-
-	// consumed tracks plan targets that have already been used. Once a
-	// destructive op succeeds against a plan, that (planID, opKey) pair
-	// is recorded here so the same plan can't authorize the same delete
-	// twice. Per-process, in-memory — not journaled.
-	consumed map[string]map[string]bool
 }
 
 // New constructs Tools bound to a Live runtime.
 func New(l *live.Live) *Tools {
-	return &Tools{
-		live:     l,
-		consumed: map[string]map[string]bool{},
-	}
+	return &Tools{live: l}
 }
 
 // Live returns the bound runtime, useful for transports that need the
@@ -339,11 +330,7 @@ func (t *Tools) DeleteEntity(_ context.Context, args DeleteEntityArgs) Result {
 	if r := t.requirePlan(args.PlanID, target); !r.OK {
 		return r
 	}
-	res := t.applyEdit(journal.OpDeleteEntity, journal.DeleteEntityPayload{Name: args.Name, Prev: prev})
-	if res.OK {
-		t.consumeTarget(args.PlanID, target)
-	}
-	return res
+	return t.applyEdit(journal.OpDeleteEntity, journal.DeleteEntityPayload{Name: args.Name, Prev: prev, PlanID: args.PlanID})
 }
 
 func (t *Tools) AddField(_ context.Context, args AddFieldArgs) Result {
@@ -382,11 +369,7 @@ func (t *Tools) DeleteField(_ context.Context, args DeleteFieldArgs) Result {
 	if r := t.requirePlan(args.PlanID, target); !r.OK {
 		return r
 	}
-	res := t.applyEdit(journal.OpDeleteField, journal.DeleteFieldPayload{Entity: args.Entity, Field: args.Field, Prev: prev})
-	if res.OK {
-		t.consumeTarget(args.PlanID, target)
-	}
-	return res
+	return t.applyEdit(journal.OpDeleteField, journal.DeleteFieldPayload{Entity: args.Entity, Field: args.Field, Prev: prev, PlanID: args.PlanID})
 }
 
 func (t *Tools) AddPage(_ context.Context, args AddPageArgs) Result {
@@ -595,11 +578,7 @@ func (t *Tools) DeletePage(_ context.Context, args DeletePageArgs) Result {
 	if r := t.requirePlan(args.PlanID, target); !r.OK {
 		return r
 	}
-	res := t.applyEdit(journal.OpDeletePage, journal.DeletePagePayload{Path: args.Path, Prev: prev})
-	if res.OK {
-		t.consumeTarget(args.PlanID, target)
-	}
-	return res
+	return t.applyEdit(journal.OpDeletePage, journal.DeletePagePayload{Path: args.Path, Prev: prev, PlanID: args.PlanID})
 }
 
 func (t *Tools) AddHook(_ context.Context, args AddHookArgs) Result {
@@ -629,11 +608,7 @@ func (t *Tools) DeleteHook(_ context.Context, args DeleteHookArgs) Result {
 	if r := t.requirePlan(args.PlanID, target); !r.OK {
 		return r
 	}
-	res := t.applyEdit(journal.OpDeleteHook, journal.DeleteHookPayload{ID: args.ID, Prev: prev})
-	if res.OK {
-		t.consumeTarget(args.PlanID, target)
-	}
-	return res
+	return t.applyEdit(journal.OpDeleteHook, journal.DeleteHookPayload{ID: args.ID, Prev: prev, PlanID: args.PlanID})
 }
 
 func (t *Tools) AddRoute(_ context.Context, args AddRouteArgs) Result {
@@ -663,11 +638,7 @@ func (t *Tools) DeleteRoute(_ context.Context, args DeleteRouteArgs) Result {
 	if r := t.requirePlan(args.PlanID, target); !r.OK {
 		return r
 	}
-	res := t.applyEdit(journal.OpDeleteRoute, journal.DeleteRoutePayload{Method: args.Method, Path: args.Path, Prev: prev})
-	if res.OK {
-		t.consumeTarget(args.PlanID, target)
-	}
-	return res
+	return t.applyEdit(journal.OpDeleteRoute, journal.DeleteRoutePayload{Method: args.Method, Path: args.Path, Prev: prev, PlanID: args.PlanID})
 }
 
 func (t *Tools) AddSeed(_ context.Context, args AddSeedArgs) Result {
@@ -756,9 +727,6 @@ func (t *Tools) ResetSession(_ context.Context, _ ResetSessionArgs) Result {
 	if err := t.live.Reload(); err != nil {
 		return failure("reload: %v", err)
 	}
-	t.mu.Lock()
-	t.consumed = map[string]map[string]bool{}
-	t.mu.Unlock()
 	// Notify so the panel re-fetches chat_html immediately. Without
 	// this the UI shows stale items until something else fires an
 	// SSE event — felt to the user like "Reset didn't work."
@@ -840,23 +808,14 @@ func (t *Tools) requirePlan(planID string, target journal.PlanTarget) Result {
 	if !matched {
 		return needsPlan(target, fmt.Sprintf("plan %q does not list this op in `targets` — propose a plan that includes %+v", planID, target))
 	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if used, ok := t.consumed[planID]; ok && used[target.Op+":"+target.Name] {
+	// Consumption is read from the session, which derives it from the
+	// journal. It used to live in a per-process map here, so every restart
+	// re-armed every already-spent plan — the record of what an approval had
+	// been used for did not survive the thing it was protecting.
+	if t.live.Session().Consumed[planID][target.Op+":"+target.Name] {
 		return needsPlan(target, fmt.Sprintf("plan %q already consumed for this target — propose a new plan", planID))
 	}
 	return Result{OK: true}
-}
-
-// consumeTarget marks (planID, target) as used. Called only after the
-// underlying applyEdit succeeded.
-func (t *Tools) consumeTarget(planID string, target journal.PlanTarget) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.consumed[planID] == nil {
-		t.consumed[planID] = map[string]bool{}
-	}
-	t.consumed[planID][target.Op+":"+target.Name] = true
 }
 
 // --- result constructors ----------------------------------------------


### PR DESCRIPTION
Closes the v0.43.0 audit backlog (#135), fixes three filed issues (#138, #139, #141), and takes the first pass at surfaces the previous audits had never opened (#136).

Same shape as v0.45.0: **guard drift** — a check one code path has and its sibling skips. Three findings below are literally the same property (*a schema is a disclosure even when the data behind it is refused*) surfacing in three different places.

Every fix is TDD'd: a failing test proving the bug on the pre-fix code, then the minimal change. Where a test passed for the wrong reason I found out and said so — see "Two tests that were lying" below.

---

## #135 — closed

| Item | What it was |
| --- | --- |
| `tools/list` unauthenticated | `mcp.Gated` wraps a *handler*, so it only reached `tools/call`. An anonymous POST returned every tool's `inputSchema` — and for entity CRUD tools those are built from live entity definitions: every entity name, every non-`Hidden` field, its type and enum set. The call refused; the schema was already out. |
| Direct-handler tools bypass middleware | `Endpoint.MCPHandler` twins see no route middleware, so an endpoint behind `auth.RequireRole("editor")` was role-checked over HTTP and ungated over MCP. `log_set_level` likewise. |
| pluginhost sandbox deny-list | v0.45.0 flipped the Go half; `host/pluginhost.js` — the sink that actually sets the attribute — was still the one-token deny-list, passing `allow-popups-to-escape-sandbox`, `allow-top-navigation`, `allow-downloads`. `Manifest.Entry` was an unvalidated arbitrary URL. |
| Four duplicate `safeURL` | See below. |

New API: `mcp.WithToolGate` (gates the *listing* as well as the call), `framework.WithMCPGate` + `framework.MCPRequireUser` (closes the whole data surface), `Server.ListToolsFor(ctx)`, `Endpoint.MCPGate` / `Endpoint.MCPPublic`.

`initialize` and `ping` stay open under the server gate by design — they carry only the protocol version, capability booleans and the server name, and a client that cannot handshake cannot present credentials.

### The `safeURL` item is a correction

The v0.45.0 commit claimed `core-ui/urlsafe` "is now the single definition". **It was not.** One call site was replaced and `core-ui/html` gained a guard it had never had; six copies kept their own. That claim also went into the v0.45.0 PR body, tag message and changelog.

All six now call it, `framework/ui` splits anchor vs subresource policy (`mailto:` on an `<img src>` is dropped), the package finally has tests — it is worse for a single definition to be untested than a copy — and a `repolint` rule fails the build on a seventh copy. Prose asking people not to duplicate it is what produced six copies.

## #138, #139, #141 — closed

- **`upload.RangeGetter`** — `Storage.Get` returns `io.ReadCloser`, which erases seekability, so a download interrupted 1.8 GB into 2 GB restarted from zero. Capability interface (following the `WithPresigner` precedent) wired into `ServeHandler`; local + memory implement it, S3 declines. `Storage.Get` keeps its narrow contract.
- **`WithAPIPrefix` applies to `EntityConfig.Endpoints`** — relative paths were mounted unprefixed, splitting an app's API across two prefixes with no warning. The reporter saw it as "the entire vendor-side API returns 404".
- **`webhook.NewSQLStore` on Postgres** — both stores dialect-switched timestamps and hardcoded `payload BLOB`; Postgres has no `BLOB`. Tests construct against a real Postgres, because only Postgres can decide whether the emitted schema is one it accepts.
- **`DBQueue.Close()`** no longer hangs when `Start` was never called.

## #136 — partially, stays open

Its two concrete bugs are fixed. Grouped entities' MCP tools dispatched to `/widgets` while the routes lived at `/api/widgets` — root-caused to `RouteGroup.Prefix()` returning only its innermost segment despite its doc saying "full URL prefix", which also meant the route-collision pre-flight was checking a path that does not exist.

Four surfaces audited, five findings:

- **kiln journal replay** skipped every guard `protocol.go` enforces. The deeper problem: the log recorded *what* was deleted but not that anyone approved it, so replay could not tell an approved delete from a forged one. Plan consumption also lived in a per-process map replay never rebuilt — every restart re-armed every spent approval.
- **blueprint `table:`** was unvalidated and landed as executable Go in the generated typed client (it is also a bare SQL identifier at runtime). `name:` was already constrained; `table:` was the way around it.
- **CORS's wildcard writer** didn't forward `Flush`/`Hijack` while every sibling wrapper does — SSE cannot stream behind `AllowedOrigins: ["*"]`, since the SSE constructor type-asserts `http.Flusher`. Also: `Flush` now strips the credentials header, and `Vary` appends instead of clobbering.
- **`/{table}/llm.md`** checked for a session but not the entity's read permission.

**#136 should not be closed by this PR.** Most of its "never opened" list is still never opened, and by the repo's own gate a single pass does not *clear* a surface — that needs the depth pass, the breadth pass, `go vet` and `govulncheck` all dry. The latter two are clean; the two adversarial passes were not run.

## Two tests that were lying

Worth stating because both would have shipped as false assurance:

1. The blueprint emitter sweep passed on the first run — because my base blueprint had an invalid screen type, so all 48 cases were rejected for an unrelated reason before reaching the emitter. Fixed, and 32 payloads now genuinely reach the emitted Go. That is when it found the `table:` bug.
2. `TestSetLevelRefusesUnauthenticatedCaller` passed against the *pre-fix* code — the plugin was uninitialized, so the handler nil-panicked into a generic error. Rewritten to assert on the refusal reason and that the level is unchanged.

## Verification

Build, vet, full suite, `repolint`, `gofmt`, coverage floors, `govulncheck` — all green. Each of the 12 commits builds and vets standalone. The `examples/site` chromedp suite times out under parallel `go test ./...` and passes isolated in 768s (known parallel-load behaviour, confirmed rather than assumed).

Nine breaking notes in the upgrade registry, each with a detect pattern and a remedy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYQes1bo9onSkHnxqAk8pW
