### PR TITLE
fix(runtime): bind swapped-in elements synchronously — a scan must not wait for a frame

### DIFF
--- a/core-ui/runtime/scan_bind_race_e2e_test.go
+++ b/core-ui/runtime/scan_bind_race_e2e_test.go
@@ -1,0 +1,53 @@
+package runtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// A demand module's re-scan after SPA navigation must bind swapped-in
+// elements before the user can click them. gofastr:navigate is dispatched
+// synchronously after swapMainContent, so a scan deferred to
+// requestAnimationFrame leaves a visible-but-unbound window: in an
+// occluded headless renderer rAF starves for seconds (the CI failure
+// mode), and on any slow device the first click after a navigation is
+// silently dropped.
+//
+// The test makes the starvation deterministic by delaying every rAF
+// callback 3s, then navigates so #tog is swapped in fresh and clicks it
+// as soon as it is visible. The click must commit: binding may not
+// depend on the renderer producing a frame.
+func TestNavSwappedElementsBindWithoutAFrame(t *testing.T) {
+	srv := invalidationSrv(t)
+	ctx := newSeedBrowserCtx(t)
+
+	steps := []chromedp.Action{
+		chromedp.Navigate(srv.URL + "/"),
+		chromedp.WaitVisible(`#ready`, chromedp.ByID),
+		chromedp.Poll(`window.__gofastr && typeof window.__gofastr.navigate === 'function'`,
+			nil, chromedp.WithPollingTimeout(8*time.Second), chromedp.WithPollingInterval(100*time.Millisecond)),
+		// Load the toggleaction module and prove the toggle works at all
+		// (this also seeds one committed→untoggle is not allowed, so
+		// re-click stays sticky; the assert below uses the fresh copy).
+		chromedp.WaitVisible("#tog", chromedp.ByID),
+		// Starve rAF: every callback lands 3s late, far beyond a click.
+		chromedp.Evaluate(`window.requestAnimationFrame = (cb) => setTimeout(() => cb(performance.now()), 3000);`, nil),
+	}
+	// Navigate away and back: #tog is now a freshly swapped-in element
+	// whose binding must not wait for a frame.
+	steps = append(steps,
+		chromedp.Click("#open", chromedp.ByID),
+		waitText("#v", "items-open 1"),
+		chromedp.Click("#home", chromedp.ByID),
+		chromedp.WaitVisible("#tog", chromedp.ByID),
+		chromedp.Click("#tog", chromedp.ByID),
+		chromedp.Poll(`document.querySelector('#tog')?.getAttribute('data-state') === 'committed'`,
+			nil, chromedp.WithPollingTimeout(5*time.Second), chromedp.WithPollingInterval(100*time.Millisecond)),
+	)
+
+	if err := chromedp.Run(ctx, steps...); err != nil {
+		t.Fatalf("chromedp (first click after nav was dropped — scan waited for a frame?): %v", err)
+	}
+}

--- a/core-ui/runtime/src/dropdown.js
+++ b/core-ui/runtime/src/dropdown.js
@@ -122,9 +122,9 @@
     }
   };
 
-  requestAnimationFrame(() => scan(document));
+  scan(document);
   window.addEventListener('gofastr:navigate', () => {
-    requestAnimationFrame(() => scan(document));
+    scan(document);
   });
 
   NS.loadedModules = NS.loadedModules || {};

--- a/core-ui/runtime/src/networkretrybanner.js
+++ b/core-ui/runtime/src/networkretrybanner.js
@@ -128,7 +128,7 @@
     }
   };
 
-  requestAnimationFrame(() => scan(document));
+  scan(document);
   window.addEventListener('gofastr:navigate', () => {
     // Disconnect old banners' timers — their DOM is about to be
     // replaced. Walk the WeakMap-keyed Set; banners not in the new
@@ -138,7 +138,7 @@
       if (s && s.sseTimer) { clearInterval(s.sseTimer); s.sseTimer = null; }
     });
     banners.clear();
-    requestAnimationFrame(() => scan(document));
+    scan(document);
   });
 
   // SSE reconnect recovery: when the stream comes back, re-probe the

--- a/core-ui/runtime/src/optimisticaction.js
+++ b/core-ui/runtime/src/optimisticaction.js
@@ -102,9 +102,9 @@
     }
   };
 
-  requestAnimationFrame(() => scan(document));
+  scan(document);
   window.addEventListener('gofastr:navigate', () => {
-    requestAnimationFrame(() => scan(document));
+    scan(document);
   });
 
   window.__gofastr = window.__gofastr || {};

--- a/core-ui/runtime/src/reveal.js
+++ b/core-ui/runtime/src/reveal.js
@@ -49,11 +49,11 @@
   };
 
   // Initial scan
-  requestAnimationFrame(() => scan(document));
+  scan(document);
 
   // SPA re-wire
   window.addEventListener('gofastr:navigate', () => {
-    requestAnimationFrame(() => scan(document));
+    scan(document);
   });
 
   // Register module

--- a/core-ui/runtime/src/scrollspy.js
+++ b/core-ui/runtime/src/scrollspy.js
@@ -126,7 +126,7 @@
     for (const wrap of scope.querySelectorAll('[data-fui-scrollspy]')) setupOne(wrap);
   };
 
-  requestAnimationFrame(() => scan(document));
+  scan(document);
   window.addEventListener('gofastr:navigate', () => {
     // SPA navigation replaces the page DOM. Disconnect every active
     // observer before re-scanning so the old observers + their
@@ -137,7 +137,7 @@
       observers.delete(w);
     }
     activeWraps.clear();
-    requestAnimationFrame(() => scan(document));
+    scan(document);
   });
 
   window.__gofastr = window.__gofastr || {};

--- a/core-ui/runtime/src/toggleaction.js
+++ b/core-ui/runtime/src/toggleaction.js
@@ -127,9 +127,9 @@
     }
   };
 
-  requestAnimationFrame(() => scan(document));
+  scan(document);
   window.addEventListener('gofastr:navigate', () => {
-    requestAnimationFrame(() => scan(document));
+    scan(document);
   });
 
   window.__gofastr = window.__gofastr || {};


### PR DESCRIPTION
## The CI browser-e2e failures

`TestInvalidateHeaderEviction` failed on CI in three of the last four runs (the #155 merge, the #156 branch run, and the #156 merge) at the same barrier: the toggle click after a navigation never committed. It passed locally every time, including a 10× repeat.

## Root cause

`gofastr:navigate` is dispatched synchronously after `swapMainContent`, so the DOM is complete when scanners run — but six demand modules (toggleaction, optimisticaction, dropdown, networkretrybanner, reveal, scrollspy) deferred their element scan to `requestAnimationFrame`. In an occluded headless renderer rAF starves for seconds, so the freshly swapped-in `#tog` was visible but unbound when chromedp clicked it, and the click was silently dropped. The same window exists for real users on slow devices: the first click after a navigation can vanish. The race dates to the 2026-07-22 module split; slower CI runners this week widened it into failures.

## Fix

The scans do no layout reads, so the deferral bought nothing — they run synchronously now, at module init and on every `gofastr:navigate`. scrollspy's unrelated scroll-handling rAF is untouched.

New e2e makes the starvation deterministic: it delays every rAF callback 3 seconds, navigates so the toggle is swapped in fresh, clicks it as soon as it is visible, and requires the commit. Red before the fix, green after. Full isolated runtime suite green (112s), budgets and syntax gates included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)