### PR TITLE
fix(meridian): state Customers island policy explicitly (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   no longer false-positives as a type change on every diff.
 - A panic inside a cron `RunOnce` (e.g. a panicking gate) now still releases
   the leader-lease instead of leaking it (the release is deferred).
+- The Meridian canary's Customers list-island now states its policy
+  explicitly (`WithIslandPolicy(authPolicy("/login", ""))`), matching the
+  contract `gofastr generate` emits on every island, instead of leaning on
+  `TableHandler`'s nil-policy sign-in fallback — which silently stops gating
+  the rows the moment the screen gains a role. (#160)
 
 ### Security
 

--- a/examples/meridian/app.go
+++ b/examples/meridian/app.go
@@ -210,7 +210,7 @@ func customersList() ResourceConfig {
 		WithCreate().
 		WithHeading("Customers").
 		WithEmpty("No customers yet — add your first to get started.").
-		WithIsland("/api/tables/customers").
+		WithIsland("/api/tables/customers").WithIslandPolicy(authPolicy("/login", "")).
 		WithActions(interactive.OpenOnClick(ui.Button(ui.ButtonConfig{Label: "Quick add", Variant: ui.ButtonSecondary}), "customer-quick-add"))
 }
 


### PR DESCRIPTION
## Summary

The Meridian canary mounted its Customers list-island (`examples/meridian/app.go:290`) without an `IslandPolicy`, relying on `TableHandler`'s nil-policy sign-in fallback.

Behaviour was correct *today* — with no policy configured, `TableHandler` falls back to requiring sign-in, which is what the customers screen requires anyway. But Meridian is the design-system canary people read to learn the pattern, and the generator (#158) now emits the policy explicitly on every island:

```go
.WithIsland("/api/tables/<screen>/<entity>").WithIslandPolicy(authPolicy("/login", "<role>"))
```

A reader comparing generated output against the flagship finds the flagship relying on a fallback the generator never relies on. Worse, it silently stops being correct the moment the screen gains a role: the screen route would enforce it, the island would not — the exact bug #158 fixed in the generator (`GET /api/secrets` answering 403 while `GET /api/tables/secrets` answered 200 with the rows).

## Change

Wire the island to its screen's own policy:

```go
.WithIsland("/api/tables/customers").WithIslandPolicy(authPolicy("/login", "")).
```

`authPolicy("/login", "")` is the **same policy the `/app/customers` screen uses** (`screen_customers_crud.go:129`). `app.Policy` (meridian) and `appui.Policy` (framework) resolve to the same package (`core-ui/app`), so the existing `authPolicy` is directly passable to `WithIslandPolicy` — no adapter needed.

For an anonymous fragment RPC the policy returns a `Redirect`, which `TableHandler` correctly refuses (document-navigation outcomes have no meaning for a fragment swap) → 403. Signed-in users pass through unchanged.

## Verification

- `go build ./...` clean
- `go vet ./...` clean, `gofmt` clean
- `framework/ui/resource` tests pass — these cover the exact mechanism (`TestIslandEnforcesScreenPolicy`, redirect→403, entity read-permission)
- Pre-commit gate (build, format, secret scan, vet, deterministic test sweep, coverage floors) — passed
- Pre-push gate (sweep, govulncheck, module integrity) — passed

Closes #160.