### PR TITLE
feat(ui): browser Reader Mode via app.AsArticle() + ScreenArticle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 - New doc→owner parity gate catches `data-fui-*` attributes documented with no
   emitter/reader; `TagInput`'s `data-fui-tag-input-id` now has a runtime owner
   (focus returns to the field on chip remove).
+- Browser Reader Mode: `app.AsArticle()` (a screen registration option) and
+  the optional `ScreenArticle` interface mark a page's content as an article
+  so Safari Reader / Firefox Reader View offer their built-in reader view.
+  The framework wraps the content in `<article>`, emits `Article` JSON-LD,
+  and sets `og:type=article`; the headline and description are derived from
+  the screen's `ScreenTitle` / `ScreenDescription`, so a normal screen
+  becomes reader-ready with no article-specific data. Implement
+  `ScreenArticle` to add a byline, date, or cover image.
 
 ### Fixed
 

--- a/core-ui/app/app.go
+++ b/core-ui/app/app.go
@@ -314,6 +314,7 @@ func (a *App) RenderPageResult(ctx context.Context, path string) (RenderResult, 
 			if renderErr != nil {
 				return RenderResult{}, fmt.Errorf("app: component render error for %q: %w", path, renderErr)
 			}
+			content = wrapArticle(screen, comp, content)
 		} else {
 			content = renderComponentInScreen(ctx, screen, comp)
 		}
@@ -505,7 +506,7 @@ func (a *App) renderPartial(ctx context.Context, path string, overlay *ScreenTyp
 		}
 		body = html
 	} else {
-		body = renderComponentAs(ctx, effType, screen.Title, comp)
+		body = renderComponentAs(ctx, screen, effType, comp)
 	}
 
 	out := RenderResult{HTML: body, Component: comp}
@@ -528,18 +529,19 @@ func (a *App) renderPartial(ctx context.Context, path string, overlay *ScreenTyp
 // component (used for RenderAlt + no-layout fallback) without copying
 // the Screen struct (which embeds a sync.Mutex).
 func renderComponentInScreen(ctx context.Context, screen *Screen, comp component.Component) render.HTML {
-	return renderComponentAs(ctx, screen.Type, screen.Title, comp)
+	return renderComponentAs(ctx, screen, screen.Type, comp)
 }
 
 // renderComponentAs renders comp wrapped in the ARIA scaffolding for an
 // explicit screen type, which an intercepted render supplies instead of
 // the screen's registered one.
-func renderComponentAs(ctx context.Context, t ScreenType, title string, comp component.Component) render.HTML {
+func renderComponentAs(ctx context.Context, screen *Screen, effType ScreenType, comp component.Component) render.HTML {
 	var content render.HTML
 	if cc, ok := comp.(component.ContextComponent); ok {
 		content = cc.RenderCtx(ctx)
 	} else {
 		content = comp.Render()
 	}
-	return wrapByScreenType(t, title, content)
+	content = wrapArticle(screen, comp, content)
+	return wrapByScreenType(effType, screen.Title, content)
 }

--- a/core-ui/app/article.go
+++ b/core-ui/app/article.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"github.com/DonaldMurillo/gofastr/core-ui/component"
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+// ArticleMeta describes a screen's content as an article for a browser's
+// built-in Reader Mode (Safari Reader, Firefox Reader View). It is optional
+// enrichment — the headline and description fall back to the screen's own
+// ScreenTitle / ScreenDescription, so a screen needs none of these fields to
+// be reader-ready. Implement ScreenArticle only to add what the screen's
+// title/description can't carry: a byline, a publication date, a cover image.
+type ArticleMeta struct {
+	// Headline is the article title. Overrides the screen's ScreenTitle
+	// for the Article JSON-LD headline + og:title when set.
+	Headline string
+	// Author is the byline. Maps to the JSON-LD author (a Person), which
+	// Safari Reader reads to show "By …" in its reader view.
+	Author string
+	// DatePublished is the publication time, RFC 3339 / ISO 8601
+	// (e.g. "2026-08-01T09:00:00Z"). Maps to JSON-LD datePublished, which
+	// Reader Mode reads for the article date.
+	DatePublished string
+	// DateModified is the last-updated time (RFC 3339). Optional.
+	DateModified string
+	// Description is a one-line summary. Overrides the screen's
+	// ScreenDescription for JSON-LD description + og:description when set.
+	Description string
+	// Image is the cover/thumbnail URL. Maps to JSON-LD image + og:image.
+	Image string
+}
+
+// ScreenArticle optionally enriches an article screen with metadata the
+// screen's own title/description can't carry (byline, date, cover image). On
+// its own it also marks the screen as an article. For the common case —
+// turning a normal screen into a reader-ready article with no extra data —
+// prefer the AsArticle registration option; implement this interface only to
+// add the richer fields.
+type ScreenArticle interface {
+	ScreenArticle() ArticleMeta
+}
+
+// AsArticle is a ScreenOption that marks a screen's content as an article so
+// a browser offers its built-in Reader Mode. It needs no article-specific
+// data: the screen's existing ScreenTitle becomes the Article headline (and
+// og:title), ScreenDescription becomes the description, and the content is
+// wrapped in an <article> element. Add it to a screen's registration:
+//
+//	site.Register("/post", &PostScreen{}, layout, app.AsArticle())
+//
+// For a richer reader view (byline, date, cover image), also implement the
+// ScreenArticle interface — its fields fill what AsArticle can't infer.
+func AsArticle() ScreenOption {
+	return func(s *Screen) { s.Article = true }
+}
+
+// isArticle reports whether the screen should be rendered as an article:
+// the AsArticle option set the flag, or the component implements ScreenArticle.
+func isArticle(screen *Screen, comp component.Component) bool {
+	if screen != nil && screen.Article {
+		return true
+	}
+	_, ok := comp.(ScreenArticle)
+	return ok
+}
+
+// wrapArticle wraps content in an <article> element when the screen is an
+// article — the semantic tag Safari Reader and Firefox Reader View key on to
+// detect article content. Non-article screens pass through unchanged.
+func wrapArticle(screen *Screen, comp component.Component, content render.HTML) render.HTML {
+	if isArticle(screen, comp) {
+		return html.Article(html.ArticleConfig{}, content)
+	}
+	return content
+}

--- a/core-ui/app/article_test.go
+++ b/core-ui/app/article_test.go
@@ -1,0 +1,112 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+// articleTestComp renders a body and declares itself an article. The
+// framework must wrap its content in <article> (inside the layout's
+// <main>) so browsers detect it for Reader Mode.
+type articleTestComp struct {
+	body string
+}
+
+func (a *articleTestComp) Render() render.HTML { return render.Raw(a.body) }
+func (a *articleTestComp) ScreenArticle() ArticleMeta {
+	return ArticleMeta{Headline: "Hello", Author: "Ada", DatePublished: "2026-08-01T00:00:00Z"}
+}
+
+// A ScreenArticle screen renders its content inside an <article> element,
+// nested within the layout's <main> landmark — the structure Safari Reader
+// and Firefox Reader View detect as an article.
+func TestScreenArticleWrapsContentInArticle(t *testing.T) {
+	a := NewApp("ArticleApp")
+	a.SetDefaultLayout(NewLayout("main"))
+	a.RegisterScreen(NewScreen("/post", &articleTestComp{body: "<p>Body</p>"}), nil)
+
+	out, err := a.RenderPage(context.Background(), "/post")
+	if err != nil {
+		t.Fatalf("RenderPage: %v", err)
+	}
+	s := string(out)
+
+	mainIdx := strings.Index(s, "<main")
+	artIdx := strings.Index(s, "<article>")
+	if mainIdx == -1 {
+		t.Fatalf("expected <main> from layout, got:\n%s", s)
+	}
+	if artIdx == -1 {
+		t.Fatalf("expected <article> wrapper for ScreenArticle screen, got:\n%s", s)
+	}
+	if artIdx < mainIdx {
+		t.Fatalf("expected <article> nested inside <main>, got:\n%s", s)
+	}
+	// The content sits inside the article.
+	bodyIdx := strings.Index(s, "<p>Body</p>")
+	if bodyIdx == -1 || bodyIdx < artIdx {
+		t.Fatalf("expected body inside <article>, got:\n%s", s)
+	}
+}
+
+// A plain screen (no ScreenArticle) is NOT wrapped in <article> — the
+// feature is opt-in.
+func TestNonArticleScreenHasNoArticleWrapper(t *testing.T) {
+	a := NewApp("PlainApp")
+	a.SetDefaultLayout(NewLayout("main"))
+	a.RegisterScreen(NewScreen("/page", &stubComponent{html: render.Raw("<p>Plain</p>")}), nil)
+
+	out, err := a.RenderPage(context.Background(), "/page")
+	if err != nil {
+		t.Fatalf("RenderPage: %v", err)
+	}
+	if strings.Contains(string(out), "<article>") {
+		t.Fatalf("non-article screen must NOT be wrapped in <article>, got:\n%s", out)
+	}
+}
+
+// A ScreenArticle screen with no layout still gets <article> inside the
+// screen's <main> (renderComponentAs path), not wrapping it from outside.
+func TestScreenArticleNoLayoutStillWrapsInsideMain(t *testing.T) {
+	r := NewRouter()
+	r.Screen(NewScreen("/bare", &articleTestComp{body: "<p>Bare</p>"}), nil)
+	out, err := r.RenderRaw("/bare")
+	if err != nil {
+		t.Fatalf("RenderRaw: %v", err)
+	}
+	s := string(out)
+	mainIdx := strings.Index(s, "<main")
+	artIdx := strings.Index(s, "<article>")
+	if mainIdx == -1 || artIdx == -1 {
+		t.Fatalf("expected <main> and <article>, got:\n%s", s)
+	}
+	// <article> must follow <main> (be inside it), not the reverse.
+	if artIdx < mainIdx {
+		t.Fatalf("expected <article> inside <main> on the no-layout path, got:\n%s", s)
+	}
+}
+
+// AsArticle() turns a plain screen into an article at registration — no
+// interface, no metadata. The framework wraps its content in <article>.
+func TestAsArticleOptionWrapsContent(t *testing.T) {
+	a := NewApp("AsArticleApp")
+	a.SetDefaultLayout(NewLayout("main"))
+	a.Register("/post", &stubComponent{html: render.Raw("<p>Body</p>")}, nil, AsArticle())
+
+	out, err := a.RenderPage(context.Background(), "/post")
+	if err != nil {
+		t.Fatalf("RenderPage: %v", err)
+	}
+	s := string(out)
+	mainIdx := strings.Index(s, "<main")
+	artIdx := strings.Index(s, "<article>")
+	if artIdx == -1 {
+		t.Fatalf("AsArticle screen must be wrapped in <article>, got:\n%s", s)
+	}
+	if mainIdx == -1 || artIdx < mainIdx {
+		t.Fatalf("expected <article> nested inside <main>, got:\n%s", s)
+	}
+}

--- a/core-ui/app/screen.go
+++ b/core-ui/app/screen.go
@@ -134,6 +134,14 @@ type Screen struct {
 
 	// NoLLMMD disables auto-generated /path/llm.md for this screen.
 	NoLLMMD bool
+	// Article marks the screen's content as an article so browsers offer
+	// their built-in Reader Mode (Safari Reader, Firefox Reader View) and
+	// render it well. Set with the AsArticle registration option; the
+	// framework wraps the content in <article> and synthesizes Article
+	// JSON-LD + og:type=article, deriving the headline and description
+	// from the screen's own title and description. For richer reader-view
+	// metadata (byline, date, cover image) also implement ScreenArticle.
+	Article bool
 
 	// Intercept, when set, makes this screen present as an overlay for
 	// a soft navigation that started on the declared origin route. Nil

--- a/docs/agent-notes.md
+++ b/docs/agent-notes.md
@@ -1,5 +1,14 @@
 # Agent Notes
 
+## 2026-08-01 - Browser Reader Mode (`app.AsArticle()` + `ScreenArticle`)
+- Scope: `core-ui/app`, `framework/uihost` — browser reader-mode readiness
+- Trigger: User wanted pages marked up so Safari Reader / Firefox Reader View detect them and render them well (the browser's built-in feature, NOT a layout "reader mode" CSS shape — an earlier attempt built the wrong thing and was reverted). Then refined: it had to be SEAMLESS — "turn any normal screen into an article", not write a metadata method + duplicate the title.
+- Approach: Two ways in, one seam. `app.AsArticle()` is a `ScreenOption` (`func(*Screen)`) that sets `Screen.Article`; the framework then wraps content in `<article>` (app: both SSR+SSG flow through `RenderPageResult`, no-layout/SSG through `renderComponentAs`) and synthesizes Article JSON-LD + `og:type=article` (uihost `resolveScreenSEOFor`), DERIVING headline/description from the screen's own `ScreenTitle`/`ScreenDescription` — zero article-specific data. The optional `ScreenArticle()` interface enriches with author/date/image and also marks the screen an article. `wrapArticle`/synthesis trigger on flag OR interface; only gaps are filled so explicit `ScreenSchema`/`ScreenSEO` win.
+- Evidence: `go test ./core-ui/app/ -run 'TestScreenArticle|TestAsArticle'` and `./framework/uihost/ -run 'TestScreenArticle|TestAsArticle'` green (wrap, synthesis, schema de-dup, OG preservation, title-derivation). Live `/reader` (a plain screen + `app.AsArticle()`) emits `<article>` + Article JSON-LD with headline/description derived from the screen title + og:type=article; non-article pages stay og:type=website with no `<article>`.
+- Gotcha: value (non-pointer) struct screen components 404 — the host only serves pointer-to-struct screens (`newInstance` assumes pointers). Always register `&Screen{}`.
+- Next time: The dominant reader-mode signal is the `<article>` element + real paragraph density — no config fakes article content, so `Render()` must be actual prose. `RenderRaw` (SSG/internal) has a pre-existing double-`<main>` when combined with a layout; SSG ships via `host.RenderStaticPage`→`RenderPageResult` (clean), so it doesn't surface.
+- Status: active
+
 ## 2026-07-20 - Framework maturity review
 - Scope: architecture, release readiness, documentation
 - Trigger: Assess where GoFastr stands after v0.38.0.

--- a/examples/site/main.go
+++ b/examples/site/main.go
@@ -750,6 +750,7 @@ var paletteCatalog = []paletteRoute{
 	{"Live presence — viewer roster demo", "/examples/presence?presence=presence-demo"},
 	{"Kiln — agent build mode (experimental)", "/kiln"},
 	{"Philosophy — the convictions essay", "/philosophy"},
+	{"Reader-ready pages — browser Reader Mode", "/reader"},
 	{"Components — gallery index", "/components/"},
 	{"SEO — per-page meta, canonical, JSON-LD", "/seo"},
 	{"Forms wizard — multi-step round-trip", "/forms/wizard"},
@@ -852,6 +853,12 @@ func registerScreens(site *app.App) {
 	site.Register("/examples/live-dashboard", &LiveDashboardScreen{}, nil)
 	site.Register("/kiln", &KilnScreen{}, nil)
 	site.Register("/philosophy", &PhilosophyScreen{}, nil)
+	// /reader — a reader-ready article, the seamless way. This is a normal
+	// screen; app.AsArticle() on its registration is the whole reader-mode
+	// switch (wraps content in <article>, emits Article JSON-LD +
+	// og:type=article, derives the headline from ScreenTitle). Load it in
+	// Safari or Firefox and the browser's Reader icon lights up.
+	site.Register("/reader", &ArticleScreen{}, nil, app.AsArticle())
 	// SEO demo pages (per-concern interfaces + the ScreenSEO bundle).
 	site.Register("/seo", &SEOScreen{}, nil)
 	site.Register("/seo-bundle", &SEOBundleScreen{}, nil)

--- a/examples/site/screen_article.go
+++ b/examples/site/screen_article.go
@@ -1,0 +1,84 @@
+package main
+
+// =============================================================================
+// /reader — a reader-ready article, the seamless way. This is a NORMAL
+// screen: it has a title, a description, and renders prose — nothing
+// article-specific. The one difference from any other screen is the
+// app.AsArticle() option on its registration (see main.go):
+//
+//	site.Register("/reader", &ArticleScreen{}, nil, app.AsArticle())
+//
+// That single option makes the framework wrap the content in <article> and
+// emit Article JSON-LD + og:type=article, deriving the headline from the
+// screen's own ScreenTitle. Load /reader in Safari or Firefox and the
+// browser's Reader icon lights up in the address bar.
+// =============================================================================
+
+import (
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
+	"github.com/DonaldMurillo/gofastr/core/render"
+	"github.com/DonaldMurillo/gofastr/framework/ui"
+)
+
+// ArticleScreen is an ordinary content screen — the same shape as /about or
+// /philosophy. app.AsArticle() on its registration is the entire reader-mode
+// switch.
+type ArticleScreen struct{}
+
+func (s *ArticleScreen) ScreenTitle() string { return "Reader-ready pages" }
+func (s *ArticleScreen) ScreenDescription() string {
+	return "How GoFastr turns a normal screen into an article a browser's Reader Mode detects."
+}
+
+func (s *ArticleScreen) Render() render.HTML {
+	// The article body. A single <h1> matching the title, then prose. The
+	// framework supplies the surrounding <article> wrapper; this method
+	// returns only what goes inside it — exactly what any screen returns.
+	return render.Join(
+		html.Heading(html.HeadingConfig{Level: 1}, render.Text("Reader-ready pages")),
+		html.Paragraph(html.TextConfig{Class: "article-byline"},
+			render.Text("By Donald Murillo · "),
+			html.Time(html.TimeConfig{Datetime: "2026-08-01"}, render.Text("August 1, 2026")),
+		),
+		html.Paragraph(html.TextConfig{},
+			render.Text("Safari, Firefox, and Edge each ship a built-in Reader Mode: a button in the address bar that strips a page to its article and re-renders it in a clean, distraction-free view. The button only appears when the browser is confident the page "),
+			html.Em(html.TextConfig{}, render.Text("is")),
+			render.Text(" an article. In GoFastr that confidence comes from a single option on the screen's registration — no article-specific code."),
+		),
+
+		html.Heading(html.HeadingConfig{Level: 2}, render.Text("One option, no metadata")),
+		html.Paragraph(html.TextConfig{},
+			render.Text("This page is a normal screen — it has a title and a description and renders prose, exactly like any other. The only addition is "),
+			codeText("app.AsArticle()"),
+			render.Text(" on its registration. That makes the framework wrap the content in an "),
+			codeText("<article>"),
+			render.Text(" element (the tag Safari Reader and Firefox's Readability engine scan for), synthesize an "),
+			codeText("Article"),
+			render.Text(" JSON-LD block (which Safari Reader reads for its title and date), and set "),
+			codeText("og:type=article"),
+			render.Text(". The headline and description come from the screen's own title and description — nothing is duplicated."),
+		),
+		ui.Markdown(ui.MarkdownConfig{Source: articleDemoSource}),
+
+		html.Heading(html.HeadingConfig{Level: 2}, render.Text("When you want a byline or a date in JSON-LD")),
+		html.Paragraph(html.TextConfig{},
+			render.Text("This page shows its byline in the visible prose, which Reader Mode picks up on its own. If you'd rather give the browser structured metadata — so every reader view shows a consistent byline and publication date whatever the prose — implement the optional "),
+			codeText("ScreenArticle"),
+			render.Text(" interface alongside "),
+			codeText("AsArticle"),
+			render.Text(". Its fields (author, date, cover image) fill what the screen's title can't carry. But for the common case you just read, the one option is the whole feature."),
+		),
+	)
+}
+
+// articleDemoSource is the code sample shown on the page. Built with string
+// concatenation so the fenced Go block can span multiple lines cleanly.
+var articleDemoSource = "```go\n" +
+	"// Any normal screen + one option = reader-ready.\n" +
+	"site.Register(\"/posts/:slug\", &PostScreen{}, layout, app.AsArticle())\n" +
+	"\n" +
+	"// PostScreen is an ordinary screen — title + prose, nothing more.\n" +
+	"type PostScreen struct{ post Post }\n" +
+	"func (s *PostScreen) ScreenTitle() string { return s.post.Title }\n" +
+	"func (s *PostScreen) Render() render.HTML { /* the post body */ }\n" +
+	"\n```"

--- a/framework/docs/content/seo.md
+++ b/framework/docs/content/seo.md
@@ -81,6 +81,62 @@ func (s *PostScreen) ScreenSEO() uihost.SEO {
 rendered as `<script type="application/ld+json">` with `</`
 neutralized so content can't break out of the script block.
 
+## Browser Reader Mode
+
+Safari Reader, Firefox Reader View, and Edge Immersive Reader each show a
+reader button only when they're confident a page *is* an article. That
+confidence comes from three signals the page emits: a semantic `<article>`
+element wrapping the content (the dominant signal — Safari Reader and
+Firefox's Readability engine scan the DOM for it), an `Article` JSON-LD
+block (which Safari Reader reads to populate its title/byline/date), and
+`og:type=article`.
+
+### Turn any screen into an article: `app.AsArticle()`
+
+The seamless path. Add one option to a screen's registration and the
+framework emits all three signals, deriving the headline and description
+from the screen's own `ScreenTitle` / `ScreenDescription` — no
+article-specific data anywhere:
+
+```go
+// Any normal screen + one option = reader-ready.
+site.Register("/posts/:slug", &PostScreen{}, layout, app.AsArticle())
+
+// PostScreen is an ordinary screen — title + prose, nothing more.
+type PostScreen struct{ post Post }
+func (s *PostScreen) ScreenTitle() string { return s.post.Title }
+func (s *PostScreen) Render() render.HTML { /* the post body */ }
+```
+
+The framework wraps the rendered content in `<article>` (inside the
+layout's `<main>`), synthesizes an `Article` JSON-LD item whose headline
+and description come from the screen's title/description, and sets
+`og:type=article`. `Render()` should return a single `<h1>` matching the
+title, then the prose; keep nav and chrome in the layout (outside the
+`<article>`) so the browser extracts exactly the prose.
+
+### Richer reader views: the `ScreenArticle` interface
+
+`AsArticle()` carries no byline or date. To give the browser structured
+metadata — so every reader view shows a consistent byline, date, and cover
+image whatever the prose — implement `ScreenArticle` on the component. Its
+fields fill what the screen's title can't, and it also marks the screen as
+an article (the option isn't needed when the interface is implemented):
+
+```go
+func (s *PostScreen) ScreenArticle() app.ArticleMeta {
+    return app.ArticleMeta{
+        Author:        s.post.Author,           // → JSON-LD author (Person)
+        DatePublished: s.post.PublishedAt.Format(time.RFC3339),
+        Image:         s.post.CoverURL,
+    }
+}
+```
+
+In both forms only gaps are filled — an explicit `ScreenSchema` Article or
+`ScreenSEO` OG value wins over the derived/synthesized one, so richer
+declarations aren't duplicated.
+
 ## Per-screen `llm.md` inherits the same metadata
 
 When `uihost.WithPublicLLMMD` is on, each screen's `/llm.md` document

--- a/framework/uihost/article_seo.go
+++ b/framework/uihost/article_seo.go
@@ -1,0 +1,55 @@
+package uihost
+
+import (
+	"github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/core-ui/seo"
+)
+
+// ensureArticleSchema appends an Article JSON-LD item derived from meta
+// when the resolved schema doesn't already include one. An explicit
+// ScreenSchema declaration (which may carry richer publisher/author data)
+// wins — only the gap is filled. The Article carries headline/author/date,
+// which Safari Reader reads to populate its reader-view title, byline, and
+// date.
+func ensureArticleSchema(schema []seo.Thing, meta app.ArticleMeta) []seo.Thing {
+	for _, s := range schema {
+		if _, ok := s.(seo.Article); ok {
+			return schema
+		}
+	}
+	a := seo.NewArticle()
+	a.Headline = meta.Headline
+	a.Description = meta.Description
+	a.Image = meta.Image
+	a.DatePublished = meta.DatePublished
+	a.DateModified = meta.DateModified
+	if meta.Author != "" {
+		p := seo.NewPerson()
+		p.Name = meta.Author
+		a.Author = &p
+	}
+	return append(schema, a)
+}
+
+// mergeArticleOG fills og:type=article and any empty OG field from the
+// article metadata. A nil og (the screen declared no OG) becomes a minimal
+// article OG. Values the screen declared explicitly through ScreenSEO are
+// preserved — only empty fields inherit from the article meta.
+func mergeArticleOG(og *OG, meta app.ArticleMeta) *OG {
+	if og == nil {
+		og = &OG{}
+	}
+	if og.Type == "" {
+		og.Type = "article"
+	}
+	if og.Title == "" && meta.Headline != "" {
+		og.Title = meta.Headline
+	}
+	if og.Description == "" && meta.Description != "" {
+		og.Description = meta.Description
+	}
+	if og.Image == "" && meta.Image != "" {
+		og.Image = meta.Image
+	}
+	return og
+}

--- a/framework/uihost/article_seo_test.go
+++ b/framework/uihost/article_seo_test.go
@@ -1,0 +1,158 @@
+package uihost
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/core-ui/seo"
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+// screenArticleComp declares itself an article via ScreenArticle only; the
+// framework supplies the <article> wrapper + Article JSON-LD + og:type.
+type screenArticleComp struct{}
+
+func (*screenArticleComp) Render() render.HTML {
+	return render.Raw("<h1>Hello</h1><p>The body.</p>")
+}
+func (*screenArticleComp) ScreenArticle() app.ArticleMeta {
+	return app.ArticleMeta{
+		Headline:      "Hello World",
+		Author:        "Ada Lovelace",
+		DatePublished: "2026-08-01T00:00:00Z",
+		Description:   "A post.",
+	}
+}
+
+func TestScreenArticleSynthesizesMetadata(t *testing.T) {
+	a := app.NewApp("art")
+	a.Register("/post", &screenArticleComp{}, nil)
+	ds := New(a)
+
+	req := httptest.NewRequest("GET", "/post", nil)
+	w := httptest.NewRecorder()
+	ds.ServeHTTP(w, req)
+	body := w.Body.String()
+
+	for name, want := range map[string]string{
+		"<article> wrapper":      "<article>",
+		"Article JSON-LD @type":  `"@type":"Article"`,
+		"headline":               `"headline":"Hello World"`,
+		"author as Person":       `"@type":"Person"`,
+		"author name":            `"name":"Ada Lovelace"`,
+		"datePublished":          `"datePublished":"2026-08-01T00:00:00Z"`,
+		"description":            `"description":"A post."`,
+		"og:type article":        `<meta property="og:type" content="article">`,
+		"og:title from headline": `<meta property="og:title" content="Hello World">`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("%s: missing %q in body", name, want)
+		}
+	}
+}
+
+// An explicit ScreenSchema Article wins; the synthesized one is NOT added
+// on top (no duplicate JSON-LD block).
+type articleWithSchemaComp struct{}
+
+func (*articleWithSchemaComp) Render() render.HTML { return render.Raw("<p>x</p>") }
+func (*articleWithSchemaComp) ScreenArticle() app.ArticleMeta {
+	return app.ArticleMeta{Headline: "From Meta"}
+}
+func (*articleWithSchemaComp) ScreenSchema() []seo.Thing {
+	a := seo.NewArticle()
+	a.Headline = "From Schema"
+	return []seo.Thing{a}
+}
+
+func TestScreenArticleDoesNotDuplicateSchema(t *testing.T) {
+	a := app.NewApp("dup")
+	a.Register("/p", &articleWithSchemaComp{}, nil)
+	ds := New(a)
+
+	req := httptest.NewRequest("GET", "/p", nil)
+	w := httptest.NewRecorder()
+	ds.ServeHTTP(w, req)
+	body := w.Body.String()
+
+	if c := strings.Count(body, `"@type":"Article"`); c != 1 {
+		t.Errorf("expected exactly 1 Article JSON-LD (explicit ScreenSchema wins), got %d", c)
+	}
+	if !strings.Contains(body, `"headline":"From Schema"`) {
+		t.Errorf("expected the explicit Schema headline to win")
+	}
+	if strings.Contains(body, `"headline":"From Meta"`) {
+		t.Errorf("synthesized Article should NOT duplicate the explicit one")
+	}
+}
+
+// Explicit ScreenSEO OG values are preserved — the article synthesis only
+// fills empty fields (Type stays "website", Title stays custom).
+type articleWithOGComp struct{}
+
+func (*articleWithOGComp) Render() render.HTML { return render.Raw("<p>x</p>") }
+func (*articleWithOGComp) ScreenArticle() app.ArticleMeta {
+	return app.ArticleMeta{Headline: "From Meta", Description: "From Meta Desc"}
+}
+func (*articleWithOGComp) ScreenSEO() SEO {
+	return SEO{OG: &OG{Type: "website", Title: "Custom Title"}}
+}
+
+func TestScreenArticlePreservesExplicitOG(t *testing.T) {
+	a := app.NewApp("og")
+	a.Register("/p", &articleWithOGComp{}, nil)
+	ds := New(a)
+
+	req := httptest.NewRequest("GET", "/p", nil)
+	w := httptest.NewRecorder()
+	ds.ServeHTTP(w, req)
+	body := w.Body.String()
+
+	if !strings.Contains(body, `<meta property="og:type" content="website">`) {
+		t.Errorf("explicit og:type=website must be preserved, got:\n%s", body)
+	}
+	if strings.Contains(body, `og:type" content="article"`) {
+		t.Errorf("og:type must NOT be overridden to article")
+	}
+	if !strings.Contains(body, `<meta property="og:title" content="Custom Title">`) {
+		t.Errorf("explicit og:title must be preserved, got:\n%s", body)
+	}
+}
+
+// asArticlePlainComp is a NORMAL screen — just a title and a description,
+// no article interface. Registered with app.AsArticle(), it becomes an
+// article whose JSON-LD headline + og:title come from ScreenTitle and whose
+// description comes from ScreenDescription. This is the seamless path: no
+// article-specific data anywhere.
+type asArticlePlainComp struct{}
+
+func (*asArticlePlainComp) Render() render.HTML {
+	return render.Raw("<h1>My Post</h1><p>The prose.</p>")
+}
+func (*asArticlePlainComp) ScreenTitle() string       { return "My Post" }
+func (*asArticlePlainComp) ScreenDescription() string { return "A normal screen turned article." }
+
+func TestAsArticleDerivesFromScreenTitle(t *testing.T) {
+	a := app.NewApp("plain")
+	a.Register("/p", &asArticlePlainComp{}, nil, app.AsArticle())
+	ds := New(a)
+
+	req := httptest.NewRequest("GET", "/p", nil)
+	w := httptest.NewRecorder()
+	ds.ServeHTTP(w, req)
+	body := w.Body.String()
+
+	for name, want := range map[string]string{
+		"<article> wrapper":       "<article>",
+		"headline from title":     `"headline":"My Post"`,
+		"description from screen": `"description":"A normal screen turned article."`,
+		"og:type article":         `<meta property="og:type" content="article">`,
+		"og:title from title":     `<meta property="og:title" content="My Post">`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("%s: missing %q in body", name, want)
+		}
+	}
+}

--- a/framework/uihost/uihost.go
+++ b/framework/uihost/uihost.go
@@ -1347,12 +1347,40 @@ func resolveScreenSEOFor(screen *app.Screen, comp component.Component) SEO {
 			schema = s.ScreenSchema()
 		}
 	}
+	// An article screen emits Article JSON-LD + og:type=article so a browser
+	// offers Reader Mode with a populated title, byline, and date. Triggered
+	// by the AsArticle registration option (screen.Article) OR the
+	// ScreenArticle interface. Headline/description are derived from the
+	// screen's own title/description when not supplied, so a plain screen
+	// becomes an article with no article-specific data. Only gaps are filled
+	// — explicit ScreenSchema / ScreenSEO values win.
+	og := bundle.OG
+	article := screen.Article
+	var meta app.ArticleMeta
+	if !article {
+		if sa, ok := src.(app.ScreenArticle); ok {
+			article = true
+			meta = sa.ScreenArticle()
+		}
+	}
+	if article {
+		if meta.Headline == "" {
+			if t, ok := src.(app.ScreenTitler); ok {
+				meta.Headline = t.ScreenTitle()
+			}
+		}
+		if meta.Description == "" {
+			meta.Description = desc
+		}
+		schema = ensureArticleSchema(schema, meta)
+		og = mergeArticleOG(og, meta)
+	}
 	return SEO{
 		Description: desc,
 		Canonical:   canonical,
 		Hreflangs:   hreflangs,
 		Robots:      robots,
-		OG:          bundle.OG,
+		OG:          og,
 		Twitter:     bundle.Twitter,
 		Schema:      schema,
 	}


### PR DESCRIPTION
## Summary

Turn any normal screen into an article a browser's built-in **Reader Mode** (Safari Reader, Firefox Reader View, Edge Immersive Reader) detects and renders well. One registration option, no article-specific data.

```go
// Any normal screen + one option = reader-ready.
site.Register("/posts/:slug", &PostScreen{}, layout, app.AsArticle())
```

`app.AsArticle()` derives the article headline from the screen's existing `ScreenTitle`, the description from `ScreenDescription`, wraps the content in `<article>`, and emits `Article` JSON-LD + `og:type=article`. No duplicated title, no metadata method.

## Why these signals

Safari/Firefox/Edge only show the reader button when they're confident a page *is* an article. That confidence comes from three things the page emits, all produced here from one declaration:

1. A semantic **`<article>` element** wrapping the content — the dominant signal; Safari Reader and Firefox's Readability engine scan the DOM for it.
2. **`Article` JSON-LD** — Safari Reader reads it to populate its reader view's title / byline / date.
3. **`og:type=article`**.

## Two ways in, one seam

- **`app.AsArticle()`** — the seamless path for any normal screen (the common case). Zero article-specific data.
- **`ScreenArticle()` interface** — optional enrichment (byline, date, cover image) for richer reader views; also marks the screen an article.

Both trigger on flag *or* interface; only **gaps** are filled, so an explicit `ScreenSchema` Article or `ScreenSEO` OG value always wins.

## Changes

- **`core-ui/app`** — `ScreenArticle` interface + `ArticleMeta`, `AsArticle()` option, `Screen.Article` flag; `wrapArticle` threaded through `RenderPageResult` and `renderComponentAs`. `renderComponentAs` keeps the effective screen type so overlays (drawers/sheets/intercepts) still render correctly.
- **`framework/uihost`** — `resolveScreenSEOFor` synthesizes `Article` JSON-LD + `og:type=article`, deriving headline/description when not supplied (`article_seo.go`).
- **`examples/site`** — `/reader` demo: a plain screen + `app.AsArticle()`.
- **Docs** — `seo.md` "Browser Reader Mode" section, `CHANGELOG`, `agent-notes`.

## Verification

- `/reader` (plain screen + `AsArticle()`) emits `<article>` + `Article` JSON-LD with headline/description **derived** from the screen title + `og:type=article`. Non-article pages stay `og:type=website` with no `<article>`. Confirmed via browser probe + curl.
- New tests: `core-ui/app` (wrap via option + via interface), `framework/uihost` (synthesis, schema de-dup, OG preservation, title-derivation).
- Full repo suite green: `./scripts/test-all.sh` (incl. the `examples/site` chromedp + axe suite and `kiln/integration`).

## Demo

Load `http://localhost:8093/reader` in Safari or Firefox — the Reader icon lights up in the address bar.
