### PR TITLE
fix(migrate): a Go map or slice JSON Default emitted invalid DDL — release 0.58.0 (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.58.0] - 2026-08-03
+
+### Fixed
+
+- **A Go map or slice `Default` on a `schema.JSON` field emitted invalid DDL**
+  (`framework/migrate`). `SQLDefault` had no arm for the shapes such a default
+  naturally takes, so a map fell to the `fmt.Sprintf("%v")` fallback and
+  rendered `DEFAULT 'map[a:1]'` — which Postgres rejects on a `JSONB` column,
+  failing `AutoMigrate` at boot. SQLite's column is `TEXT`, so the same
+  declaration stored the literal text and looked fine: the identical dialect
+  split as #174. The value was already correct in the two other places it is
+  used — `schema.validateJSON` accepts maps and slices, and
+  `crud.marshalJSONColumn` marshals them on the insert path — so only the DDL
+  rendering was wrong. It now marshals to JSON *before* quoting, which keeps
+  the deliberate literal-escaping intact rather than replacing it. (#178)
+
 ## [0.57.0] - 2026-08-03
 
 ### Breaking

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ Honest expectations:
 
 ## Supported versions
 
-GoFastr is pre-1.0. Only the **latest minor release** (currently `0.57.x`)
+GoFastr is pre-1.0. Only the **latest minor release** (currently `0.58.x`)
 receives security fixes. Older `0.x` lines are not patched — upgrade to the
 latest release to stay supported.
 

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.57.0
+through: v0.58.0
 
 releases:
   - version: v0.3.0
@@ -602,3 +602,9 @@ releases:
         breaking: true
         guidance: "Entity.Validate runs schema.Validate over every field Default, so a declaration that used to boot and fail per-request now refuses at boot with the field named. This surfaces an existing bug rather than creating one: the create path substitutes a Default AFTER ValidateAll, so a bad one reached the driver unchecked — a 500 with nothing actionable in it, or silently wrong data on a looser dialect ({Type: schema.JSON, Default: \"draft\"} 500s on Postgres JSONB and stores fine in SQLite TEXT). Fix the declaration the error names. App.Entity panics as it already does for other declaration errors; TryEntity returns the error. Two Go spellings a JSON body cannot produce are normalized rather than refused, so they keep working: a schema.Decimal default written as a Go number (what gofastr generate emits for `default: 0`) and a Timestamp/Date default written as a time.Time. Auto-generated fields are exempt."
         detect: "Default:"
+  - version: v0.58.0
+    title: JSON defaults render as JSON in DDL
+    notes:
+      - change: A Go map or slice Default on a schema.JSON field now emits valid DDL
+        breaking: false
+        guidance: "No action needed. SQLDefault used to render such a default with fmt.Sprintf(\"%v\"), emitting DEFAULT 'map[a:1]' — which Postgres rejects on a JSONB column, so AutoMigrate failed at boot while SQLite stored the literal text and looked fine. It now marshals to JSON before quoting. A declaration that could not boot on Postgres will boot; nothing that worked stops working. If you worked around this with a string Default containing JSON, that keeps working unchanged."

--- a/framework/migrate/migrate.go
+++ b/framework/migrate/migrate.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -940,6 +941,26 @@ func SQLDefault(f schema.Field, dialect Dialect) string {
 		}
 		return "0"
 	default:
+		// A schema.JSON default is naturally authored as a Go map or slice —
+		// that is what crud.marshalJSONColumn writes on the insert path and
+		// what schema.validateJSON accepts, so the same value is correct in
+		// both those places and only wrong here. fmt.Sprintf("%v") renders
+		// Go's debug form, which put DEFAULT 'map[a:1]' on a JSONB column and
+		// failed AutoMigrate on Postgres while storing the literal text on
+		// SQLite, whose column is TEXT.
+		//
+		// Marshal, THEN quote. The escaping below is not incidental: the old
+		// unescaped fmt.Sprintf("'%v'", v) fallback let a kiln add_entity
+		// payload close the literal and commit an extra column. Marshalling
+		// instead of quoting would reopen exactly that.
+		if f.Type == schema.JSON {
+			if b, err := json.Marshal(v); err == nil {
+				return quoteSQLLiteral(string(b))
+			}
+			// An unmarshalable default is a broken declaration, not something
+			// to paper over with Go's debug rendering: fall through so the
+			// value is still escaped rather than spliced.
+		}
 		// Render, then escape. Never splice the rendering raw.
 		return quoteSQLLiteral(fmt.Sprintf("%v", v))
 	}

--- a/framework/migrate/sqldefault_json_test.go
+++ b/framework/migrate/sqldefault_json_test.go
@@ -1,0 +1,64 @@
+package migrate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+)
+
+// A schema.JSON field's Default is naturally authored as a Go map or slice —
+// that is the shape the write path handles (crud.marshalJSONColumn) and the
+// shape schema.validateJSON accepts. SQLDefault had no arm for either, so both
+// fell to the fmt.Sprintf("%v") fallback and rendered as Go's debug form:
+// DEFAULT 'map[a:1]' on a JSONB column, which Postgres rejects at AutoMigrate.
+//
+// The same declaration works on SQLite, whose column is TEXT — so the value is
+// right in two places (validation, insert) and wrong only in the DDL.
+func TestSQLDefaultRendersJSONForMapsAndSlices(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		field schema.Field
+		want  string
+	}{
+		{"map", schema.Field{Name: "flags", Type: schema.JSON, Default: map[string]any{"a": 1}}, `'{"a":1}'`},
+		{"slice", schema.Field{Name: "tags", Type: schema.JSON, Default: []any{"x", "y"}}, `'["x","y"]'`},
+		{"empty map", schema.Field{Name: "cfg", Type: schema.JSON, Default: map[string]any{}}, `'{}'`},
+		{"empty slice", schema.Field{Name: "list", Type: schema.JSON, Default: []any{}}, `'[]'`},
+		// A string default is already JSON on the wire and must be untouched,
+		// or the fix would double-encode every declaration that works today.
+		{"string passthrough", schema.Field{Name: "ok", Type: schema.JSON, Default: `{"a":1}`}, `'{"a":1}'`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SQLDefault(tc.field, DialectPostgres)
+			if got != tc.want {
+				t.Errorf("SQLDefault(%s) = %s, want %s — Postgres rejects this on a JSONB column at AutoMigrate",
+					tc.name, got, tc.want)
+			}
+			if strings.Contains(got, "map[") || strings.Contains(got, "[x y]") {
+				t.Errorf("SQLDefault(%s) emitted Go's debug rendering: %s", tc.name, got)
+			}
+		})
+	}
+}
+
+// The escaping in the default arm is deliberate and documented: a kiln
+// add_entity payload once committed an extra column through the old unescaped
+// fmt.Sprintf("'%v'", v) fallback. Marshalling must happen BEFORE quoting, not
+// instead of it, so a value carrying a quote still cannot terminate the
+// literal.
+func TestSQLDefaultJSONCannotEscapeItsLiteral(t *testing.T) {
+	f := schema.Field{Name: "x", Type: schema.JSON, Default: map[string]any{"k": `'); DROP TABLE things; --`}}
+	got := SQLDefault(f, DialectPostgres)
+	if !strings.HasPrefix(got, "'") || !strings.HasSuffix(got, "'") {
+		t.Fatalf("not a quoted literal: %s", got)
+	}
+	// Every interior quote must be doubled; an odd count means one of them
+	// closed the literal and the rest is loose DDL.
+	if strings.Count(got, "'")%2 != 0 {
+		t.Errorf("unbalanced quotes — the literal can be terminated from inside: %s", got)
+	}
+	if strings.Contains(got, "DROP TABLE things; --'") && !strings.Contains(got, "''") {
+		t.Errorf("interior quote was not doubled: %s", got)
+	}
+}

--- a/framework/sqldefault_json_migrate_test.go
+++ b/framework/sqldefault_json_migrate_test.go
@@ -1,0 +1,37 @@
+package framework
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+)
+
+// The bug this closes was not in the rendering alone — it was that a valid
+// declaration could not boot. schema.validateJSON accepts a Go map, the insert
+// path json.Marshals it, and only the DDL rendered Go's debug form, so
+// AutoMigrate failed on Postgres (JSONB rejects `map[a:1]`) while SQLite's TEXT
+// column stored the literal text and looked fine.
+//
+// Asserting the rendered string is necessary but not sufficient: the question
+// an operator has is whether the app starts. This runs the real migration on
+// both dialects.
+func TestAutoMigrateAcceptsGoShapedJSONDefaults(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, db *sql.DB, dialect Dialect) {
+		app := NewApp(WithDB(db))
+		if err := app.TryEntity("jsondefaults", EntityConfig{
+			Table: "jsondefaults",
+			Fields: []schema.Field{
+				{Name: "id", Type: schema.UUID, AutoGenerate: schema.AutoUUID},
+				{Name: "name", Type: schema.String, Required: true},
+				{Name: "flags", Type: schema.JSON, Default: map[string]any{"beta": true}},
+				{Name: "tags", Type: schema.JSON, Default: []any{"a", "b"}},
+			},
+		}); err != nil {
+			t.Fatalf("registration refused a declaration the write path handles: %v", err)
+		}
+		if err := AutoMigrate(db, app.Registry); err != nil {
+			t.Fatalf("AutoMigrate on %s: %v", dialect, err)
+		}
+	})
+}


### PR DESCRIPTION
Closes #178.

## The bug

`SQLDefault` had no arm for the shapes a `schema.JSON` field's `Default`
naturally takes, so a map or slice fell to the `fmt.Sprintf("%v")` fallback and
rendered Go's debug form:

```
flags  map[string]interface {}  ->  DEFAULT 'map[a:1]'
tags   []interface {}           ->  DEFAULT '[x y]'
ok     string                   ->  DEFAULT '{"a":1}'
```

Postgres rejects that on a `JSONB` column, so `AutoMigrate` fails at boot.
SQLite's column is `TEXT`, so the same declaration stored the literal text and
looked fine — the identical dialect split as #174.

## Why the fix belongs here and not at registration

The value is already correct in the two other places it is used:

- `schema.validateJSON` accepts `map[string]any` / `[]any`, so #174's new
  registration check passes it — **correctly**. The value is fine.
- `crud.marshalJSONColumn` `json.Marshal`s the same value on the insert path,
  so it round-trips through a write.

Only the DDL rendering was wrong. Refusing the declaration at registration
would have broken a value that works everywhere else.

## Marshal, then quote

The escaping in that arm is deliberate and documented: the old unescaped
`fmt.Sprintf("'%v'", v)` fallback let a kiln `add_entity` payload close the
literal and **commit an extra column**. So marshalling happens *inside* the
escaping rather than instead of it, and a test asserts an interior quote is
still doubled and the literal cannot be terminated from inside.

## Verification

Two tests, because the rendered string is necessary but not sufficient — the
question an operator has is whether the app starts.

- `TestSQLDefaultRendersJSONForMapsAndSlices` pins the DDL for maps, slices,
  empty maps/slices, and asserts a string default passes through untouched (a
  fix that double-encoded those would break every declaration that works today).
- `TestAutoMigrateAcceptsGoShapedJSONDefaults` runs the real migration on both
  dialects.

Sabotaging the new arm fails the second with the exact error from the issue:

```
--- FAIL: TestAutoMigrateAcceptsGoShapedJSONDefaults/postgres
    AutoMigrate on postgres: migrate jsondefaults: pq: invalid input syntax for type json at position 4:22 (22P02)
```

`-v` confirms the postgres subtest genuinely executes rather than skipping —
testcontainers spins up `postgres:16-alpine`.

| Gate | Result |
|---|---|
| `make fmt-check` | clean |
| `make vet` | clean |
| `make lint` | clean |
| pre-commit hook | full deterministic sweep passed |

## Release 0.58.0

Changelog, `SECURITY.md`, and the `upgrades.yml` `through` bump with its
release entry — marked **not breaking**, because nothing that worked stops
working; this only lets a declaration that could not boot, boot.

Three release gates shaped this and all three were right:
`TestUpgradeRegistryThroughMatchesChangelog`, then
`TestNewestReleaseBreakingNotesHaveDetectors` (a `through` bump needs a
matching release entry), then `TestUpgradeRegistryParsesAndIsSorted` (the
registry is ascending; my entry went in above v0.57.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)