### PR TITLE
Image placeholders render; uploads derive their own renditions (v0.47.0)

### DIFF
--- a/.claude/skills/gofastr-host/SKILL.md
+++ b/.claude/skills/gofastr-host/SKILL.md
@@ -67,6 +67,7 @@ generated guidance.
 | background job, scheduled task, retry-on-failure | `battery/queue` (use `DBQueue` for real workloads) |
 | send email, SMTP, transactional mail | `battery/email` |
 | file upload, S3, MinIO, attachments | `battery/storage` + `framework.WithFileStorage` |
+| image upload wanting thumbnails, srcset, blur placeholder | `framework.WithImagePipeline(imagefield.MustNew(...))` — every `schema.Image` upload gets renditions + a BlurHash, written to `<field>_blurhash` / `<field>_variants` / `<field>_placeholder` sibling columns you declare. Render with `image.BlurHashDataURL` + `ui.PipelineImage`. Per-field variation via `WithImagePipelineFor`. Never hand-roll resize/encode in an upload handler |
 | full-text search | `battery/search` |
 | outbound signed webhooks with retry | `battery/webhook` |
 | cache key/value, memoize, "remember for N seconds" | `battery/cache` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,124 @@ All notable changes to GoFastr. Follows
 calendar versions (`YYYY-MM-DD` per substantive release until the API
 stabilises). Breaking changes are clearly marked with **BREAKING**.
 
+## [0.47.0] - 2026-07-26
+
+Image placeholders now actually paint. The pipeline could produce a
+BlurHash since 0.5; nothing could turn one back into pixels, and the
+`data-placeholder` / `data-blurhash` attributes the UI components emitted
+were read by no CSS rule and no JavaScript anywhere in the tree. The
+feature was inert end to end, and the tests only asserted the attributes
+were present.
+
+### Added
+
+- **`framework.WithImagePipeline` — uploads now derive their own renditions
+  and BlurHash.** Previously the generate half of the story was entirely
+  BYO: nothing in the framework or any battery ever called `VariantSet`, so
+  "when does a BlurHash get made?" had one answer — whenever you hand-wrote
+  the call in an upload handler. Now declaring a `schema.Image` field is
+  enough. Every upload on that field produces the configured renditions
+  plus a BlurHash (and optionally an LQIP), stores the renditions beside
+  the original, and writes the metadata to sibling columns the entity
+  declares: `<field>_blurhash`, `<field>_placeholder`, `<field>_variants`.
+  Undeclared columns are skipped, so adopting one means adding the column
+  and nothing else.
+- **`framework.WithImagePipelineFor(entity, field, deriver)`** — per-field
+  override of the app-wide pipeline, since an avatar (portrait components,
+  reject animated) and a hero cover (wide renditions) cannot share one
+  config. An explicit `nil` opts a single field out without unpicking the
+  default.
+- **`framework/imagefield`** — the adapter implementing
+  `file.ImageDeriver` over `image.VariantSet`. A separate package on
+  purpose: `framework/crud` is in the dependency graph of nearly every
+  app, so a direct edge to `framework/image` would link every image
+  decoder plus the WebP encoder into every binary. The dependency is
+  inverted through an interface and only apps calling
+  `WithImagePipeline` pay for the codecs — enforced by a `go list -deps`
+  test, not a comment.
+- **`file.ImageDeriver` / `file.ImageDerivatives` / `file.DerivedVariant`**
+  plus `file.WithImageDeriver` on `ProcessFileField`, for callers driving
+  uploads directly. `FileField` gains an `Image` field carrying the
+  derived metadata, and `FileField.Validate` now checks it — derived
+  references reach the same sinks as the primary file.
+- **`image.DecodeBlurHash` + `image.BlurHashDataURL`** — the missing half
+  of the BlurHash story. Store the ~28-char hash in a column at upload
+  time; call `BlurHashDataURL` at render time to turn it back into an
+  inline image. `DecodeBlurHash` returns a pipeline `*Image`, so it chains
+  with the existing encoders. Hashes are treated as untrusted input:
+  length, alphabet, and component count are validated before any pixel
+  buffer is allocated, and output dimensions are capped at
+  `MaxBlurHashRenderSize` (128 px).
+- **Placeholder memoisation** — `SetBlurHashCacheSize` /
+  `FlushBlurHashCache` / `BlurHashCacheLen`. A list view would otherwise
+  re-decode the same handful of hashes on every request.
+- **`urlsafe.ImageSource` policy** — `Resource` plus inline raster `data:`
+  URIs, for the one sink where those are a feature rather than a mistake:
+  `<img src>`. `data:image/svg+xml` is excluded (SVG is a markup
+  surface), as is every non-image media type. `Resource` itself is
+  unchanged, so `<script src>` and `<link href>` still reject `data:`.
+
+### Changed
+
+- **`OptimizedImage` / `PipelineImage` render the placeholder as a real
+  stacked `<img>`** behind the image, positioned by static CSS. No
+  JavaScript, no `attr()`, no per-instance CSS — an inline `style`
+  attribute is blocked by both the default CSP and the repo's
+  `noinlinestyles` linter, so an element is the only mechanism available.
+- **`Placeholder` takes an inline raster `data:` URI. BREAKING.** A bare
+  BlurHash string is no longer accepted — it is not an image until it is
+  decoded. Bad values (a raw hash, a remote URL, a non-raster `data:` URI)
+  are dropped and the image renders without a placeholder rather than
+  panicking, matching how `PipelineImage` already treats missing intrinsic
+  dimensions: a placeholder is data, not a caller-code bug.
+- **`data-placeholder` and `data-blurhash` are no longer emitted.
+  BREAKING** for anyone who wired their own CSS or hydration to them.
+
+### Fixed
+
+- **A `data:` image URI was silently replaced with the 1×1 blank stub.**
+  The components pre-filtered `Src`/`Fallback`/`Sources` with
+  `urlsafe.Resource`, which rejects `data:`, so a generated or inlined
+  image rendered as "broken" rather than "blocked". Every `<img src>` sink
+  now uses `safeImageURL` — `OptimizedImage`, `PipelineImage`, and
+  `Gallery`'s thumbnails. `Avatar` has no pre-filter of its own and is
+  fixed by the `html.Image` policy change; a test pins that. Caught by
+  looking at a screenshot, not by any test.
+- **`PipelineImage` applied no URL allow-list at all** — `OptimizedImage`
+  ran `safeResourceURL` on its `Src` and every `Sources` URL; its sibling
+  ran it on neither `Fallback` nor `Sources`, despite rendering storage
+  URLs that routinely originate in user data.
+- **`OptimizedImage` did not escape srcset separators.** A URL containing
+  a comma or whitespace (presigned links, keys with comma-separated
+  segments) split one candidate into several malformed ones.
+  `PipelineImage` already escaped these; both now share one
+  implementation.
+- **The `Fit: contain` placeholder no longer bleeds into the letterbox
+  bars.** The placeholder is never removed, so a cover-cropped blur behind
+  a contained image was a permanent visual change, not a loading state.
+  It now mirrors the image's `object-fit`.
+
+### Internal
+
+- A `go list -deps` gate enforces that `framework/ui` never imports
+  `framework/image` — previously only a comment. The edge would put every
+  image decoder plus the WebP encoder in the binary of any host that
+  renders any UI at all.
+- A `go list -deps` gate likewise keeps `framework/crud` and
+  `framework/file` clear of `framework/image`, so the upload path's
+  dependency inversion cannot be "simplified" away.
+- The `/components/pipelineimage` showcase is a rendered demo instead of a
+  paragraph pointing at a demo that did not exist, and a new chromedp test
+  against it asserts the browser actually decoded the placeholder, that it
+  covers the real image's box, that the real image paints in front, and that
+  with the real image hidden the remaining pixels are a colourful blur
+  rather than the flat resting grey. The predecessor tests asserted a
+  `data-placeholder` attribute was present, which stayed green for as long
+  as the feature was entirely inert.
+- The demo's source image is a drawn mockup rather than a gradient: a
+  gradient's blur is indistinguishable from the gradient, so the first
+  version of the demo demonstrated nothing.
+
 ## [0.46.0] - 2026-07-26
 
 The v0.43.0 audit backlog (#135) closed, three filed issues fixed (#138,

--- a/cmd/gofastr/embedded/gofastr-host-skill.md
+++ b/cmd/gofastr/embedded/gofastr-host-skill.md
@@ -67,6 +67,7 @@ generated guidance.
 | background job, scheduled task, retry-on-failure | `battery/queue` (use `DBQueue` for real workloads) |
 | send email, SMTP, transactional mail | `battery/email` |
 | file upload, S3, MinIO, attachments | `battery/storage` + `framework.WithFileStorage` |
+| image upload wanting thumbnails, srcset, blur placeholder | `framework.WithImagePipeline(imagefield.MustNew(...))` — every `schema.Image` upload gets renditions + a BlurHash, written to `<field>_blurhash` / `<field>_variants` / `<field>_placeholder` sibling columns you declare. Render with `image.BlurHashDataURL` + `ui.PipelineImage`. Per-field variation via `WithImagePipelineFor`. Never hand-roll resize/encode in an upload handler |
 | full-text search | `battery/search` |
 | outbound signed webhooks with retry | `battery/webhook` |
 | cache key/value, memoize, "remember for N seconds" | `battery/cache` |

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.46.0
+through: v0.47.0
 
 releases:
   - version: v0.3.0
@@ -348,3 +348,15 @@ releases:
         breaking: true
         guidance: "Replay now re-checks that a delete was covered by an approved, unspent plan naming that target. A .kiln.session.jsonl written before v0.46.0 that contains deletes will fail replay — run `kiln freeze` with the old binary first, or start a fresh session."
         detect: "\\.kiln\\.session\\.jsonl"
+  - version: v0.47.0
+    title: Image placeholders render; uploads derive their own renditions
+    notes:
+      - change: OptimizedImage/PipelineImage Placeholder takes an inline raster data URI only
+        breaking: true
+        guidance: "A bare BlurHash string is no longer accepted — it was previously emitted as a data-blurhash attribute that nothing read, so placeholders never painted. Decode first with image.BlurHashDataURL(hash, image.BlurHashRenderConfig{}) and pass the result. Unusable values are dropped and the image renders without a placeholder rather than panicking."
+      - change: The data-placeholder and data-blurhash attributes are no longer emitted
+        breaking: true
+        guidance: "Both were dead — no CSS rule or runtime script in the framework ever read them. The placeholder is now a real stacked <img> positioned by the ui-image stylesheet. If you wired your own CSS or JS hydration to either attribute, delete it; the component paints the placeholder itself with no JavaScript."
+      - change: html.Image accepts raster data URIs; other resource sinks still reject them
+        breaking: false
+        guidance: "core-ui/html.Image moved from urlsafe.Resource to the new urlsafe.ImageSource policy, so an inline data:image/{jpeg,png,gif,webp,avif} src renders instead of being swapped for the blank stub. data:image/svg+xml and every non-image media type stay rejected, and <script src>/<link href> are unchanged. framework/ui image sinks (OptimizedImage, PipelineImage, Gallery, Avatar) inherit this."

--- a/core-ui/ARCHITECTURE.md
+++ b/core-ui/ARCHITECTURE.md
@@ -1300,6 +1300,7 @@ your need:
 | You want | Use | Notes |
 | --- | --- | --- |
 | Responsive lazy-loaded imagery | `framework/ui.OptimizedImage` | `<picture>` + `srcset`, lazy by default, mandatory `Width`+`Height` to eliminate CLS. |
+| Low-fidelity image placeholder | `Placeholder` on `framework/ui.OptimizedImage` / `PipelineImage` | Takes an inline raster `data:` URI (from `framework/image.BlurHashDataURL` or `Image.Placeholder`) and renders it as a stacked `<img>` behind the real one, positioned by static CSS. Zero JS: a per-instance value cannot go into CSS here (inline style attributes are blocked by the CSP and the `noinlinestyles` linter, and a data URI cannot be enumerated into a class), so an element is the only mechanism. Unusable values are dropped rather than fatal — a placeholder is data, not a caller bug. |
 | Overlapping avatar stack | `framework/ui.AvatarGroup` | Readable 10% negative-margin stack with compact corner presence dots and an adaptive-surface "+N" overflow indicator. Size propagates to children. |
 | Animated number counter | `framework/ui.AnimatedCounter` | Ticks from → to on scroll-into-view. Respects `prefers-reduced-motion`. |
 | Text link (inline / action / muted) | `framework/ui.Link` | Three variants: inline prose link, 44px action link, subdued muted link. |

--- a/core-ui/html/media.go
+++ b/core-ui/html/media.go
@@ -47,7 +47,11 @@ func Image(cfg ImageConfig) render.HTML {
 		panic("html: Image requires Src")
 	}
 	attrs := buildAttrs(cfg.ExtraAttrs, cfg.ID, cfg.Class)
-	attrs = setURLAttr(attrs, "src", cfg.Src, urlsafe.Resource)
+	// ImageSource rather than Resource: an inline raster data: URI is a
+	// legitimate <img src> (LQIP placeholders, generated icons), while the
+	// sinks that must keep rejecting data: — <script src>, <link href> —
+	// stay on Resource.
+	attrs = setURLAttr(attrs, "src", cfg.Src, urlsafe.ImageSource)
 	attrs = setAttr(attrs, "alt", cfg.Alt)
 	if cfg.Alt == "" {
 		if _, ok := attrs["role"]; !ok {

--- a/core-ui/urlsafe/urlsafe.go
+++ b/core-ui/urlsafe/urlsafe.go
@@ -23,11 +23,32 @@ const (
 	// relative, absolute-path, query-only and fragment-only references.
 	Anchor Policy = iota
 
-	// Resource is for URLs the browser fetches on its own: <img src>,
-	// <source src>, <script src>, <link href>, and head/meta URLs.
-	// Accepts http and https plus relative references — nothing else.
+	// Resource is for URLs the browser fetches on its own: <source src>,
+	// <script src>, <link href>, and head/meta URLs. Accepts http and
+	// https plus relative references — nothing else.
 	Resource
+
+	// ImageSource is Resource plus inline raster `data:` URIs, for the one
+	// sink where those are a feature rather than a mistake: <img src>.
+	//
+	// It is a separate policy precisely so the loosening cannot reach
+	// <script src> or <link href>, where a data: URI is a code-execution
+	// path. Only the raster media types this project's image pipeline can
+	// produce are accepted; `data:image/svg+xml` is excluded because SVG is
+	// a markup surface, and relying on browsers keeping img-loaded SVG
+	// script-disabled is a weaker guarantee than never emitting it.
+	ImageSource
 )
+
+// imageDataMediaTypes is the allow-list of media types ImageSource accepts
+// in a data: URI. Raster only — see the ImageSource doc comment.
+var imageDataMediaTypes = []string{
+	"image/jpeg",
+	"image/png",
+	"image/gif",
+	"image/webp",
+	"image/avif",
+}
 
 // OK reports whether u may be rendered into a URL attribute under p.
 //
@@ -68,7 +89,13 @@ func OK(u string, p Policy) bool {
 	for i := 0; i < len(trimmed); i++ {
 		switch trimmed[i] {
 		case ':':
-			return schemeOK(strings.ToLower(trimmed[:i]), p)
+			scheme := strings.ToLower(trimmed[:i])
+			// data: is gated on the media type, not the scheme alone, and
+			// only ImageSource admits it at all.
+			if scheme == "data" {
+				return p == ImageSource && dataImageOK(trimmed)
+			}
+			return schemeOK(scheme, p)
 		case '/', '?', '#':
 			return true
 		}
@@ -86,6 +113,35 @@ func schemeOK(scheme string, p Policy) bool {
 	default:
 		return false
 	}
+}
+
+// dataImageOK reports whether u is a `data:` URI carrying one of the
+// allow-listed raster media types. u is the caller's original string; the
+// media type is matched case-insensitively because `data:IMAGE/PNG` is
+// equivalent per RFC 2397, and a case-sensitive check would be a trivial
+// bypass of the allow-list.
+func dataImageOK(u string) bool {
+	const prefix = "data:"
+	if len(u) <= len(prefix) || !strings.EqualFold(u[:len(prefix)], prefix) {
+		return false
+	}
+	// A data: URI needs a payload delimiter; everything before it is the
+	// media type plus optional parameters (";base64", ";charset=…").
+	comma := strings.IndexByte(u, ',')
+	if comma < 0 {
+		return false
+	}
+	meta := strings.ToLower(u[len(prefix):comma])
+	mediaType := meta
+	if semi := strings.IndexByte(meta, ';'); semi >= 0 {
+		mediaType = meta[:semi]
+	}
+	for _, allowed := range imageDataMediaTypes {
+		if mediaType == allowed {
+			return true
+		}
+	}
+	return false
 }
 
 // Clean returns u when OK(u, p), and "" otherwise. Convenient for the

--- a/core-ui/urlsafe/urlsafe_test.go
+++ b/core-ui/urlsafe/urlsafe_test.go
@@ -96,3 +96,55 @@ func TestColonAfterDelimiterIsNotAScheme(t *testing.T) {
 		}
 	}
 }
+
+func TestImageSourceAcceptsRasterDataURLs(t *testing.T) {
+	for _, u := range []string{
+		"data:image/jpeg;base64,/9j/4AAQ",
+		"data:image/png;base64,iVBORw0KGgo=",
+		"data:image/gif;base64,R0lGODlh",
+		"data:image/webp;base64,UklGRg==",
+		"data:image/avif;base64,AAAAIGZ0",
+		"data:image/PNG;BASE64,iVBORw0K", // case-insensitive
+		"data:image/png,rawbytes",        // non-base64 payload is legal
+		"/photo.jpg",                     // ordinary resource URLs still pass
+		"https://cdn.example.com/a.png",
+	} {
+		if !OK(u, ImageSource) {
+			t.Errorf("OK(%q, ImageSource) = false, want true", u)
+		}
+	}
+}
+
+func TestImageSourceRejectsDangerousDataURLs(t *testing.T) {
+	for _, u := range []string{
+		"data:text/html;base64,PHNjcmlwdD4=",
+		"data:text/html,<script>alert(1)</script>",
+		// SVG in an <img> is script-disabled in browsers, but it is a
+		// markup surface this package never needs to emit, so it stays out
+		// of the allow-list rather than relying on that guarantee.
+		"data:image/svg+xml;base64,PHN2Zz4=",
+		"data:image/svg+xml,<svg onload=alert(1)>",
+		"data:application/javascript,alert(1)",
+		"data:,plain",
+		"data:image",     // no comma, no payload
+		"data:image/png", // media type but no payload delimiter
+		"data:imagex/png;base64,AAAA",
+		"javascript:alert(1)",
+		"vbscript:msgbox",
+		"data:image/png;base64,AA%0dAA", // CRLF smuggling
+	} {
+		if OK(u, ImageSource) {
+			t.Errorf("OK(%q, ImageSource) = true, want false", u)
+		}
+	}
+}
+
+// The looser image policy must not leak into the policies that guard
+// <script src> / <link href> / <a href>.
+func TestDataURLsStillRejectedByOtherPolicies(t *testing.T) {
+	for _, p := range []Policy{Anchor, Resource} {
+		if OK("data:image/png;base64,iVBORw0K", p) {
+			t.Errorf("policy %d must reject data: image URLs", p)
+		}
+	}
+}

--- a/examples/site/components.go
+++ b/examples/site/components.go
@@ -1460,8 +1460,14 @@ ui.OptimisticAction(ui.OptimisticActionConfig{
 		)
 	}},
 	{"pipelineimage", "PipelineImage", "Media", "Image processed through the framework's image pipeline.", func() render.HTML {
-		return html.Div(html.DivConfig{Class: "fact"},
-			render.Text("PipelineImage runs framework/image transforms (resize, webp) — see /examples for a live demo."),
+		demo := pipelineImageDemo()
+		return html.Div(html.DivConfig{Class: "demo-stack"},
+			demo.image,
+			html.Div(html.DivConfig{Class: "fact"},
+				render.Text("Left to right: the "+demo.hash+" BlurHash decoded to a placeholder, "+
+					"and the same image with that placeholder stacked behind it. "+
+					"The placeholder is server-rendered markup — no JavaScript decodes anything in the browser."),
+			),
 		)
 	}},
 	// ---------- Clientside Interactivity ----------

--- a/examples/site/e2e_placeholder_test.go
+++ b/examples/site/e2e_placeholder_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image/png"
+	"testing"
+
+	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/chromedp"
+)
+
+type placeholderGeometry struct {
+	Found bool `json:"found"`
+	// NaturalWidth is non-zero only if the browser actually decoded the
+	// inline data URI. This is the assertion the old data-placeholder
+	// attribute could never satisfy: an attribute nothing consumes always
+	// passes a markup test while painting nothing.
+	NaturalWidth  int     `json:"naturalWidth"`
+	NaturalHeight int     `json:"naturalHeight"`
+	Width         float64 `json:"width"`
+	Height        float64 `json:"height"`
+	// Delta* compare the placeholder's box to the real image's. A
+	// placeholder covering a different box is either invisible or bleeding
+	// outside the image it stands in for.
+	DeltaLeft float64 `json:"deltaLeft"`
+	DeltaTop  float64 `json:"deltaTop"`
+	DeltaW    float64 `json:"deltaW"`
+	DeltaH    float64 `json:"deltaH"`
+	// TopMostIsRealImage records what a user actually sees at the centre of
+	// the frame — the real image has to be in front.
+	TopMostIsRealImage bool   `json:"topMostIsRealImage"`
+	TopMostClass       string `json:"topMostClass"`
+	Position           string `json:"position"`
+	Lazy               bool   `json:"lazy"`
+	Decoding           string `json:"decoding"`
+}
+
+// placeholderProbe inspects the PipelineImage instance on the showcase page —
+// the one with a placeholder stacked behind a real image.
+const placeholderProbe = `(() => {
+  const lqip = document.querySelector('.ui-image--placeheld .ui-image__lqip');
+  if (!lqip) return {found: false};
+  const root = lqip.closest('[data-fui-comp="ui-image"]');
+  const real = root && root.querySelector('.ui-image__img');
+  const a = lqip.getBoundingClientRect();
+  const b = real ? real.getBoundingClientRect() : a;
+  const cs = getComputedStyle(lqip);
+  const mid = document.elementFromPoint(b.left + b.width / 2, b.top + b.height / 2);
+  return {
+    found: true,
+    naturalWidth: lqip.naturalWidth,
+    naturalHeight: lqip.naturalHeight,
+    width: a.width,
+    height: a.height,
+    deltaLeft: Math.abs(a.left - b.left),
+    deltaTop: Math.abs(a.top - b.top),
+    deltaW: Math.abs(a.width - b.width),
+    deltaH: Math.abs(a.height - b.height),
+    topMostIsRealImage: mid === real,
+    topMostClass: mid ? String(mid.className) : '',
+    position: cs.position,
+    lazy: lqip.getAttribute('loading') === 'lazy',
+    decoding: lqip.getAttribute('decoding') || '',
+  };
+})()`
+
+// hideRealImage makes the real image transparent so a screenshot captures
+// what the placeholder alone puts on screen. Done in the browser at runtime
+// rather than by shipping a test-only CSS hook.
+const hideRealImage = `(() => {
+  const img = document.querySelector('.ui-image--placeheld .ui-image__img');
+  if (!img) return false;
+  img.style.opacity = '0';
+  return true;
+})()`
+
+// TestE2EPlaceholderPaints is the pixels-not-probes check for the image
+// placeholder. It verifies the browser decoded the inline placeholder, that it
+// covers the real image's box, that the real image is the one in front, and
+// that with the real image hidden the pixels left on screen are a colourful
+// blur rather than the component's flat resting grey.
+//
+// The predecessor tests asserted only that a data-placeholder attribute was
+// present in the markup, which stayed green for as long as the feature was
+// entirely inert.
+func TestE2EPlaceholderPaints(t *testing.T) {
+	base := siteE2EServer(t)
+	ctx := siteBrowserCtx(t)
+
+	var geo placeholderGeometry
+	var hidden bool
+	var shot []byte
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(base+"/components/pipelineimage"),
+		chromedp.WaitVisible(".ui-image__lqip", chromedp.ByQuery),
+		chromedp.Evaluate(placeholderProbe, &geo),
+		chromedp.Evaluate(hideRealImage, &hidden),
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			var err error
+			shot, err = page.CaptureScreenshot().WithFromSurface(true).Do(ctx)
+			return err
+		}),
+	); err != nil {
+		t.Fatalf("placeholder probe: %v", err)
+	}
+
+	if !geo.Found {
+		t.Fatal("no placeheld .ui-image__lqip on /components/pipelineimage — the demo regressed")
+	}
+	if geo.NaturalWidth == 0 || geo.NaturalHeight == 0 {
+		t.Errorf("browser did not decode the placeholder (natural size %dx%d) — the data URI is not a valid image",
+			geo.NaturalWidth, geo.NaturalHeight)
+	}
+	if geo.Width < 1 || geo.Height < 1 {
+		t.Errorf("placeholder has no rendered box: %.1fx%.1f", geo.Width, geo.Height)
+	}
+	if geo.Position != "absolute" {
+		t.Errorf("placeholder position = %q, want absolute so it stacks behind", geo.Position)
+	}
+	// A data URI costs no request, so deferring or async-decoding it could
+	// only make the placeholder appear after the image it stands in for.
+	if geo.Lazy {
+		t.Error("placeholder must not be lazy-loaded")
+	}
+	if geo.Decoding != "sync" {
+		t.Errorf("placeholder decoding = %q, want sync", geo.Decoding)
+	}
+	// One pixel of tolerance for subpixel layout rounding.
+	for _, d := range []struct {
+		name string
+		val  float64
+	}{
+		{"left", geo.DeltaLeft}, {"top", geo.DeltaTop},
+		{"width", geo.DeltaW}, {"height", geo.DeltaH},
+	} {
+		if d.val > 1 {
+			t.Errorf("placeholder %s differs from the real image by %.1fpx; it must cover the same box", d.name, d.val)
+		}
+	}
+	if !geo.TopMostIsRealImage {
+		t.Errorf("the placeholder is painting over the real image (top element at centre: %q)", geo.TopMostClass)
+	}
+	if !hidden {
+		t.Fatal("could not hide the real image for the pixel check")
+	}
+	if err := screenshotIsColourful(shot); err != nil {
+		t.Errorf("placeholder pixels: %v", err)
+	}
+}
+
+// screenshotIsColourful reports an error unless some pixel is meaningfully
+// saturated. With the real image hidden, an all-grey screenshot means the
+// decoded blur never painted — exactly the pre-fix behaviour, where the
+// component fell back to --color-surface-soft.
+func screenshotIsColourful(data []byte) error {
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("decode screenshot: %w", err)
+	}
+	bounds := img.Bounds()
+	best := 0
+	for y := bounds.Min.Y; y < bounds.Max.Y; y += 2 {
+		for x := bounds.Min.X; x < bounds.Max.X; x += 2 {
+			r, g, b, _ := img.At(x, y).RGBA()
+			r8, g8, b8 := int(r>>8), int(g>>8), int(b>>8)
+			hi, lo := r8, r8
+			for _, v := range []int{g8, b8} {
+				if v > hi {
+					hi = v
+				}
+				if v < lo {
+					lo = v
+				}
+			}
+			if hi-lo > best {
+				best = hi - lo
+			}
+		}
+	}
+	// The demo mockup uses saturated indigo/amber/teal blocks, so its blur
+	// has a wide channel spread. 30 sits far above the ~0-4 spread of the
+	// grey resting fill and well below what the real mockup produces.
+	if best < 30 {
+		return fmt.Errorf("no saturated pixels found (max channel spread %d); the blur did not paint", best)
+	}
+	return nil
+}

--- a/examples/site/pipeline_image_demo.go
+++ b/examples/site/pipeline_image_demo.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	stdimage "image"
+	"image/color"
+	"image/draw"
+	"sync"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
+	"github.com/DonaldMurillo/gofastr/core/render"
+	fwimage "github.com/DonaldMurillo/gofastr/framework/image"
+	"github.com/DonaldMurillo/gofastr/framework/ui"
+)
+
+// The component showcase needs a real image without committing a binary, so
+// the demo draws one in-process and inlines both it and its placeholder as
+// data URIs. Inlining a full image is a showcase convenience, not a pattern to
+// copy — a real app serves variants from storage and stores only the ~28-char
+// BlurHash, which `framework.WithImagePipeline` does automatically for
+// `schema.Image` uploads. See `gofastr docs uploads`.
+
+type pipelineDemo struct {
+	image render.HTML
+	hash  string
+}
+
+var (
+	pipelineDemoOnce sync.Once
+	pipelineDemoVal  pipelineDemo
+)
+
+func pipelineImageDemo() pipelineDemo {
+	pipelineDemoOnce.Do(func() {
+		pipelineDemoVal = buildPipelineImageDemo()
+	})
+	return pipelineDemoVal
+}
+
+// demoMockup draws a crude dashboard mock — a header bar, a chart block, and
+// two cards. Crisp edges are the point: a gradient's blur looks identical to
+// the gradient, so a showcase built on one demonstrates nothing. With edges,
+// the difference between the placeholder and the image it stands in for is
+// visible at a glance.
+func demoMockup(w, h int) *fwimage.Image {
+	canvas := stdimage.NewNRGBA(stdimage.Rect(0, 0, w, h))
+	block := func(x0, y0, x1, y1 int, c color.NRGBA) {
+		draw.Draw(canvas, stdimage.Rect(x0, y0, x1, y1), &stdimage.Uniform{C: c}, stdimage.Point{}, draw.Src)
+	}
+	var (
+		page   = color.NRGBA{R: 0xFA, G: 0xF7, B: 0xF2, A: 0xFF}
+		ink    = color.NRGBA{R: 0x24, G: 0x21, B: 0x1C, A: 0xFF}
+		amber  = color.NRGBA{R: 0xF2, G: 0xB1, B: 0x4D, A: 0xFF}
+		teal   = color.NRGBA{R: 0x0E, G: 0x7C, B: 0x86, A: 0xFF}
+		indigo = color.NRGBA{R: 0x43, G: 0x38, B: 0xCA, A: 0xFF}
+	)
+	block(0, 0, w, h, page)
+	block(0, 0, w, h/8, ink)                       // header bar
+	block(w/24, h/5, w/2, h-h/6, indigo)           // chart panel
+	block(w/2+w/24, h/5, w-w/24, h/2, amber)       // card one
+	block(w/2+w/24, h/2+h/24, w-w/24, h-h/6, teal) // card two
+	block(w/24, h-h/9, w/3, h-h/9+h/40, ink)       // footer rule
+	return fwimage.FromImage(canvas, fwimage.FormatPNG)
+}
+
+func buildPipelineImageDemo() pipelineDemo {
+	fail := func(msg string) pipelineDemo {
+		return pipelineDemo{
+			image: html.Div(html.DivConfig{Class: "fact"}, render.Text(msg)),
+			hash:  "",
+		}
+	}
+	src := demoMockup(480, 270)
+	full, err := src.JPEG(fwimage.JPEGOptions{Quality: 78}).DataURL()
+	if err != nil {
+		return fail("Demo image could not be encoded.")
+	}
+	hash, err := src.BlurHash(4, 3)
+	if err != nil {
+		return fail("Demo BlurHash could not be computed.")
+	}
+	placeholder, err := fwimage.BlurHashDataURL(hash, fwimage.BlurHashRenderConfig{})
+	if err != nil {
+		return fail("Demo placeholder could not be decoded.")
+	}
+
+	// Side by side: the placeholder on its own, then the composed component.
+	// Seeing the blur next to the image it stands in for is the only honest
+	// way to show a placeholder in a showcase, where everything loads at once.
+	return pipelineDemo{
+		hash: hash,
+		image: ui.Grid(ui.GridConfig{Min: "14rem"},
+			ui.Stack(ui.StackConfig{Gap: ui.GapXS},
+				ui.OptimizedImage(ui.OptimizedImageConfig{
+					Src: placeholder, Alt: "The decoded BlurHash placeholder on its own.",
+					Width: 480, Height: 270, Aspect: ui.ImageAspect16x9, Rounded: true,
+				}),
+				html.Div(html.DivConfig{Class: "fact"}, render.Text("Placeholder, decoded from 28 characters")),
+			),
+			ui.Stack(ui.StackConfig{Gap: ui.GapXS},
+				ui.PipelineImage(ui.PipelineImageConfig{
+					Fallback: full, Alt: "A generated gradient standing in for a product photo.",
+					Width: 480, Height: 270, Aspect: ui.ImageAspect16x9, Rounded: true,
+					Placeholder: placeholder,
+				}),
+				html.Div(html.DivConfig{Class: "fact"}, render.Text("Image with the placeholder behind it")),
+			),
+		),
+	}
+}

--- a/framework/ARCHITECTURE.md
+++ b/framework/ARCHITECTURE.md
@@ -213,7 +213,16 @@ framework/
 ├── hook/            HookRegistry / HookType + lifecycle constants
 │                    (BeforeCreate, AfterCreate, etc.)
 ├── i18nui/          Translated default strings for framework UI surfaces
-├── image/           Image decode/encode + blurhash for the file/upload path
+├── image/           Image decode/encode, variant pipeline, BlurHash encode
+│                    + decode. A zero-dependency leaf: imports nothing from
+│                    gofastr, so nothing below it may import IT either (see
+│                    imagefield/ and the framework/ui layering test).
+├── imagefield/      Adapter making framework/image satisfy file.ImageDeriver,
+│                    so a schema.Image upload auto-produces renditions +
+│                    BlurHash. Separate package on purpose: file/ and crud/
+│                    must not link every image decoder, so the dependency is
+│                    inverted through an interface and only apps that opt in
+│                    (framework.WithImagePipeline) pay for the codecs.
 ├── internal/casing/ snake↔camel helpers (private to the framework
 │                    module — not part of the public API)
 ├── lifecycle/       Graceful shutdown contract — drain, flush, stop phases

--- a/framework/agents.md
+++ b/framework/agents.md
@@ -4,7 +4,8 @@ App-level helpers worth surfacing to AI agents alongside the batteries.
 
 **Use this when** the prompt mentions: audit trail / who did what, hot
 reload, dev server, browser auto-refresh, livereload, run the app while
-developing, `.env` loading, live app introspection.
+developing, `.env` loading, live app introspection, image uploads that need
+thumbnails / responsive sizes / a blur placeholder.
 
 ## `app.WithAuditLog(cfg)` — automatic CRUD audit
 
@@ -37,6 +38,31 @@ helper for entity CRUD. DO keep custom audit writes for domain actions
 not arbitrary domain events.
 
 ---
+
+## `framework.WithImagePipeline(d)` — uploads derive their own renditions
+
+Every `schema.Image` upload produces the configured renditions plus a
+BlurHash, stores them beside the original, and writes the metadata to sibling
+columns the entity declares (`<field>_blurhash`, `<field>_variants`,
+`<field>_placeholder`). Undeclared columns are skipped, so a column is how you
+opt in.
+
+```go
+framework.WithFileStorage(store),
+framework.WithImagePipeline(imagefield.MustNew(imagefield.Config{
+    Variants:  []image.Variant{{Width: 960, Format: image.FormatJPEG, Quality: 82, Suffix: "md"}},
+    BlurHashX: 4, BlurHashY: 3,
+})),
+```
+
+`WithImagePipelineFor(entity, field, d)` overrides one field; a nil deriver
+opts a field out. Render with `image.BlurHashDataURL(hash, ...)` into
+`ui.PipelineImage`'s `Placeholder`.
+
+Two things to know: the derive is synchronous in the request (~180ms for two
+JPEG widths from a 3000px source, ~540ms once WebP is included, because that
+encoder runs five passes), and an undecodable upload fails the request rather
+than storing a file with no renditions. `gofastr docs uploads` has the detail.
 
 ## `framework/dev` — auto-wired livereload
 
@@ -100,6 +126,10 @@ a running server, or "is this app healthy". See the
 - A livereload SSE handler — framework auto-wires it under `gofastr dev`.
 - A dotenv loader — `NewApp` does it.
 - Per-test PG isolation — see `framework/testkit` (`NewIsolatedDB`).
+- Resize/encode/thumbnail code in an upload handler — `WithImagePipeline`
+  does it from the field declaration; `framework/image` is the manual path.
+- A JS BlurHash decoder — `image.BlurHashDataURL` decodes server-side and
+  `ui.PipelineImage` paints it with no JavaScript.
 - Hand-rolled markup or CSS — `framework/ui` ships ~100 components;
   see the `ui` row of AGENTS.md (`agents/ui.md`) and
   `gofastr docs ui-new-components`.

--- a/framework/app.go
+++ b/framework/app.go
@@ -38,6 +38,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/framework/dev"
 	"github.com/DonaldMurillo/gofastr/framework/entity"
 	"github.com/DonaldMurillo/gofastr/framework/event"
+	"github.com/DonaldMurillo/gofastr/framework/file"
 	"github.com/DonaldMurillo/gofastr/framework/hook"
 	"github.com/DonaldMurillo/gofastr/framework/i18nui"
 	"github.com/DonaldMurillo/gofastr/framework/isolation"
@@ -132,13 +133,15 @@ const defaultShutdownTimeout = 15 * time.Second
 // App is the top-level application container.
 // It wires together the entity registry, router, MCP server, and database.
 type App struct {
-	Registry *Registry
-	router   *router.Router // access via App.Router() method
-	MCP      *mcp.Server
-	DB       *sql.DB
-	Config   AppConfig
-	Plugins  *PluginManager
-	Storage  upload.Storage // optional; enables multipart on Image/File fields
+	Registry           *Registry
+	router             *router.Router // access via App.Router() method
+	MCP                *mcp.Server
+	DB                 *sql.DB
+	Config             AppConfig
+	Plugins            *PluginManager
+	Storage            upload.Storage                          // optional; enables multipart on Image/File fields
+	imageDeriver       file.ImageDeriver                       // optional; derives renditions + BlurHash for Image fields
+	fieldImageDerivers map[string]map[string]file.ImageDeriver // entity -> field -> override
 
 	migrationRoutines []migrate.Routine // stored procedures/functions/triggers run on boot
 	migrationViews    []migrate.View    // views (virtual tables built from entities) run on boot
@@ -513,6 +516,54 @@ func WithMCP() AppOption {
 func WithFileStorage(s upload.Storage) AppOption {
 	return func(a *App) {
 		a.Storage = s
+	}
+}
+
+// WithImagePipeline makes every schema.Image upload produce stored
+// renditions plus a BlurHash (or LQIP) automatically, instead of needing a
+// per-entity upload handler.
+//
+// Pass a deriver from framework/imagefield, which is a separate package so
+// applications that do not process images never link the image decoders:
+//
+//	framework.WithImagePipeline(imagefield.MustNew(imagefield.Config{
+//	    Variants:  []image.Variant{{Width: 960, Format: image.FormatWebP, Suffix: "md"}},
+//	    BlurHashX: 4, BlurHashY: 3,
+//	}))
+//
+// Derived values are written to sibling columns the entity declares —
+// for an Image field "cover": "cover_blurhash", "cover_placeholder", and
+// "cover_variants" (JSON). Columns that do not exist are skipped, so
+// adopting one means adding the column and nothing else.
+//
+// Requires WithFileStorage; the renditions are written through the same
+// backend as the original. A source that cannot be decoded fails the
+// upload rather than storing a file with no renditions.
+func WithImagePipeline(d file.ImageDeriver) AppOption {
+	return func(a *App) {
+		a.imageDeriver = d
+	}
+}
+
+// WithImagePipelineFor overrides WithImagePipeline for a single image field.
+// One app-wide config cannot describe every image: an avatar wants portrait
+// BlurHash components and animated sources rejected, while a hero cover wants
+// wide renditions. Compose both:
+//
+//	framework.WithImagePipeline(covers),                         // default
+//	framework.WithImagePipelineFor("users", "avatar", avatars),  // override
+//
+// Passing a nil deriver opts that one field out of the pipeline entirely
+// without unpicking the app-wide default.
+func WithImagePipelineFor(entityName, fieldName string, d file.ImageDeriver) AppOption {
+	return func(a *App) {
+		if a.fieldImageDerivers == nil {
+			a.fieldImageDerivers = map[string]map[string]file.ImageDeriver{}
+		}
+		if a.fieldImageDerivers[entityName] == nil {
+			a.fieldImageDerivers[entityName] = map[string]file.ImageDeriver{}
+		}
+		a.fieldImageDerivers[entityName][fieldName] = d
 	}
 }
 
@@ -981,6 +1032,8 @@ func (a *App) GroupEntity(g *routegroup.RouteGroup, name string, config entity.E
 		crudHandler.JSONCase = a.JSONCasing()
 		crudHandler.Hooks = a.HookRegistry(name)
 		crudHandler.Storage = a.Storage
+		crudHandler.ImageDeriver = a.imageDeriver
+		crudHandler.FieldImageDerivers = a.fieldImageDerivers[name]
 		crudHandler.Events = a.Events()
 		// Guarded assignment: a bare `= a.outbox` would wrap a typed nil
 		// in the EventOutbox interface and silently swallow every event.
@@ -1375,6 +1428,8 @@ func (a *App) TryEntity(name string, config entity.EntityConfig) (err error) {
 		crudHandler.JSONCase = a.JSONCasing()
 		crudHandler.Hooks = a.HookRegistry(name)
 		crudHandler.Storage = a.Storage
+		crudHandler.ImageDeriver = a.imageDeriver
+		crudHandler.FieldImageDerivers = a.fieldImageDerivers[name]
 		crudHandler.Events = a.Events()
 		// Guarded assignment: a bare `= a.outbox` would wrap a typed nil
 		// in the EventOutbox interface and silently swallow every event.
@@ -1425,6 +1480,8 @@ func (a *App) CrudHandler(name string) (*crud.CrudHandler, error) {
 	ch.JSONCase = a.JSONCasing()
 	ch.Hooks = a.HookRegistry(name)
 	ch.Storage = a.Storage
+	ch.ImageDeriver = a.imageDeriver
+	ch.FieldImageDerivers = a.fieldImageDerivers[name]
 	ch.Events = a.Events()
 	if a.outbox != nil {
 		ch.Outbox = a.outbox

--- a/framework/crud/crud.go
+++ b/framework/crud/crud.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/framework/db"
 	"github.com/DonaldMurillo/gofastr/framework/entity"
 	"github.com/DonaldMurillo/gofastr/framework/event"
+	"github.com/DonaldMurillo/gofastr/framework/file"
 	"github.com/DonaldMurillo/gofastr/framework/filter"
 	"github.com/DonaldMurillo/gofastr/framework/hook"
 	"github.com/DonaldMurillo/gofastr/framework/internal/casing"
@@ -63,10 +64,20 @@ type CrudHandler struct {
 	JSONCase   JSONCase           // casing strategy for JSON keys
 	Hooks      *hook.HookRegistry // optional lifecycle hooks
 	Storage    upload.Storage     // optional; enables multipart uploads for Image/File fields
-	Events     *event.EventBus    // optional; receives entity.created/updated/deleted on commit
-	Outbox     EventOutbox        // optional; when set, lifecycle events are staged in-tx (transactional outbox) and delivered to declared consumers by the relay. EmitEvent still notifies Events (real-time lane); the relay does not, so there is no double delivery.
-	Registry   entity.Registry    // optional; required for nested ?include=author.profile resolution
-	BasePath   string             // optional; URL prefix where this entity's routes are mounted (e.g. "/api/v1"). Used by MCP tools to dispatch against the same path the HTTP routes live at; empty = bare "/table".
+	// ImageDeriver, when set, runs over every schema.Image upload to
+	// produce stored renditions plus a BlurHash/LQIP. Derived values land
+	// in sibling columns the entity declares — see applyDerivedColumns.
+	// framework/imagefield provides the implementation.
+	ImageDeriver file.ImageDeriver
+	// FieldImageDerivers overrides ImageDeriver for specific image fields,
+	// keyed by field name. An avatar wants portrait components and animated
+	// sources rejected; a hero cover wants wide renditions — one app-wide
+	// config cannot express both.
+	FieldImageDerivers map[string]file.ImageDeriver
+	Events             *event.EventBus // optional; receives entity.created/updated/deleted on commit
+	Outbox             EventOutbox     // optional; when set, lifecycle events are staged in-tx (transactional outbox) and delivered to declared consumers by the relay. EmitEvent still notifies Events (real-time lane); the relay does not, so there is no double delivery.
+	Registry           entity.Registry // optional; required for nested ?include=author.profile resolution
+	BasePath           string          // optional; URL prefix where this entity's routes are mounted (e.g. "/api/v1"). Used by MCP tools to dispatch against the same path the HTTP routes live at; empty = bare "/table".
 
 	visibleFieldsCache []string
 	visibleJSONKeys    []string

--- a/framework/crud/crud_upload.go
+++ b/framework/crud/crud_upload.go
@@ -159,7 +159,7 @@ func (ch *CrudHandler) parseMultipartBody(r *http.Request) (map[string]any, erro
 				return nil, errStorageNotConfigured
 			}
 			fh := headers[0]
-			if err := saveFilePart(r.Context(), ch, key, fh, body); err != nil {
+			if err := saveFilePart(r.Context(), ch, key, fileFieldNames[key], fh, body); err != nil {
 				return nil, err
 			}
 		}
@@ -169,19 +169,94 @@ func (ch *CrudHandler) parseMultipartBody(r *http.Request) (map[string]any, erro
 }
 
 // saveFilePart opens one multipart file header, runs ProcessFileField, and
-// stores the resulting URL on body[key].
-func saveFilePart(ctx context.Context, ch *CrudHandler, key string, fh *multipart.FileHeader, body map[string]any) error {
+// stores the resulting URL on body[key]. For a schema.Image field with an
+// ImageDeriver configured, renditions and placeholder metadata are derived
+// too and spread across whichever sibling columns the entity declares.
+func saveFilePart(ctx context.Context, ch *CrudHandler, key string, fieldType schema.FieldType, fh *multipart.FileHeader, body map[string]any) error {
 	f, err := fh.Open()
 	if err != nil {
 		return fmt.Errorf("open file part %q: %w", key, err)
 	}
 	defer f.Close()
-	ff, err := file.ProcessFileField(ctx, ch.Storage, f, fh.Filename, ch.Entity.GetName(), key)
+
+	var opts []file.ProcessOption
+	// Only Image fields get the pipeline. A File field is any binary — a
+	// PDF, a CSV — and decoding it as an image would fail every upload.
+	if fieldType == schema.Image {
+		if d := ch.deriverFor(key); d != nil {
+			opts = append(opts, file.WithImageDeriver(d))
+		}
+	}
+
+	ff, err := file.ProcessFileField(ctx, ch.Storage, f, fh.Filename, ch.Entity.GetName(), key, opts...)
 	if err != nil {
 		return fmt.Errorf("upload %q: %w", key, err)
 	}
 	body[key] = ff.URL
+	if ff.Image != nil {
+		applyDerivedColumns(ch.Entity, key, ff.Image, body)
+	}
 	return nil
+}
+
+// deriverFor resolves the deriver for one image field: a per-field override
+// when present, otherwise the handler-wide default. A per-field entry of nil
+// is honoured as "no pipeline for this field", so a single noisy field can be
+// opted out without unpicking the app-wide config.
+func (ch *CrudHandler) deriverFor(field string) file.ImageDeriver {
+	if ch.FieldImageDerivers != nil {
+		if d, ok := ch.FieldImageDerivers[field]; ok {
+			return d
+		}
+	}
+	return ch.ImageDeriver
+}
+
+// derivedColumnSuffixes maps each derived artifact to the sibling column
+// that receives it. An Image field named "cover" populates
+// "cover_blurhash", "cover_placeholder", and "cover_variants" — but only
+// those the entity actually declares, so adopting one is a matter of adding
+// the column and nothing else. Columns that do not exist are skipped
+// silently; that is what makes this additive rather than a schema
+// requirement.
+var derivedColumnSuffixes = struct {
+	blurHash    string
+	placeholder string
+	variants    string
+}{
+	blurHash:    "_blurhash",
+	placeholder: "_placeholder",
+	variants:    "_variants",
+}
+
+// applyDerivedColumns writes derived values onto body for the sibling
+// columns the entity declares.
+func applyDerivedColumns(ent *entity.Entity, field string, d *file.ImageDerivatives, body map[string]any) {
+	declared := make(map[string]schema.FieldType, len(ent.GetFields()))
+	for _, f := range ent.GetFields() {
+		declared[f.Name] = f.Type
+	}
+	set := func(suffix string, value any) {
+		name := field + suffix
+		if _, ok := declared[name]; !ok {
+			return
+		}
+		body[name] = value
+	}
+	if d.BlurHash != "" {
+		set(derivedColumnSuffixes.blurHash, d.BlurHash)
+	}
+	if d.Placeholder != "" {
+		set(derivedColumnSuffixes.placeholder, d.Placeholder)
+	}
+	if len(d.Variants) > 0 {
+		// Marshalled here rather than handed over as a slice: the column is
+		// declared schema.JSON, and the write path expects a value the
+		// driver can bind directly.
+		if raw, err := json.Marshal(d.Variants); err == nil {
+			set(derivedColumnSuffixes.variants, string(raw))
+		}
+	}
 }
 
 // coerceFormValue attempts a minimal type coercion based on the schema field

--- a/framework/crud/layering_test.go
+++ b/framework/crud/layering_test.go
@@ -1,0 +1,36 @@
+package crud_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The image pipeline reaches the upload path through the file.ImageDeriver
+// interface, implemented in framework/imagefield. The indirection exists for
+// exactly one reason: framework/image carries every image decoder plus the
+// WebP encoder, and crud is in the dependency graph of essentially every
+// GoFastr application. A direct edge would put all of those codecs in every
+// binary, whether or not the app touches images.
+//
+// This is the enforceable form of that rule. A future "just import it here,
+// it's simpler" refactor fails here instead of quietly growing every
+// downstream binary.
+func TestUploadPathDoesNotLinkImageCodecs(t *testing.T) {
+	const banned = "github.com/DonaldMurillo/gofastr/framework/image"
+	for _, pkg := range []string{
+		"github.com/DonaldMurillo/gofastr/framework/crud",
+		"github.com/DonaldMurillo/gofastr/framework/file",
+	} {
+		out, err := exec.Command("go", "list", "-deps", pkg).CombinedOutput()
+		if err != nil {
+			t.Fatalf("go list -deps %s: %v\n%s", pkg, err, out)
+		}
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.TrimSpace(line) == banned {
+				t.Errorf("%s depends on %s — implement file.ImageDeriver in "+
+					"framework/imagefield instead of importing the pipeline here", pkg, banned)
+			}
+		}
+	}
+}

--- a/framework/crud/upload_derive_test.go
+++ b/framework/crud/upload_derive_test.go
@@ -1,0 +1,303 @@
+package crud
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/core/upload"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+	"github.com/DonaldMurillo/gofastr/framework/file"
+)
+
+// fakeDeriver stands in for framework/imagefield so these tests exercise the
+// upload handler's own branches without pulling the image codecs into this
+// package's dependency graph (see TestUploadPathDoesNotLinkImageCodecs).
+type fakeDeriver struct {
+	out     *file.ImageDerivatives
+	err     error
+	calls   int
+	lastRef string
+}
+
+func (f *fakeDeriver) DeriveImage(_ context.Context, _ upload.Storage, _ []byte, primaryRef string) (*file.ImageDerivatives, error) {
+	f.calls++
+	f.lastRef = primaryRef
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.out, nil
+}
+
+func fullDerivatives() *file.ImageDerivatives {
+	return &file.ImageDerivatives{
+		BlurHash:    "LEHV6nWB2yk8pyo0adR*.7kCMdnj",
+		Placeholder: "data:image/jpeg;base64,/9j/4AAQ",
+		Variants: []file.DerivedVariant{
+			{StorageRef: "media/photo/x-sm.webp", MIME: "image/webp", Width: 320, Height: 240},
+			{StorageRef: "media/photo/x-md.webp", MIME: "image/webp", Width: 640, Height: 480},
+		},
+	}
+}
+
+// deriveHandler builds a media entity whose sibling columns are declared
+// selectively, so the "declared column wins, undeclared is skipped" branch is
+// exercised by construction.
+func deriveHandler(t *testing.T, withSiblings bool) (*CrudHandler, *sql.DB) {
+	t.Helper()
+	ddl := `CREATE TABLE media (id TEXT PRIMARY KEY, caption TEXT, photo TEXT, doc TEXT)`
+	fields := []schema.Field{
+		{Name: "caption", Type: schema.String},
+		{Name: "photo", Type: schema.Image},
+		{Name: "doc", Type: schema.File},
+	}
+	if withSiblings {
+		ddl = `CREATE TABLE media (id TEXT PRIMARY KEY, caption TEXT, photo TEXT, doc TEXT,
+			photo_blurhash TEXT, photo_placeholder TEXT, photo_variants TEXT)`
+		fields = append(fields,
+			schema.Field{Name: "photo_blurhash", Type: schema.String},
+			schema.Field{Name: "photo_placeholder", Type: schema.String},
+			schema.Field{Name: "photo_variants", Type: schema.JSON},
+		)
+	}
+	db := setupDB(t, ddl)
+	ent := entity.Define("media", entity.EntityConfig{
+		Name: "media", Table: "media", Fields: fields,
+	}.WithTimestamps(false))
+	ent.SetDB(db)
+	ch := NewCrudHandler(ent, db).WithJSONCase(CaseSnake)
+	ch.Storage = upload.NewLocalStorage(t.TempDir())
+	return ch, db
+}
+
+func postPart(t *testing.T, ch *CrudHandler, field, filename string, data []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("caption", "a pic")
+	fw, _ := mw.CreateFormFile(field, filename)
+	_, _ = fw.Write(data)
+	mw.Close()
+	req := withTestUser(httptest.NewRequest("POST", "/media", &buf), "u1")
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rec := httptest.NewRecorder()
+	ch.Create()(rec, req)
+	return rec
+}
+
+func TestDerive_PopulatesDeclaredSiblingColumns(t *testing.T) {
+	ch, db := deriveHandler(t, true)
+	d := &fakeDeriver{out: fullDerivatives()}
+	ch.ImageDeriver = d
+
+	rec := postPart(t, ch, "photo", "pic.png", pngBytes())
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if d.calls != 1 {
+		t.Errorf("deriver called %d times, want 1", d.calls)
+	}
+	// The deriver is handed the primary storage key so it can place
+	// renditions beside the original.
+	if d.lastRef == "" {
+		t.Error("deriver was not given the primary storage ref")
+	}
+
+	var hash, placeholder, variants string
+	if err := db.QueryRow(`SELECT photo_blurhash, photo_placeholder, photo_variants FROM media`).
+		Scan(&hash, &placeholder, &variants); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if hash != "LEHV6nWB2yk8pyo0adR*.7kCMdnj" {
+		t.Errorf("photo_blurhash = %q", hash)
+	}
+	if placeholder == "" {
+		t.Error("photo_placeholder was not populated")
+	}
+	var refs []file.DerivedVariant
+	if err := json.Unmarshal([]byte(variants), &refs); err != nil {
+		t.Fatalf("photo_variants is not JSON (%q): %v", variants, err)
+	}
+	if len(refs) != 2 || refs[0].Width != 320 {
+		t.Errorf("photo_variants = %s", variants)
+	}
+}
+
+// The columns are optional. With none declared the upload still succeeds and
+// the derived values are simply dropped — that is what makes the feature
+// additive rather than a schema requirement.
+func TestDerive_SkipsUndeclaredSiblingColumns(t *testing.T) {
+	ch, db := deriveHandler(t, false)
+	ch.ImageDeriver = &fakeDeriver{out: fullDerivatives()}
+
+	rec := postPart(t, ch, "photo", "pic.png", pngBytes())
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var photo string
+	if err := db.QueryRow(`SELECT photo FROM media`).Scan(&photo); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if photo == "" {
+		t.Error("primary upload lost")
+	}
+}
+
+// Only schema.Image runs the pipeline; a File field is arbitrary binary.
+func TestDerive_NotRunForFileFields(t *testing.T) {
+	ch, _ := deriveHandler(t, true)
+	d := &fakeDeriver{out: fullDerivatives()}
+	ch.ImageDeriver = d
+
+	rec := postPart(t, ch, "doc", "spec.pdf", append([]byte("%PDF-1.7\n"), bytes.Repeat([]byte{'a'}, 32)...))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if d.calls != 0 {
+		t.Errorf("deriver ran on a File field (%d calls)", d.calls)
+	}
+}
+
+func TestDerive_NoDeriverLeavesSiblingsNull(t *testing.T) {
+	ch, db := deriveHandler(t, true)
+	// ch.ImageDeriver deliberately unset.
+	rec := postPart(t, ch, "photo", "pic.png", pngBytes())
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var hash string
+	if err := db.QueryRow(`SELECT COALESCE(photo_blurhash,'') FROM media`).Scan(&hash); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if hash != "" {
+		t.Errorf("photo_blurhash = %q without a deriver", hash)
+	}
+}
+
+// A derive failure fails the request. Storing a row whose renditions never
+// existed would surface much later as a page with no srcset and nothing in
+// the logs pointing back here.
+func TestDerive_FailureFailsTheRequest(t *testing.T) {
+	ch, db := deriveHandler(t, true)
+	ch.ImageDeriver = &fakeDeriver{err: errors.New("not a decodable image")}
+
+	rec := postPart(t, ch, "photo", "pic.png", pngBytes())
+	if rec.Code == http.StatusCreated {
+		t.Fatalf("failed derive was accepted: %s", rec.Body.String())
+	}
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM media`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("failed derive still wrote %d row(s)", n)
+	}
+}
+
+// Metadata that would not survive FileField.Validate must not reach a column.
+func TestDerive_RejectsUnsafeDerivedMetadata(t *testing.T) {
+	ch, db := deriveHandler(t, true)
+	ch.ImageDeriver = &fakeDeriver{out: &file.ImageDerivatives{
+		Variants: []file.DerivedVariant{{StorageRef: "../../etc/passwd", MIME: "image/webp", Width: 1, Height: 1}},
+	}}
+	rec := postPart(t, ch, "photo", "pic.png", pngBytes())
+	if rec.Code == http.StatusCreated {
+		t.Fatalf("traversal in a derived ref was accepted: %s", rec.Body.String())
+	}
+	var n int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM media`).Scan(&n)
+	if n != 0 {
+		t.Errorf("unsafe derive still wrote %d row(s)", n)
+	}
+}
+
+// Empty derived fields must not write empty strings over columns that would
+// otherwise stay NULL.
+func TestDerive_EmptyValuesAreNotWritten(t *testing.T) {
+	ch, db := deriveHandler(t, true)
+	ch.ImageDeriver = &fakeDeriver{out: &file.ImageDerivatives{
+		BlurHash: "LEHV6nWB2yk8pyo0adR*.7kCMdnj",
+		// Placeholder and Variants intentionally empty.
+	}}
+	rec := postPart(t, ch, "photo", "pic.png", pngBytes())
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var placeholder, variants any
+	if err := db.QueryRow(`SELECT photo_placeholder, photo_variants FROM media`).Scan(&placeholder, &variants); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if placeholder != nil {
+		t.Errorf("photo_placeholder = %v, want NULL", placeholder)
+	}
+	if variants != nil {
+		t.Errorf("photo_variants = %v, want NULL", variants)
+	}
+}
+
+// One app-wide config cannot describe every image, so a field may override it.
+func TestDerive_PerFieldOverrideWins(t *testing.T) {
+	ch, db := deriveHandler(t, true)
+	def := &fakeDeriver{out: fullDerivatives()}
+	override := &fakeDeriver{out: &file.ImageDerivatives{BlurHash: "OVERRIDDEN0000000000000000ab"}}
+	ch.ImageDeriver = def
+	ch.FieldImageDerivers = map[string]file.ImageDeriver{"photo": override}
+
+	if rec := postPart(t, ch, "photo", "pic.png", pngBytes()); rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if override.calls != 1 || def.calls != 0 {
+		t.Errorf("override calls=%d default calls=%d, want 1 and 0", override.calls, def.calls)
+	}
+	var hash string
+	if err := db.QueryRow(`SELECT photo_blurhash FROM media`).Scan(&hash); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if hash != "OVERRIDDEN0000000000000000ab" {
+		t.Errorf("photo_blurhash = %q, want the override's output", hash)
+	}
+}
+
+// An explicit nil override opts one field out without disturbing the default.
+func TestDerive_PerFieldNilOptsOut(t *testing.T) {
+	ch, db := deriveHandler(t, true)
+	def := &fakeDeriver{out: fullDerivatives()}
+	ch.ImageDeriver = def
+	ch.FieldImageDerivers = map[string]file.ImageDeriver{"photo": nil}
+
+	if rec := postPart(t, ch, "photo", "pic.png", pngBytes()); rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if def.calls != 0 {
+		t.Errorf("default deriver ran despite a nil override (%d calls)", def.calls)
+	}
+	var hash string
+	if err := db.QueryRow(`SELECT COALESCE(photo_blurhash,'') FROM media`).Scan(&hash); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if hash != "" {
+		t.Errorf("photo_blurhash = %q, want empty", hash)
+	}
+}
+
+// A field with no entry falls through to the app-wide default.
+func TestDerive_UnlistedFieldUsesDefault(t *testing.T) {
+	ch, _ := deriveHandler(t, true)
+	def := &fakeDeriver{out: fullDerivatives()}
+	ch.ImageDeriver = def
+	ch.FieldImageDerivers = map[string]file.ImageDeriver{"other_field": nil}
+
+	if rec := postPart(t, ch, "photo", "pic.png", pngBytes()); rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if def.calls != 1 {
+		t.Errorf("default deriver calls = %d, want 1", def.calls)
+	}
+}

--- a/framework/docs/content/README.md
+++ b/framework/docs/content/README.md
@@ -44,7 +44,8 @@ results, the harness contract) are exempt — the exemption list lives in
 - [Entity events & SSE](events.md) — `_events` stream, push-only,
   backpressure rules.
 - [File uploads](uploads.md) — multipart on `Image`/`File` fields via
-  `WithFileStorage`.
+  `WithFileStorage`, plus `WithImagePipeline` for automatic renditions,
+  BlurHash, and LQIP on every `Image` upload.
 - [Query DSL](query-dsl.md) — agent-friendly query parser →
   `core/query` builder.
 
@@ -150,8 +151,10 @@ results, the harness contract) are exempt — the exemption list lives in
 - [Search](search.md) — `battery/search` backend interface, memory
   implementation.
 - [Image pipeline](image.md) — `framework/image`: chainable
-  Resize / Rotate / Flip / Modulate / Placeholder / BlurHash, pure-Go
-  with no CGo or system codec dependencies.
+  Resize / Rotate / Flip / Modulate / Placeholder / BlurHash (encode and
+  decode), pure-Go with no CGo or system codec dependencies. For CRUD
+  uploads, wire it once with `WithImagePipeline` — see
+  [File uploads](uploads.md).
 
 ## Build-time tooling
 

--- a/framework/docs/content/image.md
+++ b/framework/docs/content/image.md
@@ -141,6 +141,24 @@ Per-format option structs:
 Inspect output before materialising via `Encoder.MIME()` and
 `Encoder.Format()`.
 
+## Already have uploads? Skip the wiring
+
+If the images arrive as CRUD uploads on a `schema.Image` field, you do not
+need to call any of this by hand. One app option makes every upload produce
+renditions plus a BlurHash and writes them to sibling columns:
+
+```go
+framework.WithImagePipeline(imagefield.MustNew(imagefield.Config{
+    Variants:  []image.Variant{{Width: 960, Format: image.FormatWebP, Suffix: "md"}},
+    BlurHashX: 4, BlurHashY: 3,
+}))
+```
+
+See [uploads.md](uploads.md) → "Automatic renditions and placeholders".
+The rest of this page is the pipeline underneath, for images that do not
+come in through an upload — generated covers, imported batches, one-off
+scripts.
+
 ## Plug-and-play: VariantSet → PipelineImage
 
 For the common case — "take this upload, produce three sizes plus a
@@ -203,18 +221,24 @@ ui.PipelineImage(ui.PipelineImageConfig{
 
 `PipelineImage` emits one `<source type="…" srcset="…">` per distinct
 `Type` in input order — put the modern format first so legacy browsers
-fall through to the `<img>` fallback. The `Placeholder` field accepts
-either a `data:` URL (set as `data-placeholder`) or a BlurHash string
-(set as `data-blurhash`); style or hydrate either as the calling page
-prefers.
+fall through to the `<img>` fallback.
 
 ## Placeholders
 
-Two placeholder strategies for above-the-fold image loading:
+A placeholder is a cheap stand-in that paints before the real image
+arrives. `Placeholder` on `ui.OptimizedImage` and `ui.PipelineImage`
+takes an inline raster `data:` URI and renders it as an image stacked
+behind the real one. No JavaScript is involved and nothing needs
+hydrating — the placeholder is server-rendered and simply stays behind
+the loaded image.
+
+Two ways to produce one.
+
+**LQIP — encode a tiny copy of the source.** Simplest when you hold the
+image at the moment you need the placeholder:
 
 ```go
-// Tiny base64 data URL — a ~20×N JPEG that browsers render directly.
-durl, err := img.Placeholder()  // ~500 bytes typical
+durl, err := img.Placeholder()  // ~500-byte JPEG data URL
 
 durl, err := img.Placeholder(image.PlaceholderOptions{
     Width:   24,  // px (height computed from aspect)
@@ -222,14 +246,68 @@ durl, err := img.Placeholder(image.PlaceholderOptions{
 })
 ```
 
+**BlurHash — store ~28 characters, render later.** Compute the hash once
+at upload time, keep it in a column, and turn it back into pixels on
+render:
+
 ```go
-// BlurHash: ~28-char base83 string that requires a client-side decoder.
-hash, err := img.Resize(32, 0).BlurHash(4, 3)  // "LEHV6nWB2yk8…"
+hash, err := img.BlurHash(4, 3)  // "LEHV6nWB2yk8…" → store this
+
+// …later, rendering a row that has only the hash:
+durl, err := image.BlurHashDataURL(hash, image.BlurHashRenderConfig{})
 ```
 
-The BlurHash implementation follows the [blurha.sh][bh-spec]
-reference. Resize first; the algorithm cost scales with
-`width × height × components`.
+Pick BlurHash when a 28-byte column beats a ~500-byte one, or when
+hashes already reach you from another client. Pick LQIP when you control
+the upload and want no decode step at render time. Either way the UI
+component takes the same `data:` URI:
+
+```go
+ui.PipelineImage(ui.PipelineImageConfig{
+    Fallback:    "/uploads/hero-md.jpg",
+    Alt:         "Sunset over the ocean",
+    Width:       800, Height: 600,
+    Placeholder: durl,
+})
+```
+
+`BlurHashDataURL` memoises its output, since the same handful of hashes
+recur on every request for a given page. `SetBlurHashCacheSize(n)` caps
+the table (`n <= 0` disables it) and `FlushBlurHashCache()` empties it.
+
+`BlurHashRenderConfig` knobs: `Width`/`Height` default to
+`DefaultBlurHashRenderSize` (20 px) and are capped at
+`MaxBlurHashRenderSize` (128 px) — a hash holds at most 9×9 cosine
+components, so rendering larger cannot recover detail it never carried.
+`Punch` raises contrast (default 1.0). `Format` defaults to
+`FormatJPEG`, whose size barely moves with dimensions (~840–940 bytes
+from 16 px to 48 px, because the quantisation and Huffman tables
+dominate a payload this small); `FormatPNG` is smaller at or below 20 px
+(~430–880 bytes) but grows to ~2.4 KB by 48 px.
+
+`DecodeBlurHash` is available directly when you want the pixels rather
+than a data URL — it returns a pipeline `*Image`, so it chains with the
+encoders like any other source.
+
+Both directions follow the [blurha.sh][bh-spec] reference. When
+encoding, note that cost scales with `width × height × components`;
+`BlurHash` auto-downscales to 64 px internally so you do not have to
+resize first.
+
+A malformed hash returns an error rather than pixels. Treat a
+placeholder as optional when rendering user data — the UI components
+already drop an unusable `Placeholder` and render the image without one,
+so a bad legacy row degrades instead of failing the page.
+
+Two behaviors worth knowing about, both consequences of the placeholder
+being a real element that is never removed:
+
+- With `Fit: ImageFitContain` the placeholder letterboxes exactly like
+  the image in front of it, so the empty bars show the component's
+  resting surface color rather than blur.
+- A real image with transparent regions lets the placeholder show
+  through them permanently. If that is unwanted, skip the placeholder
+  for transparent art.
 
 [bh-spec]: https://blurha.sh
 
@@ -324,7 +402,9 @@ picture := ui.PipelineImage(ui.PipelineImageConfig{
     Sources: ui.PipelineSourcesFromHeaders(headers, func(name string) string {
         return "/uploads/" + name
     }),
-    Placeholder: sr.BlurHash, // or sr.Placeholder for a data: URL
+    // sr.Placeholder is already a data: URL. To use the stored hash
+    // instead, decode it: image.BlurHashDataURL(sr.BlurHash, …).
+    Placeholder: sr.Placeholder,
 })
 ```
 
@@ -340,6 +420,9 @@ hand it directly to `storage.Save`).
 | Max encoded WebP dim | 16384 per axis | hard cap (spec) |
 | `VariantSet.Variants` | 64 entries | `MaxVariantsPerSet` const |
 | `BlurHash` working size | 64 px longest side | hard cap (perf) |
+| BlurHash render size | 20 px square | `BlurHashRenderConfig.Width/Height` |
+| Max BlurHash render size | 128 px per axis | `MaxBlurHashRenderSize` const |
+| Placeholder memo table | 512 entries | `SetBlurHashCacheSize` |
 | `Path` traversal | rejected on Open | none (use `OpenFS`) |
 
 ## Performance notes
@@ -354,6 +437,11 @@ hand it directly to `storage.Save`).
   inputs with one off-pixel still pay the full 5-pass.
 - **BlurHash auto-resizes** to 64 px on the longest side internally;
   callers do not need to pre-Resize.
+- **`BlurHashDataURL` memoises** decode+encode per
+  `(hash, size, punch, format, quality)`. Without the cache a list view
+  re-decodes the same handful of hashes on every request; a decode is
+  cheap but not free, and it multiplies by the number of images
+  on the page.
 - **`ProcessTo` releases resize intermediates** between variants so
   peak heap stays near one variant's worth, not all variants summed.
 - **`Modulate` fast-paths** `*image.NRGBA` and `*image.RGBA`; for

--- a/framework/docs/content/uploads.md
+++ b/framework/docs/content/uploads.md
@@ -69,17 +69,252 @@ config. (JSON requests are reverse-cased; multipart is not.)
 | `schema.Image`  | multipart file part | `TEXT` URL    |
 | `schema.File`   | multipart file part | `TEXT` URL    |
 
-Both types behave identically except that the framework emits an
-image-aware widget for `Image` fields in the UI host.
+The two differ in two ways: the UI host emits an image-aware widget for
+`Image` fields, and only `Image` fields run the image pipeline described
+below. A `File` field is any binary — a PDF, a CSV — so decoding it as an
+image would fail every upload.
+
+## Automatic renditions and placeholders
+
+By default an upload is stored as-is: one file, one URL. Adding
+`WithImagePipeline` makes every `schema.Image` upload also produce
+resized renditions and a placeholder, with no per-entity upload handler:
+
+```go
+import (
+    "github.com/DonaldMurillo/gofastr/framework/image"
+    "github.com/DonaldMurillo/gofastr/framework/imagefield"
+)
+
+app := framework.NewApp(
+    framework.WithFileStorage(store),
+    framework.WithImagePipeline(imagefield.MustNew(imagefield.Config{
+        Variants: []image.Variant{
+            {Width: 480, Format: image.FormatWebP, Suffix: "sm"},
+            {Width: 960, Format: image.FormatWebP, Suffix: "md"},
+            {Width: 480, Format: image.FormatJPEG, Quality: 82, Suffix: "sm"},
+            {Width: 960, Format: image.FormatJPEG, Quality: 82, Suffix: "md"},
+        },
+        BlurHashX: 4, BlurHashY: 3,
+    })),
+)
+```
+
+`imagefield` is a separate package on purpose: `framework/image` carries
+every image decoder plus the WebP encoder, so importing it from the upload
+path unconditionally would put all of it in the binary of every app with a
+CRUD handler. Only apps that ask for the pipeline link it.
+
+### Where the derived values go
+
+Renditions are written through the same storage backend as the original,
+into the same directory, sharing its unique base name — an original at
+`products/cover/a1b2-photo.png` yields `products/cover/a1b2-photo-sm.webp`
+and so on, so two uploads of `photo.png` never collide.
+
+The metadata lands in **sibling columns**, named for the image field:
+
+| Column                 | Type            | Contents                                    |
+|------------------------|-----------------|---------------------------------------------|
+| `<field>_blurhash`     | `schema.String` | ~28-char BlurHash                           |
+| `<field>_placeholder`  | `schema.String` | LQIP `data:` URL (only if `Placeholder` set) |
+| `<field>_variants`     | `schema.JSON`   | `[{storage_ref, mime, width, height}, …]`, ascending by width |
+
+**Columns you do not declare are skipped.** Nothing errors, nothing is
+lost — you adopt a column by adding it to the entity. So an entity with a
+`cover` image field opts into the hash alone by declaring:
+
+```go
+Fields: []schema.Field{
+    {Name: "cover", Type: schema.Image},
+    {Name: "cover_blurhash", Type: schema.String},
+}
+```
+
+### Rendering the result
+
+`<field>_variants` maps onto a responsive `<picture>`, and
+`<field>_blurhash` becomes the placeholder that paints before it:
+
+```go
+durl, _ := image.BlurHashDataURL(row.CoverBlurHash, image.BlurHashRenderConfig{})
+
+var headers []ui.HeaderInfo
+for _, v := range row.CoverVariants {
+    headers = append(headers, ui.HeaderInfo{
+        Name: v.StorageRef, Width: v.Width, Height: v.Height, MIME: v.MIME,
+    })
+}
+
+ui.PipelineImage(ui.PipelineImageConfig{
+    Fallback:    "/uploads/" + row.Cover,
+    Alt:         row.Name,
+    Sources:     ui.PipelineSourcesFromHeaders(headers, func(n string) string { return "/uploads/" + n }),
+    Placeholder: durl,
+})
+```
+
+See [image.md](image.md) for the pipeline itself and for the
+BlurHash-versus-LQIP trade-off.
+
+### Config reference
+
+| Field            | Effect                                                      |
+|------------------|-------------------------------------------------------------|
+| `Variants`       | Renditions to produce and store. `Suffix` (or width) distinguishes each key. |
+| `BlurHashX/Y`    | BlurHash component counts, 1..9. Both zero = no hash; setting only one is an error. 4×3 landscape, 3×4 portrait. |
+| `Placeholder`    | Also store an LQIP data URL. Usually redundant next to a BlurHash — ~28 bytes versus a few hundred, and both render identically. |
+| `RejectAnimated` | Fail the upload on a multi-frame source instead of silently keeping frame one. Worth setting on avatars. |
+| `AllowUpscale`   | Permit renditions wider than the source. Off by default, so a small upload does not fan out into pixel-multiplied files. |
+| `MaxPixels`      | Override the decompression-bomb guard (default 64 MP).      |
+
+`New` returns an error for a config that could not produce anything, or
+that the pipeline would reject at process time anyway — so wiring
+mistakes surface at startup rather than on the first upload. `MustNew`
+panics instead, for package-level wiring.
+
+### Per-field configuration
+
+One app-wide config cannot describe every image. An avatar wants portrait
+BlurHash components and animated sources rejected; a hero cover wants wide
+renditions. Compose a default with overrides:
+
+```go
+framework.WithImagePipeline(covers),                        // default
+framework.WithImagePipelineFor("users", "avatar", avatars),  // this field only
+framework.WithImagePipelineFor("posts", "attachment", nil),  // opt out entirely
+```
+
+A field with no entry falls through to the default. An explicit `nil` opts
+that one field out without unpicking the app-wide config.
+
+### Doing it yourself
+
+The declarative wiring is a convenience over interfaces that stay open —
+none of it is a closed system, and every layer below remains callable.
+
+**Your own deriver.** `WithImagePipeline` takes a `file.ImageDeriver`, not a
+concrete type. `imagefield` is one implementation; implement the interface
+directly to crop to a focal point, watermark, push to a CDN, or name keys
+your own way:
+
+```go
+type ImageDeriver interface {
+    DeriveImage(ctx context.Context, store upload.Storage,
+        data []byte, primaryRef string) (*file.ImageDerivatives, error)
+}
+```
+
+Whatever you return is validated and then spread across the sibling columns
+exactly as `imagefield`'s output would be, so you keep the declarative half
+while owning the processing.
+
+**Driving the upload path directly**, outside auto-CRUD — your own handler,
+your own storage keys, the full `FileField` including `.Image` rather than
+just the URL string:
+
+```go
+ff, err := file.ProcessFileField(ctx, store, part, filename, "products", "cover",
+    file.WithImageDeriver(deriver))
+// ff.Image.Variants / .BlurHash / .Placeholder
+```
+
+**Ignoring all of it** and calling the pipeline yourself. `VariantSet` is
+headless and unchanged; see [image.md](image.md). Nothing about the upload
+path is required to use it — generated covers, imported batches, and one-off
+scripts have no upload to hang off.
+
+**Storing the metadata somewhere else.** The sibling columns are a
+convention, not a requirement. Declare none of them and the derived values
+are dropped; do the persistence in a `BeforeCreate` hook, a separate table,
+or a JSON blob of your own shape instead.
+
+The one thing the framework will not do is reach into `framework/image` from
+`framework/file` or `framework/crud` — that edge would link every image
+codec into every app with a CRUD handler, which is why the dependency is
+inverted through `ImageDeriver` in the first place.
+
+### Scope of this seam
+
+`ImageDeriver` is the only per-field transform the framework has, and it is
+image-shaped on purpose: it runs on write, for `schema.Image` fields, and
+puts its output in sibling columns. It is not a general field hook.
+
+For anything else — normalising a string on write, masking a value on read,
+composing several transforms on one field — use a `BeforeCreate`/
+`BeforeUpdate` hook or an `entity.ValidatorFunc` today. Note that schema
+validation runs *after* `BeforeCreate`, so a hook can normalise a value into
+validity.
+
+A general per-field middleware chain is being designed in
+[issue #144](https://github.com/DonaldMurillo/gofastr/issues/144). The
+blocking question there is the read half: a transform applied after the query
+has already filtered and sorted on the stored value silently breaks
+`?field=`, `?sort=`, `?q=`, cursor pagination, and export. Until that is
+settled, `ImageDeriver` stays narrow rather than growing sideways.
+
+### Failure behavior
+
+A source that cannot be decoded **fails the whole request** — the row is
+not written and no file is kept. That is deliberate: the column is
+declared as an image, and a silent success would surface much later as a
+page with no `srcset` and no placeholder, with nothing in the logs
+pointing back at the upload. The original is stored before renditions are
+derived, so a derive failure never leaves a half-written primary file.
+
+Renditions stream one at a time, so peak memory stays near a single
+rendition rather than all of them summed — this runs inside a request, on
+bytes a client chose.
+
+### Cost: this is synchronous
+
+Deriving happens in the upload request, and it is CPU-bound. Measured on an
+M-series laptop, from a generated source:
+
+| Renditions                  | Source | Derive |
+|-----------------------------|--------|--------|
+| JPEG ×2, 1200 px source     | 45 KB  | ~53 ms |
+| JPEG ×2, 3000 px source     | 196 KB | ~184 ms |
+| WebP ×2 + JPEG ×2, 3000 px  | 196 KB | ~537 ms |
+
+The jump is the WebP encoder: it is lossless-only and runs five predictor
+passes, shipping the smallest (see [image.md](image.md) → Performance
+notes). So:
+
+- For a **hot upload path**, prefer JPEG renditions. Two JPEG widths plus a
+  BlurHash is under 200 ms even from a large source.
+- Reserve **WebP** for low-volume flows — admin uploads, one-off imports —
+  or accept the half-second.
+- Each upload holds a request slot for that whole time and does not
+  parallelise away. If uploads are frequent, derive out-of-band instead:
+  store the original in the request, then produce renditions in a
+  `battery/queue` job and patch the sibling columns when it finishes. The
+  pieces are the same; only the timing moves.
+
+There is no built-in async mode — `WithImagePipeline` is deliberately the
+simple synchronous one, because it is correct for the common case (a user
+uploading their own avatar or a cover image) and needs no queue.
 
 ## Validation
 
-File-field validators run before storage so an invalid file does not
-consume bytes:
+Uploads are bounded and content-checked before anything is stored:
 
-- Size limit (set via `EntityConfig.FileField(name).MaxBytes`).
-- Allowed MIME types (set via `AllowedMIMETypes`).
-- Required (set on the field).
+- **Size** is capped at `file.MaxProcessFileSize` (32 MiB), and the
+  multipart parser buffers at most `crud.MaxMultipartMemory` (32 MiB) in
+  memory before spilling to a temp file. An oversize body returns
+  `file.ErrFileFieldTooLarge` without reading past the limit.
+- **Content shape** is sniffed from the bytes — never the filename or the
+  client's `Content-Type`, both of which an attacker controls. SVG/XML,
+  HTML, and executable magic bytes (PE, ELF, Mach-O) are rejected with
+  `file.ErrFileFieldUnsafeContent`.
+- **Required** is enforced from the field declaration, like any other
+  field.
+
+These are global limits, not per-field ones: there is no per-field byte
+cap or MIME allow-list today. To bound a specific field more tightly, use
+a `BeforeCreate` hook or an `entity.ValidatorFunc` — both run before the
+row is written — or set `imagefield.Config.MaxPixels` to tighten the
+decode guard for image fields.
 
 A failing validator returns `400 Bad Request` with a `fields` map
 identifying the offending field.
@@ -210,3 +445,17 @@ characters.
   validate or upload anything.
 - **Camelcasing multipart names.** They are literal column names. Use
   snake_case if your DB columns are snake_case.
+- **Expecting sibling columns to appear on their own.** `WithImagePipeline`
+  fills `<field>_blurhash` / `<field>_placeholder` / `<field>_variants`
+  only when the entity declares them. A missing column is skipped
+  silently, so a hash that "isn't saving" is usually an undeclared column.
+- **Wiring `WithImagePipeline` without `WithFileStorage`.** Renditions are
+  written through the same backend as the original; there is nowhere to
+  put them otherwise.
+- **Putting an image on a `File` field and expecting renditions.** Only
+  `schema.Image` runs the pipeline.
+- **Reaching for `framework/image` from `framework/file` or
+  `framework/crud`.** Both are below it in the layering, and the edge
+  would link every decoder into every app with a CRUD handler. That is why
+  `file.ImageDeriver` is an interface and `framework/imagefield`
+  implements it.

--- a/framework/file/filefield.go
+++ b/framework/file/filefield.go
@@ -55,6 +55,11 @@ type FileField struct {
 
 	// StorageRef is the storage backend key used to reference this file.
 	StorageRef string `json:"storage_ref"`
+
+	// Image carries renditions and placeholder metadata derived from an
+	// uploaded image. Nil unless ProcessFileField ran with
+	// WithImageDeriver.
+	Image *ImageDerivatives `json:"image,omitempty"`
 }
 
 // Validate enforces invariants on a FileField that came from an untrusted
@@ -102,7 +107,9 @@ func (f *FileField) Validate() error {
 	if !isSafeMIMEString(f.MimeType) {
 		return fmt.Errorf("%w: %q", ErrFileFieldMimeUnsafe, f.MimeType)
 	}
-	return nil
+	// Derived references reach the same sinks as the primary file, so they
+	// are held to the same invariants.
+	return f.Image.Validate()
 }
 
 // isUnsafeURLScheme reports whether url begins with a scheme that should
@@ -186,9 +193,13 @@ func isSafeMIMEString(s string) bool {
 // deadlines are respected during slow uploads.
 func ProcessFileField(ctx context.Context, store upload.Storage, file interface {
 	Read([]byte) (int, error)
-}, filename string, entityName, fieldName string) (*FileField, error) {
+}, filename string, entityName, fieldName string, opts ...ProcessOption) (*FileField, error) {
 	if store == nil {
 		return nil, fmt.Errorf("filefield: storage backend is required")
+	}
+	var cfg processConfig
+	for _, o := range opts {
+		o(&cfg)
 	}
 
 	// Read at most MaxProcessFileSize+1 bytes so we can detect an
@@ -228,13 +239,27 @@ func ProcessFileField(ctx context.Context, store upload.Storage, file interface 
 		return nil, fmt.Errorf("filefield: saving file: %w", err)
 	}
 
-	return &FileField{
+	ff := &FileField{
 		URL:        path,
 		Filename:   filepath.Base(filename),
 		MimeType:   mimeType,
 		Size:       size,
 		StorageRef: path,
-	}, nil
+	}
+
+	// Renditions are derived after the original is safely stored, so a
+	// derive failure never leaves the primary upload half-written.
+	if cfg.deriver != nil {
+		derived, err := cfg.deriver.DeriveImage(ctx, store, data, path)
+		if err != nil {
+			return nil, fmt.Errorf("filefield: deriving image renditions: %w", err)
+		}
+		if err := derived.Validate(); err != nil {
+			return nil, fmt.Errorf("filefield: derived image metadata: %w", err)
+		}
+		ff.Image = derived
+	}
+	return ff, nil
 }
 
 // readerOf adapts the narrow Read-only interface accepted by

--- a/framework/file/imagederive.go
+++ b/framework/file/imagederive.go
@@ -1,0 +1,190 @@
+package file
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DonaldMurillo/gofastr/core/upload"
+)
+
+// DerivedVariant is one stored rendition of an uploaded image — a single
+// width/format pair produced alongside the original.
+type DerivedVariant struct {
+	// StorageRef is the storage backend key the rendition was saved under.
+	// It doubles as the URL path, matching FileField.URL/StorageRef.
+	StorageRef string `json:"storage_ref"`
+
+	// MIME is the rendition's content type (e.g. "image/webp").
+	MIME string `json:"mime"`
+
+	// Width and Height are the rendition's pixel dimensions. They feed a
+	// responsive srcset directly.
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+// ImageDerivatives holds everything derived from an uploaded image beyond
+// the original bytes: the stored renditions plus whichever low-fidelity
+// placeholder representations were requested.
+type ImageDerivatives struct {
+	// Variants are the stored renditions, ascending by width.
+	Variants []DerivedVariant `json:"variants,omitempty"`
+
+	// BlurHash is a ~28-character base83 string. Cheap to store in a
+	// column; render it with framework/image.BlurHashDataURL.
+	BlurHash string `json:"blurhash,omitempty"`
+
+	// Placeholder is a base64 data: URL (an LQIP). Larger than a BlurHash
+	// but needs no decode step at render time.
+	Placeholder string `json:"placeholder,omitempty"`
+}
+
+// Validate enforces the same invariants on derived references that
+// FileField.Validate enforces on the primary file — they reach the same
+// sinks (an <img src>, a storage delete) and arrive from the same
+// untrusted places once persisted and read back.
+func (d *ImageDerivatives) Validate() error {
+	if d == nil {
+		return nil
+	}
+	for i := range d.Variants {
+		v := &d.Variants[i]
+		if len(v.StorageRef) > MaxFileFieldStringBytes {
+			return fmt.Errorf("%w: variant %d storage_ref is %d bytes (max %d)",
+				ErrFileFieldOversize, i, len(v.StorageRef), MaxFileFieldStringBytes)
+		}
+		if isUnsafeURLScheme(v.StorageRef) {
+			return fmt.Errorf("%w: variant %d storage_ref %q", ErrFileFieldURLScheme, i, v.StorageRef)
+		}
+		if hasTraversal(v.StorageRef) {
+			return fmt.Errorf("%w: variant %d storage_ref %q", ErrFileFieldTraversal, i, v.StorageRef)
+		}
+		if v.MIME != "" && !isSafeMIMEString(v.MIME) {
+			return fmt.Errorf("%w: variant %d mime %q", ErrFileFieldMimeUnsafe, i, v.MIME)
+		}
+		if v.Width < 0 || v.Height < 0 {
+			return fmt.Errorf("%w: variant %d is %dx%d", ErrFileFieldSize, i, v.Width, v.Height)
+		}
+	}
+	// The placeholder is rendered into an <img src>. A BlurHash is not a
+	// URL and is bounded by its own format, so only length is checked.
+	if len(d.Placeholder) > MaxFileFieldStringBytes {
+		return fmt.Errorf("%w: placeholder is %d bytes (max %d)",
+			ErrFileFieldOversize, len(d.Placeholder), MaxFileFieldStringBytes)
+	}
+	if len(d.BlurHash) > MaxFileFieldStringBytes {
+		return fmt.Errorf("%w: blurhash is %d bytes (max %d)",
+			ErrFileFieldOversize, len(d.BlurHash), MaxFileFieldStringBytes)
+	}
+	if d.Placeholder != "" && isUnsafeURLScheme(d.Placeholder) {
+		// isUnsafeURLScheme rejects bare `data:`, so an LQIP has to be
+		// checked against the narrower raster allow-list instead.
+		if !isRasterDataURL(d.Placeholder) {
+			return fmt.Errorf("%w: placeholder is not an inline raster image", ErrFileFieldURLScheme)
+		}
+	}
+	return nil
+}
+
+// ImageDeriver turns uploaded image bytes into stored renditions and
+// placeholder metadata.
+//
+// It is an interface rather than a direct call into framework/image because
+// this package is a leaf that framework/crud imports: an edge to
+// framework/image would link every image decoder plus the WebP encoder into
+// every application that has a CRUD handler, whether or not it processes
+// images. framework/imagefield provides the implementation, so only
+// applications that ask for it pay for the pipeline.
+//
+// Scope note: this is the framework's only per-field transform seam, and it
+// is deliberately image-shaped — it runs on write, for schema.Image fields,
+// and its output goes to sibling columns. The general version (write and read
+// transforms for any field, composed per field) is being designed in
+// https://github.com/DonaldMurillo/gofastr/issues/144. If that lands, this
+// interface is a candidate to become one instance of it rather than its own
+// mechanism; until then, resist growing it sideways into a general hook —
+// widening this interface to cover non-image fields would prejudge the
+// harder half of that design (read transforms versus filter/sort/search).
+type ImageDeriver interface {
+	// DeriveImage is called with the raw uploaded bytes after the upload
+	// has passed content sniffing but before ProcessFileField returns.
+	//
+	// primaryRef is the storage key the original was saved under;
+	// implementations derive rendition keys from it so everything for one
+	// upload lives together. Renditions must be written through store.
+	DeriveImage(ctx context.Context, store upload.Storage, data []byte, primaryRef string) (*ImageDerivatives, error)
+}
+
+// ProcessOption configures ProcessFileField.
+type ProcessOption func(*processConfig)
+
+type processConfig struct {
+	deriver ImageDeriver
+}
+
+// WithImageDeriver runs deriver over the uploaded bytes and attaches the
+// result to FileField.Image.
+//
+// A derive failure fails the whole upload rather than yielding a file with
+// no renditions. The caller asked for renditions; silently returning a
+// FileField whose Image is nil would surface much later as a page with no
+// placeholder and no srcset, with nothing in the logs pointing back here.
+// It also means a non-image uploaded to an image field is rejected, which
+// is the desired behavior for a schema.Image column.
+func WithImageDeriver(deriver ImageDeriver) ProcessOption {
+	return func(c *processConfig) { c.deriver = deriver }
+}
+
+// isRasterDataURL reports whether s is a `data:` URL carrying one of the
+// raster media types an LQIP can legitimately use. Deliberately narrow and
+// local: this package is a leaf and does not import the UI tree's
+// urlsafe helper, and the two allow-lists are checked against each other
+// by TestPlaceholderAllowListsAgree.
+func isRasterDataURL(s string) bool {
+	const prefix = "data:image/"
+	if len(s) <= len(prefix) {
+		return false
+	}
+	for i := 0; i < len(prefix); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		if c != prefix[i] {
+			return false
+		}
+	}
+	rest := s[len(prefix):]
+	comma := -1
+	for i := 0; i < len(rest); i++ {
+		if rest[i] == ',' {
+			comma = i
+			break
+		}
+	}
+	if comma <= 0 {
+		return false
+	}
+	meta := rest[:comma]
+	for i := 0; i < len(meta); i++ {
+		if meta[i] == ';' {
+			meta = meta[:i]
+			break
+		}
+	}
+	switch lowerASCII(meta) {
+	case "jpeg", "png", "gif", "webp", "avif":
+		return true
+	}
+	return false
+}
+
+func lowerASCII(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] += 'a' - 'A'
+		}
+	}
+	return string(b)
+}

--- a/framework/image/blurhash_dataurl.go
+++ b/framework/image/blurhash_dataurl.go
@@ -1,0 +1,176 @@
+package image
+
+import "sync"
+
+// defaultBlurHashQuality is the JPEG quality BlurHashDataURL uses when
+// BlurHashRenderConfig.Quality is zero. A decoded blur is nothing but
+// low-frequency gradients, so quality below ~50 starts showing blocking
+// artifacts for no meaningful byte saving — measured across several
+// hashes, q40 saved ~12 bytes on an ~880-byte payload.
+//
+// JPEG is the default format rather than PNG because its size is nearly
+// flat in the output dimensions (a JPEG's quantisation and Huffman tables
+// dominate a payload this small): ~840–940 bytes anywhere from 16 px to
+// 48 px. PNG is smaller at or below 20 px (~430–880 bytes) but scales with
+// pixel count and reaches ~2.4 KB by 48 px, so it punishes a caller who
+// raises Width. Callers who want the smaller payload at the default size,
+// or lossless output for flat-color content, set Format: FormatPNG.
+const defaultBlurHashQuality = 50
+
+// defaultBlurHashCacheSize is the number of rendered placeholders kept in
+// memory. A page renders one placeholder per image, and a list view
+// re-renders the same handful of hashes on every request, so a few hundred
+// entries covers realistic working sets at a few hundred bytes each.
+const defaultBlurHashCacheSize = 512
+
+// BlurHashDataURL renders a BlurHash string into a data: URL ready to hand
+// to the UI layer as a placeholder:
+//
+//	durl, _ := image.BlurHashDataURL(row.CoverBlurHash, image.BlurHashRenderConfig{})
+//	ui.PipelineImage(ui.PipelineImageConfig{Placeholder: durl, …})
+//
+// This is the render-time counterpart to Image.BlurHash: store the ~28-char
+// hash in a column at upload time, call this to turn it back into pixels.
+// Results are memoised, since the same handful of hashes recur on every
+// request for a given page.
+//
+// A returned error means the hash was malformed; callers rendering
+// user-supplied data should treat a placeholder as optional and fall back
+// to no placeholder rather than failing the page.
+func BlurHashDataURL(hash string, cfg BlurHashRenderConfig) (string, error) {
+	k := blurHashKey{
+		hash:    hash,
+		width:   cfg.Width,
+		height:  cfg.Height,
+		punch:   cfg.Punch,
+		format:  cfg.Format,
+		quality: cfg.Quality,
+	}
+	if durl, ok := blurHashCache.get(k); ok {
+		return durl, nil
+	}
+
+	img, err := DecodeBlurHash(hash, cfg)
+	if err != nil {
+		return "", err
+	}
+	var durl string
+	if cfg.Format == FormatPNG {
+		durl, err = img.PNG().DataURL()
+	} else {
+		q := cfg.Quality
+		if q <= 0 {
+			q = defaultBlurHashQuality
+		}
+		durl, err = img.JPEG(JPEGOptions{Quality: q}).DataURL()
+	}
+	if err != nil {
+		return "", err
+	}
+	// Only successful renders are cached — a malformed hash must not
+	// occupy a slot, or a hot bad row would evict good entries.
+	blurHashCache.put(k, durl)
+	return durl, nil
+}
+
+// FlushBlurHashCache drops every memoised placeholder. Intended for tests
+// and for long-lived processes that want to reclaim the memory; correctness
+// never depends on calling it, since the cache keys a pure function.
+func FlushBlurHashCache() { blurHashCache.flush() }
+
+// SetBlurHashCacheSize caps how many rendered placeholders are retained.
+// A value <= 0 disables caching entirely. Shrinking the cap drops existing
+// entries beyond it.
+func SetBlurHashCacheSize(n int) { blurHashCache.resize(n) }
+
+// BlurHashCacheLen reports how many placeholders are currently memoised.
+func BlurHashCacheLen() int { return blurHashCache.len() }
+
+// blurHashKey identifies a rendered placeholder. Every field of
+// BlurHashRenderConfig that changes the output bytes participates —
+// omitting one would serve one variant's render for another's request.
+type blurHashKey struct {
+	hash    string
+	width   int
+	height  int
+	punch   float64
+	format  Format
+	quality int
+}
+
+var blurHashCache = &blurHashMemo{cap: defaultBlurHashCacheSize}
+
+// blurHashMemo is a bounded memo table for a pure function. Eviction is
+// arbitrary rather than LRU on purpose: entries are interchangeable
+// (any miss simply recomputes), and the map-iteration order Go already
+// randomises gives an adequate victim without the bookkeeping an
+// access-ordered list would need on every read.
+type blurHashMemo struct {
+	mu      sync.RWMutex
+	entries map[blurHashKey]string
+	cap     int
+}
+
+func (m *blurHashMemo) get(k blurHashKey) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	v, ok := m.entries[k]
+	return v, ok
+}
+
+func (m *blurHashMemo) put(k blurHashKey, v string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.cap <= 0 {
+		return
+	}
+	if m.entries == nil {
+		m.entries = make(map[blurHashKey]string, m.cap)
+	}
+	// Evict before inserting so the table never exceeds cap. A concurrent
+	// racer may have filled it past cap-1 between our get and this lock,
+	// hence the loop rather than a single delete.
+	for len(m.entries) >= m.cap {
+		if !m.evictOne() {
+			return
+		}
+	}
+	m.entries[k] = v
+}
+
+// evictOne removes an arbitrary entry, reporting whether one was removed.
+// Caller must hold the write lock.
+func (m *blurHashMemo) evictOne() bool {
+	for k := range m.entries {
+		delete(m.entries, k)
+		return true
+	}
+	return false
+}
+
+func (m *blurHashMemo) flush() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries = nil
+}
+
+func (m *blurHashMemo) resize(n int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cap = n
+	if n <= 0 {
+		m.entries = nil
+		return
+	}
+	for len(m.entries) > n {
+		if !m.evictOne() {
+			return
+		}
+	}
+}
+
+func (m *blurHashMemo) len() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.entries)
+}

--- a/framework/image/blurhash_dataurl_test.go
+++ b/framework/image/blurhash_dataurl_test.go
@@ -1,0 +1,129 @@
+package image
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestBlurHashDataURL(t *testing.T) {
+	FlushBlurHashCache()
+	durl, err := BlurHashDataURL(refHash, BlurHashRenderConfig{})
+	if err != nil {
+		t.Fatalf("BlurHashDataURL: %v", err)
+	}
+	if !strings.HasPrefix(durl, "data:image/jpeg;base64,") {
+		t.Fatalf("want a JPEG data URL, got %.40q", durl)
+	}
+	// The whole point of a placeholder is that it is small enough to inline
+	// into the HTML document. Guard the property, not a magic number.
+	if len(durl) > 2048 {
+		t.Errorf("placeholder data URL is %d bytes; too large to inline", len(durl))
+	}
+}
+
+func TestBlurHashDataURLPNGFormat(t *testing.T) {
+	FlushBlurHashCache()
+	durl, err := BlurHashDataURL(refHash, BlurHashRenderConfig{Format: FormatPNG})
+	if err != nil {
+		t.Fatalf("BlurHashDataURL: %v", err)
+	}
+	if !strings.HasPrefix(durl, "data:image/png;base64,") {
+		t.Fatalf("want a PNG data URL, got %.40q", durl)
+	}
+}
+
+func TestBlurHashDataURLPropagatesDecodeError(t *testing.T) {
+	FlushBlurHashCache()
+	if _, err := BlurHashDataURL("not-a-hash", BlurHashRenderConfig{}); err == nil {
+		t.Fatal("expected an error for a malformed hash")
+	}
+	if BlurHashCacheLen() != 0 {
+		t.Error("a failed decode must not be cached")
+	}
+}
+
+func TestBlurHashDataURLCachesByKey(t *testing.T) {
+	FlushBlurHashCache()
+	first, err := BlurHashDataURL(refHash, BlurHashRenderConfig{Width: 16, Height: 16})
+	if err != nil {
+		t.Fatalf("BlurHashDataURL: %v", err)
+	}
+	if got := BlurHashCacheLen(); got != 1 {
+		t.Fatalf("cache len = %d, want 1", got)
+	}
+	second, err := BlurHashDataURL(refHash, BlurHashRenderConfig{Width: 16, Height: 16})
+	if err != nil {
+		t.Fatalf("BlurHashDataURL: %v", err)
+	}
+	if first != second {
+		t.Error("cached call returned a different value")
+	}
+	if got := BlurHashCacheLen(); got != 1 {
+		t.Errorf("cache len = %d after a repeat call, want 1", got)
+	}
+	// Every config field must participate in the key, or one variant's
+	// render would be served for another's.
+	for _, cfg := range []BlurHashRenderConfig{
+		{Width: 24, Height: 16},
+		{Width: 16, Height: 24},
+		{Width: 16, Height: 16, Punch: 2},
+		{Width: 16, Height: 16, Format: FormatPNG},
+		{Width: 16, Height: 16, Quality: 90},
+	} {
+		if _, err := BlurHashDataURL(refHash, cfg); err != nil {
+			t.Fatalf("BlurHashDataURL(%+v): %v", cfg, err)
+		}
+	}
+	if got := BlurHashCacheLen(); got != 6 {
+		t.Errorf("cache len = %d, want 6 distinct keys", got)
+	}
+}
+
+func TestBlurHashCacheEvictsAtCapacity(t *testing.T) {
+	t.Cleanup(func() { SetBlurHashCacheSize(defaultBlurHashCacheSize) })
+	SetBlurHashCacheSize(4)
+	for w := 10; w < 20; w++ {
+		if _, err := BlurHashDataURL(refHash, BlurHashRenderConfig{Width: w, Height: 16}); err != nil {
+			t.Fatalf("BlurHashDataURL(width=%d): %v", w, err)
+		}
+	}
+	if got := BlurHashCacheLen(); got > 4 {
+		t.Errorf("cache len = %d, want <= 4", got)
+	}
+}
+
+func TestSetBlurHashCacheSizeZeroDisables(t *testing.T) {
+	t.Cleanup(func() { SetBlurHashCacheSize(defaultBlurHashCacheSize) })
+	SetBlurHashCacheSize(0)
+	durl, err := BlurHashDataURL(refHash, BlurHashRenderConfig{})
+	if err != nil {
+		t.Fatalf("BlurHashDataURL: %v", err)
+	}
+	if durl == "" {
+		t.Fatal("caching disabled must still return a result")
+	}
+	if got := BlurHashCacheLen(); got != 0 {
+		t.Errorf("cache len = %d with caching disabled, want 0", got)
+	}
+}
+
+func TestBlurHashDataURLConcurrent(t *testing.T) {
+	FlushBlurHashCache()
+	t.Cleanup(func() { SetBlurHashCacheSize(defaultBlurHashCacheSize) })
+	SetBlurHashCacheSize(8)
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Mix of repeats and fresh keys so readers, writers, and
+			// eviction all race under -race.
+			cfg := BlurHashRenderConfig{Width: 16 + i%6, Height: 16}
+			if _, err := BlurHashDataURL(refHash, cfg); err != nil {
+				t.Errorf("BlurHashDataURL: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/framework/image/blurhash_decode.go
+++ b/framework/image/blurhash_decode.go
@@ -1,0 +1,223 @@
+package image
+
+import (
+	"fmt"
+	stdimage "image"
+	"image/color"
+	"math"
+)
+
+// DefaultBlurHashRenderSize is the square edge DecodeBlurHash produces
+// when Width/Height are left zero.
+//
+// 20 px is chosen against the information content of the hash, not by
+// eye: a hash holds at most 9×9 cosine components, so 20 px still samples
+// the busiest possible hash about twice per component and a typical 4×3
+// one about five times. Rendering larger cannot recover detail the hash
+// never carried — it only costs bytes inlined into every HTML response.
+const DefaultBlurHashRenderSize = 20
+
+// MaxBlurHashRenderSize caps each output axis. Decoding costs
+// width × height × components, and the hash itself is untrusted input
+// (it comes out of a database column some upload wrote), so the output
+// size a caller may request is bounded rather than trusted.
+const MaxBlurHashRenderSize = 128
+
+// BlurHashRenderConfig configures BlurHash decoding.
+type BlurHashRenderConfig struct {
+	// Width and Height are the output pixel dimensions. Zero means
+	// DefaultBlurHashRenderSize; neither may exceed MaxBlurHashRenderSize.
+	//
+	// These need not match the real image's aspect ratio — the output is
+	// stretched to fill whatever box the UI paints it into, and a blur has
+	// no detail for the distortion to spoil.
+	Width, Height int
+
+	// Punch scales the AC (detail) components, raising contrast above the
+	// washed-out look a raw decode produces. Zero means 1.0 (no change);
+	// the reference implementations use the same knob.
+	Punch float64
+
+	// Format selects the placeholder encoding used by BlurHashDataURL.
+	// Zero means FormatJPEG, which is the smallest option for the smooth
+	// gradients a decoded blur consists of. FormatPNG is available for
+	// callers who want lossless output for flat-color content.
+	Format Format
+
+	// Quality is the JPEG quality for BlurHashDataURL (1..100). Zero means
+	// defaultBlurHashQuality. Ignored when Format is FormatPNG.
+	Quality int
+}
+
+// DecodeBlurHash renders a BlurHash string back into an image, returning
+// it as a pipeline value so it composes with the encoders:
+//
+//	durl, err := image.DecodeBlurHash(hash, image.BlurHashRenderConfig{}).
+//	    JPEG(image.JPEGOptions{Quality: 50}).DataURL()
+//
+// Most callers want BlurHashDataURL instead, which does exactly that and
+// memoises the result.
+//
+// The hash is treated as untrusted: length, alphabet, and component count
+// are all validated before any pixel buffer is allocated.
+func DecodeBlurHash(hash string, cfg BlurHashRenderConfig) (*Image, error) {
+	w, h := cfg.Width, cfg.Height
+	if w == 0 {
+		w = DefaultBlurHashRenderSize
+	}
+	if h == 0 {
+		h = DefaultBlurHashRenderSize
+	}
+	if w < 1 || h < 1 {
+		return nil, fmt.Errorf("image: BlurHash render dimensions must be positive, got %dx%d", w, h)
+	}
+	if w > MaxBlurHashRenderSize || h > MaxBlurHashRenderSize {
+		return nil, fmt.Errorf("image: BlurHash render dimensions %dx%d exceed MaxBlurHashRenderSize=%d",
+			w, h, MaxBlurHashRenderSize)
+	}
+
+	comps, err := decodeBlurHashComponents(hash, cfg.Punch)
+	if err != nil {
+		return nil, err
+	}
+
+	// Precompute the cosine bases per axis. Without this the inner loop
+	// recomputes math.Cos width × height × components times; a 32×32
+	// output at 4×3 components is ~12k redundant Cos calls.
+	cosX := make([]float64, w*comps.numX)
+	for x := 0; x < w; x++ {
+		for i := 0; i < comps.numX; i++ {
+			cosX[x*comps.numX+i] = math.Cos(math.Pi * float64(x) * float64(i) / float64(w))
+		}
+	}
+	cosY := make([]float64, h*comps.numY)
+	for y := 0; y < h; y++ {
+		for j := 0; j < comps.numY; j++ {
+			cosY[y*comps.numY+j] = math.Cos(math.Pi * float64(y) * float64(j) / float64(h))
+		}
+	}
+
+	out := stdimage.NewNRGBA(stdimage.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			var r, g, b float64
+			for j := 0; j < comps.numY; j++ {
+				cy := cosY[y*comps.numY+j]
+				for i := 0; i < comps.numX; i++ {
+					basis := cosX[x*comps.numX+i] * cy
+					c := comps.factors[j*comps.numX+i]
+					r += c[0] * basis
+					g += c[1] * basis
+					b += c[2] * basis
+				}
+			}
+			out.SetNRGBA(x, y, color.NRGBA{
+				R: uint8(linearToSRGB(r)),
+				G: uint8(linearToSRGB(g)),
+				B: uint8(linearToSRGB(b)),
+				A: 255,
+			})
+		}
+	}
+	return FromImage(out, FormatPNG), nil
+}
+
+// blurHashComponents is the parsed form of a hash: the component counts
+// plus the linear-RGB DCT factors, with Punch already applied.
+type blurHashComponents struct {
+	numX, numY int
+	factors    [][3]float64
+}
+
+func decodeBlurHashComponents(hash string, punch float64) (blurHashComponents, error) {
+	var zero blurHashComponents
+	// The minimum valid hash is 1×1 components: 1 size + 1 quant + 4 DC.
+	if len(hash) < 6 {
+		return zero, fmt.Errorf("image: BlurHash too short (%d chars, minimum 6)", len(hash))
+	}
+	digits, err := decodeBase83(hash)
+	if err != nil {
+		return zero, err
+	}
+
+	sizeFlag := digits[0]
+	numX := sizeFlag%9 + 1
+	numY := sizeFlag/9 + 1
+	// Mirrors the encoder's layout at blurhash.go: 1 size + 1 quant +
+	// 4 DC + 2 per AC term.
+	want := 4 + 2*numX*numY
+	if len(hash) != want {
+		return zero, fmt.Errorf("image: BlurHash length %d does not match its %dx%d component header (want %d)",
+			len(hash), numX, numY, want)
+	}
+
+	quantMax := digits[1]
+	maxValue := float64(quantMax+1) / 166.0
+	if punch <= 0 {
+		punch = 1.0
+	}
+
+	factors := make([][3]float64, numX*numY)
+	// The DC term is a 24-bit RGB triple written as four positional base83
+	// digits (see appendBase83 in blurhash.go) — not a bit-packed field.
+	dc := base83Value(digits[2:6])
+	factors[0] = [3]float64{
+		srgbToLinear(uint8(dc >> 16)),
+		srgbToLinear(uint8((dc >> 8) & 255)),
+		srgbToLinear(uint8(dc & 255)),
+	}
+	for k := 1; k < len(factors); k++ {
+		factors[k] = decodeBlurHashAC(base83Value(digits[4+k*2:6+k*2]), maxValue*punch)
+	}
+	return blurHashComponents{numX: numX, numY: numY, factors: factors}, nil
+}
+
+// base83Value folds positional base83 digits into their integer value,
+// inverse of appendBase83 in blurhash.go.
+func base83Value(digits []int) int {
+	v := 0
+	for _, d := range digits {
+		v = v*83 + d
+	}
+	return v
+}
+
+// decodeBlurHashAC unpacks one 15-bit base-19 triple back into a linear-RGB
+// AC factor. Inverse of encodeBlurHashAC in blurhash.go.
+func decodeBlurHashAC(value int, maximumValue float64) [3]float64 {
+	q := 19 * 19
+	return [3]float64{
+		signPow((float64(value/q)-9)/9, 2.0) * maximumValue,
+		signPow((float64((value/19)%19)-9)/9, 2.0) * maximumValue,
+		signPow((float64(value%19)-9)/9, 2.0) * maximumValue,
+	}
+}
+
+// decodeBase83 converts every character of s to its base83 digit,
+// rejecting anything outside the alphabet. Decoding the whole string up
+// front means an invalid character is caught before any allocation sized
+// from the hash's own header.
+func decodeBase83(s string) ([]int, error) {
+	out := make([]int, len(s))
+	for i := 0; i < len(s); i++ {
+		d := base83Digit(s[i])
+		if d < 0 {
+			return nil, fmt.Errorf("image: BlurHash contains invalid base83 byte %q at offset %d", s[i], i)
+		}
+		out[i] = d
+	}
+	return out, nil
+}
+
+// base83Digit returns the base83 value of c, or -1 when c is not in the
+// alphabet. Indexing a byte at a time is deliberate: a multi-byte UTF-8
+// rune can never be a valid base83 digit, and each of its bytes fails
+// this lookup, so non-ASCII input is rejected without a decode pass.
+func base83Digit(c byte) int {
+	for i := 0; i < len(base83Alphabet); i++ {
+		if base83Alphabet[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/framework/image/blurhash_decode_test.go
+++ b/framework/image/blurhash_decode_test.go
@@ -1,0 +1,168 @@
+package image
+
+import (
+	"image/color"
+	"strings"
+	"testing"
+)
+
+// The reference vector from https://blurha.sh — a 4×3-component hash.
+const refHash = "LEHV6nWB2yk8pyo0adR*.7kCMdnj"
+
+func TestDecodeBlurHashRefVector(t *testing.T) {
+	img, err := DecodeBlurHash(refHash, BlurHashRenderConfig{Width: 32, Height: 32})
+	if err != nil {
+		t.Fatalf("DecodeBlurHash: %v", err)
+	}
+	b := img.img.Bounds()
+	if b.Dx() != 32 || b.Dy() != 32 {
+		t.Fatalf("dims = %dx%d, want 32x32", b.Dx(), b.Dy())
+	}
+	// Every pixel must be fully opaque and in range — a decoded blur has
+	// no transparency.
+	for y := 0; y < b.Dy(); y++ {
+		for x := 0; x < b.Dx(); x++ {
+			_, _, _, a := img.img.At(x, y).RGBA()
+			if a != 0xffff {
+				t.Fatalf("pixel (%d,%d) alpha = %d, want opaque", x, y, a)
+			}
+		}
+	}
+}
+
+// The DC term of a BlurHash is the average color. Decoding must reproduce
+// it as the mean of the output, which is the strongest single check that
+// the inverse transform matches the forward one.
+func TestDecodeBlurHashDCIsAverage(t *testing.T) {
+	src := FromImage(solidRGBA(64, 64, color.RGBA{R: 12, G: 200, B: 90, A: 255}), FormatPNG)
+	hash, err := src.BlurHash(4, 3)
+	if err != nil {
+		t.Fatalf("BlurHash: %v", err)
+	}
+	got, err := DecodeBlurHash(hash, BlurHashRenderConfig{Width: 8, Height: 8})
+	if err != nil {
+		t.Fatalf("DecodeBlurHash: %v", err)
+	}
+	// A solid source has zero AC energy, so every decoded pixel should be
+	// the source color within base83 quantisation error.
+	r, g, b, _ := got.img.At(4, 4).RGBA()
+	assertNear(t, int(r>>8), 12, 4, "R")
+	assertNear(t, int(g>>8), 200, 4, "G")
+	assertNear(t, int(b>>8), 90, 4, "B")
+}
+
+func TestDecodeBlurHashRoundTripsGradient(t *testing.T) {
+	src, err := NewGradient(64, 64, "#000000", "#FFFFFF")
+	if err != nil {
+		t.Fatalf("NewGradient: %v", err)
+	}
+	hash, err := src.BlurHash(4, 4)
+	if err != nil {
+		t.Fatalf("BlurHash: %v", err)
+	}
+	got, err := DecodeBlurHash(hash, BlurHashRenderConfig{Width: 16, Height: 16})
+	if err != nil {
+		t.Fatalf("DecodeBlurHash: %v", err)
+	}
+	// The gradient runs dark top-left → light bottom-right, so the decode
+	// must preserve that ordering even though it loses detail.
+	tl, _, _, _ := got.img.At(1, 1).RGBA()
+	br, _, _, _ := got.img.At(14, 14).RGBA()
+	if tl >= br {
+		t.Fatalf("gradient direction lost: top-left=%d bottom-right=%d", tl>>8, br>>8)
+	}
+}
+
+func TestDecodeBlurHashPunchIncreasesContrast(t *testing.T) {
+	src, err := NewGradient(64, 64, "#202020", "#E0E0E0")
+	if err != nil {
+		t.Fatalf("NewGradient: %v", err)
+	}
+	hash, err := src.BlurHash(4, 4)
+	if err != nil {
+		t.Fatalf("BlurHash: %v", err)
+	}
+	spread := func(punch float64) int {
+		img, err := DecodeBlurHash(hash, BlurHashRenderConfig{Width: 16, Height: 16, Punch: punch})
+		if err != nil {
+			t.Fatalf("DecodeBlurHash(punch=%v): %v", punch, err)
+		}
+		lo, _, _, _ := img.img.At(1, 1).RGBA()
+		hi, _, _, _ := img.img.At(14, 14).RGBA()
+		return int(hi>>8) - int(lo>>8)
+	}
+	plain, punched := spread(1), spread(3)
+	if punched <= plain {
+		t.Fatalf("punch=3 spread (%d) should exceed punch=1 spread (%d)", punched, plain)
+	}
+}
+
+func TestDecodeBlurHashRejectsMalformed(t *testing.T) {
+	// A hash arrives from a DB column an upload wrote — it is untrusted
+	// input and every rejection must happen before any allocation.
+	cases := []struct{ name, hash string }{
+		{"empty", ""},
+		{"too short", "LEH"},
+		// refHash is 4x3 => 28 chars; truncating breaks the length invariant.
+		{"truncated", refHash[:27]},
+		{"overlong", refHash + "X"},
+		{"invalid base83 char", strings.Replace(refHash, "L", "\\", 1)},
+		{"non-ascii", "LEHV6nWB2yk8pyo0adR*.7kCMdn€"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := DecodeBlurHash(tc.hash, BlurHashRenderConfig{}); err == nil {
+				t.Fatalf("expected error for %q", tc.hash)
+			}
+		})
+	}
+}
+
+func TestDecodeBlurHashEnforcesDimCaps(t *testing.T) {
+	if _, err := DecodeBlurHash(refHash, BlurHashRenderConfig{Width: MaxBlurHashRenderSize + 1}); err == nil {
+		t.Fatal("expected error for oversized width")
+	}
+	if _, err := DecodeBlurHash(refHash, BlurHashRenderConfig{Height: MaxBlurHashRenderSize + 1}); err == nil {
+		t.Fatal("expected error for oversized height")
+	}
+	if _, err := DecodeBlurHash(refHash, BlurHashRenderConfig{Width: -1}); err == nil {
+		t.Fatal("expected error for negative width")
+	}
+}
+
+func TestDecodeBlurHashDefaultsDims(t *testing.T) {
+	img, err := DecodeBlurHash(refHash, BlurHashRenderConfig{})
+	if err != nil {
+		t.Fatalf("DecodeBlurHash: %v", err)
+	}
+	b := img.img.Bounds()
+	if b.Dx() != DefaultBlurHashRenderSize || b.Dy() != DefaultBlurHashRenderSize {
+		t.Fatalf("dims = %dx%d, want %d square", b.Dx(), b.Dy(), DefaultBlurHashRenderSize)
+	}
+}
+
+// The decoded value must stay chainable with the rest of the pipeline —
+// that is the whole reason it returns *Image rather than raw pixels.
+func TestDecodeBlurHashComposesWithEncoders(t *testing.T) {
+	img, err := DecodeBlurHash(refHash, BlurHashRenderConfig{Width: 16, Height: 16})
+	if err != nil {
+		t.Fatalf("DecodeBlurHash: %v", err)
+	}
+	if _, err := img.JPEG(JPEGOptions{Quality: 50}).Bytes(); err != nil {
+		t.Fatalf("JPEG: %v", err)
+	}
+	if _, err := img.PNG().Bytes(); err != nil {
+		t.Fatalf("PNG: %v", err)
+	}
+}
+
+func assertNear(t *testing.T, got, want, tol int, label string) {
+	t.Helper()
+	d := got - want
+	if d < 0 {
+		d = -d
+	}
+	if d > tol {
+		t.Errorf("%s = %d, want %d±%d", label, got, want, tol)
+	}
+}

--- a/framework/imagefield/crud_e2e_test.go
+++ b/framework/imagefield/crud_e2e_test.go
@@ -1,0 +1,260 @@
+package imagefield_test
+
+// End-to-end: a multipart POST through the real CRUD handler, with the real
+// image pipeline wired in. This is the only test that proves the whole claim
+// — "declaring a schema.Image field is what makes uploads produce renditions
+// and a BlurHash" — because it is the only one that exercises the upload
+// handler, the deriver, storage, and the sibling-column write together.
+//
+// crud is imported by the test binary only, so this does not add a
+// framework/crud → framework/image edge to anything that ships.
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/DonaldMurillo/gofastr/core/handler"
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/core/upload"
+	"github.com/DonaldMurillo/gofastr/framework/crud"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+	"github.com/DonaldMurillo/gofastr/framework/file"
+	fwimage "github.com/DonaldMurillo/gofastr/framework/image"
+	"github.com/DonaldMurillo/gofastr/framework/imagefield"
+)
+
+// productsDDL declares the image column plus two of the three optional
+// sibling columns — cover_placeholder is deliberately absent so the test
+// also pins that a missing sibling is skipped rather than erroring.
+const productsDDL = `CREATE TABLE products (
+	id TEXT PRIMARY KEY,
+	name TEXT,
+	cover TEXT,
+	cover_blurhash TEXT,
+	cover_variants TEXT
+)`
+
+func productsHandler(t *testing.T, deriver file.ImageDeriver) (*crud.CrudHandler, *sql.DB, string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec(productsDDL); err != nil {
+		t.Fatalf("ddl: %v", err)
+	}
+
+	ent := entity.Define("products", entity.EntityConfig{
+		Name: "products", Table: "products",
+		Fields: []schema.Field{
+			{Name: "name", Type: schema.String},
+			{Name: "cover", Type: schema.Image},
+			{Name: "cover_blurhash", Type: schema.String},
+			{Name: "cover_variants", Type: schema.JSON},
+		},
+	}.WithTimestamps(false))
+	ent.SetDB(db)
+
+	dir := t.TempDir()
+	ch := crud.NewCrudHandler(ent, db).WithJSONCase(crud.CaseSnake)
+	ch.Storage = upload.NewLocalStorage(dir)
+	ch.ImageDeriver = deriver
+	return ch, db, dir
+}
+
+func postCover(t *testing.T, ch *crud.CrudHandler, field, filename string, data []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("name", "Wide Chair")
+	fw, err := mw.CreateFormFile(field, filename)
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := fw.Write(data); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	mw.Close()
+
+	req := httptest.NewRequest("POST", "/products", &buf)
+	// CRUD writes are fail-closed by default, so the request needs a user.
+	req = req.WithContext(handler.SetUser(req.Context(), "test-user"))
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rec := httptest.NewRecorder()
+	ch.Create()(rec, req)
+	return rec
+}
+
+func TestUploadPopulatesSiblingColumns(t *testing.T) {
+	d, err := imagefield.New(landscapeConfig())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, db, dir := productsHandler(t, d)
+
+	rec := postCover(t, ch, "cover", "chair.png", testPNG(t, 800, 600))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	var cover, hash, variants string
+	if err := db.QueryRow(`SELECT cover, cover_blurhash, cover_variants FROM products`).
+		Scan(&cover, &hash, &variants); err != nil {
+		t.Fatalf("scan row: %v", err)
+	}
+
+	if cover == "" {
+		t.Error("cover column is empty")
+	}
+	if hash == "" {
+		t.Fatal("cover_blurhash was not populated — the whole point of the wiring")
+	}
+	// The stored hash must be renderable, not merely non-empty.
+	durl, err := fwimage.BlurHashDataURL(hash, fwimage.BlurHashRenderConfig{})
+	if err != nil {
+		t.Fatalf("stored BlurHash does not decode: %v", err)
+	}
+	if !strings.HasPrefix(durl, "data:image/") {
+		t.Errorf("decoded placeholder is not an inline image: %.40q", durl)
+	}
+
+	var refs []file.DerivedVariant
+	if err := json.Unmarshal([]byte(variants), &refs); err != nil {
+		t.Fatalf("cover_variants is not valid JSON (%q): %v", variants, err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("stored %d variants, want 2: %s", len(refs), variants)
+	}
+	// Every reference must resolve to bytes actually on disk — a manifest
+	// pointing at missing files would render as broken images.
+	store := upload.NewLocalStorage(dir)
+	for _, ref := range refs {
+		ok, err := store.Exists(context.Background(), ref.StorageRef)
+		if err != nil || !ok {
+			t.Errorf("variant %q is not in storage (err=%v)", ref.StorageRef, err)
+		}
+		if ref.Width <= 0 || ref.Height <= 0 || ref.MIME == "" {
+			t.Errorf("variant %+v is missing srcset metadata", ref)
+		}
+	}
+}
+
+// A missing sibling column must be skipped, not error — that is what makes
+// the feature additive: you adopt a column by adding it.
+func TestUploadSkipsUndeclaredSiblingColumns(t *testing.T) {
+	cfg := landscapeConfig()
+	cfg.Placeholder = &fwimage.PlaceholderOptions{Width: 20}
+	d, _ := imagefield.New(cfg)
+	ch, db, _ := productsHandler(t, d)
+
+	// cover_placeholder is not in the DDL, and the deriver produces one.
+	rec := postCover(t, ch, "cover", "chair.png", testPNG(t, 400, 300))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var hash string
+	if err := db.QueryRow(`SELECT cover_blurhash FROM products`).Scan(&hash); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if hash == "" {
+		t.Error("declared sibling column was not populated")
+	}
+}
+
+// Without a deriver the upload path must behave exactly as before.
+func TestUploadWithoutDeriverLeavesSiblingsEmpty(t *testing.T) {
+	ch, db, _ := productsHandler(t, nil)
+	rec := postCover(t, ch, "cover", "chair.png", testPNG(t, 200, 150))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var cover, hash string
+	if err := db.QueryRow(`SELECT cover, COALESCE(cover_blurhash, '') FROM products`).Scan(&cover, &hash); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if cover == "" {
+		t.Error("cover should still be stored without a deriver")
+	}
+	if hash != "" {
+		t.Errorf("cover_blurhash = %q, want empty without a deriver", hash)
+	}
+}
+
+// A non-image on an image field fails the request rather than storing a row
+// whose renditions silently never existed.
+func TestUploadRejectsNonImageOnImageField(t *testing.T) {
+	d, _ := imagefield.New(landscapeConfig())
+	ch, db, _ := productsHandler(t, d)
+
+	// A PNG magic header followed by garbage passes the upload content
+	// sniffer but cannot be decoded, which is exactly the case that used to
+	// slip through as a file with no renditions.
+	junk := append([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, bytes.Repeat([]byte{0}, 32)...)
+	rec := postCover(t, ch, "cover", "chair.png", junk)
+	if rec.Code == http.StatusCreated {
+		t.Fatalf("undecodable image was accepted: %s", rec.Body.String())
+	}
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM products`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("a failed derive still wrote %d row(s)", n)
+	}
+}
+
+// A File field is any binary — a PDF, a CSV. Running the image pipeline over
+// it would fail every upload, so only schema.Image is wired.
+func TestUploadOnFileFieldSkipsPipeline(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec(`CREATE TABLE docs (id TEXT PRIMARY KEY, name TEXT, attachment TEXT, attachment_blurhash TEXT)`); err != nil {
+		t.Fatalf("ddl: %v", err)
+	}
+	ent := entity.Define("docs", entity.EntityConfig{
+		Name: "docs", Table: "docs",
+		Fields: []schema.Field{
+			{Name: "name", Type: schema.String},
+			{Name: "attachment", Type: schema.File},
+			{Name: "attachment_blurhash", Type: schema.String},
+		},
+	}.WithTimestamps(false))
+	ent.SetDB(db)
+
+	d, _ := imagefield.New(landscapeConfig())
+	ch := crud.NewCrudHandler(ent, db).WithJSONCase(crud.CaseSnake)
+	ch.Storage = upload.NewLocalStorage(t.TempDir())
+	ch.ImageDeriver = d
+
+	// A PDF on a File field: accepted and stored, with no derive attempted.
+	pdf := append([]byte("%PDF-1.7\n"), bytes.Repeat([]byte{'a'}, 64)...)
+	rec := postCover(t, ch, "attachment", "spec.pdf", pdf)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("File-field upload = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var attachment, hash string
+	if err := db.QueryRow(`SELECT attachment, COALESCE(attachment_blurhash, '') FROM docs`).Scan(&attachment, &hash); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if attachment == "" {
+		t.Error("attachment was not stored")
+	}
+	if hash != "" {
+		t.Errorf("File field got image renditions: attachment_blurhash = %q", hash)
+	}
+}

--- a/framework/imagefield/imagefield.go
+++ b/framework/imagefield/imagefield.go
@@ -1,0 +1,200 @@
+// Package imagefield connects the image pipeline to the upload path: it
+// turns a framework/image.VariantSet into the file.ImageDeriver that
+// ProcessFileField and the CRUD upload handler call, so declaring a
+// schema.Image field is what makes uploads produce renditions and a
+// BlurHash — no per-entity upload handler.
+//
+// It is a separate package on purpose. framework/file is a leaf that
+// framework/crud imports, so an edge from there to framework/image would
+// link every image decoder plus the WebP encoder into every application
+// with a CRUD handler. Keeping the adapter here means only applications
+// that actually want the pipeline pay for it.
+//
+// Typical wiring — one option on the app:
+//
+//	framework.NewApp(
+//	    framework.WithFileStorage(store),
+//	    framework.WithImagePipeline(imagefield.MustNew(imagefield.Config{
+//	        Variants: []image.Variant{
+//	            {Width: 480, Format: image.FormatWebP, Suffix: "sm"},
+//	            {Width: 960, Format: image.FormatWebP, Suffix: "md"},
+//	            {Width: 480, Format: image.FormatJPEG, Quality: 82, Suffix: "sm"},
+//	            {Width: 960, Format: image.FormatJPEG, Quality: 82, Suffix: "md"},
+//	        },
+//	        BlurHashX: 4, BlurHashY: 3,
+//	    })),
+//	)
+package imagefield
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/DonaldMurillo/gofastr/core/upload"
+	"github.com/DonaldMurillo/gofastr/framework/file"
+	fwimage "github.com/DonaldMurillo/gofastr/framework/image"
+)
+
+// Config declares what to derive from each uploaded image. The zero value
+// derives nothing and New rejects it — an image pipeline that produces no
+// renditions, no hash, and no placeholder is a configuration mistake, not
+// a no-op worth honouring silently.
+type Config struct {
+	// Variants are the renditions to produce and store. Each entry's
+	// Suffix (or width, when Suffix is empty) distinguishes its storage
+	// key from the original's.
+	Variants []fwimage.Variant
+
+	// BlurHashX and BlurHashY are the BlurHash component counts (1..9).
+	// Both zero means no BlurHash; setting only one is an error. 4x3 suits
+	// landscape images, 3x4 portrait.
+	BlurHashX int
+	BlurHashY int
+
+	// Placeholder, when non-nil, also stores an LQIP data URL. Redundant
+	// alongside a BlurHash for most callers — a BlurHash costs ~28 bytes
+	// in the column against a few hundred, and framework/image renders
+	// either one the same way.
+	Placeholder *fwimage.PlaceholderOptions
+
+	// RejectAnimated fails the upload when the source has more than one
+	// frame instead of silently flattening to the first. Worth setting on
+	// avatar and profile-photo fields, where a surprise still frame is
+	// worse than a rejection the user can act on.
+	RejectAnimated bool
+
+	// AllowUpscale opts back in to renditions wider than the source. The
+	// default clamps each rendition to the source width, so a small upload
+	// does not fan out into pixel-multiplied storage waste.
+	AllowUpscale bool
+
+	// MaxPixels overrides the decompression-bomb guard for this pipeline
+	// (default framework/image.DefaultMaxPixels, 64 MP).
+	MaxPixels int64
+}
+
+// Deriver implements file.ImageDeriver over a VariantSet.
+type Deriver struct {
+	set fwimage.VariantSet
+	cfg fwimage.Config
+}
+
+var _ file.ImageDeriver = (*Deriver)(nil)
+
+// New builds a Deriver from cfg. It returns an error for a configuration
+// that could not produce anything, or that framework/image would reject at
+// process time anyway — better at wiring time than on the first upload.
+func New(cfg Config) (*Deriver, error) {
+	if (cfg.BlurHashX == 0) != (cfg.BlurHashY == 0) {
+		return nil, fmt.Errorf("imagefield: BlurHashX and BlurHashY must both be set or both zero")
+	}
+	if cfg.BlurHashX < 0 || cfg.BlurHashX > 9 || cfg.BlurHashY < 0 || cfg.BlurHashY > 9 {
+		return nil, fmt.Errorf("imagefield: BlurHash components must be in 1..9, got %dx%d",
+			cfg.BlurHashX, cfg.BlurHashY)
+	}
+	if len(cfg.Variants) == 0 && cfg.BlurHashX == 0 && cfg.Placeholder == nil {
+		return nil, fmt.Errorf("imagefield: Config derives nothing — set Variants, BlurHashX/Y, or Placeholder")
+	}
+	if len(cfg.Variants) > fwimage.MaxVariantsPerSet {
+		return nil, fmt.Errorf("imagefield: %d variants exceeds MaxVariantsPerSet=%d",
+			len(cfg.Variants), fwimage.MaxVariantsPerSet)
+	}
+	for i, v := range cfg.Variants {
+		if v.Width < 1 {
+			return nil, fmt.Errorf("imagefield: Variants[%d].Width must be >= 1", i)
+		}
+		if v.Format == fwimage.FormatUnknown {
+			return nil, fmt.Errorf("imagefield: Variants[%d].Format must be set", i)
+		}
+	}
+	return &Deriver{
+		set: fwimage.VariantSet{
+			Variants:       cfg.Variants,
+			Placeholder:    cfg.Placeholder,
+			BlurHashX:      cfg.BlurHashX,
+			BlurHashY:      cfg.BlurHashY,
+			RejectAnimated: cfg.RejectAnimated,
+			AllowUpscale:   cfg.AllowUpscale,
+		},
+		cfg: fwimage.Config{MaxPixels: cfg.MaxPixels},
+	}, nil
+}
+
+// MustNew is New for package-level wiring, panicking on a bad config.
+func MustNew(cfg Config) *Deriver {
+	d, err := New(cfg)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+// DeriveImage decodes the upload, produces every configured rendition,
+// stores them beside the original, and returns their references plus the
+// placeholder metadata.
+//
+// Renditions stream one at a time through VariantSet.ProcessTo, so peak
+// memory stays near a single rendition rather than all of them summed —
+// this runs inside a request, on bytes a client chose.
+func (d *Deriver) DeriveImage(ctx context.Context, store upload.Storage, data []byte, primaryRef string) (*file.ImageDerivatives, error) {
+	if store == nil {
+		return nil, fmt.Errorf("imagefield: storage backend is required")
+	}
+	src, err := fwimage.DecodeBytesWithConfig(data, d.cfg)
+	if err != nil {
+		// Reached when a non-image (or a format this build cannot decode)
+		// lands on an image field. Surfacing it fails the upload, which is
+		// the point: the column is declared as an image.
+		return nil, fmt.Errorf("imagefield: decoding upload: %w", err)
+	}
+
+	base := d.set
+	base.BaseName = baseNameFor(primaryRef)
+
+	out := &file.ImageDerivatives{}
+	dir := path.Dir(primaryRef)
+	sr, err := base.ProcessTo(src, func(h fwimage.VariantHeader, r io.Reader) error {
+		key := path.Join(dir, h.Name)
+		if err := store.Save(ctx, key, r); err != nil {
+			return fmt.Errorf("saving rendition %q: %w", h.Name, err)
+		}
+		out.Variants = append(out.Variants, file.DerivedVariant{
+			StorageRef: key,
+			MIME:       h.MIME,
+			Width:      h.Width,
+			Height:     h.Height,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("imagefield: %w", err)
+	}
+	out.BlurHash = sr.BlurHash
+	out.Placeholder = sr.Placeholder
+
+	// Ascending width so the slice drops straight into a srcset.
+	sort.Slice(out.Variants, func(i, j int) bool { return out.Variants[i].Width < out.Variants[j].Width })
+	return out, nil
+}
+
+// baseNameFor derives the rendition name prefix from the original's storage
+// key: "products/cover/a1b2-photo.jpg" becomes "a1b2-photo". Renditions
+// therefore sit beside the original under the same directory and inherit
+// its random suffix, so two uploads of the same filename never collide.
+func baseNameFor(primaryRef string) string {
+	b := path.Base(primaryRef)
+	if b == "." || b == "/" || b == "" {
+		return "image"
+	}
+	if ext := path.Ext(b); ext != "" {
+		b = strings.TrimSuffix(b, ext)
+	}
+	if b == "" {
+		return "image"
+	}
+	return b
+}

--- a/framework/imagefield/imagefield_test.go
+++ b/framework/imagefield/imagefield_test.go
@@ -1,0 +1,267 @@
+package imagefield_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/framework/file"
+	fwimage "github.com/DonaldMurillo/gofastr/framework/image"
+	"github.com/DonaldMurillo/gofastr/framework/imagefield"
+)
+
+// memStore is a minimal upload.Storage recording what got written.
+type memStore struct {
+	mu      sync.Mutex
+	objects map[string][]byte
+	failOn  string
+}
+
+func newMemStore() *memStore { return &memStore{objects: map[string][]byte{}} }
+
+func (m *memStore) Save(_ context.Context, key string, r io.Reader) error {
+	if m.failOn != "" && strings.Contains(key, m.failOn) {
+		return io.ErrUnexpectedEOF
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.objects[key] = data
+	return nil
+}
+
+func (m *memStore) Delete(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.objects, key)
+	return nil
+}
+
+func (m *memStore) Get(_ context.Context, key string) (io.ReadCloser, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	data, ok := m.objects[key]
+	if !ok {
+		return nil, io.EOF
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (m *memStore) Exists(_ context.Context, key string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.objects[key]
+	return ok, nil
+}
+
+func (m *memStore) keys() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, 0, len(m.objects))
+	for k := range m.objects {
+		out = append(out, k)
+	}
+	return out
+}
+
+func testPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img, err := fwimage.NewGradient(w, h, "#4338CA", "#0E7C86")
+	if err != nil {
+		t.Fatalf("NewGradient: %v", err)
+	}
+	data, err := img.PNG().Bytes()
+	if err != nil {
+		t.Fatalf("PNG: %v", err)
+	}
+	return data
+}
+
+func landscapeConfig() imagefield.Config {
+	return imagefield.Config{
+		Variants: []fwimage.Variant{
+			{Width: 320, Format: fwimage.FormatJPEG, Quality: 80, Suffix: "sm"},
+			{Width: 640, Format: fwimage.FormatJPEG, Quality: 82, Suffix: "md"},
+		},
+		BlurHashX: 4, BlurHashY: 3,
+	}
+}
+
+func TestDeriveImageProducesVariantsAndHash(t *testing.T) {
+	d, err := imagefield.New(landscapeConfig())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	store := newMemStore()
+	got, err := d.DeriveImage(context.Background(), store, testPNG(t, 800, 600), "products/cover/a1b2-photo.png")
+	if err != nil {
+		t.Fatalf("DeriveImage: %v", err)
+	}
+	if len(got.Variants) != 2 {
+		t.Fatalf("variants = %d, want 2: %+v", len(got.Variants), got.Variants)
+	}
+	// Ascending width so the slice drops straight into a srcset.
+	if got.Variants[0].Width >= got.Variants[1].Width {
+		t.Errorf("variants not ascending by width: %+v", got.Variants)
+	}
+	if got.BlurHash == "" {
+		t.Error("no BlurHash produced")
+	}
+	// A 4x3 hash is 28 chars; assert the decoder accepts it rather than
+	// hardcoding the length.
+	if _, err := fwimage.BlurHashDataURL(got.BlurHash, fwimage.BlurHashRenderConfig{}); err != nil {
+		t.Errorf("produced BlurHash does not decode: %v", err)
+	}
+	if got.Placeholder != "" {
+		t.Errorf("Placeholder should be empty when not requested, got %.30q", got.Placeholder)
+	}
+
+	// Renditions must land beside the original, sharing its directory and
+	// its random suffix, so two uploads of "photo.png" never collide.
+	for _, v := range got.Variants {
+		if !strings.HasPrefix(v.StorageRef, "products/cover/") {
+			t.Errorf("rendition %q is not beside the original", v.StorageRef)
+		}
+		if !strings.Contains(v.StorageRef, "a1b2-photo") {
+			t.Errorf("rendition %q dropped the original's unique base name", v.StorageRef)
+		}
+		if _, ok := store.objects[v.StorageRef]; !ok {
+			t.Errorf("rendition %q was never written to storage (wrote %v)", v.StorageRef, store.keys())
+		}
+	}
+}
+
+func TestDeriveImagePlaceholderOptIn(t *testing.T) {
+	cfg := landscapeConfig()
+	cfg.Placeholder = &fwimage.PlaceholderOptions{Width: 20}
+	d, err := imagefield.New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got, err := d.DeriveImage(context.Background(), newMemStore(), testPNG(t, 400, 300), "a/b-x.png")
+	if err != nil {
+		t.Fatalf("DeriveImage: %v", err)
+	}
+	if !strings.HasPrefix(got.Placeholder, "data:image/") {
+		t.Errorf("Placeholder = %.40q, want an inline raster data URL", got.Placeholder)
+	}
+}
+
+// The derived metadata is persisted and later read back into a render path,
+// so it has to satisfy the same invariants as the primary file.
+func TestDerivedMetadataPassesFileFieldValidation(t *testing.T) {
+	cfg := landscapeConfig()
+	cfg.Placeholder = &fwimage.PlaceholderOptions{Width: 20}
+	d, _ := imagefield.New(cfg)
+	got, err := d.DeriveImage(context.Background(), newMemStore(), testPNG(t, 400, 300), "a/b-x.png")
+	if err != nil {
+		t.Fatalf("DeriveImage: %v", err)
+	}
+	if err := got.Validate(); err != nil {
+		t.Errorf("derived metadata fails validation: %v", err)
+	}
+	ff := &file.FileField{URL: "/a/b-x.png", MimeType: "image/png", StorageRef: "a/b-x.png", Image: got}
+	if err := ff.Validate(); err != nil {
+		t.Errorf("FileField carrying derived metadata fails validation: %v", err)
+	}
+}
+
+// A non-image on an image field must fail the upload, not store a file with
+// no renditions that surfaces as a broken page much later.
+func TestDeriveImageRejectsNonImage(t *testing.T) {
+	d, _ := imagefield.New(landscapeConfig())
+	_, err := d.DeriveImage(context.Background(), newMemStore(), []byte("this is not an image"), "a/b-x.bin")
+	if err == nil {
+		t.Fatal("expected an error for a non-image upload")
+	}
+}
+
+func TestDeriveImagePropagatesStorageFailure(t *testing.T) {
+	d, _ := imagefield.New(landscapeConfig())
+	store := newMemStore()
+	store.failOn = "-sm"
+	_, err := d.DeriveImage(context.Background(), store, testPNG(t, 800, 600), "a/b-x.png")
+	if err == nil {
+		t.Fatal("expected a storage failure to surface")
+	}
+}
+
+func TestDeriveImageClampsToSourceWidth(t *testing.T) {
+	d, err := imagefield.New(imagefield.Config{
+		Variants: []fwimage.Variant{{Width: 2048, Format: fwimage.FormatJPEG, Quality: 80, Suffix: "lg"}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// A 64px source must not fan out into a 2048px pixel-multiplied file.
+	got, err := d.DeriveImage(context.Background(), newMemStore(), testPNG(t, 64, 48), "a/b-x.png")
+	if err != nil {
+		t.Fatalf("DeriveImage: %v", err)
+	}
+	if len(got.Variants) != 1 {
+		t.Fatalf("variants = %d, want 1", len(got.Variants))
+	}
+	if got.Variants[0].Width > 64 {
+		t.Errorf("rendition upscaled to %dpx from a 64px source", got.Variants[0].Width)
+	}
+}
+
+func TestNewRejectsBadConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  imagefield.Config
+	}{
+		{"derives nothing", imagefield.Config{}},
+		{"half a blurhash", imagefield.Config{BlurHashX: 4}},
+		{"blurhash out of range", imagefield.Config{BlurHashX: 10, BlurHashY: 10}},
+		{"variant without width", imagefield.Config{Variants: []fwimage.Variant{{Format: fwimage.FormatJPEG}}}},
+		{"variant without format", imagefield.Config{Variants: []fwimage.Variant{{Width: 100}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := imagefield.New(tc.cfg); err == nil {
+				t.Errorf("expected an error for %+v", tc.cfg)
+			}
+		})
+	}
+}
+
+func TestDeriveImageRequiresStore(t *testing.T) {
+	d, _ := imagefield.New(landscapeConfig())
+	if _, err := d.DeriveImage(context.Background(), nil, testPNG(t, 64, 48), "a/b.png"); err == nil {
+		t.Fatal("expected an error without a storage backend")
+	}
+}
+
+// The variants slice is persisted as JSON into a sibling column, so its
+// shape is part of the contract a caller reads back.
+func TestDerivedVariantsJSONShape(t *testing.T) {
+	d, _ := imagefield.New(landscapeConfig())
+	got, err := d.DeriveImage(context.Background(), newMemStore(), testPNG(t, 800, 600), "a/b-x.png")
+	if err != nil {
+		t.Fatalf("DeriveImage: %v", err)
+	}
+	raw, err := json.Marshal(got.Variants)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back []file.DerivedVariant
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(back) != len(got.Variants) || back[0].StorageRef != got.Variants[0].StorageRef {
+		t.Errorf("round trip lost data: %s", raw)
+	}
+	for _, key := range []string{"storage_ref", "mime", "width", "height"} {
+		if !bytes.Contains(raw, []byte(`"`+key+`"`)) {
+			t.Errorf("JSON missing %q key: %s", key, raw)
+		}
+	}
+}

--- a/framework/ui/doc.go
+++ b/framework/ui/doc.go
@@ -101,7 +101,8 @@
 //	PasswordInput        — password field with show/hide toggle
 //	PieChart             — SVG ratio chart (donut variant via InnerRadius)
 //	PipelineImage        — multi-format <picture> consuming framework/image
-//	                       VariantSet output (typed sources + LQIP/BlurHash)
+//	                       VariantSet output (typed sources + a stacked
+//	                       low-fidelity placeholder from a data: URI)
 //	PollingIndicator     — pulsing dot confirming a polling RPC is firing
 //	PricingCard          — plan tile with price + feature list + CTA
 //	ProgressSteps        — linear step indicator (horizontal + vertical)

--- a/framework/ui/gallery.go
+++ b/framework/ui/gallery.go
@@ -179,8 +179,11 @@ func Gallery(cfg GalleryConfig) render.HTML {
 		}
 		// Drop unsafe schemes on the thumbnail src (see safety.go). An
 		// unsafe value falls back to the framework's 1×1 placeholder so
-		// a javascript:/data: URL never reaches <img src>.
-		if safe := safeResourceURL(thumb); safe != "" {
+		// a javascript: URL never reaches <img src>. safeImageURL, not
+		// safeResourceURL: a generated thumbnail is legitimately inlined
+		// as a raster data: URI, and the stricter policy turned that into
+		// an image that looked broken rather than blocked.
+		if safe := safeImageURL(thumb); safe != "" {
 			thumb = safe
 		} else {
 			thumb = "/__gofastr/blank.png"

--- a/framework/ui/image.go
+++ b/framework/ui/image.go
@@ -80,9 +80,19 @@ type OptimizedImageConfig struct {
 	// Rounded toggles a token-driven border-radius treatment.
 	Rounded bool
 
-	// Placeholder, when non-empty, renders a low-fidelity background
-	// (typically a 1x1 base64-encoded pixel) that shows under the
-	// image while loading.
+	// Placeholder, when set to an inline raster data: URI, renders a
+	// low-fidelity image behind this one so something content-shaped is
+	// visible before the real pixels arrive.
+	//
+	// Produce one with framework/image: BlurHashDataURL(hash, …) to render
+	// a stored BlurHash, or Image.Placeholder() to build an LQIP straight
+	// from the source. A bare BlurHash string is not accepted — it is not
+	// an image until it is decoded.
+	//
+	// Values that are not usable inline images (a raw hash, a remote URL,
+	// a non-raster data: URI) are dropped and the image renders without a
+	// placeholder. See placeholderImage for why that degrades instead of
+	// panicking.
 	Placeholder string
 
 	ID    string
@@ -104,8 +114,12 @@ func OptimizedImage(cfg OptimizedImageConfig) render.HTML {
 	// with the framework's tiny placeholder URL — a 1×1 transparent
 	// stub the runtime serves. The browser renders nothing, and the
 	// surrounding layout is preserved. Preferable to silently shipping
-	// a `javascript:`/`data:` URL into <img src>.
-	if safe := safeResourceURL(cfg.Src); safe != "" {
+	// a `javascript:` URL into <img src>.
+	//
+	// safeImageURL, not safeResourceURL: an inline raster data: URI is a
+	// legitimate image source, and rejecting it here produced an image that
+	// looked broken rather than one that looked blocked.
+	if safe := safeImageURL(cfg.Src); safe != "" {
 		cfg.Src = safe
 	} else {
 		cfg.Src = "/__gofastr/blank.png"
@@ -113,7 +127,7 @@ func OptimizedImage(cfg OptimizedImageConfig) render.HTML {
 	if len(cfg.Sources) > 0 {
 		filtered := cfg.Sources[:0]
 		for _, s := range cfg.Sources {
-			if safeResourceURL(s.URL) != "" {
+			if safeImageURL(s.URL) != "" {
 				filtered = append(filtered, s)
 			}
 		}
@@ -128,6 +142,8 @@ func OptimizedImage(cfg OptimizedImageConfig) render.HTML {
 		panic("ui: OptimizedImage requires Width and Height > 0 to prevent CLS")
 	}
 
+	lqip := placeholderImage(cfg.Placeholder)
+
 	cls := "ui-image"
 	if cfg.Fit != ImageFitCover {
 		cls += " ui-image--fit-" + string(cfg.Fit)
@@ -137,6 +153,9 @@ func OptimizedImage(cfg OptimizedImageConfig) render.HTML {
 	}
 	if cfg.Rounded {
 		cls += " ui-image--rounded"
+	}
+	if lqip != "" {
+		cls += " ui-image--placeheld"
 	}
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
@@ -156,11 +175,6 @@ func OptimizedImage(cfg OptimizedImageConfig) render.HTML {
 	if cfg.HighPriority {
 		imgAttrs["fetchpriority"] = "high"
 	}
-	if cfg.Placeholder != "" {
-		// Pass through a CSS custom property the stylesheet reads via
-		// attr() — no inline style, CSP-clean.
-		imgAttrs["data-placeholder"] = cfg.Placeholder
-	}
 
 	imgCfg := html.ImageConfig{
 		Src:        cfg.Src,
@@ -173,7 +187,7 @@ func OptimizedImage(cfg OptimizedImageConfig) render.HTML {
 	if len(cfg.Sources) == 0 {
 		return imageStyle.WrapHTML(html.Span(html.TextConfig{
 			Class: cls, ID: cfg.ID,
-		}, html.Image(imgCfg)))
+		}, lqip, html.Image(imgCfg)))
 	}
 
 	// Multi-source <picture> wrapper.
@@ -189,7 +203,7 @@ func OptimizedImage(cfg OptimizedImageConfig) render.HTML {
 	picture := render.Tag("picture", nil, source, html.Image(imgCfg))
 	return imageStyle.WrapHTML(html.Span(html.TextConfig{
 		Class: cls, ID: cfg.ID,
-	}, picture))
+	}, lqip, picture))
 }
 
 func buildSrcset(sources []ImageSource) string {
@@ -198,7 +212,10 @@ func buildSrcset(sources []ImageSource) string {
 		if s.URL == "" || s.Width <= 0 {
 			continue
 		}
-		parts = append(parts, s.URL+" "+strconv.Itoa(s.Width)+"w")
+		// encodeSrcsetURL, not raw concatenation: a comma or space in the
+		// URL (presigned links, keys with comma-separated segments) would
+		// otherwise split one candidate into several malformed ones.
+		parts = append(parts, encodeSrcsetURL(s.URL)+" "+strconv.Itoa(s.Width)+"w")
 	}
 	return strings.Join(parts, ", ")
 }

--- a/framework/ui/image_placeholder.go
+++ b/framework/ui/image_placeholder.go
@@ -1,0 +1,84 @@
+package ui
+
+import (
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
+	"github.com/DonaldMurillo/gofastr/core-ui/urlsafe"
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+// placeholderImage renders the low-fidelity image that sits behind a real
+// one while it loads, or the empty string when durl is not a usable inline
+// image.
+//
+// Why an element and not a CSS background: a placeholder is per-instance
+// data, and this project cannot put per-instance values into CSS — inline
+// `style="…"` is blocked by the default Content-Security-Policy and by the
+// core-ui/check/noinlinestyles linter, and a data URL cannot be enumerated
+// into a class the way carousel column counts are. An `<img>` carrying the
+// data URI needs no dynamic CSS, no `attr()` (which browsers only support
+// for `content`), and no JavaScript. The stylesheet stacks it behind the
+// real image with static rules; see imageCSS.
+//
+// A bad value degrades to no placeholder rather than panicking: unlike Src
+// or Alt, which are caller-code bugs, a placeholder is data — read from a
+// column some older upload wrote, or produced by another client — and
+// user-generated data must not be able to take a page down. This mirrors
+// PipelineImage's handling of missing intrinsic dimensions.
+func placeholderImage(durl string) render.HTML {
+	if !placeholderUsable(durl) {
+		return ""
+	}
+	return html.Image(html.ImageConfig{
+		Src:   durl,
+		Alt:   "", // decorative — html.Image adds role="presentation"
+		Class: "ui-image__lqip",
+		ExtraAttrs: html.Attrs{
+			"aria-hidden": "true",
+			// A data URI costs no request, so deferring or async-decoding it
+			// could only make the placeholder appear after the image it
+			// stands in for — which is the one thing it must never do.
+			"decoding": "sync",
+		},
+	})
+}
+
+// placeholderUsable reports whether durl may be rendered as a placeholder:
+// an inline raster data: URI and nothing else. In particular a bare
+// BlurHash string is not usable — decode it first with
+// framework/image.BlurHashDataURL.
+//
+// Remote URLs are refused on purpose even though they are safe to render:
+// a placeholder exists to paint before the network settles, so one that
+// needs its own request defeats the point.
+func placeholderUsable(durl string) bool {
+	if durl == "" {
+		return false
+	}
+	if !hasDataScheme(durl) {
+		return false
+	}
+	// urlsafe.ImageSource carries the media-type allow-list, so
+	// data:text/html and data:image/svg+xml are rejected here.
+	return urlsafe.OK(durl, urlsafe.ImageSource)
+}
+
+// hasDataScheme reports whether s begins with the data: scheme,
+// case-insensitively. Used to tell "this is meant to be an inline image"
+// from "this is a remote URL or a raw hash", so the two get different
+// treatment even though both are simply dropped today.
+func hasDataScheme(s string) bool {
+	const p = "data:"
+	if len(s) < len(p) {
+		return false
+	}
+	for i := 0; i < len(p); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		if c != p[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/framework/ui/image_placeholder_test.go
+++ b/framework/ui/image_placeholder_test.go
@@ -1,0 +1,261 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+// A ~20px JPEG data URL, the shape framework/image.BlurHashDataURL returns.
+const testPlaceholder = "data:image/jpeg;base64,/9j/4AAQSkZJRg=="
+
+func TestOptimizedImagePlaceholderPaints(t *testing.T) {
+	out := string(OptimizedImage(OptimizedImageConfig{
+		Src: "/hero.jpg", Alt: "Hero", Width: 800, Height: 600,
+		Placeholder: testPlaceholder,
+	}))
+	assertPlaceholderPainted(t, out)
+}
+
+func TestPipelineImagePlaceholderPaints(t *testing.T) {
+	out := string(PipelineImage(PipelineImageConfig{
+		Fallback: "/hero.jpg", Alt: "Hero", Width: 800, Height: 600,
+		Sources:     []PipelineSource{{URL: "/hero.webp", Width: 800, Type: "image/webp"}},
+		Placeholder: testPlaceholder,
+	}))
+	assertPlaceholderPainted(t, out)
+	// The placeholder must precede the <picture> so the real image paints
+	// over it in DOM order without needing a z-index.
+	if strings.Index(out, "ui-image__lqip") > strings.Index(out, "<picture") {
+		t.Error("placeholder must be emitted before <picture>")
+	}
+}
+
+func assertPlaceholderPainted(t *testing.T, out string) {
+	t.Helper()
+	if !strings.Contains(out, `class="ui-image__lqip"`) {
+		t.Fatalf("no placeholder element rendered: %s", out)
+	}
+	if !strings.Contains(out, testPlaceholder) {
+		t.Errorf("placeholder src missing: %s", out)
+	}
+	if !strings.Contains(out, "ui-image--placeheld") {
+		t.Errorf("root is missing the --placeheld class: %s", out)
+	}
+	// Decorative: must not be announced.
+	if !strings.Contains(out, `aria-hidden="true"`) {
+		t.Errorf("placeholder must be aria-hidden: %s", out)
+	}
+	if !strings.Contains(out, `role="presentation"`) {
+		t.Errorf("placeholder must have role=presentation: %s", out)
+	}
+	// The dead attributes this feature replaced must be gone.
+	if strings.Contains(out, "data-placeholder") || strings.Contains(out, "data-blurhash") {
+		t.Errorf("dead placeholder attributes still emitted: %s", out)
+	}
+}
+
+// A data: URI needs no network, so lazy-loading or async-decoding the
+// placeholder can only make it paint later than the image it stands in for.
+func TestPlaceholderIsNotLazyOrAsync(t *testing.T) {
+	out := string(OptimizedImage(OptimizedImageConfig{
+		Src: "/hero.jpg", Alt: "Hero", Width: 800, Height: 600,
+		Placeholder: testPlaceholder,
+	}))
+	start := strings.Index(out, "ui-image__lqip")
+	if start < 0 {
+		t.Fatalf("no placeholder element rendered: %s", out)
+	}
+	lqip := out[start:]
+	lqip = lqip[:strings.IndexByte(lqip, '>')]
+	if strings.Contains(lqip, `loading="lazy"`) {
+		t.Errorf("placeholder must not be lazy: %s", lqip)
+	}
+	if strings.Contains(lqip, `decoding="async"`) {
+		t.Errorf("placeholder must not decode async: %s", lqip)
+	}
+	if !strings.Contains(lqip, `decoding="sync"`) {
+		t.Errorf("placeholder should decode sync: %s", lqip)
+	}
+}
+
+// A Placeholder arrives as data — a column an old upload wrote, a hash from
+// another client. Bad values degrade to no placeholder; they never take the
+// page down. Contrast with Src/Alt, which are caller-code bugs and panic.
+func TestBadPlaceholderDegradesSilently(t *testing.T) {
+	cases := []struct{ name, placeholder string }{
+		{"raw blurhash", "LEHV6nWB2yk8pyo0adR*.7kCMdnj"},
+		{"html data url", "data:text/html;base64,PHNjcmlwdD4="},
+		{"svg data url", "data:image/svg+xml,<svg onload=alert(1)>"},
+		{"javascript url", "javascript:alert(1)"},
+		{"remote url", "https://evil.example.com/track.gif"},
+		{"garbage", "not a url at all"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out string
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("a bad placeholder must not panic, got %v", r)
+					}
+				}()
+				out = string(OptimizedImage(OptimizedImageConfig{
+					Src: "/hero.jpg", Alt: "Hero", Width: 8, Height: 6,
+					Placeholder: tc.placeholder,
+				}))
+			}()
+			if strings.Contains(out, "ui-image__lqip") {
+				t.Errorf("bad placeholder %q was rendered: %s", tc.placeholder, out)
+			}
+			if strings.Contains(out, "ui-image--placeheld") {
+				t.Errorf("bad placeholder %q still set --placeheld: %s", tc.placeholder, out)
+			}
+			if strings.Contains(out, tc.placeholder) {
+				t.Errorf("bad placeholder %q leaked into output: %s", tc.placeholder, out)
+			}
+			// The real image must still render.
+			if !strings.Contains(out, `src="/hero.jpg"`) {
+				t.Errorf("real image lost: %s", out)
+			}
+		})
+	}
+}
+
+func TestNoPlaceholderMeansNoExtraElement(t *testing.T) {
+	out := string(OptimizedImage(OptimizedImageConfig{
+		Src: "/hero.jpg", Alt: "Hero", Width: 8, Height: 6,
+	}))
+	if strings.Contains(out, "ui-image__lqip") || strings.Contains(out, "placeheld") {
+		t.Errorf("unexpected placeholder markup: %s", out)
+	}
+}
+
+// ─── W5: parity gaps between the two components ─────────────────────
+
+func TestPipelineImageSanitizesFallback(t *testing.T) {
+	out := string(PipelineImage(PipelineImageConfig{
+		Fallback: "javascript:alert(1)", Alt: "x", Width: 8, Height: 6,
+	}))
+	if strings.Contains(out, "javascript:") {
+		t.Errorf("unsafe Fallback survived: %s", out)
+	}
+	if !strings.Contains(out, "/__gofastr/blank.png") {
+		t.Errorf("expected the blank-image stub as fallback: %s", out)
+	}
+}
+
+func TestPipelineImageSanitizesSources(t *testing.T) {
+	out := string(PipelineImage(PipelineImageConfig{
+		Fallback: "/ok.jpg", Alt: "x", Width: 8, Height: 6,
+		Sources: []PipelineSource{
+			{URL: "javascript:alert(1)", Width: 320, Type: "image/webp"},
+			{URL: "/good.webp", Width: 640, Type: "image/webp"},
+		},
+	}))
+	if strings.Contains(out, "javascript:") {
+		t.Errorf("unsafe source survived: %s", out)
+	}
+	if !strings.Contains(out, "/good.webp") {
+		t.Errorf("safe source was dropped: %s", out)
+	}
+}
+
+// A comma in a srcset URL splits it into bogus candidates. PipelineImage
+// escaped these already; OptimizedImage did not.
+func TestOptimizedImageEscapesSrcsetCommas(t *testing.T) {
+	out := string(OptimizedImage(OptimizedImageConfig{
+		Src: "/a.jpg", Alt: "x", Width: 8, Height: 6,
+		Sources: []ImageSource{{URL: "/img/a,b.jpg", Width: 320}},
+	}))
+	if strings.Contains(out, "a,b.jpg") {
+		t.Errorf("raw comma left in srcset: %s", out)
+	}
+	if !strings.Contains(out, "a%2Cb.jpg") {
+		t.Errorf("comma should be percent-escaped: %s", out)
+	}
+}
+
+// A generated image (an icon, a chart, a decoded placeholder shown on its
+// own) is legitimately inlined as a data URI. The image sinks pre-filtered
+// with the stricter Resource policy, which silently swapped it for the blank
+// stub — the image looked broken rather than blocked.
+func TestImageSrcAcceptsRasterDataURL(t *testing.T) {
+	t.Run("OptimizedImage", func(t *testing.T) {
+		out := string(OptimizedImage(OptimizedImageConfig{
+			Src: testPlaceholder, Alt: "Generated", Width: 20, Height: 20,
+		}))
+		if strings.Contains(out, "/__gofastr/blank.png") {
+			t.Errorf("data URI src was replaced with the blank stub: %s", out)
+		}
+		if !strings.Contains(out, testPlaceholder) {
+			t.Errorf("data URI src missing: %s", out)
+		}
+	})
+	t.Run("PipelineImage", func(t *testing.T) {
+		out := string(PipelineImage(PipelineImageConfig{
+			Fallback: testPlaceholder, Alt: "Generated", Width: 20, Height: 20,
+		}))
+		if strings.Contains(out, "/__gofastr/blank.png") {
+			t.Errorf("data URI fallback was replaced with the blank stub: %s", out)
+		}
+	})
+	t.Run("srcset", func(t *testing.T) {
+		out := string(OptimizedImage(OptimizedImageConfig{
+			Src: "/a.jpg", Alt: "x", Width: 20, Height: 20,
+			Sources: []ImageSource{{URL: testPlaceholder, Width: 20}},
+		}))
+		if !strings.Contains(out, "srcset") || !strings.Contains(out, "data:image/jpeg") {
+			t.Errorf("data URI source was dropped from srcset: %s", out)
+		}
+	})
+}
+
+// The looser image policy must not admit non-image data URIs anywhere.
+func TestImageSrcRejectsNonRasterDataURL(t *testing.T) {
+	out := string(OptimizedImage(OptimizedImageConfig{
+		Src: "data:text/html,<script>alert(1)</script>", Alt: "x", Width: 8, Height: 6,
+	}))
+	if strings.Contains(out, "text/html") {
+		t.Errorf("html data URI survived as an image src: %s", out)
+	}
+	if !strings.Contains(out, "/__gofastr/blank.png") {
+		t.Errorf("expected the blank stub: %s", out)
+	}
+}
+
+// Gallery is the third <img src> sink in this package and had the same
+// stricter-policy bug as OptimizedImage and PipelineImage.
+func TestGalleryThumbAcceptsRasterDataURL(t *testing.T) {
+	out := string(Gallery(GalleryConfig{
+		Items: []GalleryItem{{Src: "/full.jpg", Thumb: testPlaceholder, Alt: "Generated"}},
+	}))
+	if strings.Contains(out, "/__gofastr/blank.png") {
+		t.Errorf("data URI thumb was replaced with the blank stub: %s", out)
+	}
+	if !strings.Contains(out, testPlaceholder) {
+		t.Errorf("data URI thumb missing: %s", out)
+	}
+}
+
+func TestGalleryThumbRejectsUnsafeScheme(t *testing.T) {
+	out := string(Gallery(GalleryConfig{
+		Items: []GalleryItem{{Src: "/full.jpg", Thumb: "javascript:alert(1)", Alt: "x"}},
+	}))
+	if strings.Contains(out, "javascript:") {
+		t.Errorf("unsafe thumb survived: %s", out)
+	}
+	if !strings.Contains(out, "/__gofastr/blank.png") {
+		t.Errorf("expected the blank stub: %s", out)
+	}
+}
+
+// Avatar has no pre-filter of its own — it relies on html.Image's policy, so
+// the upstream switch to urlsafe.ImageSource is what makes an inlined avatar
+// work. Pinned here so a future tightening of html.Image does not silently
+// regress it.
+func TestAvatarAcceptsRasterDataURL(t *testing.T) {
+	out := string(Avatar(AvatarConfig{Name: "Ada Lovelace", Src: testPlaceholder}))
+	if !strings.Contains(out, testPlaceholder) {
+		t.Errorf("data URI avatar was dropped: %s", out)
+	}
+}

--- a/framework/ui/layering_test.go
+++ b/framework/ui/layering_test.go
@@ -1,0 +1,32 @@
+package ui_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// framework/ui renders placeholders that framework/image produces, and the
+// temptation is to decode a BlurHash inside the component. It must not:
+// framework/image carries every image decoder plus the WebP encoder, so the
+// edge would put all of it in the binary of any host that renders any UI at
+// all, whether or not it touches images.
+//
+// The rule was previously only a comment on HeaderInfo in pipeline_image.go.
+// A comment does not survive a refactor; this does.
+func TestUIDoesNotImportImagePipeline(t *testing.T) {
+	out, err := exec.Command("go", "list", "-deps", ".").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list -deps .: %v\n%s", err, out)
+	}
+	for _, banned := range []string{
+		"github.com/DonaldMurillo/gofastr/framework/image",
+	} {
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.TrimSpace(line) == banned {
+				t.Errorf("framework/ui depends on %q — decode placeholders in the caller "+
+					"and pass framework/ui a finished data URL instead", banned)
+			}
+		}
+	}
+}

--- a/framework/ui/pipeline_image.go
+++ b/framework/ui/pipeline_image.go
@@ -83,10 +83,18 @@ type PipelineImageConfig struct {
 	// Sizes is the CSS sizes attribute. Default "100vw".
 	Sizes string
 
-	// Placeholder accepts either a data: URL (LQIP) or a BlurHash
-	// string. The component sets data-placeholder for data: URLs and
-	// data-blurhash for anything else. Consumers wire those attributes
-	// to a CSS background or a JS hydrator as they see fit.
+	// Placeholder, when set to an inline raster data: URI, renders a
+	// low-fidelity image behind this one so something content-shaped is
+	// visible before the real pixels arrive.
+	//
+	// Produce one with framework/image: BlurHashDataURL(hash, …) to render
+	// a stored BlurHash — the natural companion to VariantResult.BlurHash —
+	// or pass VariantResult.Placeholder straight through for an LQIP.
+	// A bare BlurHash string is not accepted; it is not an image until it
+	// is decoded.
+	//
+	// Values that are not usable inline images are dropped and the image
+	// renders without a placeholder.
 	Placeholder string
 
 	Eager        bool
@@ -124,6 +132,28 @@ func PipelineImage(cfg PipelineImageConfig) render.HTML {
 		panic("ui: PipelineImage requires Alt (or add ui-image--decorative to Class for intentional decorative images with alt=\"\")")
 	}
 
+	// Same URL allow-list OptimizedImage applies: drop unsafe schemes on
+	// the fallback and on every source, replacing an unusable fallback with
+	// the framework's 1x1 stub so the surrounding layout survives. This
+	// component renders storage URLs that often originate in user data, so
+	// it needs the guard at least as much as OptimizedImage does.
+	if safe := safeImageURL(cfg.Fallback); safe != "" {
+		cfg.Fallback = safe
+	} else {
+		cfg.Fallback = "/__gofastr/blank.png"
+	}
+	if len(cfg.Sources) > 0 {
+		filtered := make([]PipelineSource, 0, len(cfg.Sources))
+		for _, s := range cfg.Sources {
+			if safeImageURL(s.URL) != "" {
+				filtered = append(filtered, s)
+			}
+		}
+		cfg.Sources = filtered
+	}
+
+	lqip := placeholderImage(cfg.Placeholder)
+
 	cls := "ui-image"
 	if cfg.Fit != ImageFitCover {
 		cls += " ui-image--fit-" + string(cfg.Fit)
@@ -133,6 +163,9 @@ func PipelineImage(cfg PipelineImageConfig) render.HTML {
 	}
 	if cfg.Rounded {
 		cls += " ui-image--rounded"
+	}
+	if lqip != "" {
+		cls += " ui-image--placeheld"
 	}
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
@@ -160,13 +193,6 @@ func PipelineImage(cfg PipelineImageConfig) render.HTML {
 	if cfg.HighPriority {
 		imgAttrs["fetchpriority"] = "high"
 	}
-	if cfg.Placeholder != "" {
-		if strings.HasPrefix(cfg.Placeholder, "data:") {
-			imgAttrs["data-placeholder"] = cfg.Placeholder
-		} else {
-			imgAttrs["data-blurhash"] = cfg.Placeholder
-		}
-	}
 
 	img := html.Image(html.ImageConfig{
 		Src:        cfg.Fallback,
@@ -186,9 +212,12 @@ func PipelineImage(cfg PipelineImageConfig) render.HTML {
 	children = append(children, img)
 	picture := render.Tag("picture", nil, children...)
 
+	// The placeholder is emitted before the picture so the real image paints
+	// over it in DOM order — both are positioned, so tree order decides,
+	// with no z-index needed.
 	return imageStyle.WrapHTML(html.Span(html.TextConfig{
 		Class: cls, ID: cfg.ID,
-	}, picture))
+	}, lqip, picture))
 }
 
 type pipelineGroup struct {

--- a/framework/ui/pipeline_image_test.go
+++ b/framework/ui/pipeline_image_test.go
@@ -90,20 +90,33 @@ func TestPipelineImageEmitsOneSourcePerType(t *testing.T) {
 	}
 }
 
-func TestPipelineImageEmitsPlaceholderDataURL(t *testing.T) {
+func TestPipelineImageRendersPlaceholderDataURL(t *testing.T) {
 	h := PipelineImage(PipelineImageConfig{
 		Fallback: "/p.jpg", Alt: "x", Width: 100, Height: 50,
 		Placeholder: "data:image/jpeg;base64,Zm9v",
 	})
-	mustContain(t, h, `data-placeholder="data:image/jpeg;base64,Zm9v"`)
+	// The placeholder is a stacked element, not an attribute for someone
+	// else to hydrate — see image_placeholder_test.go for the full contract.
+	mustContain(t, h, `class="ui-image__lqip"`)
+	mustContain(t, h, `src="data:image/jpeg;base64,Zm9v"`)
 }
 
-func TestPipelineImageEmitsBlurHashAttr(t *testing.T) {
+// A BlurHash is not an image until it is decoded; framework/image
+// .BlurHashDataURL does that. Handing the raw hash to the component used to
+// emit a data-blurhash attribute that nothing consumed, so it silently did
+// nothing at all.
+func TestPipelineImageRefusesRawBlurHash(t *testing.T) {
 	h := PipelineImage(PipelineImageConfig{
 		Fallback: "/p.jpg", Alt: "x", Width: 100, Height: 50,
 		Placeholder: "LEHV6nWB2yk8pyo0adR*.7kCMdnj",
 	})
-	mustContain(t, h, `data-blurhash="LEHV6nWB2yk8pyo0adR*.7kCMdnj"`)
+	out := string(h)
+	if strings.Contains(out, "LEHV6nWB") {
+		t.Errorf("raw BlurHash leaked into the markup: %s", out)
+	}
+	if strings.Contains(out, "ui-image__lqip") {
+		t.Errorf("raw BlurHash must not render a placeholder: %s", out)
+	}
 }
 
 func TestPipelineImageHonoursSizes(t *testing.T) {

--- a/framework/ui/safety.go
+++ b/framework/ui/safety.go
@@ -31,11 +31,23 @@ func safeURL(u string) string {
 }
 
 // safeResourceURL is safeURL for URLs the BROWSER fetches on its own —
-// <img src>, <source src>, <link href>. It drops mailto:/tel:, which are
+// <source src>, <link href>. It drops mailto:/tel:, which are
 // meaningful on an anchor the user activates and a caller mistake on a
 // subresource.
 func safeResourceURL(u string) string {
 	return urlsafe.Clean(u, urlsafe.Resource)
+}
+
+// safeImageURL is safeResourceURL for <img src> and image srcsets, which
+// additionally accept an inline raster data: URI — a generated image or a
+// low-fidelity placeholder is a legitimate thing to inline, and the media
+// types urlsafe.ImageSource admits cannot carry script.
+//
+// Image sinks must use this rather than safeResourceURL: the stricter
+// policy silently swaps a data: URI for the blank stub, which looks like
+// "the image is broken" rather than "the URL was rejected".
+func safeImageURL(u string) string {
+	return urlsafe.Clean(u, urlsafe.ImageSource)
 }
 
 // scrubAttrs filters an html.Attrs map, removing keys that look like

--- a/framework/ui/styles_primitives.go
+++ b/framework/ui/styles_primitives.go
@@ -199,9 +199,52 @@ func imageCSS(_ style.Theme) string {
 }
 [data-fui-comp="ui-image"].ui-image--fit-contain .ui-image__img { object-fit: contain; }
 [data-fui-comp="ui-image"].ui-image--fit-fill    .ui-image__img { object-fit: fill;    }
+/* The root is included so its own background (which --placeheld sets, to
+   back the letterbox bars) is rounded too — otherwise its square corners
+   peek out around the rounded image. */
+[data-fui-comp="ui-image"].ui-image--rounded,
 [data-fui-comp="ui-image"].ui-image--rounded     .ui-image__img,
+[data-fui-comp="ui-image"].ui-image--rounded     .ui-image__lqip,
 [data-fui-comp="ui-image"].ui-image--rounded     picture {
   border-radius: var(--radii-md, 8px);
+}
+
+/* Low-quality placeholder: a decoded BlurHash or tiny LQIP, stacked behind
+   the real image so something content-shaped is on screen before the real
+   pixels land. It is an element rather than a background because a data URL
+   is per-instance data and this project cannot emit per-instance CSS —
+   inline style attributes are blocked by the CSP and by the
+   noinlinestyles linter, and a data URL cannot be enumerated into a class.
+
+   Both layers are positioned, so paint order follows tree order: the
+   placeholder is emitted first and the real image covers it. No z-index and
+   no JavaScript are involved, and the placeholder is simply left in place
+   once the image has loaded. */
+[data-fui-comp="ui-image"] .ui-image__lqip {
+  position: absolute;
+  inset: 0;
+  inline-size: 100%;
+  block-size: 100%;
+  object-fit: cover;
+}
+[data-fui-comp="ui-image"] .ui-image__img,
+[data-fui-comp="ui-image"] picture {
+  position: relative;
+}
+/* The placeholder must letterbox exactly like the image in front of it.
+   Without this, a fit-contain image (which does not fill its box) would show
+   a cover-cropped blur through the empty bars — permanently, since the
+   placeholder is never removed. */
+[data-fui-comp="ui-image"].ui-image--fit-contain .ui-image__lqip { object-fit: contain; }
+[data-fui-comp="ui-image"].ui-image--fit-fill    .ui-image__lqip { object-fit: fill;    }
+/* With a placeholder present the grey resting fill moves to the root, so it
+   still backs the letterbox bars while the blur — not the grey — is what
+   shows through the image itself. */
+[data-fui-comp="ui-image"].ui-image--placeheld {
+  background: var(--color-surface-soft, #F4F4F5);
+}
+[data-fui-comp="ui-image"].ui-image--placeheld .ui-image__img {
+  background: transparent;
 }
 [data-fui-comp="ui-image"].ui-image--aspect-1-1  .ui-image__img { aspect-ratio: 1 / 1;  inline-size: 100%; block-size: auto; }
 [data-fui-comp="ui-image"].ui-image--aspect-4-3  .ui-image__img { aspect-ratio: 4 / 3;  inline-size: 100%; block-size: auto; }


### PR DESCRIPTION
Image placeholders never painted, and nothing ever produced a BlurHash on its own. Both halves are fixed here.

`data-placeholder` and `data-blurhash` were emitted by `OptimizedImage` and `PipelineImage` and read by nothing — no CSS rule, no runtime script, anywhere in the tree. The field's doc comment promised "a low-fidelity background that shows under the image while loading" and a code comment claimed the stylesheet read it via `attr()`. Neither was true, and `attr()` for non-`content` properties is Chrome-only regardless. The tests asserted the attributes were present, which an attribute nothing consumes always satisfies. Separately, nothing in the framework or any battery ever called `VariantSet`, so a BlurHash existed only if you hand-wrote the call in an upload handler.

## What changed

**Placeholders paint.** `image.DecodeBlurHash` + `image.BlurHashDataURL` turn a stored hash back into an inline image, and the UI components render it as a real `<img>` stacked behind the real one by static CSS. Zero JavaScript.

That shape is forced rather than chosen: a data URI is per-instance data, and this project cannot emit per-instance CSS — inline `style` attributes are blocked by the default CSP and by the `noinlinestyles` linter, and a data URI cannot be enumerated into a class the way carousel column counts are. An element needs no dynamic CSS, no `attr()`, and no JS, which also matters because the runtime gzip budget has no headroom.

**Uploads derive their own.** `framework.WithImagePipeline` runs every `schema.Image` upload through the configured variants, stores them beside the original, and writes the metadata to sibling columns the entity declares: `<field>_blurhash`, `<field>_placeholder`, `<field>_variants`. Undeclared columns are skipped, so adopting one means adding the column and nothing else, and existing entities are untouched. `WithImagePipelineFor` overrides a single field.

The dependency is inverted on purpose. `framework/crud` is in the dependency graph of nearly every app, so a direct edge to `framework/image` would link every decoder plus the WebP encoder into every binary. `file.ImageDeriver` is an interface in the leaf package, `framework/imagefield` implements it, and a `go list -deps` test keeps `crud` and `file` clear of the codecs.

## Breaking

- **`Placeholder` takes an inline raster `data:` URI only.** A bare BlurHash is no longer accepted — decode it with `image.BlurHashDataURL` first. Bad values are dropped and the image renders without a placeholder rather than panicking, matching how `PipelineImage` already treats missing intrinsic dimensions: a placeholder is data, often from a column an older upload wrote, not a caller-code bug.
- **`data-placeholder` and `data-blurhash` are no longer emitted.**

Both carry migration notes in `upgrades.yml`, verified by running `gofastr upgrade --to v0.47.0` against a v0.46.0 `go.mod`.

## Bugs found by surveying the siblings

- A `data:` image URI was silently swapped for the 1×1 blank stub. Every `<img src>` sink pre-filtered with `urlsafe.Resource`, which rejects `data:`, so a generated or inlined image rendered as broken rather than blocked. New `urlsafe.ImageSource` policy admits raster `data:` URIs only; `data:image/svg+xml` and every non-image type stay rejected, and `Resource` itself is unchanged so `<script src>` / `<link href>` are unaffected. Affected `OptimizedImage`, `PipelineImage`, `Gallery`, and (via `html.Image`) `Avatar`. **Found by looking at a screenshot, not by any test.**
- `PipelineImage` applied no URL allow-list at all, while `OptimizedImage` filtered its `Src` and every `Sources` URL. It renders storage URLs that routinely originate in user data.
- `OptimizedImage` did not escape srcset separators, so a URL containing a comma split one candidate into several malformed ones.
- `Fit: contain` showed a cover-cropped blur through the letterbox bars. The placeholder is never removed, so that was a permanent change to how `fit-contain` renders, not a loading state.
- `uploads.md` documented `EntityConfig.FileField(name).MaxBytes` and `AllowedMIMETypes`. Neither symbol exists anywhere in `framework/` or `core/` — the docs described per-field config that was never built.

## Verification

`gofmt`, `go vet`, `go build ./...`, coverage floors, and every package under `framework/`, `core/`, `core-ui/`, `battery/`, `cmd/`, and `examples/` — including both chromedp suites.

The new chromedp test on `/components/pipelineimage` hides the real image, screenshots, and asserts the browser actually decoded the placeholder (`naturalWidth != 0`), that it covers the real image's box, that the real image paints in front, that the placeholder is neither lazy nor async-decoded, and that the remaining pixels are a saturated blur rather than the flat resting grey.

Meridian was the first choice for that dogfood and is deliberately not used: every one of its screens is asserted by the blueprint pack round-trip against `examples/meridian/gofastr.yml`, and the yml has no body kind that can express an image section, so hand-written UI in a Meridian screen breaks `TestPack_MeridianRoundTrip`.

Two measured numbers ended up in the docs rather than being guessed at. Placeholder format defaults to JPEG because its size barely moves with dimensions (~840–940 bytes from 16px to 48px) while PNG reaches ~2.4KB by 48px. And the derive is synchronous in the request: ~53ms for two JPEG widths from a 1200px source, ~184ms from 3000px, ~537ms once WebP is included, since that encoder runs five predictor passes. `uploads.md` says so, and points at `battery/queue` for hot upload paths.

## Scope

`file.ImageDeriver` is the only per-field transform seam in the framework and stays deliberately image-shaped. The general version — write and read transforms for any field — is being designed in #144, where the blocking question is that a read transform applied after the query has already filtered and sorted on the stored value silently breaks `?field=`, `?sort=`, `?q=`, cursor pagination, and export. Pointers to that issue sit on the interface's doc comment and in `uploads.md` so the constraint is findable from the code.

Ships as v0.47.0. Not tagged — that's the release trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
