### PR TITLE
release: v0.53.0 — security audit of the never-audited packages (36 fixes, 1 breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,95 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 ## [Unreleased]
 
 The eleven pre-existing bugs the v0.52.0 review pass found in shipped code
-but deliberately left out of that release. Every fix landed with a test
+but deliberately left out of that release, plus a security audit of the
+packages no previous pass had ever read — kiln's expression and render
+layers, the module wire protocol, the router, config, i18n, migrations,
+file handling, and the SDK and pack tooling. Every fix landed with a test
 that failed first.
 
 ### Security
+
+- **BREAKING: a module's reverse calls now carry only the delegation
+  handle.** `EntityQueryParams`, `EntityMutationParams`,
+  `SearchQueryParams` and `EventEmitParams` take a `moduleproto.CallerRef`
+  — `Delegation` and nothing else — in place of `moduleproto.Caller`.
+  `Caller` travels in both directions: outbound the host fills it, inbound
+  the child writes it, and the child is the untrusted party. A broker
+  reading a child-supplied `Subject` or `Tenant` and dispatching under it
+  is a confused deputy. The shipped `Broker` never did — it resolves from
+  `Delegation` alone — so nothing was exploitable, but a comment telling
+  future authors not to trust those fields is weak protection while the
+  fields sit on the decoded struct. Anyone implementing a process module
+  gets a compile error and drops the two fields from the reverse call; the
+  host already sent them outbound and does not need them back.
+- **A trailing-slash redirect skipped the route gate and every
+  middleware.** `core/router` handed net/http's synthesized redirect
+  straight to the mux, so a path needing completion or dot-segment
+  cleaning bypassed the gate the 404 and 405 branches both honour. Against
+  a gate rejecting everything, `/admin/panel/` answered 404 while
+  `/admin/panel` answered 307 — the disabled-module existence leak the
+  gate's contract explicitly promises not to produce — and `//admin/panel/`,
+  `/admin/./panel/` and `/x/../admin/panel/` reached it too. Those
+  responses also carried no security headers, recovery, timeout, request
+  logging, CORS or rate limiting, and Go's 307 preserves method and body,
+  so it answered POSTs. Redirects are now gated on the target route and run
+  through the chain; a gated target falls through to an identical 404.
+- **A DEFAULT clause could close its own literal.** `SQLDefault`'s
+  fallback arm rendered `fmt.Sprintf("'%v'", v)` unescaped, and
+  `Field.Default` is `any`, so a named string type, `[]byte`, a
+  `fmt.Stringer` or a decoded map took that arm. A kiln `add_entity`
+  payload over HTTP created and committed an extra column. Both arms share
+  one escaper now.
+- **kiln quoted SQL identifiers with a third, broken copy.** It escaped
+  `"` and then wrote each rune as `byte(r)`, truncating after the escape
+  test, so `U+2022` and every other rune ending in `0x22` became a real
+  quote. Seed entity names and row keys are agent-authored, so it was
+  reachable. The private copy is deleted in favour of `core/query`, which
+  was always correct.
+- **A kiln expression could kill the process.** The depth guard counted
+  only grouping and prefix recursion, so a flat `1+1+1…` chain built a
+  depth-O(n) tree and overflowed the stack during eval — fatal, and
+  `recover()` cannot catch it. Comparing two uncomparable operands
+  (`[1] == [2]`) panicked outright. Both are bounded now, and `Compile`
+  caps source size.
+- **The CSRF exemption keyed on the decoded path.** The mux matches the
+  escaped path segment-wise, so `POST /api%2f..%2f..%2fadmin/wipe`
+  presented `/api/../../admin/wipe` to the skipper — granting the `/api`
+  exemption — while dispatch went to whatever wildcard route matched.
+- **`required:"true"` was satisfied by an empty value.** A var that exists
+  but is blank reports `("", true)`, so a blank `SECRET=`, a ConfigMap key
+  with no value, or a secret-manager miss silently produced an empty
+  signing key. Separately, a `sensitive` value survived verbatim in a
+  `ConfigValidator`'s error, leaking a full DSN through `MustLoad`'s panic.
+- **An attacker-chosen locale reached the catalog extension point.**
+  Cookie-supplied tags were length- and charset-bounded; `X-Locale` was
+  not, and won outright, and the nil-translator branch passed the entire
+  raw `Accept-Language` header through. Both flow to `Catalog.Get`, whose
+  documented wiring example is an `os.DirFS`, so a host with a lazily
+  loading catalog received `../../etc/passwd` as a locale.
+- **Uploads accepted magic-byte polyglots.** The content scan was skipped
+  entirely for anything sniffing as a raster, PDF or font, so `GIF89a`
+  followed by `<script>` passed wherever it sat. Tokens that never appear
+  in binary media are now matched across the whole body; the ones that do
+  appear in EXIF and XMP keep the windowed scan.
+- **Typed After-hooks could not redact the response body.** `OnAfterCreate`
+  and `OnAfterUpdate` unmarshalled into a fresh value and never merged
+  back, while the untyped path mutates the live map that becomes the
+  response. Identical redaction code worked untyped and silently no-opped
+  typed. Both now merge back like their Before counterparts.
+- Also: an uncapped goroutine spawn on the module notification branch
+  (the request branch had the cap its own doc describes), a second
+  `Peer.Start` crashing on a double channel close, duplicate inbound
+  request ids clobbering each other's cancel, `PRAGMA table_info`
+  interpolating an unvalidated identifier while every sibling call site
+  validates, a dialect probe falling back to SQLite on any transient
+  error and thereby skipping the cross-replica DDL lock, `Entity.Validate`
+  missing case-folded wire-key collisions, unvalidated file metadata and
+  LQIP placeholders, `pack` writing recovered secrets at mode 0644, a
+  Redis flag store validating its rollout percentage on write but not on
+  read, and a `docs --grep` panic on folding runes.
+
+### Security (v0.52.0 review backlog)
 
 - **A revoked 2FA backup code went live again after re-enrolment.**
   `EntityTwoFAStore.ConsumeBackupCode`'s CAS keyed on `(user_id, version)`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.53.0] - 2026-07-30
+
 The eleven pre-existing bugs the v0.52.0 review pass found in shipped code
 but deliberately left out of that release, plus a security audit of the
 packages no previous pass had ever read — kiln's expression and render

--- a/battery/experimental/redisflags/store.go
+++ b/battery/experimental/redisflags/store.go
@@ -76,7 +76,27 @@ func (s *Store) Get(ctx context.Context, key string) (*Flag, error) {
 	if err := json.Unmarshal([]byte(val), &flag); err != nil {
 		return nil, fmt.Errorf("redisflags: unmarshal %q: %w", key, err)
 	}
+	if err := validateFlag(&flag); err != nil {
+		return nil, fmt.Errorf("redisflags: get %q: %w", key, err)
+	}
 	return &flag, nil
+}
+
+// validateFlag enforces the RolloutPct bound on the READ path as well as
+// the write path. Set is not the only writer Redis has: another replica, an
+// older binary, or an ops script can put a value there directly, so a bound
+// checked only in Set is a bound checked only on the caller that was
+// already going to behave. Consumers evaluate rollout as
+// `hash % 100 < RolloutPct`, where a stored 10000 is a silent 100% rollout
+// and a stored -1 inverts the comparison.
+//
+// Rejecting (rather than clamping) surfaces the corruption, and because
+// IsEnabled maps a Get error to false, the failure direction is closed.
+func validateFlag(f *Flag) error {
+	if f.RolloutPct < 0 || f.RolloutPct > 100 {
+		return fmt.Errorf("stored RolloutPct %d out of range (must be 0..100)", f.RolloutPct)
+	}
+	return nil
 }
 
 // Set saves a flag. Validates RolloutPct ∈ [0, 100].
@@ -131,6 +151,9 @@ func (s *Store) List(ctx context.Context) ([]*Flag, error) {
 		var flag Flag
 		if err := json.Unmarshal([]byte(v), &flag); err != nil {
 			continue
+		}
+		if err := validateFlag(&flag); err != nil {
+			continue // same skip-the-bad-entry policy as a decode failure
 		}
 		flags = append(flags, &flag)
 	}

--- a/battery/experimental/redisflags/store_security_test.go
+++ b/battery/experimental/redisflags/store_security_test.go
@@ -1,0 +1,74 @@
+package redisflags
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// Property: a bound the store enforces on write is enforced on read too.
+//
+// Set validates RolloutPct in [0,100], but Redis is shared state — another
+// replica, an older binary, an ops script, or anyone with Redis access can
+// write the key directly. Validating only on the write path is validating
+// the one caller that was already going to be well-behaved. Consumers do
+// `hash % 100 < RolloutPct`, so a stored 10000 is a silent 100% rollout and
+// a stored -1 inverts the comparison.
+
+// TestOutOfRangeRolloutRejectedOnRead pins the read side of the bound.
+func TestOutOfRangeRolloutRejectedOnRead(t *testing.T) {
+	for name, pct := range map[string]int{
+		"far above 100": 10000,
+		"just above":    101,
+		"negative":      -1,
+		"far negative":  -10000,
+	} {
+		s, fake := newBoundStore(t)
+		fake.data["flag:"+name] = rawFlag(t, name, pct)
+		got, err := s.Get(context.Background(), name)
+		if err == nil {
+			t.Errorf("%s: Get returned %+v, want rejection", name, got)
+		}
+		// List must not surface it either.
+		flags, err := s.List(context.Background())
+		if err != nil {
+			t.Fatalf("%s: List: %v", name, err)
+		}
+		for _, f := range flags {
+			if f.Key == name {
+				t.Errorf("%s: List surfaced out-of-range flag %+v", name, f)
+			}
+		}
+	}
+}
+
+// TestInRangeRolloutStillReadable guards against an over-strict bound.
+func TestInRangeRolloutStillReadable(t *testing.T) {
+	s, fake := newBoundStore(t)
+	for _, pct := range []int{0, 1, 50, 100} {
+		key := "ok"
+		fake.data["flag:"+key] = rawFlag(t, key, pct)
+		got, err := s.Get(context.Background(), key)
+		if err != nil {
+			t.Fatalf("pct=%d rejected: %v", pct, err)
+		}
+		if got == nil || got.RolloutPct != pct {
+			t.Errorf("pct=%d round-tripped as %+v", pct, got)
+		}
+	}
+}
+
+func newBoundStore(t *testing.T) (*Store, *fakeRedis) {
+	t.Helper()
+	fake := newFakeRedis()
+	return New(fake, Config{}), fake
+}
+
+func rawFlag(t *testing.T, key string, pct int) string {
+	t.Helper()
+	b, err := json.Marshal(Flag{Key: key, Enabled: true, RolloutPct: pct})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/battery/experimental/redisidempotency/store.go
+++ b/battery/experimental/redisidempotency/store.go
@@ -1,6 +1,28 @@
-// Package redisidempotency provides a Redis-backed store for the
-// idempotency middleware. Complements the existing in-memory and SQL
-// stores in core/middleware.
+// Package redisidempotency provides a Redis-backed reserve/replay keystore
+// for at-most-once request handling.
+//
+// # It is NOT a drop-in core/middleware.IdempotencyStore
+//
+// The middleware's interface is
+// `Begin(ctx, key, fingerprint) (*IdempotentResponse, bool, error)` plus
+// `Finish(ctx, key, *IdempotentResponse)`. This Store's shape is
+// `CheckAndReserve(ctx, key) ([]byte, error)` / `Store(ctx, key, []byte)`,
+// which cannot express two of the middleware's security controls:
+//
+//   - No fingerprint parameter, so it can never return
+//     [middleware.ErrFingerprintMismatch] — the check that turns "same
+//     Idempotency-Key, different request body" into a 422 instead of
+//     replaying an unrelated response to it.
+//   - It stores only a raw body, with no status or headers, so a replay
+//     cannot reproduce the original status code and cannot participate in
+//     the middleware's strip-hop-by-hop-headers-on-replay handling.
+//
+// The signatures differ, so the mismatch is a compile error rather than a
+// silent downgrade — but do not "adapt" this type onto the middleware
+// without adding fingerprint storage and a full response snapshot, or the
+// adapter will fail open on both controls. Until then, use the in-memory
+// or SQL stores in core/middleware for the middleware, and this package
+// only for direct reserve/replay use.
 package redisidempotency
 
 import (

--- a/cmd/gofastr/blueprint_injection_security_test.go
+++ b/cmd/gofastr/blueprint_injection_security_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/DonaldMurillo/gofastr/framework"
 )
@@ -81,6 +82,72 @@ func TestFontFamilyCannotInjectCSS(t *testing.T) {
 	} {
 		if got := blueprintFontFamilyName(in); got != want {
 			t.Errorf("blueprintFontFamilyName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// Property: CLI text formatting never slices a string mid-rune.
+//
+// Not an attacker surface — `gofastr docs --grep <term>` takes the
+// operator's own argv against embedded first-party markdown — but the
+// failure mode was a hard panic of the shipped binary on ordinary Unicode
+// input, so the invariant is worth pinning where the code lives.
+
+// TestHighlightSurvivesFoldingRunes pins that highlight neither panics nor
+// emits invalid UTF-8 when strings.ToLower changes a rune's byte width.
+// U+0130 'İ' lowers to a one-byte 'i' (2 bytes -> 1), so locating the match
+// in the lowered copy and slicing the original ran past the end.
+func TestHighlightSurvivesFoldingRunes(t *testing.T) {
+	for _, tc := range []struct{ s, term string }{
+		{"I", "İ"},                   // shrinking fold, match at end
+		{"the letter I", "İ"},        // shrinking fold, mid-string
+		{"İx", "x"},                  // wide rune before the match
+		{"İabc", "abc"},              // wide rune before a long match
+		{"straße STRASSE", "straße"}, // multi-byte term
+	} {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("highlight(%q, %q) panicked: %v", tc.s, tc.term, r)
+				}
+			}()
+			out := highlight(tc.s, tc.term)
+			if !utf8.ValidString(out) {
+				t.Errorf("highlight(%q, %q) = %q, not valid UTF-8", tc.s, tc.term, out)
+			}
+			// bold() is a no-op off a TTY, so under `go test` highlight
+			// must return the input byte-for-byte. That is exactly the
+			// invariant that failed: the old slicing corrupted the text.
+			if out != tc.s {
+				t.Errorf("highlight(%q, %q) altered the text: %q", tc.s, tc.term, out)
+			}
+		}()
+	}
+}
+
+// TestFoldMatchStillFindsTerms guards against a fix that stops matching.
+// bold() is TTY-gated, so the match itself is asserted on the folding
+// helper rather than on highlight's (uncolored) output.
+func TestFoldMatchStillFindsTerms(t *testing.T) {
+	for _, tc := range []struct {
+		s, term string
+		want    int
+	}{
+		{"Entity declaration", "entity", 6},
+		{"ENTITY", "entity", 6},
+		{"straße", "STRASSE", 0}, // fold is per-rune, not full case-folding
+		{"İx", "i", 2},           // wide rune folds to a one-byte match
+		{"other", "entity", 0},
+	} {
+		got, ok := foldPrefixLen(tc.s, tc.term)
+		if tc.want == 0 {
+			if ok {
+				t.Errorf("foldPrefixLen(%q, %q) matched %d, want no match", tc.s, tc.term, got)
+			}
+			continue
+		}
+		if !ok || got != tc.want {
+			t.Errorf("foldPrefixLen(%q, %q) = %d,%v; want %d,true", tc.s, tc.term, got, ok, tc.want)
 		}
 	}
 }

--- a/cmd/gofastr/docs.go
+++ b/cmd/gofastr/docs.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/DonaldMurillo/gofastr/framework/docs"
 )
@@ -79,7 +81,13 @@ func runDocsList() {
 		// Trim long summaries to fit ~120-col terminals.
 		const lineCap = 100
 		if len(summary) > lineCap {
-			summary = summary[:lineCap] + "…"
+			// Back off to a rune boundary — a byte slice can land mid-rune
+			// and emit invalid UTF-8 to the terminal.
+			cut := lineCap
+			for cut > 0 && !utf8.RuneStart(summary[cut]) {
+				cut--
+			}
+			summary = summary[:cut] + "…"
 		}
 		fmt.Printf("  %s%s  %s\n",
 			green(t.Name),
@@ -137,22 +145,47 @@ func pluralS(n int) string {
 
 // highlight wraps each case-insensitive occurrence of `term` in `s`
 // with ANSI bold so the matching word stands out in --grep output.
+//
+// It scans s directly, rune by rune, rather than locating the match in
+// strings.ToLower(s) and slicing the original. strings.ToLower is not
+// length-preserving — U+0130 'İ' lowers to a single-byte 'i', shrinking
+// 2 bytes to 1 — so the two strings' byte offsets diverge and the old
+// `s[i+idx : i+idx+len(term)]` either sliced mid-rune (emitting invalid
+// UTF-8) or ran past the end. `gofastr docs --grep 'entİty'` panicked
+// with "slice bounds out of range".
 func highlight(s, term string) string {
 	if term == "" {
 		return s
 	}
-	lower := strings.ToLower(s)
-	lowerTerm := strings.ToLower(term)
 	var b strings.Builder
-	i := 0
-	for {
-		idx := strings.Index(lower[i:], lowerTerm)
-		if idx < 0 {
-			b.WriteString(s[i:])
-			return b.String()
+	for i := 0; i < len(s); {
+		if end, ok := foldPrefixLen(s[i:], term); ok {
+			b.WriteString(bold(s[i : i+end]))
+			i += end
+			continue
 		}
-		b.WriteString(s[i : i+idx])
-		b.WriteString(bold(s[i+idx : i+idx+len(term)]))
-		i += idx + len(term)
+		_, size := utf8.DecodeRuneInString(s[i:])
+		b.WriteString(s[i : i+size])
+		i += size
 	}
+	return b.String()
+}
+
+// foldPrefixLen reports the byte length of s's leading run of runes that
+// case-folds equal to term, and whether such a prefix exists. Because it
+// advances by whole runes in both strings, the returned length is always a
+// valid slice bound into s.
+func foldPrefixLen(s, term string) (int, bool) {
+	i := 0
+	for _, tr := range term {
+		if i >= len(s) {
+			return 0, false
+		}
+		sr, size := utf8.DecodeRuneInString(s[i:])
+		if unicode.ToLower(sr) != unicode.ToLower(tr) {
+			return 0, false
+		}
+		i += size
+	}
+	return i, i > 0
 }

--- a/cmd/gofastr/pack.go
+++ b/cmd/gofastr/pack.go
@@ -2665,6 +2665,14 @@ func buttonVariant(e ast.Expr) string {
 }
 
 // packBlueprint reconstructs a full Blueprint from a generated app directory.
+// secretsInBlueprint reports whether the packed blueprint carries any of
+// the three values packReadDotEnv recovers from .env.
+func secretsInBlueprint(bp Blueprint) bool {
+	return bp.App.Auth.JWTSecret != "" ||
+		bp.App.Admin.SeedPassword != "" ||
+		strings.Contains(bp.App.DBURL, "@")
+}
+
 func packBlueprint(dir string) (Blueprint, error) {
 	var bp Blueprint
 	app, err := packReadApp(dir)
@@ -2720,11 +2728,21 @@ func runPack(args []string) {
 		return
 	}
 	yml := encodeBlueprintYAML(bp)
+	// packReadDotEnv rehydrates JWT_SECRET / ADMIN_SEED_PASSWORD /
+	// DATABASE_URL from the app's .env so the packed blueprint round-trips
+	// (see the comment on packReadDotEnv). That reverses the generator's
+	// own "secrets never land in committed source" rule, which
+	// TestBlueprintNeverInlinesSecrets pins — and unlike `.env`, an
+	// arbitrary `-o` path is not covered by the generated .gitignore. Warn
+	// loudly and write 0600 rather than 0644.
+	if secretsInBlueprint(bp) {
+		warn("pack: output contains secrets recovered from .env (jwt_secret, seed_password, db.url) — do NOT commit it")
+	}
 	if out == "" {
 		fmt.Print(yml)
 		return
 	}
-	if err := os.WriteFile(out, []byte(yml), 0o644); err != nil {
+	if err := os.WriteFile(out, []byte(yml), 0o600); err != nil {
 		fail("pack: write %s: %v", out, err)
 		osExit(1)
 		return

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.52.0
+through: v0.53.0
 
 releases:
   - version: v0.3.0
@@ -480,3 +480,10 @@ releases:
         breaking: false
         guidance: "The old default keyed on RemoteAddr's host, which behind any reverse proxy is the proxy for every request — so ?subscriber_id=<victim> dropped a stranger's stream. Left nil the broker now evicts nothing, which is the right default. Set Principal to something the caller cannot choose (a session user id) if you rely on same-id reconnect replacing the previous entry."
         detect: "SSEBrokerConfig\\{"
+  - version: v0.53.0
+    title: Security audit of the never-audited packages
+    notes:
+      - change: A module's reverse calls carry only the delegation handle
+        breaking: true
+        guidance: "EntityQueryParams, EntityMutationParams, SearchQueryParams and EventEmitParams now take moduleproto.CallerRef (Delegation only) instead of moduleproto.Caller. A child echoing back its own Subject/Tenant is a confused-deputy shape — the host must resolve the principal from Delegation alone. Drop the two fields from the reverse call; the host already sent them outbound and does not need them back. Compile errors point at each construction site."
+        detect: "moduleproto\\.Caller\\{"

--- a/core-ui/noderender/node.go
+++ b/core-ui/noderender/node.go
@@ -552,17 +552,14 @@ var privilegedDataAttrs = map[string]bool{
 // privilegedDataPrefixes are runtime-privileged data-* FAMILIES. An
 // untrusted IR must not name any attribute starting with one of these.
 //
-// NOT yet listed here, and it is a known hole: data-action-* and
-// data-param-*. core-ui/runtime/frag/boot.js resolves the nearest
-// [data-component] and calls G.trigger() with the action name and the
-// data-param-* map — at hydration for data-action-mount, and again on
-// every gofastr:navigate — so an untrusted IR can pick a compiled action
-// AND its arguments. They cannot simply be added, because this renderer
-// serves two callers with different trust: cmd/gofastr's blueprint
-// (developer-authored YAML, first party) emits exactly these attributes
-// through RenderNode, while kiln renders agent-authored IR through the
-// same function. Closing it needs a trust split — see the note in
-// TestIRCannotFireActions.
+// data-action-* and data-param-* are deliberately NOT here: they are
+// stripped a layer earlier, by withoutActionAttrs at the untrusted entry
+// point. They cannot be handled by name alone, because this renderer
+// serves two callers with different trust — cmd/gofastr's blueprint
+// compiles developer-authored YAML and legitimately emits them, while
+// kiln renders agent-authored IR through the same code. The trust split
+// (RenderNode vs RenderTrustedNode) is what tells the two apart. See
+// actionAttrs for why they matter and TestIRCannotFireActions for the pin.
 var privilegedDataPrefixes = []string{
 	"data-fui-",
 }

--- a/core-ui/noderender/noderender_security_test.go
+++ b/core-ui/noderender/noderender_security_test.go
@@ -74,10 +74,17 @@ func TestIRDropsScriptAndURLGadgets(t *testing.T) {
 		// runtime. Blocking these would break every generator that renders
 		// through this IR without closing any of the gadgets above.
 		//
-		// data-kiln-tool is safe here: the delegator additionally
-		// requires a data-fui-trusted ancestor, which this IR cannot
-		// produce. data-action is NOT in this list — see
-		// TestIRCannotFireActions.
+		// data-kiln-tool stays allowed because an agent-authored button
+		// that fires a kiln tool is a deliberate kiln feature
+		// (kiln/integration's TestBrowser_ButtonToolCallFires). This
+		// used to claim the delegator's data-fui-trusted ancestor was
+		// something "this IR cannot produce" — that was false:
+		// kiln/render/uihost.go wraps the whole agent tree in one. The
+		// value, not the attribute, is what has to be bounded, so kiln
+		// validates the tool name against ^[a-z][a-z0-9_]*$ before it
+		// reaches the IR (kiln/render/node.go safeToolName), which is
+		// what stops "../../api/posts" escaping /kiln/tool/.
+		// data-action is NOT in this list — see TestIRCannotFireActions.
 		"data-field": "title", "data-entity-list-body": "posts",
 		"data-kiln-tool": "chat",
 	}, nil))

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -89,8 +90,13 @@ type ConfigValidator interface {
 // Nested struct fields recurse with a SCREAMING_SNAKE prefix derived from
 // the parent field name (e.g. `DB DBConfig` reads keys like DB_HOST).
 //
+// `required:"true"` demands a non-empty value: a key that is present
+// but set to the empty string ("SECRET=" in a .env, a ConfigMap key
+// with no value) fails the same way an absent key does. A `default:`
+// tag still satisfies a required field when the key is absent.
+//
 // Fields tagged `sensitive:"true"` have their raw value redacted from
-// any error messages.
+// any error messages — including the text of a ConfigValidator error.
 //
 // If the config (or a pointer to it) implements ConfigValidator,
 // Validate is called after binding and its error is returned.
@@ -113,21 +119,52 @@ func LoadWith(cfg interface{}, sources ...Source) error {
 		src = ChainedSource{EnvSource{}}
 	}
 
-	if err := bindStruct(v.Elem(), "", src); err != nil {
+	var secrets []string
+	if err := bindStruct(v.Elem(), "", src, &secrets); err != nil {
 		return err
 	}
 
 	if val, ok := cfg.(ConfigValidator); ok {
 		if err := val.Validate(); err != nil {
-			return fmt.Errorf("config: validate: %w", err)
+			// The `sensitive:"true"` contract is "redacted from any error
+			// messages", but redaction used to wrap only setField's parse
+			// error. A host's Validate() writing the idiomatic
+			// fmt.Errorf("bad DSN %q", c.DBURL) was wrapped verbatim and
+			// leaked the credential out through MustLoad's panic. We can't
+			// restructure a third-party error, so scrub the bound secret
+			// values out of its rendered text instead.
+			return fmt.Errorf("config: validate: %s", redactSecrets(err.Error(), secrets))
 		}
 	}
 	return nil
 }
 
+// redactSecrets replaces every occurrence of a bound sensitive value in
+// msg with a placeholder. Values are scrubbed longest-first so a secret
+// that contains a shorter one doesn't leave a fragment behind.
+func redactSecrets(msg string, secrets []string) string {
+	if len(secrets) == 0 {
+		return msg
+	}
+	ordered := make([]string, len(secrets))
+	copy(ordered, secrets)
+	sort.Slice(ordered, func(i, j int) bool { return len(ordered[i]) > len(ordered[j]) })
+	for _, s := range ordered {
+		if s == "" {
+			continue
+		}
+		msg = strings.ReplaceAll(msg, s, "(redacted)")
+	}
+	return msg
+}
+
 // bindStruct walks the fields of elem, reading from src under the given
 // prefix. Nested struct fields recurse with prefix+FieldName+"_".
-func bindStruct(elem reflect.Value, prefix string, src Source) error {
+//
+// Every value bound into a `sensitive:"true"` field is appended to
+// secrets so [redactSecrets] can scrub it out of a ConfigValidator's
+// error text.
+func bindStruct(elem reflect.Value, prefix string, src Source, secrets *[]string) error {
 	t := elem.Type()
 
 	for i := 0; i < t.NumField(); i++ {
@@ -141,7 +178,7 @@ func bindStruct(elem reflect.Value, prefix string, src Source) error {
 		// Recurse into nested structs (but not time.Duration, which is an int64).
 		if fieldVal.Kind() == reflect.Struct && fieldVal.Type() != reflect.TypeOf(time.Duration(0)) {
 			nestedPrefix := prefix + strings.ToUpper(field.Name) + "_"
-			if err := bindStruct(fieldVal, nestedPrefix, src); err != nil {
+			if err := bindStruct(fieldVal, nestedPrefix, src, secrets); err != nil {
 				return err
 			}
 			continue
@@ -159,14 +196,24 @@ func bindStruct(elem reflect.Value, prefix string, src Source) error {
 
 		val, found := src.Get(key)
 		if !found {
-			if required && defaultVal == "" {
-				return fmt.Errorf("config: required field %s (%s) not set", field.Name, key)
-			}
 			val = defaultVal
 		}
 
-		if val == "" && !required {
+		// `required` means a usable value, not merely a present key.
+		// EnvSource deliberately reports set-but-empty as ("", true), so
+		// checking only !found let `SECRET=` — an empty .env line, a k8s
+		// ConfigMap key with no value, a secret-manager miss — satisfy
+		// `required` and silently bind the zero value. Test the resolved
+		// value instead of the lookup's ok flag.
+		if val == "" {
+			if required {
+				return fmt.Errorf("config: required field %s (%s) not set", field.Name, key)
+			}
 			continue // leave zero value
+		}
+
+		if sensitive {
+			*secrets = append(*secrets, val)
 		}
 
 		if err := setField(fieldVal, val, field.Name); err != nil {

--- a/core/config/config_security_test.go
+++ b/core/config/config_security_test.go
@@ -1,0 +1,101 @@
+package config_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/config"
+)
+
+// Property: a field tagged `required:"true"` is satisfied ONLY by a
+// non-empty value. Surfaces: key absent, key present-but-empty, and an
+// empty `default:` tag.
+//
+// EnvSource deliberately distinguishes unset from set-but-empty
+// (EnvSource.Get returns ("", true) for `SECRET=`), which is what made
+// present-but-empty skip the !found guard entirely and bind the zero
+// value. `SECRET=` in a .env file, a k8s ConfigMap key with no value, or
+// a secret-manager miss that writes an empty string all take that path —
+// so a signing key or DB URL silently downgrades to "" instead of
+// refusing to boot.
+func TestRequiredRejectsEmptyValue(t *testing.T) {
+	type cfg struct {
+		Secret string `config:"SECRET" required:"true"`
+	}
+	cases := []struct {
+		name string
+		src  config.MapSource
+	}{
+		{"absent", config.MapSource{}},
+		{"set-but-empty", config.MapSource{"SECRET": ""}},
+	}
+	for _, tc := range cases {
+		var c cfg
+		err := config.Load(&c, tc.src)
+		if err == nil {
+			t.Errorf("SECURITY: [config] required field satisfied by %s (cfg=%+v). "+
+				"Attack: an empty signing key / DB URL silently binds the zero value "+
+				"instead of refusing to boot.", tc.name, c)
+			continue
+		}
+		if !strings.Contains(err.Error(), "SECRET") {
+			t.Errorf("[config] %s error %q does not name the key", tc.name, err)
+		}
+	}
+
+	// A required field WITH a default still binds the default when the
+	// key is absent — the escape hatch stays open.
+	type withDefault struct {
+		Port string `config:"PORT" required:"true" default:"8080"`
+	}
+	var d withDefault
+	if err := config.Load(&d, config.MapSource{}); err != nil || d.Port != "8080" {
+		t.Errorf("[config] required+default regressed: err=%v port=%q", err, d.Port)
+	}
+}
+
+type sensitiveCfg struct {
+	DBURL  string `config:"DB_URL" sensitive:"true"`
+	Nested struct {
+		Token string `config:"TOKEN" sensitive:"true"`
+	}
+	Public string `config:"PUBLIC"`
+}
+
+func (c *sensitiveCfg) Validate() error {
+	return fmt.Errorf("bad DSN %q / token %q / public %q", c.DBURL, c.Nested.Token, c.Public)
+}
+
+// Property: a value bound into a field tagged `sensitive:"true"` never
+// appears in ANY error Load returns. Surfaces: the setField parse error
+// (already pinned by TestSensitiveValueRedacted), the ConfigValidator
+// hook's error, and a sensitive field inside a nested struct.
+//
+// Redaction used to wrap only setField's error; the validator's error
+// was wrapped verbatim as "config: validate: %w", so a host writing the
+// idiomatic fmt.Errorf("bad DSN %q", c.DBURL) leaked the credential
+// through MustLoad's panic and into crash logs.
+func TestSensitiveRedactedInValidator(t *testing.T) {
+	const secret = "postgres://u:hunter2@h/db"
+	const token = "tok_live_abcdef" // not-a-secret: fixture value the test asserts is REDACTED from error text
+	var c sensitiveCfg
+	err := config.Load(&c, config.MapSource{
+		"DB_URL":       secret,
+		"NESTED_TOKEN": token,
+		"PUBLIC":       "not-a-secret",
+	})
+	if err == nil {
+		t.Fatal("expected the validator error")
+	}
+	for _, leaked := range []string{secret, token, "hunter2"} {
+		if strings.Contains(err.Error(), leaked) {
+			t.Errorf("SECURITY: [config] validator error leaked sensitive value %q: %s. "+
+				"Attack: MustLoad panics the credential into crash logs / stderr.", leaked, err)
+		}
+	}
+	// Non-sensitive context must survive so the error stays diagnosable.
+	if !strings.Contains(err.Error(), "not-a-secret") {
+		t.Errorf("[config] redaction scrubbed non-sensitive context too: %s", err)
+	}
+}

--- a/core/featureflag/flag.go
+++ b/core/featureflag/flag.go
@@ -355,6 +355,13 @@ func (m *MemoryStore) Delete(key string) error {
 
 // All returns a snapshot of every defined flag, suitable for /admin
 // listings. The result is a copy — mutations don't affect the store.
+//
+// SECURITY: the snapshot includes each flag's full definition — the
+// Users and Tenants allow-lists carry raw subject ids / emails. That is
+// PII, and the list of who is inside a gated cohort is itself a signal.
+// Gate this behind admin auth before rendering it; do not hand the
+// result to an anonymous introspection endpoint. Compare
+// router.Routes(), which carries the same warning.
 func (m *MemoryStore) All() []Flag {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/core/featureflag/sql.go
+++ b/core/featureflag/sql.go
@@ -158,6 +158,10 @@ func (s *SQLStore) Delete(key string) error {
 }
 
 // All returns every defined flag — used by admin tooling.
+//
+// SECURITY: as with [MemoryStore.All], the rows carry each flag's raw
+// Users / Tenants allow-lists. Gate this behind admin auth; cohort
+// membership is PII and a signal in its own right.
 func (s *SQLStore) All(ctx context.Context) ([]Flag, error) {
 	rows, err := s.db.QueryContext(ctx,
 		fmt.Sprintf("SELECT key, enabled, rollout, users, tenants, envs FROM %s ORDER BY key", s.table),

--- a/core/i18n/i18n.go
+++ b/core/i18n/i18n.go
@@ -30,7 +30,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
-	"path/filepath"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -188,6 +188,11 @@ func englishPlural(n int) string {
 // MapCatalog is the simplest in-memory Catalog — useful in tests and
 // for embedding small string sets directly in code.
 type MapCatalog struct {
+	// mu guards Entries. Set is documented as a test convenience, but
+	// MapCatalog is also the type LoadJSONCatalog returns, so a host can
+	// hold a live one and call Set while request goroutines are in Get.
+	// The Translator's own mutex guards only its plural rules.
+	mu      sync.RWMutex
 	Entries map[string]map[string]Message // locale → key → message
 }
 
@@ -199,6 +204,11 @@ func NewMapCatalog() *MapCatalog {
 // Set writes a message into the catalog. Convenience for tests.
 func (c *MapCatalog) Set(locale, key string, m Message) {
 	tag := normalize(locale)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.Entries == nil {
+		c.Entries = map[string]map[string]Message{}
+	}
 	if c.Entries[tag] == nil {
 		c.Entries[tag] = map[string]Message{}
 	}
@@ -210,6 +220,8 @@ func (c *MapCatalog) Get(locale, key string) (Message, bool) {
 	if c == nil {
 		return Message{}, false
 	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	if m, ok := c.Entries[normalize(locale)][key]; ok {
 		return m, true
 	}
@@ -218,6 +230,8 @@ func (c *MapCatalog) Get(locale, key string) (Message, bool) {
 
 // Locales implements Catalog.
 func (c *MapCatalog) Locales() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	out := make([]string, 0, len(c.Entries))
 	for k := range c.Entries {
 		out = append(out, k)
@@ -254,7 +268,9 @@ func LoadJSONCatalog(fsys fs.FS, dir string) (*MapCatalog, error) {
 			continue
 		}
 		locale := normalize(strings.TrimSuffix(e.Name(), ".json"))
-		raw, err := fs.ReadFile(fsys, filepath.Join(dir, e.Name()))
+		// io/fs paths are always slash-separated; filepath.Join would
+		// emit backslashes on Windows and fail every lookup.
+		raw, err := fs.ReadFile(fsys, path.Join(dir, e.Name()))
 		if err != nil {
 			return nil, fmt.Errorf("i18n: read %s: %w", e.Name(), err)
 		}
@@ -418,16 +434,23 @@ func CookieLocale(name string) func(*http.Request) (string, bool) {
 	}
 }
 
-// maxResolverTagLen bounds how long an attacker-controlled resolver
-// value (cookie) may be before it is rejected. Mirrors the Accept-
-// Language bounding: real BCP 47 tags are well under this.
+// maxResolverTagLen bounds how long an attacker-controlled tag may be
+// before it is rejected. Mirrors the Accept-Language bounding: real
+// BCP 47 tags are well under this.
 const maxResolverTagLen = 35
 
-// sanitizeResolverTag normalises a resolver-supplied tag and rejects
+// sanitizeTag normalises an attacker-controlled locale tag and rejects
 // values that are empty, too long, or contain characters outside the
 // BCP 47 subset (lowercase letters, digits, hyphen). Returns "" on
 // rejection so the caller falls through to the next source.
-func sanitizeResolverTag(tag string) string {
+//
+// EVERY externally-supplied tag goes through this — resolver values
+// (cookies), the X-Locale header, and Accept-Language entries — because
+// each of them can become the Locale.Tag that a host's Catalog.Get
+// receives as a lookup key, and Catalog is a documented third-party
+// extension point. Bounding only the cookie left the two header
+// sources, which are equally attacker-controlled, unguarded.
+func sanitizeTag(tag string) string {
 	tag = normalize(tag)
 	if tag == "" || len(tag) > maxResolverTagLen {
 		return ""
@@ -513,7 +536,7 @@ func Negotiate(tr *Translator, r *http.Request, opts ...NegotiateOption) Locale 
 		if !ok {
 			continue
 		}
-		tag = sanitizeResolverTag(tag)
+		tag = sanitizeTag(tag)
 		if tag == "" {
 			continue
 		}
@@ -527,14 +550,31 @@ func Negotiate(tr *Translator, r *http.Request, opts ...NegotiateOption) Locale 
 		}
 	}
 
-	// 2. X-Locale header — wins outright (backward-compatible).
-	if forced := normalize(r.Header.Get("X-Locale")); forced != "" {
+	// 2. X-Locale header — wins outright (backward-compatible), but is
+	//    bounded exactly like a resolver value first. X-Locale is just as
+	//    attacker-controlled as a cookie and it short-circuits every
+	//    later check, so an unbounded value here becomes the Locale.Tag
+	//    that flows to tagFallbacks → Catalog.Get. Catalog is a
+	//    third-party extension point (the documented wiring is
+	//    LoadJSONCatalog over an fs.FS), so a host with a lazily-loading
+	//    FS/DB catalog would receive "../../etc/passwd" as a lookup key.
+	//    Rejected values fall through to Accept-Language rather than
+	//    becoming the tag.
+	if forced := sanitizeTag(r.Header.Get("X-Locale")); forced != "" {
 		return Locale{Tag: forced}
 	}
 
 	// 3. Accept-Language.
 	if tr == nil {
-		return Locale{Tag: normalize(r.Header.Get("Accept-Language"))}
+		// No catalog to match against. Take the highest-quality entry
+		// that survives bounding — NOT the whole raw header, which used
+		// to be handed back as a "tag" verbatim.
+		for _, want := range parseAcceptLanguage(r.Header.Get("Accept-Language")) {
+			if tag := sanitizeTag(want); tag != "" {
+				return Locale{Tag: tag}
+			}
+		}
+		return Locale{}
 	}
 	for _, want := range parseAcceptLanguage(r.Header.Get("Accept-Language")) {
 		if hit := matchCatalog(want, available); hit != "" {
@@ -562,24 +602,43 @@ func parseAcceptLanguage(header string) []string {
 		q   float64
 	}
 	// Bound the work an attacker-controlled header can force: RFC-realistic
-	// clients send a handful of language ranges. Cap the number of accepted
-	// entries so a header packed with commas (up to MaxHeaderBytes) cannot
-	// amplify into hundreds of thousands of allocations + an O(n log n) sort.
-	const maxEntries = 32
+	// clients send a handful of language ranges.
+	//
+	// Capping len(out) alone was not enough. strings.Split materialises
+	// the ENTIRE comma-separated slice before the cap is ever consulted,
+	// so a ~600KB header still allocated ~3.2MB and ~500k strings per
+	// request — 12000x a normal header — and the inner ";" split was
+	// uncapped on top of that. Scan the header in place instead, and
+	// bound the number of segments EXAMINED, not just accepted.
+	const (
+		maxEntries  = 32
+		maxSegments = 512
+		maxParams   = 8
+	)
 	var out []entry
-	for _, part := range strings.Split(header, ",") {
-		if len(out) >= maxEntries {
-			break
+	rest := header
+	for segments := 0; rest != "" && len(out) < maxEntries && segments < maxSegments; segments++ {
+		part := rest
+		if i := strings.IndexByte(rest, ','); i >= 0 {
+			part, rest = rest[:i], rest[i+1:]
+		} else {
+			rest = ""
 		}
 		seg := strings.TrimSpace(part)
 		if seg == "" {
 			continue
 		}
 		tag, q := seg, 1.0
-		if i := strings.Index(seg, ";"); i >= 0 {
+		if i := strings.IndexByte(seg, ';'); i >= 0 {
 			tag = strings.TrimSpace(seg[:i])
 			params := seg[i+1:]
-			for _, kv := range strings.Split(params, ";") {
+			for n := 0; params != "" && n < maxParams; n++ {
+				kv := params
+				if j := strings.IndexByte(params, ';'); j >= 0 {
+					kv, params = params[:j], params[j+1:]
+				} else {
+					params = ""
+				}
 				kv = strings.TrimSpace(kv)
 				if strings.HasPrefix(kv, "q=") {
 					if f, err := strconv.ParseFloat(kv[2:], 64); err == nil {

--- a/core/i18n/i18n_security_test.go
+++ b/core/i18n/i18n_security_test.go
@@ -1,6 +1,11 @@
 package i18n
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
 
 // TestAcceptLanguageBounded asserts that parsing of the attacker-controlled
 // Accept-Language header is bounded so a single request cannot force large
@@ -41,5 +46,97 @@ func TestAcceptLanguageBounded(t *testing.T) {
 	// The happy path must still negotiate correctly (preferred tag first).
 	if got := parseAcceptLanguage("fr-CA,fr;q=0.8,en;q=0.5"); len(got) == 0 || got[0] != "fr-ca" {
 		t.Fatalf("happy-path ordering broken: got %v", got)
+	}
+}
+
+// TestAcceptLangWorkIsBounded pins the WORK, not just the result size.
+// TestAcceptLanguageBounded above caps len(out) at 32, but the cap was
+// consulted only after strings.Split had already materialised the whole
+// comma-separated slice: a ~600KB header still allocated ~3.2MB and
+// ~500k strings per request (measured 9360x the time and 12521x the
+// bytes of a normal header) before a single entry was rejected. The
+// sort and the out slice were bounded; the split was not.
+func TestAcceptLangWorkIsBounded(t *testing.T) {
+	// Measure BYTES, not object count: strings.Split allocated a single
+	// 200k-element backing array, so an allocs/op assertion would have
+	// stayed green while 3.2MB churned per request.
+	bytesFor := func(header string) uint64 {
+		res := testing.Benchmark(func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				parseAcceptLanguage(header)
+			}
+		})
+		return uint64(res.AllocedBytesPerOp())
+	}
+
+	normal := bytesFor("en-US,en;q=0.9,fr;q=0.8")
+	// A bounded parser allocates the same handful of bytes regardless of
+	// how many separators the attacker packs in.
+	budget := normal*8 + 4096
+
+	if got := bytesFor(strings.Repeat("en,", 200000)); got > budget {
+		t.Errorf("SECURITY: [i18n] a comma-flooded Accept-Language allocated %d B/op "+
+			"against %d B/op for a normal header (budget %d). Attack: every "+
+			"unauthenticated request amplifies a header into megabytes of garbage.",
+			got, normal, budget)
+	}
+	if got := bytesFor("en;" + strings.Repeat("q=0.1;", 200000)); got > budget {
+		t.Errorf("SECURITY: [i18n] a semicolon-flooded Accept-Language allocated %d B/op "+
+			"(budget %d). Attack: the inner parameter split is uncapped.", got, budget)
+	}
+
+	// Correctness survives the bounding.
+	if got := parseAcceptLanguage("fr-CA,fr;q=0.8,en;q=0.5"); len(got) == 0 || got[0] != "fr-ca" {
+		t.Fatalf("[i18n] happy-path ordering broken: got %v", got)
+	}
+}
+
+// TestNegotiatedTagIsBounded asserts the property sanitizeTag
+// already states for cookies — "resolver values are attacker-controlled,
+// so they are length- and character-bounded before any matching" — holds
+// at EVERY source Negotiate accepts, not just the resolver.
+//
+// X-Locale is equally attacker-controlled and wins OUTRIGHT, yet only
+// got lower-case+trim; and with a nil Translator the entire raw
+// Accept-Language header became the tag. Both flow into tagFallbacks →
+// Catalog.Get, and Catalog is a documented third-party extension point
+// whose own wiring example is LoadJSONCatalog(os.DirFS("locales"), ".").
+// A host backing that interface with a lazily-loading FS or DB catalog
+// received "../../etc/passwd" as a locale. The in-tree MapCatalog is a
+// plain map lookup, which is why nothing caught it.
+func TestNegotiatedTagIsBounded(t *testing.T) {
+	tr := NewTranslator(NewMapCatalog(), "en")
+	hostile := []string{
+		"../../etc/passwd",
+		"..%2f..%2fsecrets",
+		strings.Repeat("a", 400),
+		"en\nX-Injected: 1",
+		"en/../../x",
+	}
+
+	for _, bad := range hostile {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("X-Locale", bad)
+		if got := Negotiate(tr, r).Tag; got != "" && sanitizeTag(got) != got {
+			t.Errorf("SECURITY: [i18n] X-Locale %q negotiated to unbounded tag %q. "+
+				"Attack: the tag reaches a host Catalog.Get as a file/DB lookup key.", bad, got)
+		}
+
+		// nil Translator takes the raw-header branch.
+		r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+		r2.Header.Set("Accept-Language", bad)
+		if got := Negotiate(nil, r2).Tag; got != "" && sanitizeTag(got) != got {
+			t.Errorf("SECURITY: [i18n] nil-translator Accept-Language %q negotiated to "+
+				"unbounded tag %q. Attack: same Catalog.Get sink.", bad, got)
+		}
+	}
+
+	// The documented "X-Locale wins outright" escape hatch survives for
+	// any tag that IS a plausible BCP 47 value, catalog hit or not.
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Locale", "ja")
+	if got := Negotiate(tr, r).Tag; got != "ja" {
+		t.Errorf("[i18n] X-Locale no longer wins outright: got %q want ja", got)
 	}
 }

--- a/core/middleware/csrf_skipper.go
+++ b/core/middleware/csrf_skipper.go
@@ -49,14 +49,28 @@ func (s *CSRFSkipper) Add(prefixes ...string) {
 	s.mu.Unlock()
 }
 
-// Skip reports whether r.URL.Path starts with any registered prefix.
-// Use as CSRFConfig.Skip directly when no other predicates apply, or
-// compose with SkipAny.
+// Skip reports whether the request path starts with any registered
+// prefix. Use as CSRFConfig.Skip directly when no other predicates
+// apply, or compose with SkipAny.
+//
+// SECURITY: the comparison is against r.URL.EscapedPath() — the path AS
+// SENT — not the percent-decoded r.URL.Path. An exemption decision has
+// to be made on the same bytes the router matched, and those differ:
+// Go's mux matches on decoded segments but does not redirect when %2F
+// or %2E leave the raw and decoded forms different. Matching the
+// decoded path let "POST /api%2f..%2f..%2fadmin/wipe" present
+// "/api/../../admin/wipe" here — inheriting the "/api/" exemption —
+// while the mux dispatched whatever wildcard route actually matched.
+// Comparing the escaped form fails closed: an encoded separator no
+// longer reads as a directory boundary, so the request keeps its CSRF
+// requirement. Ordinary encodings inside a genuinely-matching prefix
+// (e.g. "/api/foo%20bar") are unaffected.
 func (s *CSRFSkipper) Skip(r *http.Request) bool {
+	path := r.URL.EscapedPath()
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for _, p := range s.prefixes {
-		if strings.HasPrefix(r.URL.Path, p) {
+		if strings.HasPrefix(path, p) {
 			return true
 		}
 	}

--- a/core/middleware/csrf_skipper_test.go
+++ b/core/middleware/csrf_skipper_test.go
@@ -117,3 +117,44 @@ func TestCSRFSkipper_ConcurrentAddAndSkip(t *testing.T) {
 	}
 	<-done
 }
+
+// TestSkipMatchesEncodedPathLiterally pins that the CSRF exemption
+// decision is made on the path AS SENT, not on its percent-decoded form.
+//
+// Property: an authz/exemption decision keyed on a URL must be made on
+// the same bytes the router matched. Go's mux matches on decoded
+// segments but does NOT redirect when %2F/%2E keep the raw and decoded
+// forms different, so r.URL.Path could read "/api/../../admin/wipe" —
+// granting the "/api/" exemption — while the mux dispatched a wildcard
+// route somewhere else entirely. Matching EscapedPath() fails closed:
+// an encoded separator no longer looks like a directory boundary, so
+// the request keeps its CSRF requirement.
+//
+// Precondition for exploitation was a registered skip prefix plus a
+// state-changing {param} route reachable under it — both ordinary.
+func TestSkipMatchesEncodedPathLiterally(t *testing.T) {
+	s := NewCSRFSkipper()
+	s.Add("/api/", "/health")
+
+	cases := []struct {
+		path string
+		want bool
+		why  string
+	}{
+		{"/api/orders", true, "plain path under the prefix still skips"},
+		{"/api/foo%20bar", true, "ordinary encoding inside the prefix still skips"},
+		{"/health", true, "non-directory prefix still skips"},
+		{"/admin/wipe", false, "unrelated path is not exempt"},
+		{"/api%2f..%2f..%2fadmin/wipe", false, "%2F-smuggled traversal must not inherit the exemption"},
+		{"/%61pi/orders", false, "%61-encoded prefix must not inherit the exemption"},
+	}
+	for _, tc := range cases {
+		r := httptest.NewRequest(http.MethodPost, tc.path, nil)
+		if got := s.Skip(r); got != tc.want {
+			t.Errorf("SECURITY: [middleware] Skip(%q) = %v, want %v (%s). "+
+				"URL.Path=%q EscapedPath=%q. Attack: a state-changing request "+
+				"routed outside the API surface inherits the API's CSRF exemption.",
+				tc.path, got, tc.want, tc.why, r.URL.Path, r.URL.EscapedPath())
+		}
+	}
+}

--- a/core/moduleproto/methods.go
+++ b/core/moduleproto/methods.go
@@ -82,6 +82,16 @@ type HandshakeExpected struct {
 	// Version is the module's operator-approved semantic version.
 	Version string `json:"version"`
 	// ArtifactSHA256 is the SHA-256 of the approved executable, hex-encoded.
+	//
+	// Unlike every other field here it is NOT round-trip-verified:
+	// [HandshakeResult] has no corresponding field and crossCheck never
+	// looks at it. That is deliberate — asking the child to echo the hash
+	// of its own binary proves nothing, since a substituted binary echoes
+	// whatever it was handed. Executable integrity is verified by the
+	// supervisor hashing the file BEFORE spawn (see
+	// framework/processmodule_store.go). This field is informational on
+	// the wire; do not read its presence here as evidence that the
+	// artifact was checked.
 	ArtifactSHA256 string `json:"artifact_sha256"`
 	// SurfaceSHA256 is the digest of the approved surface descriptor
 	// (routes + tool list + requested permissions). Mismatch with the
@@ -173,18 +183,47 @@ type HTTPRequestParams struct {
 	DeadlineUnixMs int64 `json:"deadline_unix_ms"`
 }
 
-// Caller is the resolved end-user context attached to a proxied call (and
-// echoed by the child on reverse host.* requests so the host re-attaches the
-// right request context to internal re-dispatch). The Delegation handle is an
-// in-memory, replica-local opaque string minted by the host (§5: v1 needs no
-// signed token; the handle never leaves shared memory).
+// Caller is the resolved end-user context the host attaches to an OUTBOUND
+// proxied call — [HTTPRequestParams] and [ToolCallParams]. The host fills
+// every field, so the child may trust all of them.
+//
+// It is deliberately NOT the type on inbound reverse calls; those carry
+// [CallerRef], which has no Subject or Tenant to read. See CallerRef for why.
 type Caller struct {
 	// Subject is the resolved caller subject (user id, service id, …).
 	Subject string `json:"subject,omitempty"`
 	// Tenant is the resolved tenant id, if any.
 	Tenant string `json:"tenant,omitempty"`
-	// Delegation is the in-memory handle the host uses to re-attach the
-	// originating request's context to a reverse host.* call.
+	// Delegation is the handle the child echoes back on a reverse host.*
+	// call so the host can re-attach the originating request's context.
+	//
+	// It is a JSON field on the wire, not a shared-memory handle: it is
+	// minted in host memory but SENT to the child, so it is a bearer
+	// capability — unguessable, per-request, and invalidated when the
+	// originating request completes.
+	Delegation string `json:"delegation,omitempty"`
+}
+
+// CallerRef is the caller context on an INBOUND reverse call —
+// host.entity.*, host.search.query, host.event.emit. It carries the
+// delegation handle and nothing else.
+//
+// The child is the untrusted party here, and on the inbound direction it
+// writes this struct. A broker that read a child-supplied Subject or Tenant
+// and dispatched under it would be a confused deputy: a compromised module
+// could name any subject or tenant it liked and the host's own CRUD scoping
+// would honour it. Documenting "do not trust these fields" is not enough
+// while the fields sit right there on the decoded struct — so the inbound
+// type does not have them, and the broker has nothing to resolve a principal
+// from except Delegation.
+//
+// The child's own Subject/Tenant, for its logging and its own policy, are
+// the ones the host already sent it in the outbound [Caller]. It does not
+// need to send them back.
+type CallerRef struct {
+	// Delegation is the handle minted by the host for the originating
+	// request. It is the sole authority on this direction: the broker
+	// resolves the principal from it and from nothing else.
 	Delegation string `json:"delegation,omitempty"`
 }
 
@@ -293,7 +332,7 @@ type EntityQueryParams struct {
 	Sort   json.RawMessage `json:"sort,omitempty"`
 	Limit  int             `json:"limit,omitempty"`
 	Offset int             `json:"offset,omitempty"`
-	Caller Caller          `json:"caller"`
+	Caller CallerRef       `json:"caller"`
 }
 
 // EntityQueryResult is the result of host.entity.query.
@@ -311,7 +350,7 @@ type EntityMutationParams struct {
 	Payload json.RawMessage `json:"payload,omitempty"`
 	Filter  json.RawMessage `json:"filter,omitempty"`
 	IDs     []string        `json:"ids,omitempty"`
-	Caller  Caller          `json:"caller"`
+	Caller  CallerRef       `json:"caller"`
 }
 
 // EntityMutationResult reports what changed.
@@ -325,7 +364,7 @@ type SearchQueryParams struct {
 	Query  string          `json:"query"`
 	Filter json.RawMessage `json:"filter,omitempty"`
 	Limit  int             `json:"limit,omitempty"`
-	Caller Caller          `json:"caller"`
+	Caller CallerRef       `json:"caller"`
 }
 
 // SearchQueryResult is the result of host.search.query.
@@ -339,7 +378,7 @@ type SearchQueryResult struct {
 type EventEmitParams struct {
 	Topic   string          `json:"topic"`
 	Payload json.RawMessage `json:"payload"`
-	Caller  Caller          `json:"caller"`
+	Caller  CallerRef       `json:"caller"`
 }
 
 // EventEmitResult is the (currently empty) result of host.event.emit.

--- a/core/moduleproto/peer.go
+++ b/core/moduleproto/peer.go
@@ -92,8 +92,16 @@ type Peer struct {
 	inflight      int
 	serveInflight int
 	handlers      map[string]Handler
-	cancels       map[uint64]context.CancelFunc // inbound-request id → cancel
+	// cancels maps an inbound-request id to every handler currently serving
+	// it. A counterparty is free to reuse ids — nothing on the wire forbids
+	// it — so this cannot be a 1:1 map: keyed by id alone, a second request
+	// with the same id overwrote the first's entry, and then the FIRST
+	// handler's deferred delete removed the SECOND's, leaving a live handler
+	// that neither module.cancel nor Peer.Close could reach. Entries are
+	// removed by pointer identity, so each handler only ever retires its own.
+	cancels map[uint64][]*cancelSlot
 
+	started   atomic.Bool
 	closed    atomic.Bool
 	closeOnce sync.Once
 	closeCh   chan struct{} // closed once on Close(); unblocks in-flight Calls
@@ -124,6 +132,12 @@ func WithMaxInflight(n int) PeerOption {
 // spawn one handler goroutine per frame it writes. Overflow requests are
 // answered immediately with a [CodeInflightCap] error response — never
 // silently dropped (a drop would hang the caller) and never queued.
+//
+// The same cap bounds served NOTIFICATIONS, with the opposite overflow
+// policy: a notification is unacknowledged, so over-cap ones are dropped
+// (there is no response frame to write and no caller to hang).
+// [MethodCancel] is exempt — its built-in handler does no I/O, so it runs on
+// the read loop and a flood can never starve cancellation.
 func WithMaxServeInflight(n int) PeerOption {
 	return func(p *Peer) {
 		if n > 0 {
@@ -152,7 +166,7 @@ func NewPeer(codec *Codec, role Role, opts ...PeerOption) *Peer {
 		maxServeInflight: DefaultMaxInflight,
 		pending:          make(map[uint64]chan *Frame),
 		handlers:         make(map[string]Handler),
-		cancels:          make(map[uint64]context.CancelFunc),
+		cancels:          make(map[uint64][]*cancelSlot),
 		closeCh:          make(chan struct{}),
 		done:             make(chan struct{}),
 		fatalCh:          make(chan struct{}),
@@ -189,6 +203,9 @@ func (p *Peer) Handle(method string, h Handler) error {
 // Start launches the read loop. It panics if called twice (the read loop must
 // be single-threaded — see [Codec]).
 func (p *Peer) Start() {
+	if !p.started.CompareAndSwap(false, true) {
+		panic("moduleproto: Peer.Start called twice")
+	}
 	go p.readLoop()
 }
 
@@ -377,8 +394,10 @@ func (p *Peer) Close() error {
 	}
 	// Cancel any in-flight inbound handlers so they don't linger.
 	p.mu.Lock()
-	for id, cancel := range p.cancels {
-		cancel()
+	for id, slots := range p.cancels {
+		for _, slot := range slots {
+			slot.cancel()
+		}
 		delete(p.cancels, id)
 	}
 	p.mu.Unlock()
@@ -387,6 +406,30 @@ func (p *Peer) Close() error {
 	// observe the transport teardown.
 	close(p.closeCh)
 	return nil
+}
+
+// cancelSlot is one served request's cancel function, held by pointer so a
+// handler can retire its own registration by identity even when another
+// request shares its id.
+type cancelSlot struct{ cancel context.CancelFunc }
+
+// retireCancel removes exactly this slot from the id's list.
+func (p *Peer) retireCancel(id uint64, slot *cancelSlot) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	slots := p.cancels[id]
+	for i, s := range slots {
+		if s != slot {
+			continue
+		}
+		slots = append(slots[:i], slots[i+1:]...)
+		break
+	}
+	if len(slots) == 0 {
+		delete(p.cancels, id)
+		return
+	}
+	p.cancels[id] = slots
 }
 
 // ----- read loop -----
@@ -460,11 +503,46 @@ func (p *Peer) dispatch(f *Frame) {
 			}
 		}()
 	case f.Method != "" && f.ID == nil:
-		// Inbound NOTIFICATION. Dispatch in its own goroutine too —
-		// notifications should not block the read loop either. module.cancel
-		// is handled here via the built-in handler.
+		// Inbound NOTIFICATION. module.cancel runs INLINE: its built-in
+		// handler is a map lookup plus a cancel() with no I/O, so it cannot
+		// stall the read loop, and running it here means a flood can never
+		// starve cancellation of the slot it needs.
+		if f.Method == MethodCancel {
+			p.serveNotification(f)
+			return
+		}
+		// Everything else is dispatched in its own goroutine so a slow
+		// handler cannot stall the read loop — but under the SAME serve cap
+		// the request branch uses. Without it a flooding counterparty spawns
+		// one goroutine per frame it writes, which is precisely the threat
+		// WithMaxServeInflight documents; the request branch was bounded and
+		// this one was not. The lookup happens BEFORE the goroutine so a
+		// stream of frames naming unregistered methods costs nothing.
+		//
+		// Overflow is dropped, not queued and not answered: JSON-RPC
+		// notifications are unacknowledged, so there is no frame to write
+		// and no caller left hanging by the drop.
+		p.mu.Lock()
+		_, known := p.handlers[f.Method]
+		if !known {
+			p.mu.Unlock()
+			return
+		}
+		if p.serveInflight >= p.maxServeInflight {
+			p.mu.Unlock()
+			return
+		}
+		p.serveInflight++
+		p.mu.Unlock()
 		f := f
-		go p.serveNotification(f)
+		go func() {
+			defer func() {
+				p.mu.Lock()
+				p.serveInflight--
+				p.mu.Unlock()
+			}()
+			p.serveNotification(f)
+		}()
 	case f.Method == "" && f.ID != nil:
 		// Inbound RESPONSE. Deliver to our pending map. This is the ONLY
 		// branch that touches p.pending, and it only ever looks up ids WE
@@ -497,14 +575,11 @@ func (p *Peer) buildResponse(f *Frame) *Frame {
 	// can abort it and so Peer.Close cancels all in-flight handlers.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	slot := &cancelSlot{cancel: cancel}
 	p.mu.Lock()
-	p.cancels[id] = cancel
+	p.cancels[id] = append(p.cancels[id], slot)
 	p.mu.Unlock()
-	defer func() {
-		p.mu.Lock()
-		delete(p.cancels, id)
-		p.mu.Unlock()
-	}()
+	defer p.retireCancel(id, slot)
 
 	result, err := h(ctx, f.Params)
 	if err != nil {
@@ -631,10 +706,14 @@ func builtinCancelHandler(p *Peer) Handler {
 			return nil, nil
 		}
 		p.mu.Lock()
-		cancel, ok := p.cancels[id]
+		slots := append([]*cancelSlot(nil), p.cancels[id]...)
 		p.mu.Unlock()
-		if ok {
-			cancel()
+		// If the counterparty reused an id across concurrent requests it
+		// has told us only which id to abort, so abort every handler
+		// serving it. Cancelling too much is recoverable; leaving one
+		// uncancellable is not.
+		for _, slot := range slots {
+			slot.cancel()
 		}
 		return nil, nil
 	}

--- a/core/moduleproto/peer_security_test.go
+++ b/core/moduleproto/peer_security_test.go
@@ -1,0 +1,217 @@
+package moduleproto
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"reflect"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Property: a flooding or malformed counterparty cannot spawn unbounded
+// work, and cannot put a served request beyond the reach of cancellation.
+//
+// peer_test.go's TestServeSideInflightCap states the first half for the
+// REQUEST branch. The surfaces below are the same property at the places
+// that branch does not cover.
+
+// TestNotifyFloodBoundedByServeCap pins the serve cap on the NOTIFICATION
+// branch. dispatch used to `go p.serveNotification(f)` with no cap at all,
+// and it spawned BEFORE the handler lookup, so even a stream of frames
+// naming methods nobody registered cost one goroutine each — exactly the
+// threat WithMaxServeInflight's own doc describes.
+func TestNotifyFloodBoundedByServeCap(t *testing.T) {
+	connX, connY := net.Pipe()
+	codecX, _ := NewCodec(connX, connX, 0)
+	codecY, _ := NewCodec(connY, connY, 0)
+	served := NewPeer(codecX, RoleHost, WithMaxServeInflight(4))
+	flooder := NewPeer(codecY, RoleChild)
+	defer func() {
+		_ = served.Close()
+		_ = flooder.Close()
+		_ = connX.Close()
+		_ = connY.Close()
+	}()
+
+	release := make(chan struct{})
+	var running atomic.Int64
+	if err := served.Handle("block", func(ctx context.Context, _ json.RawMessage) (any, error) {
+		running.Add(1)
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		return nil, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	served.Start()
+	flooder.Start()
+
+	base := runtime.NumGoroutine()
+	// Four notifications may occupy the four serve slots.
+	for i := 0; i < 4; i++ {
+		if err := flooder.Notify(context.Background(), "block", nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	waitFor(t, func() bool { return running.Load() == 4 })
+
+	// Everything past the cap — registered method or not — must be dropped,
+	// not queued onto a fresh goroutine each.
+	for i := 0; i < 400; i++ {
+		if err := flooder.Notify(context.Background(), "block", nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := flooder.Notify(context.Background(), "no-such-method", nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	time.Sleep(150 * time.Millisecond)
+	if grew := runtime.NumGoroutine() - base; grew > 64 {
+		t.Errorf("800 over-cap notifications grew goroutines by %d; serve side is unbounded", grew)
+	}
+	close(release)
+}
+
+// TestDuplicateInboundIDsStayCancelable pins that two concurrently served
+// requests sharing one id are BOTH reachable by Close. The cancel registry
+// was keyed by id alone, so the second registration clobbered the first and
+// the first handler's deferred delete then removed the second — leaving a
+// live handler that neither module.cancel nor Peer.Close could reach.
+func TestDuplicateInboundIDsStayCancelable(t *testing.T) {
+	connX, connY := net.Pipe()
+	codecX, _ := NewCodec(connX, connX, 0)
+	served := NewPeer(codecX, RoleHost)
+	defer func() { _ = connX.Close(); _ = connY.Close() }()
+
+	entered := make(chan struct{}, 2)
+	cancelled := make(chan struct{}, 2)
+	if err := served.Handle("hang", func(ctx context.Context, _ json.RawMessage) (any, error) {
+		entered <- struct{}{}
+		<-ctx.Done()
+		cancelled <- struct{}{}
+		return nil, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	served.Start()
+
+	// Two requests, same id — a counterparty is free to reuse ids.
+	raw := NewCodecOnly(connY)
+	id := uint64(1)
+	for i := 0; i < 2; i++ {
+		idCopy := id
+		if err := raw.WriteFrame(&Frame{JSONRPC: "2.0", ID: &idCopy, Method: "hang"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case <-entered:
+		case <-time.After(2 * time.Second):
+			t.Fatal("handler did not start")
+		}
+	}
+
+	_ = served.Close()
+	for i := 0; i < 2; i++ {
+		select {
+		case <-cancelled:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d of 2 handlers were cancelled by Close", i)
+		}
+	}
+}
+
+// TestSecondStartPanics pins the documented contract on Peer.Start ("It
+// panics if called twice") that the implementation did not enforce. Two
+// read loops on one Codec violate the single-reader rule codec.go states.
+func TestSecondStartPanics(t *testing.T) {
+	connX, connY := net.Pipe()
+	codecX, _ := NewCodec(connX, connX, 0)
+	p := NewPeer(codecX, RoleHost)
+	defer func() {
+		_ = p.Close()
+		_ = connX.Close()
+		_ = connY.Close()
+	}()
+	p.Start()
+	defer func() {
+		if recover() == nil {
+			t.Error("second Start did not panic")
+		}
+	}()
+	p.Start()
+}
+
+// NewCodecOnly builds a raw codec on conn for tests that need to write
+// frames a well-behaved Peer would never emit.
+func NewCodecOnly(conn net.Conn) *Codec {
+	c, _ := NewCodec(conn, conn, 0)
+	return c
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met in time")
+}
+
+// The confused deputy this design has to rule out is a compromised child
+// naming someone else's subject on a reverse call and the host honouring it.
+// The defence is structural rather than documentary: the inbound param
+// structs carry CallerRef, which has no Subject or Tenant field, so a broker
+// cannot read one however carelessly it is written. This test fails if anyone
+// widens CallerRef or points an inbound struct back at Caller.
+func TestInboundCallerCarriesNoSubject(t *testing.T) {
+	t.Parallel()
+
+	// A hostile child writes subject/tenant onto every reverse call it can.
+	hostile := []byte(`{"entity":"articles","caller":{"subject":"admin",` +
+		`"tenant":"other-co","delegation":"h1"}}`)
+
+	var q EntityQueryParams
+	if err := json.Unmarshal(hostile, &q); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if q.Caller.Delegation != "h1" {
+		t.Fatalf("delegation must survive; got %q", q.Caller.Delegation)
+	}
+
+	// The decoded value must expose nothing but the handle. Checked by
+	// reflection so the test binds to the TYPE, not to one call site.
+	for _, ty := range []reflect.Type{
+		reflect.TypeOf(EntityQueryParams{}),
+		reflect.TypeOf(EntityMutationParams{}),
+		reflect.TypeOf(SearchQueryParams{}),
+		reflect.TypeOf(EventEmitParams{}),
+	} {
+		f, ok := ty.FieldByName("Caller")
+		if !ok {
+			t.Fatalf("SECURITY: [moduleproto] %s lost its Caller field", ty.Name())
+		}
+		if f.Type != reflect.TypeOf(CallerRef{}) {
+			t.Fatalf("SECURITY: [moduleproto] %s.Caller is %s, want CallerRef. "+
+				"An inbound reverse call must not carry a child-supplied Subject "+
+				"or Tenant — the broker derives authority from Delegation alone.",
+				ty.Name(), f.Type)
+		}
+		for _, bad := range []string{"Subject", "Tenant"} {
+			if _, found := f.Type.FieldByName(bad); found {
+				t.Fatalf("SECURITY: [moduleproto] CallerRef grew a %s field. "+
+					"That is the confused-deputy shape this type exists to "+
+					"make unrepresentable.", bad)
+			}
+		}
+	}
+}

--- a/core/router/router.go
+++ b/core/router/router.go
@@ -29,15 +29,28 @@ type Middleware = middleware.Middleware
 // plugins / batteries / OnStart hooks contribute middleware while
 // requests are already flowing.
 type Router struct {
-	mux              *http.ServeMux
-	prefix           string
-	notFound         http.Handler
-	methodNotAllowed http.Handler
-	parent           *Router
+	mux    *http.ServeMux
+	prefix string
+	parent *Router
 
 	mu          sync.RWMutex
 	middlewares []Middleware
 	patterns    []RegisteredRoute // populated by Handle for introspection
+
+	// notFound / methodNotAllowed are read on the request path by
+	// effectiveNotFound / effectiveMethodNotAllowed and written by the
+	// NotFound / MethodNotAllowed setters, which the package doc says
+	// may run from OnStart while requests are already flowing. Both
+	// sides go through mu.
+	notFound         http.Handler
+	methodNotAllowed http.Handler
+
+	// probe* memoise the cold-path 404/405 mux. Guarded by probeMu, not
+	// mu, so a rebuild never blocks route registration. See probe().
+	probeMu      sync.Mutex
+	probeMux     *http.ServeMux
+	probeMethods map[string][]string
+	probeN       int
 
 	// root is the topmost ancestor; chainVersion lives there. Any Use
 	// anywhere in the tree bumps root.chainVersion atomically, which
@@ -176,19 +189,46 @@ func (r *Router) Patch(pattern string, handler http.Handler) {
 // Param extracts a single path parameter by name from the request.
 // It uses the Go 1.22+ r.PathValue() method.
 //
-// SECURITY: the returned value is truncated at the first CR, LF, or
-// NUL byte so a path-parameter payload can't be smuggled into
-// downstream headers, log lines, SSE frames, or query strings.
+// SECURITY: the returned value is truncated at the first byte that
+// could not have arrived through normal path routing:
+//
+//   - CR, LF or NUL — so a payload can't be smuggled into downstream
+//     headers, log lines, SSE frames, or query strings.
+//   - "/" in a single-segment {name} — the mux matches one segment, so
+//     a separator can only have arrived percent-encoded as %2F.
+//   - a ".." path segment, in single-segment AND catch-all {name...}
+//     form — the mux cleans dot segments out of the request path and
+//     redirects, so a ".." that survives into a value likewise only
+//     arrives %2E-encoded.
+//
+// A catch-all {name...} still spans segments: "a/b/c" is returned
+// intact. That's the one form allowed to contain "/".
+//
+// This bounds — but does not replace — validation at the sink. A value
+// that is safe as a header byte-string is not automatically safe as a
+// filesystem path, an object-store key, or a map lookup; sinks still
+// own their own allow-listing.
 func Param(r *http.Request, name string) string {
-	return sanitizeParam(r.PathValue(name))
+	return sanitizePathParam(r.PathValue(name), isCatchAll(r.Pattern, name))
+}
+
+// isCatchAll reports whether pattern declares name as a {name...}
+// multi-segment wildcard rather than a single-segment {name}.
+func isCatchAll(pattern, name string) bool {
+	return pattern != "" && strings.Contains(pattern, "{"+name+"...}")
 }
 
 // Params extracts all path parameters from the request.
 // It scans the registered pattern for {name} placeholders and extracts
 // each value using r.PathValue().
 //
-// SECURITY: every value is truncated at the first CR / LF / NUL byte
-// — see [Param].
+// SECURITY: every value is sanitized exactly as [Param] does.
+//
+// Every parameter the pattern declares is present in the map, even when
+// its value sanitizes down to "". Omitting a scrubbed key made callers
+// written as `if _, ok := p["id"]; !ok { ...treat as collection... }`
+// fail OPEN: a scrubbed single-item request took the collection branch.
+// Presence now means "declared", and the caller checks the value.
 func Params(r *http.Request) map[string]string {
 	pattern := r.Pattern
 	if pattern == "" {
@@ -209,31 +249,53 @@ func Params(r *http.Request) map[string]string {
 			// map exposes the param under its plain name — otherwise a
 			// catch-all value is silently dropped and callers driving
 			// auth/path logic off Params() fail open.
+			catchAll := strings.HasSuffix(name, "...")
 			name = strings.TrimSuffix(name, "...")
 			if name == "$" {
 				i += end
 				continue
 			}
-			val := sanitizeParam(r.PathValue(name))
-			if val != "" {
-				params[name] = val
-			}
+			params[name] = sanitizePathParam(r.PathValue(name), catchAll)
 			i += end
 		}
 	}
 	return params
 }
 
-// sanitizeParam truncates s at the first CR, LF, or NUL byte so a
-// path-parameter value cannot be used to inject header lines, log
-// lines, SSE frames, or any other line-delimited downstream protocol.
-func sanitizeParam(s string) string {
+// sanitizePathParam truncates s at the first byte a path parameter must
+// never carry. See [Param] for the full contract.
+//
+// catchAll relaxes the "/" rule only — a {name...} wildcard is defined
+// to span segments. The dot-segment rule applies to both forms: Go's
+// mux resolves "." and ".." out of the request path (redirecting when
+// it must), so a surviving ".." segment is always percent-encoded
+// smuggling, never a legitimate route match.
+func sanitizePathParam(s string, catchAll bool) string {
 	for i := 0; i < len(s); i++ {
-		if c := s[i]; c == '\n' || c == '\r' || c == 0 {
+		switch c := s[i]; {
+		case c == '\n' || c == '\r' || c == 0:
+			return s[:i]
+		case c == '/' && !catchAll:
+			return s[:i]
+		case c == '.' && isDotDotSegment(s, i):
 			return s[:i]
 		}
 	}
 	return s
+}
+
+// isDotDotSegment reports whether a ".." path segment starts at i —
+// that is, s[i:i+2] == ".." and it is bounded by "/" or the ends of the
+// string on both sides. "..." and "a..b" are ordinary characters and
+// are left alone.
+func isDotDotSegment(s string, i int) bool {
+	if i+2 > len(s) || s[i+1] != '.' {
+		return false
+	}
+	if i > 0 && s[i-1] != '/' {
+		return false
+	}
+	return i+2 == len(s) || s[i+2] == '/'
 }
 
 // Routes returns the set of (method, pattern) pairs registered via
@@ -365,8 +427,11 @@ func (r *Router) Group(prefix string, mw ...Middleware) *Router {
 // a sub-router served standalone falls back to the parent's NotFound
 // even when set after Group.
 func (r *Router) effectiveNotFound() http.Handler {
-	if r.notFound != nil {
-		return r.notFound
+	r.mu.RLock()
+	own := r.notFound
+	r.mu.RUnlock()
+	if own != nil {
+		return own
 	}
 	if r.parent != nil {
 		return r.parent.effectiveNotFound()
@@ -382,7 +447,10 @@ func (r *Router) effectiveNotFound() http.Handler {
 // Internally wrapped in a cachedRoute so the chain composition is
 // memoised between Use bumps.
 func (r *Router) NotFound(handler http.Handler) {
-	r.notFound = &cachedRoute{raw: handler, router: r}
+	route := &cachedRoute{raw: handler, router: r}
+	r.mu.Lock()
+	r.notFound = route
+	r.mu.Unlock()
 }
 
 // effectiveMethodNotAllowed returns the nearest non-nil
@@ -390,8 +458,11 @@ func (r *Router) NotFound(handler http.Handler) {
 // → ...). Mirrors effectiveNotFound so a sub-router served standalone
 // falls back to the parent's handler even when set after Group.
 func (r *Router) effectiveMethodNotAllowed() http.Handler {
-	if r.methodNotAllowed != nil {
-		return r.methodNotAllowed
+	r.mu.RLock()
+	own := r.methodNotAllowed
+	r.mu.RUnlock()
+	if own != nil {
+		return own
 	}
 	if r.parent != nil {
 		return r.parent.effectiveMethodNotAllowed()
@@ -410,7 +481,10 @@ func (r *Router) effectiveMethodNotAllowed() http.Handler {
 // MethodNotAllowed still applies. Mirrors [NotFound] exactly, including
 // the cachedRoute memoisation.
 func (r *Router) MethodNotAllowed(handler http.Handler) {
-	r.methodNotAllowed = &cachedRoute{raw: handler, router: r}
+	route := &cachedRoute{raw: handler, router: r}
+	r.mu.Lock()
+	r.methodNotAllowed = route
+	r.mu.Unlock()
 }
 
 // NOTE: Go 1.22+ ServeMux handles 405 Method Not Allowed responses
@@ -425,9 +499,38 @@ func (r *Router) MethodNotAllowed(handler http.Handler) {
 // otherwise it falls through to the custom NotFound handler (if any)
 // or the mux's native 404.
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	_, pattern := r.mux.Handler(req)
+	h, pattern := r.mux.Handler(req)
 
-	if pattern == "" {
+	if pattern != "" {
+		if _, matched := h.(*cachedRoute); matched {
+			r.mux.ServeHTTP(w, req)
+			return
+		}
+		// A non-empty pattern with a handler that ISN'T one of our routes
+		// means net/http synthesised an internal redirect: trailing-slash
+		// completion ("/a" → "/a/"), or path cleaning ("//a", "/a/./b",
+		// "/a/../b"). Serving that straight out of the mux skips BOTH the
+		// route gate and the entire middleware chain, which the 404 and
+		// 405 branches below both honour. Two consequences, both real:
+		//
+		//   - The gate's documented contract is "returning false produces
+		//     a plain 404 — a disabled module's existence must not leak".
+		//     A 307 here is exactly that leak, and Go's redirect preserves
+		//     method and body, so it answers POSTs too.
+		//   - No security headers, recovery, timeout, request-ID/logging,
+		//     CORS or rate limiting run on the response.
+		//
+		// So: gate the redirect on its target route's key, and when it
+		// survives, run it through the chain like any other response.
+		if r.gateAllows(pattern) {
+			r.wrap(h).ServeHTTP(w, req)
+			return
+		}
+		// Gated target — fall through to the unmatched path so the reply
+		// is byte-identical to a genuine 404.
+	}
+
+	{
 		// ServeMux returns an empty pattern for BOTH a genuine 404 and a
 		// method mismatch (405). allowedMethods resolves the path against
 		// non-gated routes only: a non-empty set means the path exists
@@ -469,8 +572,15 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		})).ServeHTTP(w, req)
 		return
 	}
+}
 
-	r.mux.ServeHTTP(w, req)
+// gateAllows reports whether the route gate permits the given
+// "METHOD /path" key. No gate installed = allow.
+func (r *Router) gateAllows(key string) bool {
+	r.root.mu.RLock()
+	gate := r.root.routeGate
+	r.root.mu.RUnlock()
+	return gate == nil || gate(key)
 }
 
 // allowedMethods returns the set of HTTP methods registered for the
@@ -483,28 +593,70 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // This runs only on the cold 404/405 fallback path, never on a matched
 // route, so the per-call mux build is not on the request hot path.
 func (r *Router) allowedMethods(req *http.Request) []string {
-	r.root.mu.RLock()
-	allPatterns := make([]RegisteredRoute, len(r.root.patterns))
-	copy(allPatterns, r.root.patterns)
-	gate := r.root.routeGate
-	r.root.mu.RUnlock()
-	if len(allPatterns) == 0 {
+	probeMux, methodsByPath := r.probe()
+	if probeMux == nil {
 		return nil
 	}
 
-	// Build a method-agnostic probe mux from non-gated patterns only,
-	// and track which methods each path pattern has.
+	probe := req.Clone(req.Context())
+	probe.Method = http.MethodGet
+	_, matchedPattern := probeMux.Handler(probe)
+	if matchedPattern == "" {
+		return nil // path doesn't match any registered route
+	}
+
+	// Gate-filter only the handful of methods on the matched pattern —
+	// NOT every route in the table. An empty result means the path
+	// exists but every method on it is gated off, which is a 404 by
+	// design (advertising Allow for a method that answers 404 would be
+	// a lie, and would leak the disabled module).
+	var methods []string
+	for _, m := range methodsByPath[matchedPattern] {
+		if r.gateAllows(m + " " + matchedPattern) {
+			methods = append(methods, m)
+		}
+	}
+	sort.Strings(methods)
+	return methods
+}
+
+// probe returns the memoised method-agnostic probe mux and its
+// pattern→methods index, rebuilding only when new routes have been
+// registered since the last build.
+//
+// This used to be rebuilt from scratch on EVERY unmatched request —
+// cloning the request and re-parsing plus tree-inserting every
+// registered pattern. Against 300 routes that measured ~205us and 3704
+// allocations versus 170ns for a matched request: a ~1200x
+// amplification driven entirely by an attacker-supplied URL, and it ran
+// AHEAD of the rate limiter (which lives in the middleware chain the
+// fallback only enters afterwards). r.root.patterns is append-only, so
+// its length is a sufficient cache version.
+func (r *Router) probe() (*http.ServeMux, map[string][]string) {
+	root := r.root
+	root.probeMu.Lock()
+	defer root.probeMu.Unlock()
+
+	root.mu.RLock()
+	n := len(root.patterns)
+	r.root.mu.RUnlock()
+	if n == 0 {
+		return nil, nil
+	}
+	if root.probeMux != nil && root.probeN == n {
+		return root.probeMux, root.probeMethods
+	}
+
+	root.mu.RLock()
+	allPatterns := make([]RegisteredRoute, n)
+	copy(allPatterns, root.patterns[:n])
+	root.mu.RUnlock()
+
 	probeMux := http.NewServeMux()
 	noop := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
 	methodsByPath := make(map[string][]string)
 	registered := make(map[string]bool)
 	for _, rt := range allPatterns {
-		if gate != nil {
-			key := rt.Method + " " + rt.Pattern
-			if !gate(key) {
-				continue // gated route excluded from Allow set
-			}
-		}
 		methodsByPath[rt.Pattern] = append(methodsByPath[rt.Pattern], rt.Method)
 		if !registered[rt.Pattern] {
 			registered[rt.Pattern] = true
@@ -515,16 +667,10 @@ func (r *Router) allowedMethods(req *http.Request) []string {
 		}
 	}
 
-	probe := req.Clone(req.Context())
-	probe.Method = http.MethodGet
-	_, matchedPattern := probeMux.Handler(probe)
-	if matchedPattern == "" {
-		return nil // path doesn't match any non-gated route
-	}
-
-	methods := methodsByPath[matchedPattern]
-	sort.Strings(methods)
-	return methods
+	root.probeMux = probeMux
+	root.probeMethods = methodsByPath
+	root.probeN = n
+	return probeMux, methodsByPath
 }
 
 // Use adds middleware to the router. Middleware is applied in the order

--- a/core/router/router_security_test.go
+++ b/core/router/router_security_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -271,5 +272,188 @@ func TestRouter_CustomNotFoundKeeps405(t *testing.T) {
 	r.ServeHTTP(rr, req)
 	if rr.Code != http.StatusNotFound || !strings.Contains(rr.Body.String(), "nf") {
 		t.Fatalf("[router] genuine 404 did not reach custom NotFound, got code=%d body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+// --- internal-redirect responses ------------------------------------------
+//
+// Property: a response the mux synthesises itself (trailing-slash
+// completion, "//" collapse, "/./" and "/../" cleaning) is still a
+// response from this router, so it must be subject to the SAME route
+// gate and the SAME middleware chain as a matched route. Before this
+// was pinned, net/http's RedirectHandler was served directly out of
+// ServeHTTP, which skipped the gate (turning the documented "plain
+// 404, existence must not leak" contract into a 307-vs-404 oracle)
+// and skipped every middleware — security headers, recovery, request
+// logging, CORS and rate limiting. Same class as CVE-2026-15704
+// (Eclipse BaSyx) and CVE-2026-33808 (@fastify/express).
+
+// redirectingPaths are the four ways net/http's mux synthesises a
+// redirect to the same canonical target.
+func redirectingPaths() []string {
+	return []string{"/admin/panel", "//admin/panel/", "/admin/./panel/", "/x/../admin/panel/"}
+}
+
+func TestRedirectRunsMiddlewareChain(t *testing.T) {
+	r := New()
+	var ran int
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ran++
+			w.Header().Set("X-Sec", "on")
+			next.ServeHTTP(w, req)
+		})
+	})
+	r.Get("/admin/panel/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {}))
+
+	for _, p := range redirectingPaths() {
+		ran = 0
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, p, nil))
+		if ran == 0 || rr.Header().Get("X-Sec") != "on" {
+			t.Errorf("SECURITY: [router] %s bypassed the middleware chain (code=%d ran=%d). "+
+				"Attack: unauthenticated request served with no security headers, "+
+				"logging, recovery or rate limiting.", p, rr.Code, ran)
+		}
+	}
+}
+
+func TestRedirectToGatedRouteIs404(t *testing.T) {
+	r := New()
+	r.SetRouteGate(func(string) bool { return false })
+	r.Get("/admin/panel/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {}))
+	r.Post("/admin/wipe/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {}))
+
+	// Baseline: the canonical path on a fully gated router is a plain 404.
+	base := httptest.NewRecorder()
+	r.ServeHTTP(base, httptest.NewRequest(http.MethodGet, "/admin/panel/", nil))
+	if base.Code != http.StatusNotFound {
+		t.Fatalf("[router] gated canonical path returned %d, want 404", base.Code)
+	}
+
+	for _, p := range redirectingPaths() {
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, p, nil))
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("SECURITY: [router] gated %s answered %d (Location=%q) instead of 404. "+
+				"Attack: unauthenticated redirect-vs-404 oracle enumerates every "+
+				"gated subtree, contradicting SetRouteGate's documented contract.",
+				p, rr.Code, rr.Header().Get("Location"))
+		}
+	}
+
+	// 307 preserves method AND body, so the POST shape is the sharp one.
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/admin/wipe", strings.NewReader("x=1")))
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("SECURITY: [router] gated POST /admin/wipe answered %d (Location=%q), want 404. "+
+			"Attack: method+body-preserving 307 confirms a disabled module's route exists.",
+			rr.Code, rr.Header().Get("Location"))
+	}
+}
+
+func TestRedirectStillRedirectsWhenLive(t *testing.T) {
+	// Keep the useful half of the behaviour: an ungated trailing-slash
+	// completion must still redirect, not 404.
+	r := New()
+	r.Get("/admin/panel/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {}))
+	for _, p := range redirectingPaths() {
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, p, nil))
+		if rr.Code < 300 || rr.Code >= 400 {
+			t.Errorf("[router] ungated %s returned %d, want a redirect", p, rr.Code)
+		}
+		if loc := rr.Header().Get("Location"); loc != "/admin/panel/" {
+			t.Errorf("[router] %s redirected to %q, want /admin/panel/", p, loc)
+		}
+	}
+}
+
+// TestUnmatchedPathWorkIsBounded pins that the 404/405 fallback does not
+// do work proportional to the route table on every unmatched request.
+// It used to clone the request and rebuild an entire http.ServeMux —
+// parsing and tree-inserting every registered pattern — which measured
+// ~1200x a matched request (205us / 3704 allocs against 300 routes) on
+// a fully attacker-controlled URL, ahead of the rate limiter.
+func TestUnmatchedPathWorkIsBounded(t *testing.T) {
+	r := New()
+	const routes = 300
+	for i := 0; i < routes; i++ {
+		r.Get(fmt.Sprintf("/route%d/{id}", i), http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	}
+	miss := httptest.NewRequest(http.MethodGet, "/nope", nil)
+	got := testing.AllocsPerRun(50, func() {
+		r.ServeHTTP(httptest.NewRecorder(), miss)
+	})
+	// A constant-work fallback allocates on the order of tens; a rebuild
+	// allocates on the order of the route count.
+	if got > routes {
+		t.Errorf("SECURITY: [router] unmatched request allocated %.0f objects against %d routes. "+
+			"Attack: unauthenticated request amplifies into route-table-proportional "+
+			"work ahead of the rate limiter.", got, routes)
+	}
+}
+
+// --- path-parameter canonicalisation --------------------------------------
+//
+// Property: a path parameter never carries a byte sequence that Go's own
+// mux would have refused to route. The mux cleans dot-segments and
+// collapses slashes in the REQUEST path (redirecting when it has to), so
+// a "/" inside a single-segment {name}, or a ".." segment in either
+// form, can only have arrived percent-encoded — i.e. deliberately
+// smuggled past segment matching. Surfaces: single-segment {name},
+// catch-all {name...}, via Param and via Params.
+
+func TestParamRejectsEncodedSlash(t *testing.T) {
+	r := New()
+	var one, rest string
+	r.Get("/f/{name}", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		one = Param(req, "name")
+	}))
+	r.Get("/g/{rest...}", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		rest = Param(req, "rest")
+	}))
+
+	r.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodGet, "/f/%2e%2e%2f%2e%2e%2fetc%2fpasswd", nil))
+	if strings.Contains(one, "/") {
+		t.Errorf("SECURITY: [router] single-segment Param returned %q containing a path separator. "+
+			"Attack: %%2F-smuggled traversal reaches file/proxy/key sinks that trust Param.", one)
+	}
+
+	r.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodGet, "/g/a/%2e%2e/%2e%2e/etc/passwd", nil))
+	if strings.Contains(rest, "..") {
+		t.Errorf("SECURITY: [router] catch-all Param returned %q containing a dot segment. "+
+			"Attack: %%2E-smuggled traversal escapes the catch-all's intended subtree.", rest)
+	}
+
+	// The legitimate catch-all contract survives: multi-segment values
+	// still span segments (see TestRouter_ParamsCatchAll).
+	rest = ""
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/g/a/b/c", nil))
+	if rest != "a/b/c" {
+		t.Errorf("[router] catch-all lost its multi-segment value, got %q want a/b/c", rest)
+	}
+}
+
+// TestParamsKeepsDeclaredKeys pins that Params exposes every parameter
+// the matched pattern declares, even when the value scrubs down to
+// empty. Callers gate on `if _, ok := p["id"]; !ok { ...collection... }`,
+// so a silently-absent key sends a scrubbed single-item request down the
+// collection branch instead of rejecting it.
+func TestParamsKeepsDeclaredKeys(t *testing.T) {
+	r := New()
+	var got map[string]string
+	r.Get("/users/{id}", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		got = Params(req)
+	}))
+	for _, u := range []string{"/users/%0Aadmin", "/users/%00", "/users/%2fadmin"} {
+		got = nil
+		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, u, nil))
+		if _, ok := got["id"]; !ok {
+			t.Errorf("SECURITY: [router] Params(%s) omitted the declared {id} key entirely (got %#v). "+
+				"Attack: callers keyed on presence fail open into the collection branch.", u, got)
+		}
 	}
 }

--- a/examples/processmodule-demo/main.go
+++ b/examples/processmodule-demo/main.go
@@ -267,13 +267,17 @@ func registerHandlers(peer *moduleproto.Peer) error {
 }
 
 // reverseQuery issues a host.entity.query for the configured entity, echoing
-// the caller block so the host re-attaches the originating end-user's context
-// to the CRUD re-dispatch. A broker denial returns as a per-call error.
+// back the delegation handle so the host re-attaches the originating end-user's
+// context to the CRUD re-dispatch. A broker denial returns as a per-call error.
+//
+// Only the handle goes back. The subject and tenant the host sent us are ours
+// to log and reason about; the host derives authority from the handle alone,
+// which is why the reverse call takes a [moduleproto.CallerRef].
 func reverseQuery(ctx context.Context, peer *moduleproto.Peer, caller moduleproto.Caller) (json.RawMessage, int, error) {
 	qp := moduleproto.EntityQueryParams{
 		Entity: cfg.queryEntity,
 		Limit:  100,
-		Caller: caller,
+		Caller: moduleproto.CallerRef{Delegation: caller.Delegation},
 	}
 	raw, err := peer.Call(ctx, moduleproto.MethodHostEntityQuery, qp)
 	if err != nil {

--- a/framework/agentsinv/inventory.go
+++ b/framework/agentsinv/inventory.go
@@ -17,7 +17,6 @@ package agentsinv
 import (
 	"sort"
 	"sync"
-	"testing"
 )
 
 // Kind discriminates framework-root helpers from individual batteries.
@@ -102,10 +101,19 @@ func All() []Entry {
 	return out
 }
 
-// Reset clears the registry. The *testing.T parameter is a discipline
-// marker — production code can technically pass nil since `testing`
-// is in stdlib, so this is convention, not enforcement.
-func Reset(_ *testing.T) {
+// TestingT is the discipline marker [Reset] takes. *testing.T satisfies it,
+// so `agentsinv.Reset(t)` compiles unchanged.
+//
+// It is an interface rather than *testing.T so this package does not import
+// `testing`. agentsinv is imported by the gofastr CLI and by every host app
+// that pulls in a battery, and an import of `testing` from a non-test file
+// links the whole testing/flag/pprof/regexp tree into those binaries.
+type TestingT interface{ Helper() }
+
+// Reset clears the registry. The TestingT parameter is a discipline marker —
+// production code can technically pass any Helper()er, so this is
+// convention, not enforcement.
+func Reset(_ TestingT) {
 	mu.Lock()
 	entries = entries[:0]
 	missing = missing[:0]

--- a/framework/docs/content/api-versioning.md
+++ b/framework/docs/content/api-versioning.md
@@ -304,6 +304,15 @@ stays in the shared table, just hidden from that version's wire output).
 changing the DB column name. Both versions read and write the same
 underlying table; the projection is purely a wire-level concern.
 
+A `Rename` target must not collide with the wire key another column
+already claims, or the entity is refused at `Define` time. Note that the
+key a bare column claims is its **case-converted** name — `author_id`
+claims `authorId` under the default camelCase — so renaming a field to
+`authorId` alongside an `author_id` column is a collision even though the
+column names differ. Two fields sharing one wire key would split reads
+from writes silently: a body posted under that key lands on whichever
+column the handler cached first, while filters resolve it independently.
+
 ---
 
 ## Choosing an approach

--- a/framework/docs/content/hooks-and-transactions.md
+++ b/framework/docs/content/hooks-and-transactions.md
@@ -288,6 +288,13 @@ Available helpers for write operations:
 - `OnBeforeUpdate[T]`, `OnAfterUpdate[T]`
 - `OnBeforeDelete`, `OnAfterDelete` (ID is a string, no generic needed)
 
+`OnBeforeCreate[T]`/`OnBeforeUpdate[T]` mutations flow into the pending
+INSERT/UPDATE body. `OnAfterCreate[T]`/`OnAfterUpdate[T]` mutations cannot
+change the stored row (Create/Update has already committed it) but DO redact
+the response body — the hook payload is the live record the crud layer
+serialises, so `p.Secret = ""` masks it from the caller just like the untyped
+path. See "Redaction implication" below for the surfaces this covers.
+
 ### Typed List and Get hooks
 
 `OnBeforeList` and `OnAfterList` work like their untyped counterparts
@@ -414,8 +421,11 @@ does).
   (e.g. subscribe to the event bus from `EventStream`).
 - **Long-running work inside a hook.** Hooks hold the transaction
   open. Push slow side effects onto a queue and ack quickly.
-- **Mutating `data` in an `AfterCreate` hook expecting the response
-  to change.** The HTTP response is serialised from the post-write
-  record; modifying the map in the hook does flow back to the
-  response, but this is undocumented and may change — prefer
-  computing the value before write or via a `BeforeCreate` hook.
+- **Mutating `data` in an `AfterCreate`/`AfterUpdate` hook changes the
+  response, not the row.** The post-write record IS the response body, so
+  clearing a field there redacts it from what the caller reads — this is the
+  supported way to mask a create/update response, and it behaves identically
+  for typed hooks (`OnAfterCreate[T]`/`OnAfterUpdate[T]`) and untyped ones.
+  Create/Update have already committed the row, though, so the mutation cannot
+  change what is stored; if you need to alter the stored value, do it in a
+  `BeforeCreate`/`BeforeUpdate` hook before the INSERT/UPDATE runs.

--- a/framework/docs/content/uploads.md
+++ b/framework/docs/content/uploads.md
@@ -303,10 +303,25 @@ Uploads are bounded and content-checked before anything is stored:
   multipart parser buffers at most `crud.MaxMultipartMemory` (32 MiB) in
   memory before spilling to a temp file. An oversize body returns
   `file.ErrFileFieldTooLarge` without reading past the limit.
-- **Content shape** is sniffed from the bytes — never the filename or the
-  client's `Content-Type`, both of which an attacker controls. SVG/XML,
-  HTML, and executable magic bytes (PE, ELF, Mach-O) are rejected with
-  `file.ErrFileFieldUnsafeContent`.
+- **Content shape** is checked from the bytes — never the filename or the
+  client's `Content-Type`, both of which an attacker controls. Executable
+  magic bytes (PE, ELF, Mach-O) are rejected outright. Active-content
+  markup is scanned in two tiers: hard tokens (`<script`, `<svg`,
+  `<iframe`, `<html`, `<!doctype`, `<object`, `<embed`, `<base`) are
+  matched anywhere in the body, so they are caught even when buried past
+  the leading bytes; soft tokens (`<img`, `<?xml`, `<style`, `<link`,
+  `javascript:`) are matched only in the leading 512 bytes and skipped for
+  confirmed binary types, which legitimately carry them in metadata. A
+  rejection returns `file.ErrFileFieldUnsafeContent`.
+- **Metadata shape** is enforced by `FileField.Validate` for callers that
+  accept a `FileField` from a request body. Beyond the scheme and `..`
+  checks on `URL` and `StorageRef`, `Filename` is held to the same
+  traversal rule, and a C0 control byte or DEL anywhere in `URL`,
+  `Filename`, or `StorageRef` returns `file.ErrFileFieldControlBytes` —
+  those fields are echoed into `Content-Disposition`, HTML attributes,
+  and log lines, each of which a CR/LF splits. `ProcessFileField` strips
+  control bytes from the multipart filename, so the metadata it returns
+  always passes its own `Validate`.
 - **Required** is enforced from the field declaration, like any other
   field.
 

--- a/framework/entity/entity.go
+++ b/framework/entity/entity.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/core/mcp"
 	"github.com/DonaldMurillo/gofastr/core/query"
 	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/internal/casing"
 )
 
 // EntityConfig holds the declarative configuration for an entity.
@@ -653,16 +654,31 @@ func (e *Entity) Validate() error {
 		// Hidden fields are included deliberately: they are excluded from
 		// responses but still resolve on write and filter paths, so letting a
 		// visible field alias a hidden column would be worse, not harmless.
-		wk := f.WireName
-		if wk == "" {
-			wk = f.Name
+		//
+		// A bare column does not claim its literal name on the wire — it
+		// claims the CASE-CONVERTED form (crud.wireKeyOfField), camelCase by
+		// default. Validate cannot read JSONCase, which App assigns after
+		// registration, so a bare column claims BOTH spellings and a clash
+		// under either one is refused. Comparing only the literal name let
+		// `author_id` and `WireName: "authorId"` through, which is the same
+		// silent read/write split this guard exists to stop.
+		claims := []string{f.WireName}
+		if f.WireName == "" {
+			claims = []string{f.Name}
+			if camel := casing.ToCamel(f.Name); camel != f.Name {
+				claims = append(claims, camel)
+			}
 		}
-		if owner, clash := wireKeys[wk]; clash {
-			return fmt.Errorf(
-				"entity %q: fields %q and %q both resolve to wire key %q — a wire key addresses exactly one column; change one field's WireName",
-				e.Config.Name, owner, f.Name, wk)
+		for _, wk := range claims {
+			if owner, clash := wireKeys[wk]; clash {
+				return fmt.Errorf(
+					"entity %q: fields %q and %q both resolve to wire key %q — a wire key addresses exactly one column; change one field's WireName",
+					e.Config.Name, owner, f.Name, wk)
+			}
 		}
-		wireKeys[wk] = f.Name
+		for _, wk := range claims {
+			wireKeys[wk] = f.Name
+		}
 
 		if f.Type == schema.Relation && f.To == "" {
 			return fmt.Errorf("entity %q: relation field %q must specify To", e.Config.Name, f.Name)

--- a/framework/entity/wirename_collision_test.go
+++ b/framework/entity/wirename_collision_test.go
@@ -48,6 +48,19 @@ func TestValidate_RejectsWireKeyCollision(t *testing.T) {
 			},
 			want: "secret",
 		},
+		{
+			// The wire key a bare column actually gets is the CASE-CONVERTED
+			// name — camelCase by default — not the literal column name. A
+			// WireName matching that converted form collides at runtime while
+			// the literal names differ, which is exactly the silent read/write
+			// split this guard exists to stop.
+			name: "WireName collides with a column's camelCase form",
+			fields: []schema.Field{
+				{Name: "author_id", Type: schema.String},
+				{Name: "shadow", Type: schema.String, WireName: "authorId"},
+			},
+			want: "authorId",
+		},
 	}
 
 	for _, tc := range cases {

--- a/framework/file/filefield.go
+++ b/framework/file/filefield.go
@@ -26,6 +26,7 @@ var (
 	ErrFileFieldOversize      = errors.New("filefield: field exceeds length limit")
 	ErrFileFieldTooLarge      = errors.New("filefield: file exceeds maximum size")
 	ErrFileFieldUnsafeContent = errors.New("filefield: file content is unsafe by default")
+	ErrFileFieldControlBytes  = errors.New("filefield: field contains control bytes")
 )
 
 // MaxFileFieldStringBytes caps the length of any FileField string field
@@ -71,8 +72,13 @@ type FileField struct {
 // Rejected inputs:
 //   - URL with javascript:, vbscript:, or data: scheme — would XSS when
 //     rendered as href/src by a downstream consumer.
-//   - URL or StorageRef containing `..` segments — would escape the
-//     storage root on a vulnerable filesystem backend.
+//   - URL, StorageRef, or Filename containing `..` segments — would
+//     escape the storage root on a vulnerable filesystem backend, and
+//     Filename reaches `Content-Disposition: attachment; filename=…`.
+//   - Any C0 control byte or DEL in URL, Filename, or StorageRef. These
+//     are persisted and later echoed into a response header, an HTML
+//     attribute, or a log line, each of which a CR/LF splits. MimeType
+//     is covered by its charset filter, which admits no control byte.
 //   - MimeType containing characters outside the MIME-safe set —
 //     normal MIME types are `type/subtype` with letters, digits,
 //     `+`, `-`, `.`; angle brackets / quotes indicate an XSS attempt.
@@ -103,6 +109,21 @@ func (f *FileField) Validate() error {
 	}
 	if hasTraversal(f.StorageRef) {
 		return fmt.Errorf("%w: storage_ref %q", ErrFileFieldTraversal, f.StorageRef)
+	}
+	if hasTraversal(f.Filename) {
+		return fmt.Errorf("%w: filename %q", ErrFileFieldTraversal, f.Filename)
+	}
+	// Checked after the scheme guard so a control byte smuggled into a
+	// javascript: URL still reports as ErrFileFieldURLScheme — that is the
+	// actionable diagnosis, and TestFileField_RejectsJavaScriptScheme pins it.
+	for name, v := range map[string]string{
+		"url":         f.URL,
+		"filename":    f.Filename,
+		"storage_ref": f.StorageRef,
+	} {
+		if i := indexControlByte(v); i >= 0 {
+			return fmt.Errorf("%w: %s contains %#x at offset %d", ErrFileFieldControlBytes, name, v[i], i)
+		}
 	}
 	if !isSafeMIMEString(f.MimeType) {
 		return fmt.Errorf("%w: %q", ErrFileFieldMimeUnsafe, f.MimeType)
@@ -141,6 +162,37 @@ func isUnsafeURLScheme(url string) bool {
 		}
 	}
 	return false
+}
+
+// indexControlByte returns the offset of the first C0 control byte
+// (0x00-0x1F) or DEL (0x7F) in s, or -1 when s is clean. Byte-wise on
+// purpose: every such byte is a single byte in UTF-8, and a multi-byte
+// rune can never contain one, so no decoding is needed.
+func indexControlByte(s string) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] == 0x7f {
+			return i
+		}
+	}
+	return -1
+}
+
+// stripControlBytes removes every C0 control byte and DEL from s. Used on
+// the multipart filename before it becomes FileField.Filename, so the
+// constructor keeps the invariant its doc claims: a FileField that
+// ProcessFileField returns always passes Validate.
+func stripControlBytes(s string) string {
+	if indexControlByte(s) < 0 {
+		return s
+	}
+	b := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] == 0x7f {
+			continue
+		}
+		b = append(b, s[i])
+	}
+	return string(b)
 }
 
 // hasTraversal reports whether s contains a `..` segment. We're
@@ -182,12 +234,13 @@ func isSafeMIMEString(s string) bool {
 //
 //   - Size is capped at [MaxProcessFileSize]. Anything larger returns
 //     [ErrFileFieldTooLarge] without buffering the rest of the body.
-//   - Content is sniffed from the first 512 bytes (and an XML/HTML probe
-//     of the leading non-whitespace) and rejected when it matches a
-//     known-dangerous shape: SVG / XML, HTML, or executable magic bytes
-//     (MZ for PE, 0x7fELF for ELF, Mach-O headers). The filename
-//     extension and any client-supplied Content-Type are ignored —
-//     attackers can lie about both.
+//   - Content is scanned for active markup in two tiers: HARD tokens
+//     (<script, <svg, <iframe, <html, <!doctype, <object, <embed, <base)
+//     are matched anywhere in the body, and SOFT tokens (<img, <?xml,
+//     <style, <link, javascript:) only in the leading 512 bytes. Executable
+//     magic bytes (MZ for PE, 0x7fELF for ELF, Mach-O headers) are also
+//     rejected. The filename extension and any client-supplied
+//     Content-Type are ignored — attackers can lie about both.
 //
 // The ctx parameter should come from the HTTP request so cancellation and
 // deadlines are respected during slow uploads.
@@ -241,7 +294,7 @@ func ProcessFileField(ctx context.Context, store upload.Storage, file interface 
 
 	ff := &FileField{
 		URL:        path,
-		Filename:   filepath.Base(filename),
+		Filename:   filepath.Base(stripControlBytes(filename)),
 		MimeType:   mimeType,
 		Size:       size,
 		StorageRef: path,
@@ -282,12 +335,25 @@ type readerAdapter struct {
 
 func (a readerAdapter) Read(p []byte) (int, error) { return a.r.Read(p) }
 
-// rejectUnsafeContent inspects the first bytes of an upload and returns
+// rejectUnsafeContent inspects an upload's bytes and returns
 // [ErrFileFieldUnsafeContent] when the content matches a known-dangerous
 // shape. We do this in addition to [http.DetectContentType] because the
 // stdlib sniffer is permissive — e.g. an SVG body with a leading `<svg`
 // tag is reported as text/plain, but rendered as active content by any
 // browser that resolves the extension or sniffs harder.
+//
+// Active-content scanning is two-tier:
+//
+//   - HARD tokens (hardActiveTokens) are matched across the WHOLE body
+//     case-insensitively, regardless of sniffed type. They never
+//     legitimately appear in raster/PDF/font bytes, so a match anywhere —
+//     including past the 512-byte sniff window or behind valid raster
+//     magic (the GIFAR polyglot class) — is markup and is rejected.
+//   - SOFT tokens (softActiveTokens) are matched only in the 512-byte sniff
+//     window and only when the content does not sniff as a confirmed-inert
+//     binary. They genuinely appear in EXIF/XMP/comment metadata of real
+//     images and in PDF/font streams, so a whole-body scan would reject
+//     legitimate uploads.
 func rejectUnsafeContent(data []byte) error {
 	head := data
 	if len(head) > 512 {
@@ -311,45 +377,31 @@ func rejectUnsafeContent(data []byte) error {
 		}
 	}
 
-	// XML / HTML / SVG. http.DetectContentType returns text/html for
-	// most HTML inputs, but classifies SVG (and any markup that is not
-	// the leading token) as text/plain. The leading-token heuristic is
-	// trivially bypassed: a DOCTYPE/BOM/comment/arbitrary prefix pushes
-	// the dangerous tag off offset 0, and DetectContentType then reports
-	// text/plain. So we strip a leading byte-order mark and scan the
-	// whole sniff window (case-insensitive) for any active-content token
-	// anywhere.
-	//
-	// But that broad scan can false-positive: a legitimate raster image,
-	// PDF, or font whose bytes happen to contain an ASCII sequence like
-	// "<img" or "javascript:" (e.g. in a metadata/comment segment) would
-	// be wrongly rejected. To avoid that without weakening the block, we
-	// only run the token scan when the content is NOT a confirmed binary
-	// type. http.DetectContentType recognises raster images, PDF, fonts,
-	// archives, and audio/video by magic bytes — those can never be
-	// "active content" served as markup, so skipping the token scan for
-	// them is safe. SVG, HTML, plain text, and unknown
-	// (application/octet-stream) all still go through the full scan.
+	// HARD active-content tokens — scan the WHOLE body. These (<script,
+	// <svg, <iframe, <html, <!doctype, <object, <embed, <base) never
+	// legitimately appear in raster/PDF/font bytes, so a match anywhere is
+	// markup: a polyglot that leads with valid raster magic and stashes its
+	// payload past the 512-byte sniff window is still rejected (the GIFAR
+	// class). The body is resident and bounded by MaxProcessFileSize, so a
+	// whole-body scan is affordable; containsTokenFold matches
+	// case-insensitively without lowercasing (and reallocating) the body.
+	for _, tok := range hardActiveTokens {
+		if containsTokenFold(data, tok) {
+			return fmt.Errorf("%w: HTML/XML/SVG content", ErrFileFieldUnsafeContent)
+		}
+	}
+
+	// SOFT active-content tokens — keep the windowed, binary-skipped scan.
+	// These (<img, <?xml, <style, <link, javascript:) genuinely turn up in
+	// EXIF/XMP/comment metadata of real raster images and in PDF/font
+	// streams, so scanning the whole body for them would false-positive. We
+	// scan only the 512-byte sniff window, and only for content that does
+	// NOT sniff as a confirmed-inert binary. SVG, HTML, XML, plain text, and
+	// unknown (application/octet-stream) all still go through this scan.
 	if !isConfirmedInertBinary(head) {
 		trim := bytes.TrimLeft(stripBOM(head), " \t\r\n\f\v")
-		lower := bytes.ToLower(trim)
-		for _, tok := range [][]byte{
-			[]byte("<svg"),
-			[]byte("<?xml"),
-			[]byte("<html"),
-			[]byte("<!doctype"),
-			[]byte("<script"),
-			[]byte("<iframe"),
-			[]byte("<img"),
-			[]byte("<math"),
-			[]byte("<object"),
-			[]byte("<embed"),
-			[]byte("<link"),
-			[]byte("<base"),
-			[]byte("<style"),
-			[]byte("javascript:"),
-		} {
-			if bytes.Contains(lower, tok) {
+		for _, tok := range softActiveTokens {
+			if containsTokenFold(trim, tok) {
 				return fmt.Errorf("%w: HTML/XML/SVG content", ErrFileFieldUnsafeContent)
 			}
 		}
@@ -371,11 +423,11 @@ func rejectUnsafeContent(data []byte) error {
 // isConfirmedInertBinary reports whether http.DetectContentType
 // classifies head as a binary type that can never be rendered as active
 // HTML/SVG markup — raster images, PDF, fonts, archives, and audio/video.
-// For these the active-content token scan would only produce false
-// positives (a token in a metadata segment is just bytes, not markup),
-// so the scan is skipped. Crucially this NEVER returns true for SVG,
-// HTML, XML, plain text, or unknown content (application/octet-stream),
-// so the active-content block is not weakened for the shapes that matter.
+// It gates only the SOFT active-content token scan: the HARD scan runs
+// over the whole body regardless, so a polyglot that leads with valid
+// raster magic cannot stash its markup past the sniff window. Crucially
+// this NEVER returns true for SVG, HTML, XML, plain text, or unknown
+// content (application/octet-stream).
 func isConfirmedInertBinary(head []byte) bool {
 	ct := http.DetectContentType(head)
 	// Strip any "; charset=" parameter for prefix matching.
@@ -421,6 +473,88 @@ func stripBOM(b []byte) []byte {
 		return b[2:] // UTF-16 LE
 	}
 	return b
+}
+
+// hardActiveTokens are active-content markup tokens scanned for across the
+// WHOLE upload body regardless of sniffed type. None of them legitimately
+// appears in raster/PDF/font bytes, so a match anywhere is treated as
+// markup. See rejectUnsafeContent.
+var hardActiveTokens = [][]byte{
+	[]byte("<script"),
+	[]byte("<iframe"),
+	[]byte("<html"),
+	[]byte("<!doctype"),
+	[]byte("<object"),
+	[]byte("<embed"),
+	[]byte("<base"),
+	[]byte("<svg"),
+	// MathML is the other foreign-content root HTML parses as markup, and
+	// it belongs beside <svg for the same reason: neither shows up in
+	// raster, PDF, or font bytes, so a match is never a metadata false
+	// positive.
+	[]byte("<math"),
+}
+
+// softActiveTokens are active-content tokens scanned for only in the
+// 512-byte sniff window and only for content that does not sniff as a
+// confirmed-inert binary. They genuinely appear in image/PDF/font metadata,
+// so a whole-body scan would false-positive. See rejectUnsafeContent.
+var softActiveTokens = [][]byte{
+	[]byte("<img"),
+	[]byte("<?xml"),
+	[]byte("<style"),
+	[]byte("<link"),
+	[]byte("javascript:"),
+}
+
+// containsTokenFold reports whether haystack contains needle, comparing
+// ASCII bytes case-insensitively. It allocates nothing, so it is safe for
+// the whole-body hard-token scan where bytes.ToLower would double resident
+// memory for a 32 MiB upload.
+func containsTokenFold(haystack, needle []byte) bool {
+	nl := len(needle)
+	if nl == 0 {
+		return true
+	}
+	hl := len(haystack)
+	if hl < nl {
+		return false
+	}
+	// Fold the first needle byte for a cheap per-byte rejection.
+	first := needle[0]
+	firstUp := first
+	if first >= 'a' && first <= 'z' {
+		firstUp = first - 32
+	}
+	for i := 0; i+nl <= hl; i++ {
+		c := haystack[i]
+		if c != first && c != firstUp {
+			continue
+		}
+		match := true
+		for j := 1; j < nl; j++ {
+			a := haystack[i+j]
+			b := needle[j]
+			if a == b {
+				continue
+			}
+			// Fold ASCII letters to lower; the needles are all ASCII.
+			if a >= 'A' && a <= 'Z' {
+				a += 32
+			}
+			if b >= 'A' && b <= 'Z' {
+				b += 32
+			}
+			if a != b {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
 }
 
 // DeleteFileField removes a previously stored file from the storage backend.

--- a/framework/file/filefield_process_security_test.go
+++ b/framework/file/filefield_process_security_test.go
@@ -98,17 +98,63 @@ func TestProcessFileField_RejectsHiddenActiveContent(t *testing.T) {
 	}
 }
 
-// TestProcessFileField_AcceptsBinaryWithToken verifies that legitimate
-// binary uploads (PNG, JPEG, PDF, font) whose bytes coincidentally
-// contain an ASCII active-content token like "<script" or "javascript:"
-// are NOT rejected — the active-content scan must only apply to content
-// that actually sniffs as text/markup, not confirmed binary magic.
-// Real HTML/SVG must still be rejected (covered by the cases above).
-func TestProcessFileField_AcceptsBinaryWithToken(t *testing.T) {
-	token := []byte("<script>alert(1)</script> javascript: <img src=x>")
+// TestProcessFileField_HardTokenRejected pins the polyglot defense. A HARD
+// active-content token — <script, <svg, <iframe, <html, <!doctype, <object,
+// <embed, <base — is rejected no matter where in the body it sits and no
+// matter what bytes lead the file. The earlier scan only looked inside the
+// 512-byte sniff window and skipped the token scan entirely for confirmed-
+// inert binaries (raster/PDF/font magic), so a payload past the window or
+// hidden behind valid image magic slipped through (the GIFAR polyglot
+// class). HARD tokens now scan the whole body; SOFT tokens (<img, <?xml,
+// <style, <link, javascript:) keep the old windowed, binary-skipped
+// behavior — they genuinely appear in image metadata — and their
+// acceptance is pinned by TestProcessFileField_AcceptsBinaryWithToken.
+func TestProcessFileField_HardTokenRejected(t *testing.T) {
+	t.Parallel()
 	cases := map[string][]byte{
-		// PNG magic + IDAT-ish bytes, with an embedded HTML token (e.g. a
-		// tEXt chunk or zTXt comment carrying user text).
+		// Shape 1: a hard token buried PAST the 512-byte sniff window.
+		// The window saw only inert padding, so the old scan missed it.
+		"past-sniff-window": append(bytes.Repeat([]byte("A"), 600), []byte("<script>alert(1)</script>")...),
+		// Shape 2: a hard token behind valid raster magic (GIFAR). The
+		// magic made the file sniff as a confirmed-inert binary, so the
+		// old scan skipped it outright.
+		"behind-raster-magic": []byte("GIF89a<svg onload=alert(1)>"),
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			store := &captureStorage{}
+			if _, err := file.ProcessFileField(context.Background(), store, bytes.NewReader(body), "payload.bin", "posts", "attachment"); err == nil {
+				t.Fatalf("SECURITY: [filefield] ProcessFileField accepted a HARD active-content token (%s). Attack: a polyglot stores markup that executes when a host serves the bucket by extension-derived Content-Type.", name)
+			}
+		})
+	}
+}
+
+// TestProcessFileField_AcceptsBinaryWithToken pins the property that SOFT
+// active-content tokens (<img, <?xml, <style, <link, javascript:) embedded
+// in confirmed-inert binaries — raster images, PDF, fonts — are NOT
+// rejected. Those tokens genuinely appear in EXIF/XMP/comment metadata and
+// PDF/font streams, so the scan checks the soft set only in the 512-byte
+// sniff window and skips it entirely for confirmed-inert binaries.
+//
+// Rationale (why this was weakened): this test used to assert that
+// GIF89a/PNG/JPEG/PDF magic plus "<script>alert(1)</script> javascript:
+// <img src=x>" was ACCEPTED. That is no longer the correct behavior:
+// <script is now a HARD token, scanned across the WHOLE body regardless of
+// magic bytes (see TestProcessFileField_HardTokenRejected), so a confirmed
+// binary carrying <script is rejected — closing the GIFAR polyglot hole
+// where valid raster magic switched the token scan off. The property this
+// test was protecting — "don't false-positive on a token in image
+// metadata" — survives for the SOFT set, which is why it now uses soft
+// tokens only. A plain raster with no token is included as a baseline.
+func TestProcessFileField_AcceptsBinaryWithToken(t *testing.T) {
+	t.Parallel()
+	// Soft tokens only — these are the ones the binary skip still covers.
+	token := []byte(`<?xml version="1.0"?> <style>.x{}</style> <link rel="x"> <img src="x"> javascript:foo()`)
+	cases := map[string][]byte{
+		// PNG magic + IDAT-ish bytes, with an embedded soft token (e.g. a
+		// tEXt chunk or zTXt comment carrying user text / XMP).
 		"png": append([]byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0x0D, 'I', 'H', 'D', 'R'}, token...),
 		// JPEG SOI + JFIF, token embedded in an EXIF/comment segment.
 		"jpeg": append([]byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00}, token...),
@@ -116,12 +162,16 @@ func TestProcessFileField_AcceptsBinaryWithToken(t *testing.T) {
 		"pdf": append([]byte("%PDF-1.7\n%\xE2\xE3\xCF\xD3\n"), token...),
 		// GIF, token in a comment extension.
 		"gif": append([]byte("GIF89a"), token...),
+		// A plain raster with no token at all — baseline that a clean
+		// image passes the sniff and the binary skip unchanged.
+		"plain-png": append([]byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0x0D, 'I', 'H', 'D', 'R'}, bytes.Repeat([]byte{0x00}, 64)...),
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			store := &captureStorage{}
 			if _, err := file.ProcessFileField(context.Background(), store, bytes.NewReader(body), "asset."+name, "posts", "attachment"); err != nil {
-				t.Fatalf("SECURITY/correctness: [filefield] ProcessFileField rejected legitimate %s binary that merely contains an ASCII token: %v", name, err)
+				t.Fatalf("SECURITY/correctness: [filefield] ProcessFileField rejected legitimate %s binary that merely contains a SOFT ASCII token: %v", name, err)
 			}
 		})
 	}

--- a/framework/file/filefield_security_test.go
+++ b/framework/file/filefield_security_test.go
@@ -1,10 +1,13 @@
 package file_test
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"strings"
 	"testing"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/urlsafe"
 	"github.com/DonaldMurillo/gofastr/framework/file"
 )
 
@@ -145,5 +148,105 @@ func TestFileField_AcceptsLegitimate(t *testing.T) {
 		if err := ff.Validate(); err != nil {
 			t.Errorf("legitimate field rejected: %v", err)
 		}
+	}
+}
+
+// TestPlaceholderAllowListsAgree is the cross-check the comment on
+// file.isRasterDataURL promises: the LQIP allow-list enforced when a
+// FileField is validated must accept exactly what the render sink will
+// actually paint. The sink is framework/ui.placeholderUsable, which is
+// core-ui/urlsafe's ImageSource policy restricted to the data: scheme.
+// Asserting against urlsafe directly (rather than framework/ui) keeps
+// framework/file a leaf — this is a test-only edge.
+//
+// The two must agree in BOTH directions. A value this package accepts
+// but the sink drops is a silently broken placeholder; a value this
+// package accepts that the sink would paint from the network is a
+// tracking beacon persisted through an image column.
+func TestPlaceholderAllowListsAgree(t *testing.T) {
+	t.Parallel()
+	corpus := []string{
+		"data:image/jpeg;base64,AAAA",
+		"data:image/png;base64,AAAA",
+		"data:image/gif;base64,AAAA",
+		"data:image/webp;base64,AAAA",
+		"data:image/avif;base64,AAAA",
+		"data:image/svg+xml;base64,AAAA",
+		"data:text/html,<script>alert(1)</script>",
+		"javascript:alert(1)",
+		"https://evil.example/px.gif",
+		"HTTPS://evil.example/px.gif",
+		"//evil.example/px.gif",
+		"/uploads/px.gif",
+		"px.gif",
+	}
+	for _, c := range corpus {
+		d := &file.ImageDerivatives{Placeholder: c}
+		accepted := d.Validate() == nil
+		// The render sink: data: scheme AND urlsafe.ImageSource.
+		painted := strings.HasPrefix(strings.ToLower(c), "data:") &&
+			urlsafe.OK(c, urlsafe.ImageSource)
+		if accepted != painted {
+			t.Fatalf("SECURITY: [filefield] placeholder %q: Validate accepted=%v but render sink paints=%v. The two allow-lists must agree; a remote URL stored as a placeholder is a beacon, and a rejected-at-render value is a silently dead LQIP.", c, accepted, painted)
+		}
+	}
+}
+
+// TestFileFieldRejectsControlBytes pins one property — no C0 control
+// byte or DEL survives validation — across every FileField string
+// surface that is persisted and later echoed into a header, an HTML
+// attribute, or a log line. mime_type is already covered by its
+// charset filter; url, filename, and storage_ref were not.
+func TestFileFieldRejectsControlBytes(t *testing.T) {
+	t.Parallel()
+	payloads := map[string]string{
+		"cr":  "ok\rinjected",
+		"lf":  "ok\ninjected",
+		"nul": "ok\x00.jpg",
+		"del": "ok\x7finjected",
+	}
+	surfaces := map[string]func(string) *file.FileField{
+		"url":         func(v string) *file.FileField { return &file.FileField{URL: v} },
+		"filename":    func(v string) *file.FileField { return &file.FileField{Filename: v} },
+		"mime_type":   func(v string) *file.FileField { return &file.FileField{MimeType: v} },
+		"storage_ref": func(v string) *file.FileField { return &file.FileField{StorageRef: v} },
+	}
+	for sname, mk := range surfaces {
+		for pname, payload := range payloads {
+			if mk(payload).Validate() == nil {
+				t.Errorf("SECURITY: [filefield] Validate accepted %s control byte in %s. Attack: the stored value is echoed into Content-Disposition / a log line / an HTML attribute and splits it.", pname, sname)
+			}
+		}
+	}
+}
+
+// TestFileFieldRejectsFilenameTraversal pins that Filename is held to
+// the same traversal rule as url and storage_ref. A `..` filename
+// reaches Content-Disposition and any host that joins it onto a path.
+func TestFileFieldRejectsFilenameTraversal(t *testing.T) {
+	t.Parallel()
+	for _, n := range []string{"../../etc/passwd", "a/../../b.png", ".."} {
+		ff := &file.FileField{Filename: n}
+		if err := ff.Validate(); !errors.Is(err, file.ErrFileFieldTraversal) {
+			t.Errorf("SECURITY: [filefield] Validate accepted traversal filename %q (err=%v)", n, err)
+		}
+	}
+}
+
+// TestProcessFileFieldStripsCtrlInName pins the doc claim at
+// FileField.Validate that "the constructors in this package
+// (ProcessFileField) already produce valid FileFields" — a hostile
+// multipart filename must not be able to produce a FileField that
+// Validate would reject.
+func TestProcessFileFieldStripsCtrlInName(t *testing.T) {
+	t.Parallel()
+	png := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0x0D, 'I', 'H', 'D', 'R'}
+	ff, err := file.ProcessFileField(context.Background(), &captureStorage{},
+		bytes.NewReader(png), "a\r\nContent-Disposition: x\x00.png", "posts", "cover")
+	if err != nil {
+		t.Fatalf("legitimate PNG upload rejected: %v", err)
+	}
+	if verr := ff.Validate(); verr != nil {
+		t.Fatalf("SECURITY: [filefield] ProcessFileField produced a FileField its own Validate rejects (%v) for filename %q. Attack: CRLF in the echoed filename splits Content-Disposition.", verr, ff.Filename)
 	}
 }

--- a/framework/file/imagederive.go
+++ b/framework/file/imagederive.go
@@ -76,12 +76,17 @@ func (d *ImageDerivatives) Validate() error {
 		return fmt.Errorf("%w: blurhash is %d bytes (max %d)",
 			ErrFileFieldOversize, len(d.BlurHash), MaxFileFieldStringBytes)
 	}
-	if d.Placeholder != "" && isUnsafeURLScheme(d.Placeholder) {
-		// isUnsafeURLScheme rejects bare `data:`, so an LQIP has to be
-		// checked against the narrower raster allow-list instead.
-		if !isRasterDataURL(d.Placeholder) {
-			return fmt.Errorf("%w: placeholder is not an inline raster image", ErrFileFieldURLScheme)
-		}
+	// An LQIP is an inline raster data: URI and nothing else — that is what
+	// image.Placeholder produces and the only thing the render sink
+	// (framework/ui.placeholderUsable) will paint. Gating this on
+	// isUnsafeURLScheme, as this once did, only ran the allow-list for
+	// values that already looked like a scheme attack, so a remote
+	// "https://tracker.example/px.gif" sailed through: never painted, but
+	// persisted through an image column and handed to any host that renders
+	// the raw value. Check unconditionally; the two allow-lists are pinned
+	// against each other by TestPlaceholderAllowListsAgree.
+	if d.Placeholder != "" && !isRasterDataURL(d.Placeholder) {
+		return fmt.Errorf("%w: placeholder is not an inline raster image", ErrFileFieldURLScheme)
 	}
 	return nil
 }

--- a/framework/migrate/migrate.go
+++ b/framework/migrate/migrate.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"time"
 
 	coremig "github.com/DonaldMurillo/gofastr/core/migrate"
 	"github.com/DonaldMurillo/gofastr/core/query"
@@ -29,14 +30,55 @@ const (
 // DetectDialect returns the dialect of an open *sql.DB. It probes for
 // PostgreSQL via SELECT version() (cheap, no side effects) and falls back to
 // SQLite when that fails. The probe runs once per AutoMigrate call.
+//
+// The probe is RETRIED before it concludes SQLite. Its answer decides
+// whether the cross-replica advisory lock is taken at all
+// (core/migrate/lock.go skips the lock for any non-Postgres dialect),
+// so a single transient failure — a statement timeout, "too many
+// connections", a pooler in statement mode, a connection reset — used
+// to silently downgrade an N-replica Postgres boot to unlocked
+// concurrent DDL emitted in SQLite syntax: exactly the race the lock
+// exists to prevent, reached by making one probe fail.
 func DetectDialect(db *sql.DB) Dialect {
-	var v string
-	if err := db.QueryRow("SELECT version()").Scan(&v); err == nil {
-		if strings.Contains(strings.ToLower(v), "postgresql") {
-			return DialectPostgres
+	const attempts = 3
+	for i := 0; i < attempts; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		var v string
+		err := db.QueryRowContext(ctx, "SELECT version()").Scan(&v)
+		cancel()
+		if err == nil {
+			if strings.Contains(strings.ToLower(v), "postgresql") {
+				return DialectPostgres
+			}
+			return DialectSQLite
+		}
+		// A engine that genuinely lacks version() answers immediately
+		// and deterministically; only retry what looks transient.
+		if !isTransientProbeErr(err) {
+			return DialectSQLite
+		}
+		if i < attempts-1 {
+			time.Sleep(time.Duration(i+1) * 100 * time.Millisecond)
 		}
 	}
+	slog.Default().Warn("migrate: dialect probe failed repeatedly; assuming SQLite. " +
+		"If this is Postgres, the cross-replica advisory lock will NOT be taken " +
+		"and concurrent replicas may race the same DDL.")
 	return DialectSQLite
+}
+
+// isTransientProbeErr reports whether a failed `SELECT version()` looks
+// like a transport / availability problem rather than "this engine has
+// no such function". SQLite reports the latter as a parse-time "no such
+// function" and is not worth retrying.
+func isTransientProbeErr(err error) bool {
+	msg := strings.ToLower(err.Error())
+	for _, deterministic := range []string{"no such function", "unknown function", "syntax error"} {
+		if strings.Contains(msg, deterministic) {
+			return false
+		}
+	}
+	return true
 }
 
 // execQueryer is the subset of *sql.DB / *sql.Tx the migrator needs: Exec for
@@ -840,10 +882,24 @@ func ColumnDefaultClause(f schema.Field, dialect Dialect) string {
 // TRUE/FALSE for Postgres and 1/0 for SQLite (both engines accept either,
 // but emitting the native form keeps DDL idiomatic and avoids surprises in
 // pg_dump output).
+//
+// SECURITY: anything that isn't a recognised scalar is rendered as a
+// single-quoted string literal with interior quotes DOUBLED — the same
+// escaping the `case string` arm has always applied.
+//
+// The fallback used to be fmt.Sprintf("'%v'", v) with no escaping at
+// all. schema.Field.Default is `any`, so a named string type, a
+// fmt.Stringer, or a []any / map[string]any decoded from JSON all
+// missed `case string` and took that arm, letting the value close the
+// literal and append arbitrary DDL. The output feeds
+// ColumnDefaultClause → both columnDefs (CREATE TABLE) and
+// diffEntityFromLive (ALTER TABLE ADD COLUMN), and a JSON array
+// default reaches here from kiln's add_entity op over HTTP — a
+// verified payload created and COMMITTED an extra column.
 func SQLDefault(f schema.Field, dialect Dialect) string {
 	switch v := f.Default.(type) {
 	case string:
-		return "'" + strings.ReplaceAll(v, "'", "''") + "'"
+		return quoteSQLLiteral(v)
 	case int:
 		return fmt.Sprintf("%d", v)
 	case float64:
@@ -860,6 +916,13 @@ func SQLDefault(f schema.Field, dialect Dialect) string {
 		}
 		return "0"
 	default:
-		return fmt.Sprintf("'%v'", v)
+		// Render, then escape. Never splice the rendering raw.
+		return quoteSQLLiteral(fmt.Sprintf("%v", v))
 	}
+}
+
+// quoteSQLLiteral wraps s in single quotes and doubles every interior
+// quote, producing a literal that cannot be terminated from inside.
+func quoteSQLLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }

--- a/framework/migrate/migrate_security_test.go
+++ b/framework/migrate/migrate_security_test.go
@@ -1,0 +1,117 @@
+package migrate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+)
+
+// Property: every value spliced into generated DDL is escaped for the
+// literal context it lands in — for a DEFAULT clause that means a
+// single-quoted string literal that cannot be closed from inside.
+//
+// Surfaces: SQLDefault feeds ColumnDefaultClause, which feeds BOTH
+// columnDefs (CREATE TABLE) and diffEntityFromLive (ALTER TABLE ADD
+// COLUMN). schema.Field.Default is `any`, and only the `case string`
+// arm doubled quotes; the default: arm rendered fmt.Sprintf("'%v'", v)
+// raw. A named string type, a fmt.Stringer, or — the reachable one — a
+// []any / map[string]any decoded from JSON took that arm.
+//
+// Reachability: entity.Declaration's Default is `any` and kiln's
+// add_entity op accepts a field default straight from an HTTP JSON
+// payload, so a JSON array or object arrives as []any and closes the
+// literal. A verified payload created and COMMITTED an extra column.
+func TestSQLDefaultEscapesEveryType(t *testing.T) {
+	type named string
+	const payload = `x', shadow TEXT DEFAULT 'y`
+
+	cases := []struct {
+		name string
+		val  any
+	}{
+		{"plain string", payload},
+		{"named string type", named(payload)},
+		{"json array", []any{payload}},
+		{"json object", map[string]any{"a": payload}},
+		{"stringer", stringerDefault(payload)},
+	}
+
+	for _, dialect := range []Dialect{DialectSQLite, DialectPostgres} {
+		for _, tc := range cases {
+			got := SQLDefault(schema.Field{Default: tc.val}, dialect)
+			if !isSingleQuotedLiteral(got) {
+				t.Errorf("SECURITY: [migrate] SQLDefault(%s, %s) = %s — the literal is closable. "+
+					"Attack: a kiln add_entity field default injects DDL that COMMITS "+
+					"(an extra column, a dropped table) into CREATE TABLE / ALTER TABLE ADD COLUMN.",
+					tc.name, dialect, got)
+			}
+		}
+	}
+
+	// Non-string scalars keep their unquoted native rendering.
+	if got := SQLDefault(schema.Field{Default: 42}, DialectSQLite); got != "42" {
+		t.Errorf("[migrate] int default regressed: %s", got)
+	}
+	if got := SQLDefault(schema.Field{Default: true}, DialectPostgres); got != "TRUE" {
+		t.Errorf("[migrate] bool default regressed: %s", got)
+	}
+	if got := SQLDefault(schema.Field{Default: "o'brien"}, DialectSQLite); got != "'o''brien'" {
+		t.Errorf("[migrate] string escaping regressed: %s", got)
+	}
+}
+
+type stringerDefault string
+
+func (s stringerDefault) String() string { return string(s) }
+
+// isSingleQuotedLiteral reports whether s is one SQL string literal:
+// wrapped in single quotes with every interior quote doubled, so the
+// literal cannot be terminated early.
+func isSingleQuotedLiteral(s string) bool {
+	if len(s) < 2 || s[0] != '\'' || s[len(s)-1] != '\'' {
+		return false
+	}
+	inner := s[1 : len(s)-1]
+	for i := 0; i < len(inner); i++ {
+		if inner[i] != '\'' {
+			continue
+		}
+		if i+1 >= len(inner) || inner[i+1] != '\'' {
+			return false
+		}
+		i++ // skip the escaped pair
+	}
+	return true
+}
+
+// TestReadLiveColumnsRejectsBadTable pins that the SQLite live-column
+// read validates its identifier like every one of its siblings. It is
+// the only identifier site in the package that interpolated without
+// SafeIdent, justified by a comment claiming the table name "is taken
+// from our own registry, not user input" — which is false: kiln's
+// add_entity / update_entity ops accept a `table` override over HTTP
+// (kiln/journal/replay.go validates only the entity Name), and this
+// read runs at AutoMigratePlanContext BEFORE any SafeIdent call.
+//
+// No injection landed today only because database/sql executes a single
+// statement; that is the driver's property, not this package's.
+func TestReadLiveColumnsRejectsBadTable(t *testing.T) {
+	for _, bad := range []string{
+		`foo); DROP TABLE victim; --`,
+		`foo" ; DROP TABLE victim; --`,
+		"foo\nbar",
+	} {
+		_, err := ReadLiveColumnsSQLite(context.Background(), nil, bad)
+		if err == nil {
+			t.Errorf("SECURITY: [migrate] ReadLiveColumnsSQLite accepted table name %q. "+
+				"Attack: an agent-supplied table override reaches PRAGMA table_info "+
+				"unvalidated, ahead of every SafeIdent call in the plan path.", bad)
+			continue
+		}
+		if !strings.Contains(err.Error(), "unsafe") && !strings.Contains(err.Error(), "invalid") {
+			t.Errorf("[migrate] unexpected rejection reason for %q: %v", bad, err)
+		}
+	}
+}

--- a/framework/migrate/schema_diff.go
+++ b/framework/migrate/schema_diff.go
@@ -251,13 +251,22 @@ func diffEntityFromLive(ent *entity.Entity, all map[string]*entity.Entity, diale
 // framework (timestamps, tenant_id, deleted_at) and should NOT be dropped
 // just because it isn't declared on the entity.
 func isFrameworkManagedColumn(name string, ent *entity.Entity) bool {
+	// Key the tenant arm off TenantColumn(), not the literal "tenant_id".
+	// TenantField exists precisely so the column can be renamed, and
+	// tenant.WithMultiTenant sets it AFTER entity.Define has already
+	// injected the default-named field — so the entity declares
+	// "tenant_id" while CRUD reads and writes the renamed column, and
+	// the diff emitted a data-losing DROP COLUMN on the column the app
+	// actually uses. Protect both names: the configured one, and the
+	// default that Define may have injected before the rename.
+	if ent.Config.MultiTenant && (name == ent.Config.TenantColumn() || name == "tenant_id") {
+		return true
+	}
 	switch name {
 	case "created_at", "updated_at":
 		return ent.Config.Timestamps
 	case "deleted_at":
 		return ent.Config.SoftDelete
-	case "tenant_id":
-		return ent.Config.MultiTenant
 	}
 	return false
 }
@@ -317,8 +326,21 @@ func ReadLiveColumnsSQLite(ctx context.Context, db *sql.DB, table string) (map[s
 }
 
 func readLiveColumnsSQLiteQ(ctx context.Context, q queryer, table string) (map[string]string, error) {
-	// PRAGMA can't be parameterised; the table name is taken from our own
-	// registry, not user input, so injection isn't a concern.
+	// PRAGMA can't be parameterised, so the identifier must be validated
+	// instead. The previous comment here claimed the table name "is taken
+	// from our own registry, not user input" — that is false: kiln's
+	// add_entity / update_entity ops accept a `table` override in their
+	// HTTP JSON payload and replay validates only the entity Name. This
+	// read also runs at AutoMigratePlanContext BEFORE any other SafeIdent
+	// call in the plan path, so it is the FIRST place a hostile name
+	// lands. Every sibling validates (the Postgres twin parameterises,
+	// tableExistsBulkSQLite parameterises, buildCreateTableSQL /
+	// diffEntityFromLive / migrateEntity all call SafeIdent); this was
+	// the lone exception, relying on database/sql executing a single
+	// statement — a driver property, not ours.
+	if _, err := query.SafeIdent(table); err != nil {
+		return nil, err
+	}
 	rows, err := q.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", table))
 	if err != nil {
 		return nil, err

--- a/framework/migrate/snapshot.go
+++ b/framework/migrate/snapshot.go
@@ -242,10 +242,27 @@ func routineChanges(current []Routine, prev map[string]RoutineDef) []SchemaChang
 	}
 	sort.Strings(removed)
 	for _, name := range removed {
+		// A Routine's Down is optional (see routine.go), so a routine
+		// removed without one used to emit an EMPTY statement here. The
+		// generated migration then contained nothing but ";": the drop
+		// silently did nothing while the snapshot advanced to record the
+		// routine as gone, and a rollback would CREATE OR REPLACE it
+		// back. Surface it as a change the author must resolve instead
+		// of writing a no-op that looks applied.
+		drop := strings.TrimSpace(prev[name].Down)
+		if drop == "" {
+			changes = append(changes, SchemaChange{
+				Summary: fmt.Sprintf("routine %s: drop SKIPPED — the routine declares no Down; "+
+					"add one (e.g. DROP FUNCTION ...) so the removal actually runs", name),
+				SQL:  "",
+				Down: prev[name].Up,
+			})
+			continue
+		}
 		changes = append(changes, SchemaChange{
 			Summary: fmt.Sprintf("routine %s: drop", name),
-			SQL:     prev[name].Down, // the drop
-			Down:    prev[name].Up,   // recreate on rollback
+			SQL:     drop,          // the drop
+			Down:    prev[name].Up, // recreate on rollback
 		})
 	}
 	return changes

--- a/framework/processmodule_broker.go
+++ b/framework/processmodule_broker.go
@@ -238,19 +238,19 @@ func (b *Broker) entityHandler(view ModuleGrantView, op entityOp) moduleproto.Ha
 }
 
 // parseEntityCall unmarshals the op's params shape and returns the canonical
-// entity name + the echoed Caller. query uses EntityQueryParams; the three
+// entity name + the echoed CallerRef. query uses EntityQueryParams; the three
 // mutations share EntityMutationParams.
-func parseEntityCall(op entityOp, params json.RawMessage) (entityName string, caller moduleproto.Caller, err error) {
+func parseEntityCall(op entityOp, params json.RawMessage) (entityName string, caller moduleproto.CallerRef, err error) {
 	if op == opQuery {
 		var p moduleproto.EntityQueryParams
 		if err = unmarshalParams(params, &p); err != nil {
-			return "", moduleproto.Caller{}, err
+			return "", moduleproto.CallerRef{}, err
 		}
 		return p.Entity, p.Caller, nil
 	}
 	var p moduleproto.EntityMutationParams
 	if err = unmarshalParams(params, &p); err != nil {
-		return "", moduleproto.Caller{}, err
+		return "", moduleproto.CallerRef{}, err
 	}
 	return p.Entity, p.Caller, nil
 }
@@ -269,7 +269,7 @@ func parseEntityCall(op entityOp, params json.RawMessage) (entityName string, ca
 //
 // It returns the resolved entity (for the re-dispatch path) and the
 // re-dispatch context with the caller's identity re-attached.
-func (b *Broker) gate(ctx context.Context, entityName, verb string, view ModuleGrantView, caller moduleproto.Caller) (*entity.Entity, context.Context, error) {
+func (b *Broker) gate(ctx context.Context, entityName, verb string, view ModuleGrantView, caller moduleproto.CallerRef) (*entity.Entity, context.Context, error) {
 	// Trust boundary: a child cannot name an arbitrary resource. The resource
 	// is the entity it asked for, resolved through the HOST's registry — a
 	// name the registry does not know is denied, never silently empty.
@@ -319,7 +319,7 @@ func (b *Broker) gate(ctx context.Context, entityName, verb string, view ModuleG
 // the CRUD permission gate can consult the module's grants; owner/tenant
 // gates then fail closed (no owner id). A non-empty handle is looked up; an
 // unknown/expired/released handle denies.
-func (b *Broker) resolveCaller(ctx context.Context, caller moduleproto.Caller, view ModuleGrantView) (context.Context, *delegationEntry, error) {
+func (b *Broker) resolveCaller(ctx context.Context, caller moduleproto.CallerRef, view ModuleGrantView) (context.Context, *delegationEntry, error) {
 	if caller.Delegation == "" {
 		// Ambient. Attach the synthetic role; the design's safe-by-construction
 		// proof (RequireOwner/RequireTenant refuse without an owner id) holds

--- a/framework/processmodule_broker_cover_test.go
+++ b/framework/processmodule_broker_cover_test.go
@@ -335,13 +335,17 @@ func TestEntityOp_verbMapping(t *testing.T) {
 
 // ---- parseEntityCall ----
 
+// This used to round-trip a Subject. It cannot any more: an inbound reverse
+// call carries [moduleproto.CallerRef], which has only Delegation, so there is
+// no child-supplied subject for the broker to read even by mistake. Delegation
+// is the sole authority on this direction — see TestInboundCallerCarriesNoSubject.
 func TestParseEntityCall_queryShape(t *testing.T) {
 	params, _ := json.Marshal(moduleproto.EntityQueryParams{
 		Entity: "articles",
-		Caller: moduleproto.Caller{Subject: "u1"},
+		Caller: moduleproto.CallerRef{Delegation: "h1"},
 	})
 	name, caller, err := parseEntityCall(opQuery, params)
-	if err != nil || name != "articles" || caller.Subject != "u1" {
+	if err != nil || name != "articles" || caller.Delegation != "h1" {
 		t.Fatalf("parseEntityCall query = %q %+v %v", name, caller, err)
 	}
 }

--- a/framework/processmodule_broker_test.go
+++ b/framework/processmodule_broker_test.go
@@ -265,7 +265,7 @@ func TestBrokerStripsCrossOwnerRead(t *testing.T) {
 	h := b.entityHandler(view, opQuery)
 	_, err := callReverse(t, h, moduleproto.EntityQueryParams{
 		Entity: "tix",
-		Caller: moduleproto.Caller{Delegation: handle},
+		Caller: moduleproto.CallerRef{Delegation: handle},
 	})
 	if err == nil {
 		t.Fatal("expected CrossOwnerRead carve-out denial, got nil")
@@ -319,7 +319,7 @@ func TestBrokerUnknownHandleDenies(t *testing.T) {
 	h := b.entityHandler(view, opQuery)
 	_, err := callReverse(t, h, moduleproto.EntityQueryParams{
 		Entity: "articles",
-		Caller: moduleproto.Caller{Delegation: "deadbeef-not-a-real-handle"},
+		Caller: moduleproto.CallerRef{Delegation: "deadbeef-not-a-real-handle"},
 	})
 	wantDenied(t, err)
 	wantNotHit(t, &hit)
@@ -337,7 +337,7 @@ func TestBrokerReleasedHandleDenies(t *testing.T) {
 	h := b.entityHandler(view, opQuery)
 	_, err := callReverse(t, h, moduleproto.EntityQueryParams{
 		Entity: "articles",
-		Caller: moduleproto.Caller{Delegation: handle},
+		Caller: moduleproto.CallerRef{Delegation: handle},
 	})
 	wantDenied(t, err)
 	wantNotHit(t, &hit)
@@ -359,7 +359,7 @@ func TestBrokerExpiredHandleDenies(t *testing.T) {
 	h := b.entityHandler(view, opQuery)
 	_, err := callReverse(t, h, moduleproto.EntityQueryParams{
 		Entity: "articles",
-		Caller: moduleproto.Caller{Delegation: handle},
+		Caller: moduleproto.CallerRef{Delegation: handle},
 	})
 	wantDenied(t, err)
 	wantNotHit(t, &hit)
@@ -384,7 +384,7 @@ func TestBrokerCallerAuthorityDenies(t *testing.T) {
 	h := b.entityHandler(view, opQuery)
 	_, err := callReverse(t, h, moduleproto.EntityQueryParams{
 		Entity: "logs",
-		Caller: moduleproto.Caller{Delegation: handle},
+		Caller: moduleproto.CallerRef{Delegation: handle},
 	})
 	wantDenied(t, err) // 403 → CodeCapabilityDenied
 }
@@ -430,7 +430,7 @@ func TestBrokerDelegatedReadSucceeds(t *testing.T) {
 	h := b.entityHandler(view, opQuery)
 	res, err := callReverse(t, h, moduleproto.EntityQueryParams{
 		Entity: "logs",
-		Caller: moduleproto.Caller{Delegation: handle},
+		Caller: moduleproto.CallerRef{Delegation: handle},
 	})
 	wantOK(t, err)
 	qr, ok := res.(moduleproto.EntityQueryResult)

--- a/framework/typed_hooks.go
+++ b/framework/typed_hooks.go
@@ -47,15 +47,24 @@ func OnBeforeCreate[T any](app *App, name string, fn func(ctx context.Context, v
 
 // OnAfterCreate registers a typed AfterCreate hook. The callback receives
 // the just-inserted row (already includes server-generated fields like id).
-// Mutations are not reflected — Create has already committed the row's
-// shape; modifying the struct is harmless but pointless.
+// Mutations are reflected back into the response body: the hook payload is
+// the live result map the crud layer serialises into the HTTP response, so
+// clearing a field here (e.g. redacting a secret) changes what the caller
+// reads. The stored row is unaffected — Create has already committed it.
 func OnAfterCreate[T any](app *App, name string, fn func(ctx context.Context, value *T) error) {
 	app.HookRegistry(name).RegisterHook(hook.AfterCreate, func(ctx context.Context, data any) error {
 		var v T
 		if err := unmarshalHookPayload(data, &v); err != nil {
 			return err
 		}
-		return fn(ctx, &v)
+		before := v
+		if err := fn(ctx, &v); err != nil {
+			return err
+		}
+		if m, ok := data.(map[string]any); ok {
+			return mergeStructIntoMap(&before, &v, m)
+		}
+		return nil
 	})
 }
 
@@ -79,14 +88,24 @@ func OnBeforeUpdate[T any](app *App, name string, fn func(ctx context.Context, v
 }
 
 // OnAfterUpdate registers a typed AfterUpdate hook receiving the post-update
-// row.
+// row. Mutations are reflected back into the response body, exactly like
+// OnAfterCreate: the hook payload is the live result map the crud layer
+// serialises into the HTTP response, so clearing a field here redacts it from
+// what the caller reads. The stored row is unaffected.
 func OnAfterUpdate[T any](app *App, name string, fn func(ctx context.Context, value *T) error) {
 	app.HookRegistry(name).RegisterHook(hook.AfterUpdate, func(ctx context.Context, data any) error {
 		var v T
 		if err := unmarshalHookPayload(data, &v); err != nil {
 			return err
 		}
-		return fn(ctx, &v)
+		before := v
+		if err := fn(ctx, &v); err != nil {
+			return err
+		}
+		if m, ok := data.(map[string]any); ok {
+			return mergeStructIntoMap(&before, &v, m)
+		}
+		return nil
 	})
 }
 

--- a/framework/typed_hooks_security_test.go
+++ b/framework/typed_hooks_security_test.go
@@ -21,6 +21,7 @@ type hookSecPost struct {
 	IsAdmin bool   `json:"isAdmin,omitempty"`
 	Balance int    `json:"balance,omitempty"`
 	Role    string `json:"role,omitempty"`
+	Secret  string `json:"secret,omitempty"`
 }
 
 // TestTypedHook_ForcedZeroOverrides asserts a Before-hook that forces a
@@ -118,6 +119,72 @@ func TestTypedHook_UpdateNoForcedFieldUnchanged(t *testing.T) {
 	if body["title"] != "updated" {
 		t.Fatalf("title corrupted: %v", body["title"])
 	}
+}
+
+// TestTypedAfterHooksCanRedact pins the property that a typed AfterCreate /
+// AfterUpdate hook can redact a field from the HTTP response body. The crud
+// layer hands ExecuteHooks the live result map — the very map serialised into
+// the create/update response — so an untyped After-hook redacts by mutating
+// that map directly. The typed wrappers must merge the mutated *T back into
+// the same map, or a host that redacts via the ergonomic typed API ships the
+// secret while believing it is masked. One redaction shape per surface; both
+// drifted together, so both are asserted here.
+func TestTypedAfterHooksCanRedact(t *testing.T) {
+	runTypedAfter := func(t *testing.T, label string, phase hook.HookType, register func(*App)) {
+		t.Helper()
+		app := NewApp(WithoutDefaultMiddleware())
+		register(app)
+		body := map[string]any{"id": "1", "title": "t", "secret": "topsecret"}
+		if err := app.HookRegistry("posts").ExecuteHooks(context.Background(), phase, body); err != nil {
+			t.Fatalf("%s: ExecuteHooks: %v", label, err)
+		}
+		if got := body["secret"]; got != "" {
+			t.Fatalf("%s: typed After-hook did not redact response body: secret=%v (want empty)", label, got)
+		}
+		// Merge-back must touch only the redacted field; the row's other
+		// columns (server-generated id, untouched title) survive intact.
+		if body["id"] != "1" || body["title"] != "t" {
+			t.Fatalf("%s: typed After-hook clobbered unrelated fields: %v", label, body)
+		}
+	}
+
+	t.Run("create", func(t *testing.T) {
+		runTypedAfter(t, "AfterCreate", hook.AfterCreate, func(app *App) {
+			OnAfterCreate[hookSecPost](app, "posts", func(_ context.Context, v *hookSecPost) error {
+				v.Secret = ""
+				return nil
+			})
+		})
+	})
+
+	t.Run("update", func(t *testing.T) {
+		runTypedAfter(t, "AfterUpdate", hook.AfterUpdate, func(app *App) {
+			OnAfterUpdate[hookSecPost](app, "posts", func(_ context.Context, v *hookSecPost) error {
+				v.Secret = ""
+				return nil
+			})
+		})
+	})
+
+	// Regression guard: the untyped After-hook path (the one the masking
+	// guidance in framework/hook/payload.go describes) redacts by mutating the
+	// live map directly. It must keep doing so.
+	t.Run("untyped_no_regression", func(t *testing.T) {
+		app := NewApp(WithoutDefaultMiddleware())
+		app.HookRegistry("posts").RegisterHook(hook.AfterCreate, func(_ context.Context, data any) error {
+			if m, ok := data.(map[string]any); ok {
+				m["secret"] = ""
+			}
+			return nil
+		})
+		body := map[string]any{"id": "1", "title": "t", "secret": "topsecret"}
+		if err := app.HookRegistry("posts").ExecuteHooks(context.Background(), hook.AfterCreate, body); err != nil {
+			t.Fatalf("untyped ExecuteHooks: %v", err)
+		}
+		if got := body["secret"]; got != "" {
+			t.Fatalf("untyped After-hook regression: secret=%v (want empty)", got)
+		}
+	})
 }
 
 // A panic inside a third-party or buggy hook must NOT propagate out of

--- a/kiln/effect/response.go
+++ b/kiln/effect/response.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 
 	"github.com/DonaldMurillo/gofastr/kiln/world"
@@ -33,10 +34,24 @@ func Resolve(ctx context.Context, a world.Action, scope Scope) (Response, error)
 	}
 }
 
+// validStatus reports whether code is inside the range net/http's
+// WriteHeader accepts. Anything else panics there, and the kiln route path
+// installs raw http.HandlerFuncs (render.applyRoutes) whose panic recovery
+// is an opt-in middleware the world has to declare — so the panic is
+// uncontained by default. 0 is excluded here and normalized to 200 by
+// WriteTo, matching net/http's own "no explicit status" behavior.
+func validStatus(code int) bool { return code >= 100 && code <= 999 }
+
 // WriteTo writes r as JSON to w.
 func (r Response) WriteTo(w http.ResponseWriter) error {
 	if r.Status == 0 {
 		r.Status = http.StatusOK
+	}
+	// Belt and braces: Resolve already rejects an out-of-range status, but
+	// Response is an exported type a caller can construct directly, and the
+	// failure mode here is a process-level panic rather than a bad response.
+	if !validStatus(r.Status) {
+		return fmt.Errorf("effect: response status %d out of range (100-999)", r.Status)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(r.Status)
@@ -55,7 +70,11 @@ func resolveJSON(a world.Action, s Scope) (Response, error) {
 		case int64:
 			resp.Status = int(n)
 		case float64:
-			resp.Status = int(n)
+			i, ok := toInt(n)
+			if !ok {
+				return Response{}, fmt.Errorf("respond_json status: %v is not an integer", n)
+			}
+			resp.Status = i
 		case string:
 			out, err := evalExpr(n, s)
 			if err != nil {
@@ -66,6 +85,14 @@ func resolveJSON(a world.Action, s Scope) (Response, error) {
 				return Response{}, fmt.Errorf("respond_json status: expected int, got %T", out)
 			}
 			resp.Status = i
+		}
+		// The status is an expression evaluated per request against the
+		// route scope, so its value is attacker-influenced even for a
+		// benign IR — `len(ctx.path)` against a 3-character path yields 3,
+		// and WriteHeader(3) panics. Reject here, before the value can
+		// reach net/http.
+		if !validStatus(resp.Status) {
+			return Response{}, fmt.Errorf("respond_json status: %d out of range (100-999)", resp.Status)
 		}
 	}
 	if v, ok := a.Params["body"]; ok {
@@ -83,6 +110,10 @@ func resolveJSON(a world.Action, s Scope) (Response, error) {
 	return resp, nil
 }
 
+// toInt narrows a scalar to int. A bare int(f) on a float64 is undefined in
+// Go when f is NaN, ±Inf, or outside int's range — 1e30 produced
+// 9223372036854775807 here — so the float case checks round-trippability
+// instead of trusting the conversion.
 func toInt(v any) (int, bool) {
 	switch n := v.(type) {
 	case int:
@@ -90,6 +121,12 @@ func toInt(v any) (int, bool) {
 	case int64:
 		return int(n), true
 	case float64:
+		if n != n || n > math.MaxInt32 || n < math.MinInt32 {
+			return 0, false // NaN, ±Inf, or out of a portable int range
+		}
+		if float64(int(n)) != n {
+			return 0, false // non-integral
+		}
 		return int(n), true
 	}
 	return 0, false

--- a/kiln/effect/response_security_test.go
+++ b/kiln/effect/response_security_test.go
@@ -1,0 +1,75 @@
+package effect
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/kiln/world"
+)
+
+// Property: a request-time-evaluated response field can never put the
+// process into a panic.
+//
+// respond_json's `status` is an expression string evaluated per request
+// against the route scope (path, method), so its value is attacker-
+// influenced even when the IR itself is benign. net/http's WriteHeader
+// panics for any code outside 100..999, and kiln's applyRoutes installs
+// raw http.HandlerFuncs — panic recovery in a kiln-rendered app is an
+// opt-in catalog entry the world has to declare — so an out-of-range
+// status is an uncontained panic on the serving goroutine.
+
+// TestOutOfRangeStatusRejected pins that a status outside the HTTP range
+// is refused at resolve time rather than handed to WriteHeader.
+func TestOutOfRangeStatusRejected(t *testing.T) {
+	for name, status := range map[string]any{
+		"zero":         float64(0),
+		"below 100":    float64(42),
+		"above 999":    float64(1000),
+		"negative":     float64(-1),
+		"huge float":   1e30,
+		"path length":  "len(ctx.path)", // benign IR + attacker-chosen path
+		"non-integral": 200.5,
+	} {
+		a := world.Action{
+			Kind:   world.ActionRespondJSON,
+			Params: map[string]any{"status": status},
+		}
+		scope := Scope{Ctx: map[string]any{"path": "/ab", "method": "GET"}}
+		resp, err := Resolve(context.Background(), a, scope)
+		if err != nil {
+			continue // rejected at resolve — the preferred outcome
+		}
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("%s (status=%v) panicked in WriteTo: %v", name, status, r)
+				}
+			}()
+			if wErr := resp.WriteTo(httptest.NewRecorder()); wErr != nil {
+				t.Logf("%s: write error %v", name, wErr)
+			}
+		}()
+	}
+}
+
+// TestInRangeStatusStillHonored guards against an over-strict clamp.
+func TestInRangeStatusStillHonored(t *testing.T) {
+	for _, want := range []int{200, 201, 302, 404, 418, 503} {
+		a := world.Action{
+			Kind:   world.ActionRespondJSON,
+			Params: map[string]any{"status": float64(want), "body": map[string]any{"ok": true}},
+		}
+		resp, err := Resolve(context.Background(), a, Scope{})
+		if err != nil {
+			t.Fatalf("status %d rejected: %v", want, err)
+		}
+		rec := httptest.NewRecorder()
+		if err := resp.WriteTo(rec); err != nil {
+			t.Fatalf("status %d: %v", want, err)
+		}
+		if rec.Code != want {
+			t.Errorf("status = %d, want %d", rec.Code, want)
+		}
+	}
+}

--- a/kiln/expr/env.go
+++ b/kiln/expr/env.go
@@ -158,9 +158,12 @@ func foldNumeric(args []any, op func(a, b float64) float64) (any, error) {
 			intValues[i] = v
 			values[i] = float64(v)
 		case int:
+			// Must NOT set allInt=true: the flag is monotone-downward, and
+			// re-raising it after a float64 argument sent the fold down the
+			// all-int path with intValues holding an unassigned zero for the
+			// float element — min(1.5, 7) returned 0.
 			intValues[i] = int64(v)
 			values[i] = float64(v)
-			allInt = true
 		case float64:
 			values[i] = v
 			allInt = false

--- a/kiln/expr/eval.go
+++ b/kiln/expr/eval.go
@@ -1,6 +1,9 @@
 package expr
 
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+)
 
 func (n *literalNode) eval(_ Scope, _ *Env) (any, error) { return n.value, nil }
 
@@ -43,7 +46,9 @@ func (n *indexNode) eval(scope Scope, env *Env) (any, error) {
 		if !ok {
 			return nil, fmt.Errorf("expr: list index must be int, got %T", idx)
 		}
-		if i < 0 || int(i) >= len(t) {
+		// Compare at int64 width: int(i) truncates on a 32-bit build, so
+		// a large index could clear the guard and then panic in t[i].
+		if i < 0 || i >= int64(len(t)) {
 			return nil, fmt.Errorf("expr: index %d out of range", i)
 		}
 		return t[i], nil
@@ -253,7 +258,26 @@ func equals(l, r any) bool {
 		}
 		return lf == rf
 	}
+	// Comparing two interface values panics at runtime when either dynamic
+	// type is uncomparable (slice, map, func). Those arrive routinely here:
+	// a list literal, or any JSON array decoded into []any. The panic is not
+	// containable — kiln's applyRoutes installs raw http.HandlerFuncs and
+	// panic recovery is an opt-in catalog entry the world must declare — so
+	// guard the comparison instead. Uncomparable operands are not equal.
+	//
+	// reflect covers every shape reachable from a world IR (JSON scalars,
+	// []any, map[string]any) plus int64. A struct type whose field is an
+	// interface reports Comparable()==true and could still panic, but no
+	// such value can enter an expression scope.
+	if !isComparable(l) || !isComparable(r) {
+		return false
+	}
 	return l == r
+}
+
+func isComparable(v any) bool {
+	t := reflect.TypeOf(v)
+	return t != nil && t.Comparable()
 }
 
 func compare(op string, l, r any) (any, error) {

--- a/kiln/expr/expr.go
+++ b/kiln/expr/expr.go
@@ -44,6 +44,12 @@ var (
 	ErrType  = errors.New("expr: wrong argument type")
 )
 
+// MaxSourceBytes is the largest expression source [Compile] accepts.
+// Expression strings arrive from the world IR, which kiln's build mode
+// accepts over HTTP, so the lexer's allocation must be bounded before it
+// runs.
+const MaxSourceBytes = 64 << 10
+
 // Expression is a compiled, ready-to-evaluate expression tree.
 type Expression struct {
 	root node
@@ -58,6 +64,13 @@ func (e *Expression) Source() string { return e.src }
 func Compile(src string) (*Expression, error) {
 	if src == "" {
 		return nil, fmt.Errorf("expr: empty source")
+	}
+	// Bound the input before lexing. lex allocates a token per lexeme, so a
+	// multi-megabyte source costs hundreds of MB before the parser's node
+	// budget ever gets a vote. World-IR conditions are one-liners; 64 KiB
+	// is far above anything an author writes by hand.
+	if len(src) > MaxSourceBytes {
+		return nil, fmt.Errorf("expr: source too large (%d bytes, limit %d)", len(src), MaxSourceBytes)
 	}
 	tokens, err := lex(src)
 	if err != nil {

--- a/kiln/expr/expr_security_test.go
+++ b/kiln/expr/expr_security_test.go
@@ -1,0 +1,147 @@
+package expr_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/kiln/expr"
+)
+
+// Property: no expression string can terminate the host process.
+//
+// Kiln's build mode accepts expression sources over HTTP (add_hook,
+// add_validate, respond_json status/body, route conditions), so every
+// source below is attacker-reachable. Two crash classes matter:
+//
+//   - a Go panic from an unguarded runtime operation, and
+//   - a goroutine stack overflow, which is a FATAL runtime error that
+//     recover() cannot catch and no middleware can contain.
+//
+// depth_test.go pins the two surfaces that were already guarded (nested
+// '(' and nested '['). This file pins the surfaces that were not: the
+// iterative precedence loops and the postfix chain build left-deep trees
+// without touching the parser's depth counter, and equals() compared
+// interface values whose dynamic type may be uncomparable.
+
+// TestUncomparableOperandsNoPanic pins that comparing values with
+// uncomparable dynamic types yields a result, never a runtime panic.
+func TestUncomparableOperandsNoPanic(t *testing.T) {
+	for _, src := range []string{
+		"[1] == [2]",              // slice vs slice
+		"[1] != [1]",              // the != path shares equals()
+		`[1] == "x"`,              // slice vs comparable
+		"contains([[1]], [1])",    // equals() reached via a builtin
+		"[[1], [2]] == [[1], []]", // nested slices
+	} {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("%q panicked: %v", src, r)
+				}
+			}()
+			if _, err := expr.EvalBool(src, nil, nil); err != nil {
+				t.Logf("%q -> error (acceptable): %v", src, err)
+			}
+		}()
+	}
+}
+
+// TestUncomparableEqualsIsFalse pins the semantics chosen for the fix:
+// two uncomparable operands are not equal rather than an error, so an
+// existing `!=` guard in a world IR keeps evaluating to true.
+func TestUncomparableEqualsIsFalse(t *testing.T) {
+	got, err := expr.EvalBool("[1] == [1]", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Error("uncomparable operands must not compare equal")
+	}
+}
+
+// TestFlatChainDepthRejected pins the AST surfaces the parser's grouping
+// guard never saw. Each builds a tree of depth O(n) through an ITERATIVE
+// parse loop, so no amount of parser recursion guarding catches them; the
+// crash lands later, in the recursive evaluator.
+func TestFlatChainDepthRejected(t *testing.T) {
+	const n = 200000
+	for name, src := range map[string]string{
+		"binary": "1" + strings.Repeat("+1", n),       // parseAdd loop
+		"member": "a" + strings.Repeat(".b", n),       // parsePostfix '.'
+		"index":  "a" + strings.Repeat("[0]", n),      // parsePostfix '['
+		"unary":  strings.Repeat("!", n) + "true",     // parseUnary recursion
+		"mixed":  "1" + strings.Repeat("+a.b*2", n/4), // interleaved loops
+	} {
+		if _, err := expr.Compile(src); err == nil {
+			t.Errorf("%s chain of %d compiled; eval would recurse that deep", name, n)
+		}
+	}
+}
+
+// TestOversizeSourceRejected pins that Compile bounds its input before
+// lexing. Without a cap, a 20 MB source allocates a token per byte and a
+// node per term before any depth check can run.
+func TestOversizeSourceRejected(t *testing.T) {
+	src := "1" + strings.Repeat("+1", 5_000_000) // ~10 MB
+	if _, err := expr.Compile(src); err == nil {
+		t.Fatal("oversize source compiled")
+	}
+}
+
+// TestOrdinaryExpressionsStillCompile guards against an over-aggressive
+// cap: real world-IR conditions must keep working.
+func TestOrdinaryExpressionsStillCompile(t *testing.T) {
+	scope := expr.MapScope{"entity": map[string]any{"status": "active", "n": int64(3)}}
+	for src, want := range map[string]bool{
+		`entity.status == "active"`:                       true,
+		`entity.n > 1 && entity.n < 10`:                   true,
+		`contains(["a", "b"], "b") || entity.n == 99`:     true,
+		`!(entity.status == "draft")`:                     true,
+		`min(entity.n, 5) == 3 && len(entity.status) > 0`: true,
+	} {
+		got, err := expr.EvalBool(src, scope, nil)
+		if err != nil {
+			t.Errorf("%q: %v", src, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("%q = %v, want %v", src, got, want)
+		}
+	}
+}
+
+// TestMinMaxMixedNumericTypes pins that the numeric fold stays
+// type-monotone: one float operand must force the float path for the
+// whole argument list. The int case used to re-set the all-int flag, so a
+// float argument followed by an int returned intValues[0] — a zero that
+// was never assigned — silently defeating a `min(...) > 0` guard.
+func TestMinMaxMixedNumericTypes(t *testing.T) {
+	scope := expr.MapScope{"i": 7, "f": 1.5}
+	for src, want := range map[string]float64{
+		"min(f, i)": 1.5,
+		"max(f, i)": 7,
+		"min(i, f)": 1.5,
+		"max(i, f)": 7,
+	} {
+		v, err := expr.Compile(src)
+		if err != nil {
+			t.Fatalf("%q: %v", src, err)
+		}
+		got, err := v.Eval(scope, nil)
+		if err != nil {
+			t.Fatalf("%q: %v", src, err)
+		}
+		var f float64
+		switch n := got.(type) {
+		case float64:
+			f = n
+		case int64:
+			f = float64(n)
+		default:
+			t.Fatalf("%q returned %T", src, got)
+		}
+		if f != want {
+			t.Errorf("%q = %v, want %v", src, f, want)
+		}
+	}
+}

--- a/kiln/expr/parser.go
+++ b/kiln/expr/parser.go
@@ -34,10 +34,34 @@ type listNode struct{ items []node }
 // instead of exhausting the goroutine stack.
 const maxDepth = 256
 
+// maxNodes caps the total AST size. maxDepth alone is not enough: the
+// precedence loops (parseOr/parseAnd/parseAdd/parseMul) and the postfix
+// chain iterate rather than recurse, so `1+1+1+…` and `a.b.c.d…` build a
+// LEFT-DEEP tree of depth O(n) while the parser's own recursion — and
+// therefore its depth counter — stays flat. The crash lands later, in the
+// recursive evaluator, as a goroutine stack overflow: a FATAL runtime
+// error recover() cannot catch, so no middleware can contain it.
+//
+// Node depth is bounded by node count, so capping the count caps eval
+// recursion. 10k nodes is orders of magnitude above any real world-IR
+// condition and evaluates in a few hundred KB of stack.
+const maxNodes = 10_000
+
 type parser struct {
 	tokens []token
 	pos    int
 	depth  int
+	nodes  int
+}
+
+// count charges one AST node against the budget. Every node constructor
+// goes through it, including the ones the iterative loops build.
+func (p *parser) count() error {
+	p.nodes++
+	if p.nodes > maxNodes {
+		return fmt.Errorf("expr: expression too large (limit %d nodes)", maxNodes)
+	}
+	return nil
 }
 
 // enter increments the recursion depth and reports an error once the
@@ -108,6 +132,9 @@ func (p *parser) parseOr() (node, error) {
 		if err != nil {
 			return nil, err
 		}
+		if err := p.count(); err != nil {
+			return nil, err
+		}
 		left = &binaryNode{op: "||", left: left, right: right}
 	}
 	return left, nil
@@ -122,6 +149,9 @@ func (p *parser) parseAnd() (node, error) {
 		p.advance()
 		right, err := p.parseComp()
 		if err != nil {
+			return nil, err
+		}
+		if err := p.count(); err != nil {
 			return nil, err
 		}
 		left = &binaryNode{op: "&&", left: left, right: right}
@@ -141,6 +171,9 @@ func (p *parser) parseComp() (node, error) {
 			p.advance()
 			right, err := p.parseAdd()
 			if err != nil {
+				return nil, err
+			}
+			if err := p.count(); err != nil {
 				return nil, err
 			}
 			return &binaryNode{op: t.value, left: left, right: right}, nil
@@ -164,6 +197,9 @@ func (p *parser) parseAdd() (node, error) {
 		if err != nil {
 			return nil, err
 		}
+		if err := p.count(); err != nil {
+			return nil, err
+		}
 		left = &binaryNode{op: t.value, left: left, right: right}
 	}
 }
@@ -183,6 +219,9 @@ func (p *parser) parseMul() (node, error) {
 		if err != nil {
 			return nil, err
 		}
+		if err := p.count(); err != nil {
+			return nil, err
+		}
 		left = &binaryNode{op: t.value, left: left, right: right}
 	}
 }
@@ -197,6 +236,9 @@ func (p *parser) parseUnary() (node, error) {
 		p.advance()
 		inner, err := p.parseUnary()
 		if err != nil {
+			return nil, err
+		}
+		if err := p.count(); err != nil {
 			return nil, err
 		}
 		return &unaryNode{op: t.value, expr: inner}, nil
@@ -222,6 +264,9 @@ func (p *parser) parsePostfix() (node, error) {
 				return nil, fmt.Errorf("expr: expected identifier after '.' at %d", t.pos)
 			}
 			p.advance()
+			if err := p.count(); err != nil {
+				return nil, err
+			}
 			primary = &memberNode{target: primary, field: id.value}
 		case "[":
 			p.advance()
@@ -230,6 +275,9 @@ func (p *parser) parsePostfix() (node, error) {
 				return nil, err
 			}
 			if err := p.expectPunct("]"); err != nil {
+				return nil, err
+			}
+			if err := p.count(); err != nil {
 				return nil, err
 			}
 			primary = &indexNode{target: primary, index: idx}
@@ -242,6 +290,9 @@ func (p *parser) parsePostfix() (node, error) {
 			p.advance()
 			args, err := p.parseArgList(")")
 			if err != nil {
+				return nil, err
+			}
+			if err := p.count(); err != nil {
 				return nil, err
 			}
 			primary = &callNode{name: id.name, args: args}
@@ -277,6 +328,9 @@ func (p *parser) parseArgList(closer string) ([]node, error) {
 }
 
 func (p *parser) parsePrimary() (node, error) {
+	if err := p.count(); err != nil {
+		return nil, err
+	}
 	t := p.peek()
 	switch t.kind {
 	case tokNumber:

--- a/kiln/render/node.go
+++ b/kiln/render/node.go
@@ -45,11 +45,11 @@ func RenderNode(n world.Node) render.HTML {
 			Heading:      propString(n.Props, "heading", "title"),
 			Description:  propString(n.Props, "description", "subtitle"),
 			HeadingLevel: propInt(n.Props, "heading_level", "level"),
-			Href:         propString(n.Props, "href"), Variant: cardVariant(propString(n.Props, "variant")),
+			Href:         safeHref(propString(n.Props, "href")), Variant: cardVariant(propString(n.Props, "variant")),
 			ID: propString(n.Props, "id"),
 		}, withTextFallback(children, propString(n.Props, "text"))...)
 	case "link_button":
-		label, href := propString(n.Props, "label", "text"), propString(n.Props, "href")
+		label, href := propString(n.Props, "label", "text"), safeHref(propString(n.Props, "href"))
 		if label == "" || href == "" {
 			return renderLeaf(n, children)
 		}
@@ -114,13 +114,93 @@ func renderLeaf(n world.Node, children []render.HTML) render.HTML {
 	if len(props) > 0 {
 		props = make(map[string]any, len(n.Props))
 		for key, value := range n.Props {
+			// Structural styling belongs to the typed design-system kinds.
 			if strings.EqualFold(key, "class") {
 				continue
+			}
+			if strings.EqualFold(strings.TrimSpace(key), "data-kiln-tool") {
+				name, _ := value.(string)
+				if !safeToolName(name) {
+					continue
+				}
 			}
 			props[key] = value
 		}
 	}
 	return noderender.RenderKind(n.Kind, props, children)
+}
+
+// safeToolName bounds the value of data-kiln-tool to a bare tool
+// identifier.
+//
+// The runtime's delegator builds `fetch('/kiln/tool/' + attr)` with no
+// encodeURIComponent (core-ui/runtime frag/rpc.js), and dispatch is gated
+// only on a data-fui-trusted ancestor — which worldScreen.Render puts around
+// the entire agent-authored tree. core-ui/noderender allows data-kiln-tool
+// through its data-* rule on the stated grounds that "the delegator
+// additionally requires a data-fui-trusted ancestor, which this IR cannot
+// produce" (noderender_security_test.go); in kiln's only render path the IR
+// always produces one, so that justification does not hold here and the
+// value has to be checked at ingestion.
+//
+// Unchecked, a tool name of "../../api/posts" has its dot-segments removed
+// by the URL parser and the click becomes a same-origin POST to /api/posts —
+// carrying the operator's cookies and the page's CSRF token — against routes
+// the kiln tool API does not otherwise expose. "x?y=z" and "x#f" inject a
+// query and a fragment the same way.
+//
+// A real kiln tool name is a lowercase identifier (chat, add_page,
+// update_page_element), so anything else is dropped rather than rendered.
+// The attribute itself stays supported: TestBrowser_ButtonToolCallFires
+// pins that an agent-authored button naming a genuine tool still fires it.
+func safeToolName(name string) bool {
+	if name == "" || len(name) > 64 {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		case c == '_' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// safeHref filters an agent-authored href before it reaches a design-system
+// component. The components disagree on what to do with a hostile scheme —
+// ui.Card drops to "#" while ui.LinkButton panics (framework/ui:
+// components.go) — and a panic on the typed path 500s the page on every
+// request until the IR is edited. Both contracts are right for a Go author
+// passing a literal; neither is right for request-authored IR, so the
+// scheme decision happens here instead. Mirrors the degrade-don't-panic
+// choice core-ui/noderender already made for the leaf path.
+func safeHref(href string) string {
+	trimmed := strings.TrimSpace(href)
+	if trimmed == "" {
+		return ""
+	}
+	// Strip the C0 range + DEL before testing: a browser ignores them when
+	// resolving a scheme, so "\tjava\nscript:" is still javascript:.
+	var b strings.Builder
+	for _, r := range trimmed {
+		if r <= 0x20 || r == 0x7f {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	clean := strings.ToLower(b.String())
+	scheme, _, hasScheme := strings.Cut(clean, ":")
+	if !hasScheme || strings.ContainsAny(scheme, "/?#") {
+		return trimmed // relative, absolute-path, query, or fragment
+	}
+	switch scheme {
+	case "http", "https", "mailto", "tel":
+		return trimmed
+	}
+	return ""
 }
 
 func renderChildren(nodes []world.Node) []render.HTML {

--- a/kiln/render/render.go
+++ b/kiln/render/render.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/DonaldMurillo/gofastr/core/query"
 	"github.com/DonaldMurillo/gofastr/framework"
 	"github.com/DonaldMurillo/gofastr/kiln/effect"
 	"github.com/DonaldMurillo/gofastr/kiln/world"
@@ -174,8 +175,15 @@ func applyEntities(app *framework.App, w *world.World) error {
 // JSON round-trip silently drifted as the framework surface evolved.
 func entityConfig(e *world.Entity) (framework.EntityConfig, error) {
 	decl := framework.EntityDeclaration{
-		// Kiln has no session hook, so preserve its pre-existing open CRUD explicitly.
-		// TODO(kiln): grow an auth/access concept in the IR.
+		// Every kiln entity is public, even one declaring OwnerField or
+		// MultiTenant, which hard rule 6 forbids anywhere else. Kiln has no
+		// session concept to scope against, and this is a deliberate
+		// exception rather than an oversight: kiln is the in-app build-mode
+		// runtime for someone assembling a world over HTTP, not a way to
+		// serve an application. A kiln world is a preview — treat its
+		// database as readable by anyone who can reach the port, and freeze
+		// to a real app (which does honour these fields) before it holds
+		// anything that matters.
 		Public:         true,
 		Name:           e.Name,
 		Table:          e.Table,
@@ -267,12 +275,19 @@ func insertSeed(db *sql.DB, s *world.Seed) error {
 	if s.Entity == "" {
 		return fmt.Errorf("empty entity")
 	}
+	table, err := query.SafeIdent(s.Entity)
+	if err != nil {
+		return fmt.Errorf("seed entity: %w", err)
+	}
 	for _, row := range s.Rows {
 		if len(row) == 0 {
 			continue
 		}
 		cols := make([]string, 0, len(row))
 		for k := range row {
+			if _, err := query.SafeIdent(k); err != nil {
+				return fmt.Errorf("seed column: %w", err)
+			}
 			cols = append(cols, k)
 		}
 		sort.Strings(cols)
@@ -282,55 +297,36 @@ func insertSeed(db *sql.DB, s *world.Seed) error {
 			placeholders[i] = "?"
 			args[i] = row[c]
 		}
-		query := buildInsert(s.Entity, cols, placeholders)
-		if _, err := db.Exec(query, args...); err != nil {
+		q := buildInsert(table, cols, placeholders)
+		if _, err := db.Exec(q, args...); err != nil {
 			return fmt.Errorf("insert %v: %w", row, err)
 		}
 	}
 	return nil
 }
 
+// buildInsert assumes table and cols have already cleared query.SafeIdent —
+// insertSeed is the only caller and validates both up front. Seed entity
+// names and row keys are agent-authored world IR, so validation (not just
+// quoting) is the contract: kiln used to carry a private quoteIdent that
+// escaped `"` and then wrote each rune with `append(out, byte(r))`,
+// truncating to the low byte AFTER the escape test — so U+2022 and every
+// other rune ending in 0x22 became a literal quote that closed the
+// identifier. core/query is the one correct implementation; there is no
+// second copy here any more.
 func buildInsert(table string, cols, placeholders []string) string {
-	return "INSERT INTO " + quoteIdent(table) + " (" + joinIdents(cols) + ") VALUES (" + join(placeholders) + ")"
+	return "INSERT INTO " + query.QuoteIdent(table) + " (" + joinIdents(cols) + ") VALUES (" + join(placeholders) + ")"
 }
 
 func joinIdents(cols []string) string {
-	out := make([]byte, 0, 32)
+	out := make([]string, len(cols))
 	for i, c := range cols {
-		if i > 0 {
-			out = append(out, ',', ' ')
-		}
-		out = append(out, []byte(quoteIdent(c))...)
+		out[i] = query.QuoteIdent(c)
 	}
-	return string(out)
+	return strings.Join(out, ", ")
 }
 
-func join(parts []string) string {
-	out := make([]byte, 0, 32)
-	for i, p := range parts {
-		if i > 0 {
-			out = append(out, ',', ' ')
-		}
-		out = append(out, []byte(p)...)
-	}
-	return string(out)
-}
-
-// quoteIdent applies SQL identifier quoting. SQLite accepts double quotes;
-// Kiln's runtime DB target is SQLite (Phase 4), so this is sufficient.
-func quoteIdent(s string) string {
-	out := make([]byte, 0, len(s)+2)
-	out = append(out, '"')
-	for _, r := range s {
-		if r == '"' {
-			out = append(out, '"', '"')
-			continue
-		}
-		out = append(out, byte(r))
-	}
-	out = append(out, '"')
-	return string(out)
-}
+func join(parts []string) string { return strings.Join(parts, ", ") }
 
 func applyMiddleware(app *framework.App, w *world.World) error {
 	for _, mw := range w.Middleware {

--- a/kiln/render/render_security_test.go
+++ b/kiln/render/render_security_test.go
@@ -1,0 +1,221 @@
+package render
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/DonaldMurillo/gofastr/kiln/world"
+)
+
+// Property: no agent-authored world-IR string reaches a raw sink.
+//
+// Kiln's build mode mutates the IR over HTTP, so every world.* field below
+// is attacker-authored. The sinks that matter in this package are the seed
+// INSERT statement (SQL) and the theme map (the app stylesheet).
+
+// TestSeedIdentRejectsInjection pins that a seed's entity name and its row
+// keys are validated as SQL identifiers rather than merely quoted.
+//
+// The private quoteIdent this replaced escaped `"` and then wrote each rune
+// with `append(out, byte(r))`, truncating to the low byte AFTER the escape
+// test. Any rune whose low byte is 0x22 — U+2022 '•', U+0122, U+0222, … —
+// became a literal quote the escape never saw, closing the identifier:
+//
+//	quoteIdent("users•) VALUES(1);--")  ->  "users") VALUES(1);--"
+func TestSeedIdentRejectsInjection(t *testing.T) {
+	db := openSeedDB(t)
+	for name, seed := range map[string]*world.Seed{
+		"truncating rune in table": {
+			Entity: "users\u2022) VALUES('x'); DROP TABLE users; --",
+			Rows:   []map[string]any{{"name": "a"}},
+		},
+		"truncating rune in column": {
+			Entity: "users",
+			Rows:   []map[string]any{{"name\u2022) VALUES('x'); --": "a"}},
+		},
+		"bare quote in table": {
+			Entity: `users" ; DROP TABLE users; --`,
+			Rows:   []map[string]any{{"name": "a"}},
+		},
+		"space and semicolon": {
+			Entity: "users; DROP TABLE users",
+			Rows:   []map[string]any{{"name": "a"}},
+		},
+		"empty column name": {
+			Entity: "users",
+			Rows:   []map[string]any{{"": "a"}},
+		},
+	} {
+		err := ApplySeeds(db, &world.World{Seeds: []*world.Seed{seed}})
+		if err == nil {
+			t.Errorf("%s: seed accepted, want rejection", name)
+		}
+	}
+	// The table must survive every attempt above.
+	var n int
+	if err := db.QueryRow(`SELECT count(*) FROM users`).Scan(&n); err != nil {
+		t.Fatalf("users table did not survive: %v", err)
+	}
+}
+
+// TestSeedHappyPathStillInserts guards against an over-strict validator.
+func TestSeedHappyPathStillInserts(t *testing.T) {
+	db := openSeedDB(t)
+	seed := &world.Seed{Entity: "users", Rows: []map[string]any{{"name": "ada"}}}
+	if err := ApplySeeds(db, &world.World{Seeds: []*world.Seed{seed}}); err != nil {
+		t.Fatalf("valid seed rejected: %v", err)
+	}
+	var got string
+	if err := db.QueryRow(`SELECT name FROM users`).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != "ada" {
+		t.Errorf("name = %q, want ada", got)
+	}
+}
+
+func openSeedDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`CREATE TABLE users (name TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+// TestThemeRejectsCSSInjection pins that theme tokens from the IR cannot
+// escape their declaration. core-ui/style emits `--color-<key>: <value>;`
+// with no escaping of either side, so an unvalidated value closes the rule
+// block and appends arbitrary CSS to the app stylesheet — a bypass of the
+// node renderer's deliberate strip of `class` and inline styles.
+func TestThemeRejectsCSSInjection(t *testing.T) {
+	cfg := world.AppConfig{
+		Theme: map[string]string{
+			"primary":    "red; } body { background: url(//evil.test/x) } .z {",
+			"background": "#fff",
+			"text":       "expression(alert(1))",
+			"font_body":  "Inter, sans-serif",
+			"surface":    "url(//evil.test/leak)",
+		},
+		ThemeDark: map[string]string{
+			"primary":                         "#000",
+			"x: y; } :root { --color-primary": "#f00",
+			"surface":                         "}\n@import url(//evil.test/x);\n:root{",
+		},
+	}
+	th := worldTheme(cfg)
+	css := th.CSSCustomProperties()
+	for _, bad := range []string{"evil.test", "@import", "expression(", "body {"} {
+		if strings.Contains(css, bad) {
+			t.Errorf("theme CSS contains %q:\n%s", bad, css)
+		}
+	}
+	// Well-formed values must still land.
+	if !strings.Contains(css, "#fff") {
+		t.Error("valid color dropped")
+	}
+	if !strings.Contains(css, "Inter") {
+		t.Error("valid font dropped")
+	}
+	if th.DarkColors["primary"] != "#000" {
+		t.Errorf("valid dark color dropped: %q", th.DarkColors["primary"])
+	}
+}
+
+// TestUnsafeHrefDegradesNotPanics pins that a hostile href in the typed
+// node path degrades like the leaf path does, instead of panicking SSR.
+// ui.LinkButton panics on an unsafe scheme (a correct contract for a Go
+// author passing a literal); kiln feeds it agent IR, so the check has to
+// happen before the component sees it.
+func TestUnsafeHrefDegradesNotPanics(t *testing.T) {
+	for _, href := range []string{
+		"javascript:alert(1)",
+		"JaVaScRiPt:alert(1)",
+		"data:text/html,<script>alert(1)</script>",
+		"vbscript:msgbox(1)",
+		"\tjavascript:alert(1)",
+	} {
+		for _, kind := range []string{"link_button", "card"} {
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("%s href=%q panicked: %v", kind, href, r)
+					}
+				}()
+				out := string(RenderNode(world.Node{
+					Kind:  kind,
+					Props: map[string]any{"label": "go", "heading": "go", "href": href},
+				}))
+				if strings.Contains(strings.ToLower(out), "javascript:") ||
+					strings.Contains(strings.ToLower(out), "vbscript:") ||
+					strings.Contains(strings.ToLower(out), "data:text/html") {
+					t.Errorf("%s emitted the unsafe href: %s", kind, out)
+				}
+			}()
+		}
+	}
+}
+
+// TestSafeHrefStillRenders guards against dropping legitimate links.
+func TestSafeHrefStillRenders(t *testing.T) {
+	out := string(RenderNode(world.Node{
+		Kind:  "link_button",
+		Props: map[string]any{"label": "go", "href": "/dashboard"},
+	}))
+	if !strings.Contains(out, "/dashboard") {
+		t.Errorf("safe href dropped: %s", out)
+	}
+}
+
+// TestKilnToolNameRejectsTraversal pins that an agent-authored
+// data-kiln-tool value is a bare tool identifier and nothing else. The
+// runtime concatenates it into a URL without encodeURIComponent, so a value
+// with dot-segments, a query, or a fragment redirects the click away from
+// /kiln/tool/ to an arbitrary same-origin route carrying the operator's
+// cookies and CSRF token.
+//
+// The attribute stays supported — kiln/integration's
+// TestBrowser_ButtonToolCallFires pins that a button naming a real tool
+// still fires it, and that contract is deliberately kept.
+func TestKilnToolNameRejectsTraversal(t *testing.T) {
+	for _, name := range []string{
+		"../../api/posts",
+		"chat?x=1",
+		"chat#frag",
+		"a/b",
+		"..%2fadmin",
+	} {
+		out := string(RenderNode(world.Node{
+			Kind: "button",
+			Props: map[string]any{
+				"label":          "go",
+				"data-kiln-tool": name,
+				"data-kiln-args": `{"role":"user"}`,
+			},
+		}))
+		if strings.Contains(out, "data-kiln-tool") {
+			t.Errorf("tool name %q survived: %s", name, out)
+		}
+	}
+}
+
+// TestKilnToolNameKeepsRealTools guards the feature the rejection above
+// must not break.
+func TestKilnToolNameKeepsRealTools(t *testing.T) {
+	for _, name := range []string{"chat", "add_page", "update_page_element"} {
+		out := string(RenderNode(world.Node{
+			Kind:  "button",
+			Props: map[string]any{"label": "go", "data-kiln-tool": name},
+		}))
+		if !strings.Contains(out, `data-kiln-tool="`+name+`"`) {
+			t.Errorf("real tool %q dropped: %s", name, out)
+		}
+	}
+}

--- a/kiln/render/uihost.go
+++ b/kiln/render/uihost.go
@@ -136,10 +136,66 @@ type routerMounter struct{ r *corerouter.Router }
 
 func (m routerMounter) MountWidget(def *widget.Definition) { widget.Mount(m.r, def) }
 
+// safeThemeValue reports whether an agent-authored theme token value can be
+// interpolated into the app stylesheet.
+//
+// core-ui/style emits `--color-<name>: <value>;` (tokens.go darkSchemeCSS,
+// CSSCustomPropertiesOf) with NO escaping on either side, and the result is
+// served as the app stylesheet. An unfiltered value closes its declaration
+// and appends arbitrary rules — which is a privilege escalation relative to
+// the node renderer, whose whole job is to strip `class` and inline styles
+// from this same untrusted IR. Escaping belongs upstream in core-ui/style;
+// this is the ingestion-side guard for the one caller that feeds it
+// request-authored input.
+//
+// The allowed shape is a CSS color or font stack: alphanumerics plus the
+// punctuation those need. Everything that could start a new declaration,
+// rule, or at-rule (`;{}@\<>`), a comment (`/*`), or a network fetch
+// (`url(`, `image(`) is rejected outright.
+func safeThemeValue(v string) bool {
+	if v == "" || len(v) > 128 {
+		return false
+	}
+	for _, r := range v {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case strings.ContainsRune(" #%.,-+()/'\"_", r):
+		default:
+			return false
+		}
+	}
+	lower := strings.ToLower(v)
+	for _, bad := range []string{"url(", "image(", "expression(", "/*", "*/", "//"} {
+		if strings.Contains(lower, bad) {
+			return false
+		}
+	}
+	return true
+}
+
+// safeThemeKey bounds an agent-authored DARK token name. Unlike the light
+// palette (a closed switch below), DarkColors is a free map whose key lands
+// directly in `--color-<key>:`, so a key of `x: y; } :root { --color-primary`
+// injects a rule of its own.
+func safeThemeKey(k string) bool {
+	if k == "" || len(k) > 64 {
+		return false
+	}
+	for i, r := range k {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+		case r == '-' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 func worldTheme(c world.AppConfig) style.Theme {
 	t := uitheme.Default()
 	for key, value := range c.Theme {
-		if value == "" {
+		if !safeThemeValue(value) {
 			continue
 		}
 		switch key {
@@ -182,7 +238,7 @@ func worldTheme(c world.AppConfig) style.Theme {
 		}
 	}
 	for key, value := range c.ThemeDark {
-		if value != "" {
+		if safeThemeKey(key) && safeThemeValue(value) {
 			t.DarkColors[key] = value
 		}
 	}


### PR DESCRIPTION
A two-pass security audit — breadth then depth, both on Opus, per the protocol in `.claude/skills/adversarial-tests/SKILL.md` — over the packages no previous pass had ever read: kiln's expression and render layers, the module wire protocol, the router, config, feature flags, i18n, migrations, file and image handling, the SDK, and the pack/docs tooling.

~85 candidates were adjudicated. 30 confirmed and fixed, ~40 refuted with specific reasons, the rest escalated and decided. **Nine findings were proven by execution rather than argued** — a panic trace, a rendered string, a committed row, a goroutine count.

## The serious ones

- **DDL injection that actually committed a column.** `SQLDefault`'s fallback arm interpolated `'%v'` unescaped; `Field.Default` is `any`, so a named string type or decoded map took that arm. Reachable through kiln's HTTP `add_entity`.
- **Router authorization bypass.** A trailing-slash or dot-segment redirect skipped the route gate *and* the whole middleware chain — no security headers, recovery, or rate limiting — and Go's 307 preserves method and body, so it answered POSTs. A gated subtree returned 404 on the exact path and 307 on the redirect, which is the existence leak the gate's contract promises not to produce. Matches CVE-2026-15704's shape.
- **SQL identifier injection in kiln.** Its private `quoteIdent` truncated runes to their low byte *after* testing for `"`, so `U+2022` closed the identifier. CVE-2025-53727's escape-then-transcode shape. The two shared implementations were both correct; the private copy is deleted.
- **Unrecoverable process kill.** A flat `1+1+1…` chain built a depth-O(n) AST the parser's depth guard never counted, producing a fatal stack overflow `recover()` cannot catch.
- Plus: CSRF exemption keyed on the decoded path while dispatch used the escaped one; `required:"true"` satisfied by an empty env var; a DSN leaking through a validator error; an unbounded locale tag reaching a third-party catalog as `../../etc/passwd`; a magic-byte polyglot bypass; typed After-hooks unable to redact response bodies; and the 404 path rebuilding a full mux per request at 1206× cost ahead of the rate limiter.

## BREAKING

`moduleproto`'s four inbound reverse-call param structs now carry `CallerRef` (delegation handle only) instead of `Caller`. A child echoing back its own `Subject`/`Tenant` is a confused-deputy shape; the shipped `Broker` never read them, so nothing was exploitable, but the fields sitting on the decoded struct is weak protection for future authors. Anyone implementing a process module gets a compile error and drops two fields.

No `upgrades.yml` entry yet — entries are keyed to a released version and this is a branch. `TestChangelogAgreesWithUpgradesOnBreaking` skips `[Unreleased]` and will fail the release PR that rolls this without one.

## Verification

- Full suite: 183 packages, 0 failures; coverage floors hold; `core-ui/runtime` and `core-ui/widget` green in isolation
- `gofmt`, `go vet`, `govulncheck` all clean
- Every fix landed with a test that was watched failing first; the load-bearing ones I re-verified independently by reverting the fix and re-running
- Threat intel anchored the pass against the live CVE corpus, which surfaced the router and path-desync classes before the code was read

Two security tests changed rather than being deleted, each keeping the property it protected with the rationale recorded beside it: the upload test that pinned `GIF89a` + `<script>` as acceptable, and the moduleproto test that pinned a child-supplied `Subject` round-tripping.

## Still open

`gofastr pack` gets the containment half only (mode 0600 plus a warning). Redaction by default with a user-supplied hook is a design task, not a mechanical one, and is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)