### PR TITLE
fix(island): SSE streams outlive the request deadline without stranding (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   `ScreenArticle` to add a byline, date, or cover image.
 
 ### Fixed
+- SSE streams no longer die at the request timeout (issue #159). A live
+  subscriber was cut at `middleware.Timeout`'s 30s deadline, and the naive
+  fix (clearing the connection's read/write deadlines, reverted in #158)
+  stranded streams instead — exhausting the browser's per-origin connection
+  pool. The stream loop now ignores the request context's
+  `DeadlineExceeded` (the timeout firing on a still-connected client) while
+  unwinding on a real `context.Canceled` (client disconnect); a heartbeat
+  (`island.WithSSEHeartbeat`, default 15s) keeps live streams writing, and a
+  bounded stream lifetime (`island.WithSSEStreamBound`, default 5m) reclaims a
+  stranded stream even when its heartbeat writes keep succeeding into the
+  kernel buffer. Read/write deadlines are no longer cleared, so net/http's
+  close-notify (and thus prompt disconnect detection) stays intact.
 
 - Boot `AutoMigrate` no longer applies `RENAME COLUMN` (additive-only); a stale
   `Renames` hint can no longer rename the wrong in-use column at startup.

--- a/core-ui/island/manager.go
+++ b/core-ui/island/manager.go
@@ -53,6 +53,18 @@ const (
 	DefaultGlobalStreams     = 4096
 )
 
+// Default SSE stream-keepalive and lifetime bounds. The heartbeat writes a
+// comment frame on an idle stream so proxies and load balancers don't
+// idle-kill a live connection; the stream bound closes any one stream after
+// a fixed lifetime so a stream stranded by a peer the server can't observe as
+// gone is reclaimed even when its heartbeat writes keep succeeding into the
+// kernel buffer. The bound must exceed the heartbeat. Override per manager
+// with WithSSEHeartbeat / WithSSEStreamBound. See issue #159.
+const (
+	DefaultSSEHeartbeat   = 15 * time.Second
+	DefaultSSEStreamBound = 5 * time.Minute
+)
+
 // ErrSessionStreamLimit is returned when a session already holds its per-session
 // cap of concurrent SSE streams. The connect is refused, not evicted.
 var ErrSessionStreamLimit = errors.New("island: per-session SSE stream limit reached")
@@ -75,6 +87,35 @@ func WithStreamCaps(perSession, global int) ManagerOption {
 	}
 }
 
+// WithSSEHeartbeat sets the interval between SSE keepalive comment frames
+// (": ping") written on an idle stream (default DefaultSSEHeartbeat = 15s).
+// The keepalive keeps proxies and load balancers from idle-killing a live
+// connection, and is what keeps a live stream writing so a write error can
+// surface a half-closed peer. A non-positive value restores the default.
+func WithSSEHeartbeat(d time.Duration) ManagerOption {
+	return func(m *Manager) {
+		if d > 0 {
+			m.sseHeartbeat = d
+		}
+	}
+}
+
+// WithSSEStreamBound sets the maximum lifetime of a single SSE stream
+// (default DefaultSSEStreamBound = 5m). A stream is closed after this
+// duration even when its heartbeat writes keep succeeding into the kernel
+// buffer — the safety net that reclaims a stream stranded by a peer the
+// server cannot observe as gone (which otherwise exhausts the browser's
+// per-origin connection pool). EventSource reconnects seamlessly on a live
+// stream. The bound must exceed the heartbeat interval; a non-positive or
+// sub-heartbeat value restores the default. See issue #159.
+func WithSSEStreamBound(d time.Duration) ManagerOption {
+	return func(m *Manager) {
+		if d > 0 {
+			m.sseStreamBound = d
+		}
+	}
+}
+
 // Manager tracks active islands across all client sessions.
 type Manager struct {
 	mu      sync.RWMutex
@@ -87,6 +128,16 @@ type Manager struct {
 	// than a map walk on every connect.
 	caps       streamCaps
 	globalSubs int
+
+	// sseHeartbeat/sseStreamBound tune the SSE stream loop in
+	// ServeSSEWithPresence (see stream.go). sseHeartbeat is the period
+	// between keepalive comment frames on an idle stream; sseStreamBound
+	// is the maximum lifetime of one stream. Defaults from
+	// DefaultSSEHeartbeat / DefaultSSEStreamBound; override with
+	// WithSSEHeartbeat / WithSSEStreamBound. Read-only after
+	// NewManager. See issue #159.
+	sseHeartbeat   time.Duration
+	sseStreamBound time.Duration
 
 	// ── Presence ──
 	// presenceConns maps a unique connection id to its presence
@@ -211,6 +262,8 @@ func NewManager(opts ...ManagerOption) *Manager {
 			perSession: DefaultStreamsPerSession,
 			global:     DefaultGlobalStreams,
 		},
+		sseHeartbeat:   DefaultSSEHeartbeat,
+		sseStreamBound: DefaultSSEStreamBound,
 	}
 	for _, o := range opts {
 		o(m)

--- a/core-ui/island/stream.go
+++ b/core-ui/island/stream.go
@@ -1,8 +1,10 @@
 package island
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/DonaldMurillo/gofastr/core/stream"
 )
@@ -90,13 +92,59 @@ func (m *Manager) ServeSSEWithPresence(w http.ResponseWriter, r *http.Request, i
 		return
 	}
 
-	// Respect client context cancellation — the sole exit signal; this
-	// connection's channel is private, so no sibling can tear it down.
-	ctx := r.Context()
+	// A long-lived SSE stream must satisfy three constraints at once (issue #159):
+	//
+	//  1. It must outlive middleware.Timeout's request deadline — a context
+	//     derived via context.WithTimeout(r.Context(), d) sits on the request
+	//     and would otherwise cut a live stream at d (the original bug).
+	//  2. It must keep writing on an idle connection so proxies and load
+	//     balancers don't idle-kill a live stream (the heartbeat).
+	//  3. It must be reclaimed if the peer vanishes in a way the server cannot
+	//     promptly observe — a stranded stream whose heartbeat writes keep
+	//     succeeding into the kernel buffer would otherwise hold a socket
+	//     forever, exhausting the browser's per-origin connection pool (the
+	//     #158 regression).
+	//
+	// This is NOT done by clearing the connection's read/write deadlines (the
+	// reverted 217e8d06 did, which stranded streams by defeating net/http's
+	// close-notify). Instead:
+	//
+	//   - the request-context deadline is distinguished from a real disconnect:
+	//     DeadlineExceeded is middleware.Timeout firing on a still-connected
+	//     client (ignored — let the bound decide lifetime); context.Canceled is
+	//     a genuine peer disconnect (unwind immediately);
+	//   - a heartbeat ticker writes a keepalive comment so a live stream is
+	//     never idle and a half-closed peer eventually surfaces as a write
+	//     error;
+	//   - a bounded-lifetime timer closes any stream after a fixed duration
+	//     regardless of write success — the safety net for a stranded stream.
+	//     The bound exceeds the heartbeat; EventSource reconnects seamlessly.
+	reqCtx := r.Context()
+	streamCtx, streamCancel := context.WithCancel(context.Background())
+	defer streamCancel()
+	go func() {
+		<-reqCtx.Done()
+		// DeadlineExceeded == the request timeout fired on a live client: the
+		// original bug. Leave the stream running; the bound owns its lifetime.
+		// context.Canceled == the peer actually went away: reclaim promptly.
+		if reqCtx.Err() == context.Canceled {
+			streamCancel()
+		}
+	}()
+
+	heartbeat := time.NewTicker(m.sseHeartbeat)
+	defer heartbeat.Stop()
+	bound := time.NewTimer(m.sseStreamBound)
+	defer bound.Stop()
 
 	for {
 		select {
-		case <-ctx.Done():
+		case <-streamCtx.Done():
+			return
+		case <-bound.C:
+			// Bounded lifetime: a stranded stream is reclaimed even when its
+			// heartbeat writes keep succeeding. EventSource reconnects on a
+			// live stream; a dead peer's socket is simply released.
 			return
 		case update := <-ch:
 			payload := ssePayload{
@@ -109,6 +157,13 @@ func (m *Manager) ServeSSEWithPresence(w http.ResponseWriter, r *http.Request, i
 				continue
 			}
 			if err := sse.WriteEvent("island", string(data)); err != nil {
+				return
+			}
+		case <-heartbeat.C:
+			// Keepalive comment: keeps intermediaries from idle-killing the
+			// connection and keeps the stream writing so a dead peer is heard
+			// from as a write error rather than silence.
+			if err := sse.WriteComment("ping"); err != nil {
 				return
 			}
 		}

--- a/core-ui/island/stream_lifetime_test.go
+++ b/core-ui/island/stream_lifetime_test.go
@@ -1,0 +1,275 @@
+package island
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// readSSE reads from an SSE response body until stop matches the buffered
+// output OR the read returns an error (EOF / connection close). It reports
+// the buffered text and the terminal error. Used by the stream-lifetime
+// tests to observe what the server actually wrote and when the stream ended.
+func readSSE(t *testing.T, body io.Reader, stop func(buf string) bool) (string, error) {
+	t.Helper()
+	var buf strings.Builder
+	tmp := make([]byte, 4096)
+	for {
+		n, err := body.Read(tmp)
+		if n > 0 {
+			buf.Write(tmp[:n])
+			if stop != nil && stop(buf.String()) {
+				return buf.String(), nil
+			}
+		}
+		if err != nil {
+			return buf.String(), err
+		}
+	}
+}
+
+// TestSSEStreamOutlivesRequestDeadline is the core regression for issue #159:
+// middleware.Timeout's request deadline (a context.WithTimeout on r.Context())
+// must NOT cut a live SSE stream mid-flight. A stream that survives its own
+// request deadline and still delivers a post-deadline update proves the fix.
+//
+// The handler simulates exactly what middleware.Timeout does — derive a short
+// deadline from r.Context() and run the handler under it — without importing
+// the middleware (which would risk a cycle and couple the unit test to the
+// middleware's goroutine plumbing).
+func TestSSEStreamOutlivesRequestDeadline(t *testing.T) {
+	mgr := NewManager(WithSSEStreamBound(1 * time.Second)) // bound past the 300ms push, short enough for prompt cleanup
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 100*time.Millisecond)
+		defer cancel()
+		mgr.ServeSSE(w, r.WithContext(ctx))
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"?session=deadline", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Wait until WELL past the 100ms request deadline.
+	time.Sleep(300 * time.Millisecond)
+
+	// A stream cut at the deadline is gone here; a surviving stream delivers.
+	mgr.PushUpdate(IslandUpdate{IslandID: "after-deadline", HTML: "<p>survived</p>"}, "deadline")
+
+	type result struct {
+		body string
+		err  error
+	}
+	got := make(chan result, 1)
+	go func() {
+		b, err := readSSE(t, resp.Body, func(s string) bool {
+			return strings.Contains(s, "after-deadline")
+		})
+		got <- result{b, err}
+	}()
+
+	select {
+	case r := <-got:
+		if !strings.Contains(r.body, "after-deadline") {
+			t.Fatalf("stream did not deliver the post-deadline update (request deadline cut the stream); body=%q err=%v", r.body, r.err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("stream was cut by the request deadline — the post-deadline update never arrived")
+	}
+}
+
+// TestSSEHeartbeatKeepsIdleStreamAlive proves the stream writes keepalive
+// comment frames on an idle connection, so proxies and load balancers don't
+// idle-kill a live stream and so a half-closed peer surfaces as a write error.
+func TestSSEHeartbeatKeepsIdleStreamAlive(t *testing.T) {
+	mgr := NewManager(
+		WithSSEHeartbeat(50*time.Millisecond),
+		WithSSEStreamBound(30*time.Second),
+	)
+	server := httptest.NewServer(http.HandlerFunc(mgr.ServeSSE))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"?session=heartbeat", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// ": connected" is the initial comment; a heartbeat writes ": ping". Only
+	// the heartbeat produces "ping", so its presence proves periodic writes.
+	got := make(chan string, 1)
+	go func() {
+		b, _ := readSSE(t, resp.Body, func(s string) bool {
+			return strings.Contains(s, "ping")
+		})
+		got <- b
+	}()
+	select {
+	case body := <-got:
+		if !strings.Contains(body, "ping") {
+			t.Fatalf("no heartbeat comment frame on idle stream; body=%q", body)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for a heartbeat comment frame on an idle stream")
+	}
+}
+
+// TestSSEStreamBoundReclaimsStream proves a stream is closed after the bound
+// even when nothing else ends it — the safety net that reclaims a stream
+// stranded by a peer the server cannot observe as gone (whose heartbeat writes
+// keep succeeding into the kernel buffer). With the bound, EventSource simply
+// reconnects on a live stream; a stranded stream is dropped.
+func TestSSEStreamBoundReclaimsStream(t *testing.T) {
+	mgr := NewManager(
+		WithSSEHeartbeat(50*time.Millisecond),
+		WithSSEStreamBound(150*time.Millisecond),
+	)
+	server := httptest.NewServer(http.HandlerFunc(mgr.ServeSSE))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"?session=bound", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read until the server closes the body (EOF). The bound closes the
+	// stream; without it the loop blocks forever and this times out.
+	got := make(chan error, 1)
+	go func() {
+		_, err := readSSE(t, resp.Body, nil)
+		got <- err
+	}()
+	select {
+	case err := <-got:
+		if err == nil {
+			t.Fatal("stream body ended without an error; expected EOF from the bound closing the stream")
+		}
+		// EOF (or a transport reset from the closed connection) is the proof
+		// the handler returned at the bound.
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream was not reclaimed within the bound — the loop is blocking forever (stranded stream)")
+	}
+}
+
+// TestSSEStreamClosesOnClientDisconnect is the regression guard: ignoring the
+// request deadline (DeadlineExceeded) must NOT also ignore a real client
+// disconnect (context.Canceled). The stream must unwind promptly when the peer
+// goes away.
+func TestSSEStreamClosesOnClientDisconnect(t *testing.T) {
+	mgr := NewManager(
+		WithSSEHeartbeat(50*time.Millisecond),
+		WithSSEStreamBound(30*time.Second),
+	)
+	server := httptest.NewServer(http.HandlerFunc(mgr.ServeSSE))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"?session=disconnect", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Give the stream a moment to be serving, then drop the client.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	got := make(chan error, 1)
+	go func() {
+		_, err := readSSE(t, resp.Body, nil)
+		got <- err
+	}()
+	select {
+	case <-got:
+		// The body closed (EOF/reset): the handler observed the disconnect.
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream did not close after client disconnect — context.Canceled is not being observed")
+	}
+}
+
+// TestSSEStreamBoundReclaimsNoGoroutineLeak defends the invariant the new
+// watcher goroutine introduces: a stream reclaimed by the BOUND (not by a
+// client disconnect) must still release its watcher goroutine. The watcher
+// blocks on the request context's Done channel, which net/http cancels when
+// ServeHTTP returns — so once the bound closes the stream the watcher must
+// unwind, not linger for the lifetime of the keep-alive connection.
+func TestSSEStreamBoundReclaimsNoGoroutineLeak(t *testing.T) {
+	mgr := NewManager(
+		WithSSEHeartbeat(20*time.Millisecond),
+		WithSSEStreamBound(80*time.Millisecond),
+	)
+	server := httptest.NewServer(http.HandlerFunc(mgr.ServeSSE))
+	defer server.Close()
+
+	// DisableKeepAlives so the client's transport goroutines release as soon as
+	// the response body closes — otherwise they linger in the connection pool
+	// and mask whether the SERVER-side watcher goroutine unwound.
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+
+	// Settle the baseline AFTER the test server and client are up so their
+	// goroutines are already counted; only the per-stream watcher should move
+	// the number.
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"?session=noleak", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	// The bound closes the stream; read to EOF so ServeHTTP returns and the
+	// request context is cancelled (which unblocks the watcher).
+	if _, err := readSSE(t, resp.Body, nil); err == nil {
+		resp.Body.Close()
+		t.Fatal("expected the bound to close the stream (read error/EOF)")
+	}
+	resp.Body.Close()
+
+	// The watcher unblocks shortly after ServeHTTP returns. Poll rather than
+	// sleep: a real leak never settles, a clean unwind does so within ms.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline {
+			return
+		}
+		runtime.Gosched()
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Errorf("goroutine leak after bound reclaim: baseline=%d now=%d (watcher did not unwind)", baseline, runtime.NumGoroutine())
+}

--- a/framework/docs/content/reactivity.md
+++ b/framework/docs/content/reactivity.md
@@ -121,9 +121,18 @@ sensibly reflect (sub-second internal dashboards).
 - Push only. The result of a user action arrives in the RPC response, never
   on the event stream.
 - Streams outlive the request timeout. A response that flushes (every SSE
-  subscription does) sheds the middleware deadline and the server-level
-  read/write deadlines at its first flush, so `RequestTimeout` never cuts
-  a live subscriber; buffered responses keep the hard cap.
+  subscription does) flips the timeout writer into streaming mode so its 504
+  can no longer fire; the stream loop then ignores the request context's
+  `DeadlineExceeded` (middleware.Timeout firing on a still-connected
+  subscriber — the original bug) while still unwinding promptly on a real
+  `context.Canceled` (client disconnect). A heartbeat (default 15s,
+  `island.WithSSEHeartbeat`) writes keepalive comments so proxies and load
+  balancers don't idle-kill a live stream, and a bounded stream lifetime
+  (default 5m, `island.WithSSEStreamBound`) reclaims a stream stranded by a
+  peer the server can't observe as gone — even when its heartbeat writes
+  keep succeeding into the kernel buffer. The connection's read/write
+  deadlines are NOT cleared (the reverted 217e8d06 did, which broke
+  net/http's close-notify and stranded streams instead). See issue #159.
 - Concurrent streams are capped (default 16 per session, 4096 per replica;
   configurable via `island.WithStreamCaps`). The policy is reject-not-evict:
   an over-cap connect gets a `429 Too Many Requests` with `Retry-After`, and


### PR DESCRIPTION
Closes #159.

## Problem

A live SSE subscriber was cut mid-flight at `middleware.Timeout`'s 30s request deadline, which stays on `r.Context()` after the handler starts streaming. The naive fix (commit `217e8d06`, reverted in #158) cleared the connection's read/write deadlines at first flush — but that deadline was the only thing reclaiming a **stranded** stream, so it exhausted the browser's 6-connections-per-origin pool instead (`examples/site`'s `TestE2E_InteractiveComponents_RenderCorrectly` hung on the 7th navigation).

Heartbeat-alone and rolling-write-deadline-alone both fail (writes to a half-closed socket keep succeeding into the kernel buffer), as documented in the issue.

## Fix

The stream loop in `core-ui/island/stream.go` now satisfies all three constraints together, **without** clearing read/write deadlines (so net/http's close-notify — and prompt disconnect detection — stays intact):

1. **Outlives the request deadline.** A watcher distinguishes `context.DeadlineExceeded` (the middleware firing on a *still-connected* client → ignored; the original bug) from `context.Canceled` (a real peer disconnect → unwind promptly).
2. **Heartbeat** (`WithSSEHeartbeat`, default 15s) writes `: ping` keepalives so proxies/LBs don't idle-kill a live stream and a half-closed peer surfaces as a write error.
3. **Bounded lifetime** (`WithSSEStreamBound`, default 5m) closes any stream after a fixed duration even when its heartbeat writes keep succeeding into the kernel buffer — the safety net that reclaims a stranded stream. The bound exceeds the heartbeat; EventSource reconnects seamlessly.

## TDD

4 behavioral tests (`stream_lifetime_test.go`), each failing for the right reason before the fix and passing after:

- `TestSSEStreamOutlivesRequestDeadline` — survives a 100ms request deadline and delivers a post-deadline update (was: cut, `body=": connected" err=EOF`).
- `TestSSEHeartbeatKeepsIdleStreamAlive` — emits keepalive comments on an idle stream.
- `TestSSEStreamBoundReclaimsStream` — closes the stream at the bound (was: blocking forever).
- `TestSSEStreamClosesOnClientDisconnect` — still unwinds promptly on `context.Canceled` (regression guard).
- `TestSSEStreamBoundReclaimsNoGoroutineLeak` — the new watcher goroutine unwinds after a bound reclaim.

## Verification

- `core-ui/island` full suite, plus `core-ui/...`, `core/middleware`, `framework`, `framework/uihost` — green.
- The issue's exact repro `examples/site TestE2E_InteractiveComponents_RenderCorrectly` — passes (65s, no socket-exhaustion hang).
- Pre-commit/pre-push gates: full deterministic sweep + coverage floors + govulncheck + `go mod verify` — all clean.

Docs: `framework/docs/content/reactivity.md` corrected (the old text described the *reverted* deadline-clearing approach) + `CHANGELOG.md`.