### PR TITLE
fix(entity): validate field Default values at registration — release 0.57.0 (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.57.0] - 2026-08-03
+
+### Breaking
+
+- **BREAKING: a malformed field `Default` now fails registration.** The change
+  surfaces an existing bug rather than creating one — the declaration was
+  already broken, it just failed per-request instead of at boot — but an app
+  that starts today can stop starting, so treat it as breaking. `App.Entity`
+  panics as it already does for other declaration errors (relation without
+  `To`, duplicate fields, wire-key collisions); `TryEntity` returns the error.
+  Fix the declaration the message names.
+
+### Fixed
+
+- **Field `Default` values are validated at registration** (`framework/entity`).
+  A `Default` is the value `crud.doCreate` substitutes for a field the request
+  body omitted, and it reached the driver through the same column as a
+  client-sent value but through none of the same checks — `ValidateAll` ran
+  over the body and the `Default` was applied afterwards. A caller who *sent*
+  the bad value got a 400 naming the field; a caller who *omitted* it got a
+  500 with nothing actionable in it. `Entity.Validate` now runs
+  `schema.Validate` over every `Default`, so a malformed one fails the
+  declaration at boot with the field named. The clearest case was
+  `{Type: schema.JSON, Default: "draft"}`: 500 against Postgres `JSONB`, and
+  stored unchanged in SQLite's `TEXT` — the same declaration broken on one
+  dialect and silently fine on the other. Auto-generated fields are exempt
+  (their `Default` is never an insert value; it survives only as the column's
+  DDL `DEFAULT`). Two Go spellings a JSON body cannot produce are normalized
+  before validating rather than refused: a `schema.Decimal` default written as
+  a Go number (what `gofastr generate` emits for `default: 0`) and a
+  `Timestamp`/`Date` default written as a `time.Time`. (#174)
+
 ## [0.56.0] - 2026-08-02
 
 Windows support, and the SQLite driver swap it required. `mattn/go-sqlite3`
@@ -565,6 +597,8 @@ failed first.
   the pages that existed but were unreachable. New pages: `email.md`,
   `storage.md`, and `core-packages.md` (a map of the exported `core/*`
   packages that had no page).
+
+## [0.53.0] - 2026-07-30
 
 The eleven pre-existing bugs the v0.52.0 review pass found in shipped code
 but deliberately left out of that release, plus a security audit of the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ Honest expectations:
 
 ## Supported versions
 
-GoFastr is pre-1.0. Only the **latest minor release** (currently `0.55.x`)
+GoFastr is pre-1.0. Only the **latest minor release** (currently `0.57.x`)
 receives security fixes. Older `0.x` lines are not patched — upgrade to the
 latest release to stay supported.
 

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.56.0
+through: v0.57.0
 
 releases:
   - version: v0.3.0
@@ -595,3 +595,10 @@ releases:
         breaking: true
         guidance: "A second '## Setup' renders id=\"setup-2\" instead of a duplicate id=\"setup\". Anchor links pointing at the later of two identically-named headings change target."
         detect: "markdown\\.(Render|RenderHTML)\\("
+  - version: v0.57.0
+    title: Field defaults are validated at registration
+    notes:
+      - change: A malformed EntityConfig field Default now fails registration
+        breaking: true
+        guidance: "Entity.Validate runs schema.Validate over every field Default, so a declaration that used to boot and fail per-request now refuses at boot with the field named. This surfaces an existing bug rather than creating one: the create path substitutes a Default AFTER ValidateAll, so a bad one reached the driver unchecked — a 500 with nothing actionable in it, or silently wrong data on a looser dialect ({Type: schema.JSON, Default: \"draft\"} 500s on Postgres JSONB and stores fine in SQLite TEXT). Fix the declaration the error names. App.Entity panics as it already does for other declaration errors; TryEntity returns the error. Two Go spellings a JSON body cannot produce are normalized rather than refused, so they keep working: a schema.Decimal default written as a Go number (what gofastr generate emits for `default: 0`) and a Timestamp/Date default written as a time.Time. Auto-generated fields are exempt."
+        detect: "Default:"

--- a/framework/docs/content/entity-declarations.md
+++ b/framework/docs/content/entity-declarations.md
@@ -240,7 +240,7 @@ Each entry under `fields:` accepts:
 | `type` | string | One of the field types above (`string`, `text`, `int`, `float`, `decimal`, `bool`, `enum`, `date`, `timestamp`, `uuid`, `json`, `image`, `file`, `relation`). |
 | `required` | bool | NOT NULL + presence validation. |
 | `unique` | bool | Unique constraint on the column. |
-| `default` | scalar | Default value. |
+| `default` | scalar | Value written when the field is omitted on create. Checked against the field's own rules when the entity is registered — see "Defaults are validated at registration" below. |
 | `max` / `min` | number | Length (strings) or value (numbers) bounds. |
 | `values` | list | Allowed values for `type: enum`. |
 | `pattern` | string | Regex the value must match (validated on write). |
@@ -249,6 +249,40 @@ Each entry under `fields:` accepts:
 | `hidden` | bool | Excluded from generated UI grids, forms, MCP tool schemas, AND from API responses; silently skipped on client create/update. Server code can persist it via `crud.WithServerWrites` (the value is stored but still not returned — `visibleFields` shapes the projection). |
 | `no_query` | bool | Returned in responses, but rejected by filters, `?sort=` (including alongside `?cursor=`), `?where=`, `?q=` search, the DSL, and nested `?rel.field=`. Rejected at generate time in `search:`, `filters:`, a `stat_card` `source.filter` or summed `source.field`, and a chart `group_by`; `entity.Define` panics if it names one in `SearchFields` or a cursor field. For values the caller may only see in transformed form — see "Masked fields" below. |
 | `to` | string | For `type: relation`, the target entity. |
+
+### Defaults are validated at registration
+
+A `default` is the value the create path writes when the request body omits
+the field. It goes into the same column a client-sent value would, so it is
+checked against the same field rules — `values`, `pattern`, `min`/`max`,
+`required`, and the type itself — when the entity is registered.
+
+A default that fails those rules fails the declaration. `app.Entity` panics
+and `app.TryEntity` returns the error, both naming the field:
+
+```go
+{Name: "flags", Type: schema.JSON, Default: "draft"}
+// entity "things": field "flags" has an invalid Default "draft": must be valid JSON
+```
+
+Before this check the mismatch was per-request and per-dialect. A create that
+omitted `flags` returned 500 against a Postgres `JSONB` column (`invalid input
+syntax for type json`) and stored `draft` unchanged in SQLite's `TEXT` column,
+while a caller who *sent* `"draft"` got a 400 naming the field. The same holds
+for an `enum` default outside `values` and a `required` string defaulted to
+`""`.
+
+Two spellings are accepted that a request body could not use, because a Go
+declaration is not JSON:
+
+- `decimal` written as a number. `{Type: schema.Decimal, Default: 0}` is
+  equivalent to `Default: "0"`; both render `DEFAULT 0` in DDL and bind as a
+  number on insert.
+- `timestamp` and `date` written as a `time.Time`.
+
+A default on an `auto_generate` field is not validated, because the create path
+never writes it — the generated value takes that slot. It still becomes the
+column's DDL `DEFAULT`.
 
 ### Masked fields
 

--- a/framework/entity/default_validation_test.go
+++ b/framework/entity/default_validation_test.go
@@ -1,0 +1,155 @@
+package entity
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+)
+
+func validateFields(t *testing.T, fields ...schema.Field) error {
+	t.Helper()
+	e := Define("things", EntityConfig{Fields: fields})
+	return e.Validate()
+}
+
+// A Default the same validator would reject coming from a client must be
+// rejected at registration. Issue #174: the create path validated the request
+// body and only afterwards substituted Defaults, so a malformed Default
+// reached the driver unchecked.
+func TestValidateRejectsMalformedDefaults(t *testing.T) {
+	cases := []struct {
+		name  string
+		field schema.Field
+		want  string // substring the error must contain, beyond the field name
+	}{
+		{
+			// The issue's own case: JSONB rejects `draft` on Postgres, SQLite
+			// stores it in a TEXT column and reads it back unchanged.
+			name:  "json default that is not JSON",
+			field: schema.Field{Name: "flags", Type: schema.JSON, Default: "draft"},
+			want:  "must be valid JSON",
+		},
+		{
+			name:  "enum default outside Values",
+			field: schema.Field{Name: "flags", Type: schema.Enum, Values: []string{"draft", "published"}, Default: "archived"},
+			want:  "must be one of",
+		},
+		{
+			// ValidateAll treats a Required field as satisfied when Default is
+			// non-nil, so "" passes request validation and then writes "".
+			name:  "required string defaulted to empty",
+			field: schema.Field{Name: "flags", Type: schema.String, Required: true, Default: ""},
+			want:  "is required",
+		},
+		{
+			name:  "int default out of range",
+			field: schema.Field{Name: "flags", Type: schema.Int, Max: floatPtr(10), Default: 99},
+			want:  "must be at most",
+		},
+		{
+			name:  "string default violating Pattern",
+			field: schema.Field{Name: "flags", Type: schema.String, Pattern: "^[a-z]+$", Default: "NOPE"},
+			want:  "must match pattern",
+		},
+		{
+			name:  "timestamp default that is not RFC 3339",
+			field: schema.Field{Name: "flags", Type: schema.Timestamp, Default: "yesterday"},
+			want:  "must be a valid RFC 3339 timestamp",
+		},
+		{
+			name:  "uuid default that is not a uuid",
+			field: schema.Field{Name: "flags", Type: schema.UUID, Default: "nope"},
+			want:  "must be a valid UUID",
+		},
+		{
+			name:  "decimal default that is not a number",
+			field: schema.Field{Name: "flags", Type: schema.Decimal, Default: "abc"},
+			want:  "must be a valid decimal number",
+		},
+		{
+			name:  "decimal default below Min",
+			field: schema.Field{Name: "flags", Type: schema.Decimal, Min: floatPtr(0), Default: -1},
+			want:  "must be at least",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateFields(t, c.field)
+			if err == nil {
+				t.Fatalf("Validate() accepted field %q with Default %#v (%s) — the create path substitutes it for an omitted field AFTER ValidateAll, so it reaches the driver unchecked: a 500 with nothing actionable in it, or silently wrong data on a dialect whose column type is looser",
+					c.field.Name, c.field.Default, c.want)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, `"flags"`) {
+				t.Errorf("error must name the field: %v", msg)
+			}
+			if !strings.Contains(msg, c.want) {
+				t.Errorf("error = %q, want substring %q", msg, c.want)
+			}
+			if !strings.Contains(msg, "Default") {
+				t.Errorf("error must say the problem is the Default, got %q", msg)
+			}
+		})
+	}
+}
+
+// Every Default shape that works today must keep working — a false refusal at
+// boot is worse than the bug it guards, because it breaks every caller at once.
+func TestValidateAcceptsWorkingDefaults(t *testing.T) {
+	cases := []struct {
+		name  string
+		field schema.Field
+	}{
+		{"enum in Values", schema.Field{Name: "status", Type: schema.Enum, Values: []string{"draft", "published"}, Default: "draft"}},
+		{"string", schema.Field{Name: "status", Type: schema.String, Default: "draft"}},
+		{"int zero on a required field", schema.Field{Name: "stock", Type: schema.Int, Required: true, Min: floatPtr(0), Default: 0}},
+		{"bool literal", schema.Field{Name: "active", Type: schema.Bool, Default: true}},
+		// battery/auth declares its Bool columns this way.
+		{"bool as string", schema.Field{Name: "active", Type: schema.Bool, Default: "false"}},
+		{"float", schema.Field{Name: "ratio", Type: schema.Float, Min: floatPtr(0), Default: 0}},
+		// examples/meridian spells its Decimal defaults as wire-form strings…
+		{"decimal as string", schema.Field{Name: "mrr", Type: schema.Decimal, Min: floatPtr(0), Default: "0"}},
+		// …examples/ecommerce and every `decimal` blueprint field spell them
+		// as Go numbers. Both reach the driver and both render valid DDL.
+		{"decimal as int", schema.Field{Name: "tax", Type: schema.Decimal, Min: floatPtr(0), Default: 0}},
+		{"decimal as float", schema.Field{Name: "tax", Type: schema.Decimal, Min: floatPtr(0), Default: 1.5}},
+		// #170: a Go map/slice Default round-trips through marshalJSONColumn.
+		{"json as map", schema.Field{Name: "flags", Type: schema.JSON, Default: map[string]any{"a": 1}}},
+		{"json as slice", schema.Field{Name: "flags", Type: schema.JSON, Default: []any{"a"}}},
+		{"json as JSON text", schema.Field{Name: "flags", Type: schema.JSON, Default: `{"a":1}`}},
+		{"timestamp as RFC 3339", schema.Field{Name: "at", Type: schema.Timestamp, Default: "2026-01-02T15:04:05Z"}},
+		{"timestamp as time.Time", schema.Field{Name: "at", Type: schema.Timestamp, Default: time.Unix(0, 0).UTC()}},
+		{"date as time.Time", schema.Field{Name: "on", Type: schema.Date, Default: time.Unix(0, 0).UTC()}},
+		{"text", schema.Field{Name: "body", Type: schema.Text, Default: ""}},
+		{"relation", schema.Field{Name: "author_id", Type: schema.Relation, To: "users", Default: "sys"}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := validateFields(t, c.field); err != nil {
+				t.Fatalf("Validate() = %v, want nil — this Default works today", err)
+			}
+		})
+	}
+}
+
+// Auto-generated fields never take their Default as an insert value: doCreate
+// overwrites the body slot with the generated value. The Default survives only
+// as the column's DDL DEFAULT, so it is not validated as a field value —
+// matching schema.ValidateAll, which skips these fields too.
+func TestValidateSkipsAutoGeneratedDefaults(t *testing.T) {
+	err := validateFields(t, schema.Field{
+		Name:         "code",
+		Type:         schema.UUID,
+		AutoGenerate: schema.AutoUUID,
+		Default:      "not-a-uuid",
+	})
+	if err != nil {
+		t.Fatalf("Validate() = %v, want nil (auto-generated field)", err)
+	}
+}
+
+func floatPtr(f float64) *float64 { return &f }

--- a/framework/entity/entity.go
+++ b/framework/entity/entity.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/DonaldMurillo/gofastr/core/mcp"
 	"github.com/DonaldMurillo/gofastr/core/query"
@@ -631,9 +633,77 @@ func (e *Entity) Validate() error {
 		if f.Type == schema.Relation && f.To == "" {
 			return fmt.Errorf("entity %q: relation field %q must specify To", e.Config.Name, f.Name)
 		}
+
+		// A Default is the value crud.doCreate substitutes for a field the
+		// request body omitted. It reaches the driver through the same column
+		// as a client-sent value but, before this check, through none of the
+		// same checks: ValidateAll ran over the body and the Default was
+		// applied afterwards. A malformed one therefore surfaced as a
+		// per-request 500 with nothing actionable in it — or, on a dialect
+		// whose column type is looser, as silently wrong data (a non-JSON
+		// Default on a schema.JSON field 500s against Postgres JSONB and
+		// stores fine in SQLite's TEXT).
+		//
+		// The value is static, so it is checked once here rather than on
+		// every request, and a bad one is a bug in the app's own declaration
+		// rather than in a request — so it fails the declaration, naming the
+		// field, instead of reporting an app-authored bug as a caller's 400.
+		//
+		// Auto-generated fields are skipped, exactly as schema.ValidateAll
+		// skips them: doCreate overwrites their body slot with the generated
+		// value, so their Default is never an insert value. It survives only
+		// as the column's DDL DEFAULT (migrate.ColumnDefaultClause), where an
+		// explicit Default deliberately outranks gen_random_uuid().
+		if f.Default != nil && f.AutoGenerate == schema.AutoNone {
+			if err := schema.Validate(f, defaultAsWireValue(f)); err != nil {
+				return fmt.Errorf("entity %q: field %q has an invalid Default %#v: %v", e.Config.Name, f.Name, f.Default, err)
+			}
+		}
 	}
 
 	return nil
+}
+
+// defaultAsWireValue renders a field's Default in the form schema.Validate
+// expects, which is the form a client sends. The two differ because a Default
+// is authored in Go, not JSON, and for a few types the natural Go literal is
+// not the wire literal. Normalizing here keeps the registration check from
+// refusing declarations the write path accepts — a false refusal fires at
+// boot, for every caller at once, which is worse than the bug it guards.
+//
+// The patterns this permits, both of which reach the driver intact today:
+//
+//   - Decimal spelled as a Go number. Decimal travels as a string on the wire
+//     so it keeps exact precision, but `{Type: schema.Decimal, Default: 0}` is
+//     what examples/ecommerce writes and what `gofastr generate` emits for a
+//     blueprint `decimal` field with `default: 0`. It renders `DEFAULT 0` in
+//     DDL and binds as a number on insert; both dialects accept it.
+//   - Timestamp/Date spelled as a time.Time. time.Time's String() is not
+//     RFC 3339, so schema.Validate's generic fmt.Stringer path would reject a
+//     value the driver takes verbatim.
+func defaultAsWireValue(f schema.Field) any {
+	switch f.Type {
+	case schema.Decimal:
+		switch v := f.Default.(type) {
+		case int:
+			return strconv.Itoa(v)
+		case int64:
+			return strconv.FormatInt(v, 10)
+		case float32:
+			return strconv.FormatFloat(float64(v), 'f', -1, 32)
+		case float64:
+			return strconv.FormatFloat(v, 'f', -1, 64)
+		}
+	case schema.Timestamp:
+		if t, ok := f.Default.(time.Time); ok {
+			return t.Format(time.RFC3339)
+		}
+	case schema.Date:
+		if t, ok := f.Default.(time.Time); ok {
+			return t.Format(time.DateOnly)
+		}
+	}
+	return f.Default
 }
 
 // toSnake converts CamelCase or kebab-case to snake_case.

--- a/framework/entity_default_registration_test.go
+++ b/framework/entity_default_registration_test.go
@@ -1,0 +1,55 @@
+package framework
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+)
+
+// Issue #174, the reported case verbatim: a JSON field whose Default is not
+// JSON used to be accepted at registration and then 500 on any create that
+// omitted the field (Postgres JSONB rejects `draft`) while silently storing
+// the garbage on SQLite. It must be refused at registration instead, naming
+// the field.
+func TestEntityRejectsMalformedJSONDefault(t *testing.T) {
+	app := atomicTestApp(t)
+
+	err := app.TryEntity("things", EntityConfig{
+		Fields: []schema.Field{
+			{Name: "name", Type: schema.String, Required: true},
+			{Name: "flags", Type: schema.JSON, Default: "draft"},
+		},
+	})
+	if err == nil {
+		t.Fatal(`TryEntity accepted flags: schema.JSON with Default "draft" — POST /things omitting "flags" now 500s against a Postgres JSONB column (invalid input syntax for type json) and silently stores "draft" in SQLite's TEXT column, while a caller who SENDS "draft" gets a 400 naming the field`)
+	}
+	if !strings.Contains(err.Error(), "flags") {
+		t.Errorf("error must name the offending field, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Default") {
+		t.Errorf("error must point at the Default, got: %v", err)
+	}
+	if _, gerr := app.Registry.Get("things"); gerr == nil {
+		t.Error("rejected entity must not remain in the registry")
+	}
+}
+
+// Entity is the panicking variant; TryEntity callers get the error. Both must
+// fail the same declaration.
+func TestEntityPanicsOnMalformedDefault(t *testing.T) {
+	app := atomicTestApp(t)
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal(`Entity accepted flags: schema.JSON with Default "draft" — the bad declaration boots, and every create that omits "flags" fails at the driver instead`)
+		}
+		if msg, ok := r.(string); !ok || !strings.Contains(msg, "flags") {
+			t.Fatalf("panic = %v, want it to name %q", r, "flags")
+		}
+	}()
+	app.Entity("things", EntityConfig{
+		Fields: []schema.Field{{Name: "flags", Type: schema.JSON, Default: "draft"}},
+	})
+}


### PR DESCRIPTION
Closes #174.

## The bug

`EntityConfig` field `Default` values were never validated. `doCreate` ran
`schema.ValidateAll` over the request body and substituted a `Default` for
each omitted field **afterwards**, so a value the entity's own declaration
supplied reached the driver through the same column as a client-sent value
but through none of the same checks. A caller who *sent* the bad value got a
400 naming the field; a caller who *omitted* it got a 500 with nothing
actionable in it.

Reproduced against both live dialects before the fix:

```
dialect=sqlite3   POST /things {"name":"x"} -> 201 {"data":{"flags":"draft",…}}
dialect=postgres  POST /things {"name":"x"} -> 500 internal server error
```

The same declaration — `{Name: "flags", Type: schema.JSON, Default: "draft"}` —
is broken on one dialect and silently fine on the other.

## The fix

`Entity.Validate` runs `schema.Validate` over every field's `Default`
(`framework/entity/entity.go`). `Registry.Register` is the single chokepoint,
so every registration path is covered: `TryEntity` returns the error,
`Entity` / `GroupEntity` / `Table` / `View` panic — the same shape those paths
already have for relation-without-`To`, duplicate fields and wire-key
collisions.

Auto-generated fields are exempt, matching `ValidateAll`: `doCreate`
overwrites their body slot with the generated value, so their `Default` is
never an insert value — it survives only as the column's DDL `DEFAULT`, where
an explicit value deliberately outranks `gen_random_uuid()`.

### One narrowing, and why

`defaultAsWireValue` normalizes two Go spellings a JSON body cannot produce,
because a false refusal fires at boot for every caller at once — worse than
the bug it guards:

- **`schema.Decimal` written as a Go number.** Decimal travels as a string to
  keep exact precision, but `Default: 0` is what `examples/ecommerce` writes
  and what `gofastr generate` emits for a blueprint `decimal` field with
  `default: 0`. Without this arm, `gofastr generate` produces apps that do not
  boot. Counterfactual, with it removed:
  `entity "orders": field "tax" has an invalid Default 0: must be a decimal string`
- **`Timestamp`/`Date` written as a `time.Time`.** `time.Time.String()` is not
  RFC 3339, so the generic `fmt.Stringer` path would refuse a value the driver
  takes verbatim. No instance in this repo — precautionary, and easy to drop
  if you would rather keep the check strictly minimal.

**No declaration in this repo was changed.** `examples/ecommerce`,
`examples/meridian`, `examples/lms` (generated from its blueprint) and
`battery/auth`'s `UserEntityFields` were all registered against the new check
and accepted.

## SQL-expression defaults are not a thing here

Worth recording since it drove the design: a string `Default` can never be a
SQL expression. `SQLDefault`'s string arm goes through `quoteSQLLiteral`, so
`Default: "CURRENT_TIMESTAMP"` renders `DEFAULT 'CURRENT_TIMESTAMP'` — a
literal. That escaping is a deliberate security fix. There was no pattern to
protect.

## Release 0.57.0

Second commit carries the release chore, and three repo gates shaped it:

- **`## [0.53.0]` was missing.** Its content was in `CHANGELOG.md` all along
  with no header, running on inside the 0.54.0 section — the file claimed one
  release where there were two.
- **`make lint` was red on `main`.** repolint's `supported-version-drift`
  compares the latest CHANGELOG section against `SECURITY.md`; the v0.56.0
  release bumped one and not the other. Now clean.
- **`upgrades.yml`** gets the v0.57.0 entry and the `through` bump.
  `TestUpgradeRegistryThroughMatchesChangelog` caught the missing bump the
  moment the changelog moved, then `TestChangelogAgreesWithUpgradesOnBreaking`
  caught the registry marking v0.57.0 breaking while the changelog section did
  not say so. Both gates were right.

Registered as **breaking** deliberately: a declaration that used to boot and
fail per-request now refuses at boot. That surfaces an existing bug rather
than creating one, but an app that starts today can stop starting.

## Verification

| Gate | Result |
|---|---|
| `make fmt-check` | clean |
| `make vet` | clean |
| `make lint` | clean (was red on `main`) |
| `make test` | 183 packages ok, 0 FAIL |
| `make test-pg` | 78 packages ok, 0 FAIL |
| pre-commit hook | full deterministic sweep passed |

Sabotage, run independently of the authoring pass: inverting the guard
(`f.Default != nil` → `false && …`) fails all nine subtests of
`TestValidateRejectsMalformedDefaults`, each naming the field, the bad value,
and the consequence. Restored, both packages green.

## Separate bug found, not fixed

A Go-map `Default` on a `schema.JSON` field registers and inserts fine but
produces invalid DDL on Postgres: `SQLDefault` has no map arm, so
`map[string]any{"a":1}` falls through to `fmt.Sprintf("%v")` and emits
`DEFAULT 'map[a:1]'` on a `JSONB` column. Pre-existing and distinct from #174
— that one is about the insert path bypassing validation. The fix belongs in
`SQLDefault`, not in a registration refusal, since the same declaration works
on SQLite. It fails loudly at boot naming the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)