### PR TITLE
docs(changelog): #136 is partially addressed, not fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [0.46.0] - 2026-07-26
 
-The v0.43.0 audit backlog (#135) closed, four filed issues fixed (#136,
-#138, #139, #141), and the first audit of surfaces the previous passes had
-never opened.
+The v0.43.0 audit backlog (#135) closed, three filed issues fixed (#138,
+#139, #141), and the first audit of surfaces the previous passes had never
+opened (#136 — partially; its two concrete bugs are fixed and four of its
+listed surfaces audited, but most of its never-opened list is still never
+opened, and one pass does not clear a surface by this repo's gate).
 
 Same shape as 0.45.0: **guard drift** — a check one path has and its
 sibling skips. Three of the findings below are the *same* property


### PR DESCRIPTION
The v0.46.0 changelog entry claims "four filed issues fixed (#136, #138, #139, #141)". #136 is not fixed — it is an audit-*coverage* checklist. Its two concrete bugs are fixed and four of its listed surfaces were audited, but most of its never-opened list is still never opened, and by this repo's own gate one pass does not clear a surface.

This is the same class of over-claim that v0.46.0 partly exists to correct in v0.45.0 (`core-ui/urlsafe` "is now the single definition", when six copies remained). Catching it one release later is not an improvement worth having twice.

The GitHub release body will be regenerated from the corrected section after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYQes1bo9onSkHnxqAk8pW