### PR TITLE
Fix every verified finding from the nine-analyst holistic round

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,14 @@ jobs:
     timeout-minutes: 45
     env:
       CGO_ENABLED: "1" # mattn/go-sqlite3 requires cgo
+      # Fail-closed for the real-Postgres suites: when set, internal/pgtest
+      # escalates the no-Postgres t.Skip to t.Fatal so the ~30 dual-dialect
+      # tests can't silently degrade to SQLite-only behind a green build
+      # (e.g. if testcontainers breaks on a runner-image bump). Ubuntu
+      # runners have Docker, so testcontainers spins up postgres:16-alpine;
+      # this var just guarantees that fact is asserted, not assumed. Local
+      # dev leaves it unset → tests keep skipping when Docker is absent.
+      PGTEST_REQUIRED: "1"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   or hijacks, the deadline now stops terminating the response (the request
   context still expires, so handlers that honor it still unwind); hung
   non-streaming handlers keep their 504 at the deadline.
+- **Navigated-away pages no longer hoard SSE connections.** The SSE client
+  module never closed its EventSource on navigation, and Chrome keeps
+  bfcached pages' sockets open — so hard-navigating six SSE-bearing pages
+  exhausted the tab's per-host connection budget and the seventh page never
+  loaded. The transport now closes on `pagehide` and reconnects on a
+  bfcache restore (`pageshow.persisted`). This had been masked by the
+  request-timeout bug above, which was killing every stream at 30s.
 - **The harness ws control channel could lose an entire turn's events.** The
   event pump subscribed to the bus in its own goroutine after the read loop
   was already accepting commands, so a turn dispatched before the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   seeded nothing on boot; all are wired with `@entity.field=value`
   references, and the flagship's e2e now asserts seeded reviews and that
   every category has products.
+- **SSE streams no longer die at the request timeout.** The Timeout
+  middleware returned to net/http at the deadline even when the response
+  was already streaming, finalizing the response under the live handler —
+  so every SSE connection older than the 30s default died with a recovered
+  heartbeat panic and a silent client reconnect, violating the documented
+  "streams outlive the request timeout" contract. Once a handler flushes
+  or hijacks, the deadline now stops terminating the response (the request
+  context still expires, so handlers that honor it still unwind); hung
+  non-streaming handlers keep their 504 at the deadline.
 - **The harness ws control channel could lose an entire turn's events.** The
   event pump subscribed to the bus in its own goroutine after the read loop
   was already accepting commands, so a turn dispatched before the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Flat blueprint booleans that gate access are strict.** The entity-level
+  `soft_delete:` and `multi_tenant:` keys and `app.auth.enabled` now demand a
+  real `true`/`false`, exactly like their grouped `scope.*` twins. A YAML-1.1
+  truthy such as `multi_tenant: yes` decoded to *false*, silently dropping
+  tenant scoping — and `enabled: yes` left the whole app public with no
+  login. `gofastr validate` and `generate` both reject the spelling with an
+  error naming the key.
+- **Detail screens must put `{id}` in their route.** The blueprint validator
+  rejects an `entity_detail` (or edit-mode `entity_form`) screen whose route
+  declares no parameter: such screens rendered an empty record and every
+  list-view "View" link pointed at a route that matched nothing. Six bundled
+  example blueprints had exactly this bug; their detail routes now live under
+  the entity's list path (`/products/{id}`, `/posts/{id}`, …) and the
+  regenerated ecommerce flagship serves them with an e2e guard that follows a
+  real View link.
+- **Directory-mode blueprints keep their seeds.** `gofastr generate
+  --from=<dir>` merged every section except `seed:` — multi-file blueprints
+  silently lost all seed data.
+- **Generated apps no longer mount a dead delete-confirmation widget.**
+  Soft-delete entities emitted a `ui.ConfirmAction` nothing referenced, aimed
+  at a nonexistent RPC path; the resource engine's own delete flow is the one
+  that works, and now it's the only one emitted.
+- **`gofastr init --db=` validates its value.** An unknown driver (say
+  `--db=mysql`) used to silently scaffold a SQLite project that only looked
+  configured; it now errors listing the accepted values — `sqlite`,
+  `postgres`, aliases `sqlite3`/`postgresql`.
+- **Example seeds no longer skip rows silently.** The ecommerce reviews
+  (missing required product reference), lms courses (missing instructor),
+  and project-manager tasks/comments (whole board→column chains absent)
+  seeded nothing on boot; all are wired with `@entity.field=value`
+  references, and the flagship's e2e now asserts seeded reviews and that
+  every category has products.
+- **The harness ws control channel could lose an entire turn's events.** The
+  event pump subscribed to the bus in its own goroutine after the read loop
+  was already accepting commands, so a turn dispatched before the
+  subscription registered broadcast to nobody — the intermittent
+  `TestWSHandshakeAndCommand` CI failure. Subscription now happens before the
+  read loop starts.
+- **Meridian's auth footers match the generator again** (#185): the
+  hand-owned login/signup screens now render the URL-checked `ui.Link`
+  footer the generator emits, verified byte-identical and screenshotted in
+  both themes.
+- **`gofastr pack` reads the v0.61 auth footer.** The reverse reader only
+  understood the old raw-anchor footer, so packing a current app dropped
+  `register_href`/`login_href` from auth screens and broke the round-trip.
+- **The website taught an entity shape that no longer compiles.** The Get
+  Started and framework-hub pages showed the pre-v0.54 flat `EntityConfig`
+  fields (`CRUD:`, `Public:`, `OwnerField:` at top level) and a scaffold
+  layout `gofastr init` never writes; the samples are fixed and every Go
+  code block on both pages is now extracted and compile-gated in CI.
+- **Docs corrected against code**: init/blueprint scaffold layouts in four
+  docs, install pins unified on `@latest`, the CLI doc now covers `gofastr
+  build`'s contracts gate and the real `--db` values, the README's
+  cursor-paging field path (`Pagination.CursorField`), the overview's
+  embed-vs-semantic-search mixup, and the embedded-docs count floor is exact
+  so a deleted doc fails the build.
+
 ## [0.61.0] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ app.Entity("posts", framework.EntityConfig{
 | SSE stream       | `GET /posts/_events` — entity.created/updated/deleted, scoped per tenant        |
 | Filtering        | `?status=published&views_gte=10&sort=-created_at&page=2`                        |
 | Eager loading    | `?include=author.profile,comments` — flat or nested, validated against the registry |
-| Cursor paging    | `?cursor=&limit=50` — keyset by `EntityConfig.CursorField` (defaults to PK)     |
+| Cursor paging    | `?cursor=&limit=50` — keyset by `EntityConfig.Pagination.CursorField` (defaults to PK); composite `Pagination.CursorFields` takes precedence     |
 | Multipart upload | `multipart/form-data` on `Image`/`File` fields → streamed through `WithFileStorage` |
 | Validation       | Required, unique, enum, min/max, regex pattern, multi-tenant scope              |
 | Migrations       | Versioned runner — advisory-lock serialization, checksum-drift + dirty-state guards, `NoTransaction` escape hatch, a down section when a safe inverse exists; declarative incremental generation; real-Postgres tested |

--- a/cmd/gofastr/blueprint.go
+++ b/cmd/gofastr/blueprint.go
@@ -307,6 +307,7 @@ func mergeBlueprints(a, b Blueprint) Blueprint {
 	a.Entities = append(a.Entities, b.Entities...)
 	a.Screens = append(a.Screens, b.Screens...)
 	a.Nav = append(a.Nav, b.Nav...)
+	a.Seed = append(a.Seed, b.Seed...)
 	a.Endpoints = append(a.Endpoints, b.Endpoints...)
 	a.Middleware = append(a.Middleware, b.Middleware...)
 	a.Plugins = append(a.Plugins, b.Plugins...)
@@ -532,8 +533,16 @@ func decodeBlueprintAuth(node *coreyaml.Node) (BlueprintAuth, error) {
 		}
 		devMode = v
 	}
+	// enabled is access-gating: false means the auth subsystem is OFF and the
+	// whole app is public (no login, no JWT, no enforced screen policies). A
+	// YAML-1.1 truthy like `enabled: yes` (a string in YAML 1.2) silently
+	// reading false is fail-OPEN, so decode it strictly. See protectiveBool.
+	enabled, err := protectiveBool(m, "enabled", "app.auth")
+	if err != nil {
+		return BlueprintAuth{}, err
+	}
 	return BlueprintAuth{
-		Enabled:   boolValue(m["enabled"]),
+		Enabled:   enabled,
 		DevMode:   devMode,
 		BasePath:  stringValue(m["base_path"]),
 		JWTSecret: stringValue(m["jwt_secret"]),
@@ -744,15 +753,26 @@ func mergeEntityScopeDeclaration(
 	if grouped == nil {
 		grouped = &fwentity.ScopeDeclaration{}
 	}
+	// soft_delete and multi_tenant are access-gating: their FALSE value is the
+	// permissive state (hard deletes, no tenant scoping). The grouped
+	// scope.* spellings use protectiveBool; the flat spellings MUST too, or a
+	// YAML-1.1 truthy like `multi_tenant: yes` (a string in YAML 1.2) silently
+	// reads false and drops tenant isolation. See protectiveBool for the why.
 	if node := root["soft_delete"]; node != nil {
-		flat := boolValue(node)
+		flat, err := protectiveBool(root, "soft_delete", context)
+		if err != nil {
+			return nil, err
+		}
 		if groupMap["soft_delete"] != nil && flat != grouped.SoftDelete {
 			return nil, entityDeclarationConflict(name, "soft_delete", "scope.soft_delete", flat, grouped.SoftDelete)
 		}
 		grouped.SoftDelete = flat
 	}
 	if node := root["multi_tenant"]; node != nil {
-		flat := boolValue(node)
+		flat, err := protectiveBool(root, "multi_tenant", context)
+		if err != nil {
+			return nil, err
+		}
 		if groupMap["multi_tenant"] != nil && flat != grouped.MultiTenant {
 			return nil, entityDeclarationConflict(name, "multi_tenant", "scope.multi_tenant", flat, grouped.MultiTenant)
 		}
@@ -2044,6 +2064,19 @@ func validateBlueprint(bp Blueprint) error {
 		for _, block := range screen.Body {
 			if err := validateBlueprintBlock(screen.Name, entitiesByName, block); err != nil {
 				return err
+			}
+		}
+		// entity_detail renders .Detail(ctx, s.id) and the list's "View" link is
+		// BasePath+"/"+id; entity_form mode:edit posts to {entity}/{id}. Both
+		// need the record id from a route param. A route with no {id} produces
+		// an empty render and a dead link that matches no registered route.
+		if detail, edit := screenNeedsRouteID(screen); detail || edit {
+			if len(routeParamNames(screen.Route)) == 0 {
+				what := "entity_detail"
+				if !detail {
+					what = "entity_form (mode: edit)"
+				}
+				return fmt.Errorf("blueprint: screen %q has an %s block but its route %q has no {id} parameter — add {id} (e.g. %s/{id}) so the record id is in the URL", screen.Name, what, screen.Route, strings.TrimRight(screen.Route, "/"))
 			}
 		}
 		if err := validateBlueprintActions(screen.Name, screen.Body); err != nil {
@@ -5078,6 +5111,27 @@ func screenNeedsParams(screen BlueprintScreen) bool {
 	return false
 }
 
+// screenNeedsRouteID reports whether a screen's body tree contains an
+// entity_detail block or an entity_form with mode "edit" — both render a
+// specific record identified by a route {id} param. The first return is the
+// detail case, the second the edit-form case, so the validator can name it.
+func screenNeedsRouteID(screen BlueprintScreen) (detail, editForm bool) {
+	var walk func([]BlueprintBlock)
+	walk = func(blocks []BlueprintBlock) {
+		for _, b := range blocks {
+			if isEntityDetailBlock(b) {
+				detail = true
+			}
+			if isEntityFormBlock(b) && strings.EqualFold(strings.TrimSpace(b.Mode), "edit") {
+				editForm = true
+			}
+			walk(b.Children)
+		}
+	}
+	walk(screen.Body)
+	return
+}
+
 // blueprintDetailExpr emits the server-side detail render call, with any
 // status-transition workflow buttons chained in via WithTransitions.
 func blueprintDetailExpr(block BlueprintBlock) string {
@@ -6365,8 +6419,8 @@ func renderBlueprintApp(bp Blueprint) string {
 			hasAccess = true
 		}
 	}
-	needWidget := len(bp.Nav) > 0 || blueprintNeedsToasts(bp) || blueprintHasSoftDelete(bp)
-	needUI := len(bp.Nav) > 0 || hasMarketing || blueprintHasSoftDelete(bp)
+	needWidget := len(bp.Nav) > 0 || blueprintNeedsToasts(bp)
+	needUI := len(bp.Nav) > 0 || hasMarketing
 	roleNav := bp.App.Auth.Enabled && blueprintNavHasRoles(bp.Nav)
 	// authHeader: an auth-aware marketing header (Sign in ↔ account + Sign out).
 	// guestRedirect: bounce already-signed-in visitors off the auth screens.
@@ -6769,22 +6823,6 @@ func renderBlueprintApp(bp Blueprint) string {
 		sb.WriteString("\t\t// HTML forms, mount auth.CSRF — see `gofastr docs blueprints`\n")
 		sb.WriteString("\t\t// (Auth section) and `gofastr docs auth`.\n")
 		sb.WriteString("\t}\n")
-	}
-	// ConfirmAction dialogs — mount a delete confirmation modal for each
-	// soft-delete entity so entity_detail screens can render a trigger.
-	for _, decl := range bp.Entities {
-		if entityDeclarationScope(decl).SoftDelete {
-			sb.WriteString("\t{\n")
-			sb.WriteString(fmt.Sprintf("\t\t_, b := ui.ConfirmAction(ui.ConfirmActionConfig{Name: %q, TriggerLabel: \"Delete\", Title: %q, Body: %q, RPCPath: %q})\n",
-				"delete-"+decl.Name,
-				"Delete this "+toDisplayName(decl.Name)+"?",
-				"This action will soft-delete the record. It can be restored later.",
-				"/"+decl.Name+"/{id}",
-			))
-			sb.WriteString("\t\td := b.Build()\n")
-			sb.WriteString("\t\twidget.Mount(fwApp.Router(), &d)\n")
-			sb.WriteString("\t}\n")
-		}
 	}
 	// Screens (authored + synthesized CRUD) mount themselves: each screen_*.go
 	// self-registers a mount func, and mountGenerated runs them in declaration
@@ -7509,8 +7547,10 @@ func boolValue(node *coreyaml.Node) bool {
 //
 // Deliberately NOT applied to flags whose false value is the safe/inert one
 // (`exposure.public`, `exposure.mcp`, `exposure.crud`, `app.public_openapi`,
-// `*.enabled`, `llm_md`, `timestamps`, `many`, `create`): there, a coerced
-// false turns a feature OFF, which is the direction we would want anyway.
+// `pwa.enabled`, `admin.enabled`, `llm_md`, `timestamps`, `many`, `create`):
+// there, a coerced false turns a feature OFF, which is the direction we would
+// want anyway. NOTE: `*.enabled` is NOT a blanket exception — app.auth.enabled
+// IS routed here: false means the auth subsystem is off and the app is public.
 func protectiveBool(m map[string]*coreyaml.Node, key, context string) (bool, error) {
 	node, ok := m[key]
 	if !ok || node == nil {
@@ -7660,14 +7700,6 @@ func blueprintBlockNeedsToasts(block BlueprintBlock) bool {
 	}
 	for _, child := range block.Children {
 		if blueprintBlockNeedsToasts(child) {
-			return true
-		}
-	}
-	return false
-}
-func blueprintHasSoftDelete(bp Blueprint) bool {
-	for _, decl := range bp.Entities {
-		if entityDeclarationScope(decl).SoftDelete {
 			return true
 		}
 	}

--- a/cmd/gofastr/blueprint_confirmaction_test.go
+++ b/cmd/gofastr/blueprint_confirmaction_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/framework"
+	fwentity "github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// softDeleteOnlyBlueprint is the edge case for import flags: an entity with
+// soft_delete, no screens, no nav, no marketing. Before the ConfirmAction
+// removal, blueprintHasSoftDelete alone forced the ui + widget imports into
+// app.go (for the now-dead ConfirmAction mount). After removal those imports
+// must NOT be emitted for this shape, or the generated package fails to build
+// with "imported and not used".
+func softDeleteOnlyBlueprint() Blueprint {
+	return Blueprint{
+		App: BlueprintApp{Name: "Demo", Module: "example.com/demo"},
+		Entities: []framework.EntityDeclaration{{
+			Name:  "posts",
+			Scope: &fwentity.ScopeDeclaration{SoftDelete: true},
+			Fields: []framework.FieldDeclaration{
+				{Name: "title", Type: "string"},
+			},
+		}},
+	}
+}
+
+// The dead ui.ConfirmAction mount (trigger discarded, RPCPath wrong on three
+// axes, nothing referencing it) must not be emitted. The resource engine ships
+// the working delete (framework/ui/resource/resource.go).
+func TestSoftDeleteAppOmitsDeadConfirmAction(t *testing.T) {
+	app := renderBlueprintApp(softDeleteOnlyBlueprint())
+	if strings.Contains(app, "ConfirmAction") {
+		t.Errorf("generated app.go still emits the dead ConfirmAction widget mount:\n%s", app)
+	}
+	if strings.Contains(app, "delete-") {
+		t.Errorf("generated app.go still emits a delete-* ConfirmAction name:\n%s", app)
+	}
+}
+
+// The minimal soft-delete-only shape must still render a compiling app.go: the
+// ui/widget imports must be absent (nothing uses them), not merely unreferenced.
+func TestSoftDeleteOnlyAppCompiles(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	goVersion, err := repoGoVersion(repoRoot)
+	if err != nil {
+		t.Fatalf("repoGoVersion: %v", err)
+	}
+	goMod := "module example.com/demo\n\ngo " + goVersion + "\n\nrequire github.com/DonaldMurillo/gofastr v0.0.0\n\nreplace github.com/DonaldMurillo/gofastr => " + repoRoot + "\n"
+	writeTestFile(t, filepath.Join(dir, "go.mod"), goMod)
+	if err := copyGoSum(repoRoot, dir); err != nil {
+		t.Fatalf("copy go.sum: %v", err)
+	}
+	bp := softDeleteOnlyBlueprint()
+	bp.App.OutputDir = "gen"
+	files, err := renderBlueprintFiles(bp)
+	if err != nil {
+		t.Fatalf("renderBlueprintFiles: %v", err)
+	}
+	for _, file := range files {
+		full := filepath.Join(dir, "gen", file.name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(file.content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cmd := exec.Command("go", "build", "-mod=mod", "./gen/entities", "./gen")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOCACHE="+filepath.Join(t.TempDir(), "gocache"))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("minimal soft-delete app did not build: %v\n%s", err, output)
+	}
+}

--- a/cmd/gofastr/blueprint_detail_route_test.go
+++ b/cmd/gofastr/blueprint_detail_route_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// entity_detail renders .Detail(ctx, s.id) and the resource list links to
+// BasePath+"/"+id — a detail screen whose route has no {id} param renders an
+// empty record and its "View" link matches no registered route. The validator
+// must reject it and say what to change.
+func TestEntityDetailRequiresIDInRoute(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gofastr.yml")
+	writeTestFile(t, path, `
+app:
+  name: Demo
+  module: ex.com/demo
+entities:
+  - name: products
+    crud: true
+    fields:
+      - name: title
+        type: string
+screens:
+  - name: product_detail
+    route: /product-detail
+    body:
+      - type: entity_detail
+        entity: products
+`)
+	_, err := loadBlueprint(path)
+	if err == nil {
+		t.Fatal("entity_detail screen with no {id} in route should fail validation")
+	}
+	if !strings.Contains(err.Error(), "{id}") {
+		t.Fatalf("error should mention {id}, got: %v", err)
+	}
+}
+
+// entity_form mode: edit posts to {entity}/{id} and targets a specific record,
+// so it has the same {id} requirement. mode: create does not (new record).
+func TestEntityFormEditRequiresIDInRoute(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gofastr.yml")
+	writeTestFile(t, path, `
+app:
+  name: Demo
+  module: ex.com/demo
+entities:
+  - name: products
+    crud: true
+    fields:
+      - name: title
+        type: string
+screens:
+  - name: product_edit
+    route: /product-edit
+    body:
+      - type: entity_form
+        entity: products
+        mode: edit
+`)
+	_, err := loadBlueprint(path)
+	if err == nil {
+		t.Fatal("entity_form mode:edit screen with no {id} in route should fail validation")
+	}
+	if !strings.Contains(err.Error(), "{id}") {
+		t.Fatalf("error should mention {id}, got: %v", err)
+	}
+}
+
+// Controls: a detail screen WITH {id}, and an edit form WITH {id}, validate.
+// A create form (no id needed) on a param-less route also validates.
+func TestEntityDetailAndEditAcceptIDInRoute(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gofastr.yml")
+	writeTestFile(t, path, `
+app:
+  name: Demo
+  module: ex.com/demo
+entities:
+  - name: products
+    crud: true
+    fields:
+      - name: title
+        type: string
+screens:
+  - name: product_detail
+    route: /products/{id}
+    body:
+      - type: entity_detail
+        entity: products
+  - name: product_edit
+    route: /products/{id}/edit
+    body:
+      - type: entity_form
+        entity: products
+        mode: edit
+  - name: product_new
+    route: /products/new
+    body:
+      - type: entity_form
+        entity: products
+        mode: create
+`)
+	if _, err := loadBlueprint(path); err != nil {
+		t.Fatalf("valid detail/edit/new screens should validate, got: %v", err)
+	}
+}

--- a/cmd/gofastr/blueprint_dirmerge_seed_test.go
+++ b/cmd/gofastr/blueprint_dirmerge_seed_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Directory mode (--from=blueprints/) loads every blueprint file in a dir and
+// folds them with mergeBlueprints. Seed was the only slice field that
+// mergeBlueprints dropped, so a `seed:` block in any file but the last was
+// silently discarded — demos shipped empty with no error.
+func TestDirMergePreservesSeedFromEveryFile(t *testing.T) {
+	dir := t.TempDir()
+	bpDir := filepath.Join(dir, "bp")
+	if err := os.MkdirAll(bpDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bpDir, "a.yml"), []byte(`app:
+  name: Demo
+  module: ex.com/demo
+entities:
+  - name: posts
+    fields:
+      - name: title
+        type: string
+seed:
+  - entity: posts
+    rows:
+      - title: seeded post
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bpDir, "b.yml"), []byte(`entities:
+  - name: tags
+    fields:
+      - name: label
+        type: string
+seed:
+  - entity: tags
+    rows:
+      - label: seeded tag
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bp, err := loadBlueprintPath(bpDir, false)
+	if err != nil {
+		t.Fatalf("dir merge: %v", err)
+	}
+	if len(bp.Seed) != 2 {
+		t.Fatalf("directory merge dropped seed: want 2 seed entities, got %d (%+v)", len(bp.Seed), bp.Seed)
+	}
+	entities := map[string]bool{}
+	for _, s := range bp.Seed {
+		entities[s.Entity] = true
+	}
+	if !entities["posts"] || !entities["tags"] {
+		t.Fatalf("directory merge lost a seed entity: got %v", entities)
+	}
+}

--- a/cmd/gofastr/blueprint_failclosed_security_test.go
+++ b/cmd/gofastr/blueprint_failclosed_security_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -37,11 +38,20 @@ var protectiveFlagSurfaces = []struct {
 	{"screens[].access.auth", func(v string) string {
 		return "app:\n  name: app\n  module: local/app\nscreens:\n  - name: secret\n    route: /secret\n    type: page\n    access:\n      auth: " + v + "\n"
 	}, "the screen is registered with no policy — publicly reachable"},
+	{"app.auth.enabled", func(v string) string {
+		return "app:\n  name: app\n  module: local/app\n  auth:\n    enabled: " + v + "\n"
+	}, "the auth subsystem is off — the whole app is public, no login"},
 	{"entities[].scope.multi_tenant", func(v string) string {
 		return "app:\n  name: app\n  module: local/app\nentities:\n  - name: tickets\n    fields:\n      - name: title\n        type: string\n    scope:\n      multi_tenant: " + v + "\n"
 	}, "tenant scoping is off — every tenant reads every row"},
 	{"entities[].scope.soft_delete", func(v string) string {
 		return "app:\n  name: app\n  module: local/app\nentities:\n  - name: tickets\n    fields:\n      - name: title\n        type: string\n    scope:\n      soft_delete: " + v + "\n"
+	}, "deletes are permanent — no forensic trail"},
+	{"entities[].multi_tenant", func(v string) string {
+		return "app:\n  name: app\n  module: local/app\nentities:\n  - name: tickets\n    fields:\n      - name: title\n        type: string\n    multi_tenant: " + v + "\n"
+	}, "tenant scoping is off — every tenant reads every row"},
+	{"entities[].soft_delete", func(v string) string {
+		return "app:\n  name: app\n  module: local/app\nentities:\n  - name: tickets\n    fields:\n      - name: title\n        type: string\n    soft_delete: " + v + "\n"
 	}, "deletes are permanent — no forensic trail"},
 	{"entities[].fields[].hidden", func(v string) string {
 		return "app:\n  name: app\n  module: local/app\nentities:\n  - name: tickets\n    fields:\n      - name: secret_note\n        type: string\n        hidden: " + v + "\n"
@@ -99,10 +109,11 @@ func TestProtectiveBoolsAcceptRealBools(t *testing.T) {
 		}
 	}
 }
-
 func protectiveFlagIsSet(t *testing.T, bp Blueprint, surface string) bool {
 	t.Helper()
 	switch {
+	case strings.HasSuffix(surface, "app.auth.enabled"):
+		return bp.App.Auth.Enabled
 	case strings.HasSuffix(surface, "access.auth"):
 		return bp.Screens[0].Access.Auth
 	case strings.HasSuffix(surface, "multi_tenant"):
@@ -118,4 +129,29 @@ func protectiveFlagIsSet(t *testing.T, bp Blueprint, surface string) bool {
 	}
 	t.Fatalf("no reader for surface %q", surface)
 	return false
+}
+
+// The table above exercises decodeBlueprintString (the shared decode entry
+// for validate AND generate). This pins the same failure through the full
+// loadBlueprint path (decode + validate) and checks the error names the key,
+// so a reader of the failure knows which line to fix.
+func TestFlatProtectiveBoolErrorsFromLoad(t *testing.T) {
+	for _, tc := range []struct {
+		key   string
+		value string
+	}{
+		{"multi_tenant", "yes"},
+		{"soft_delete", "yes"},
+	} {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "gofastr.yml")
+		writeTestFile(t, path, "app:\n  name: app\n  module: local/app\nentities:\n  - name: tickets\n    fields:\n      - name: title\n        type: string\n    "+tc.key+": "+tc.value+"\n")
+		_, err := loadBlueprint(path)
+		if err == nil {
+			t.Fatalf("%s: %s: expected a load error naming the key", tc.key, tc.value)
+		}
+		if !strings.Contains(err.Error(), tc.key) {
+			t.Fatalf("%s: error should name the key, got: %v", tc.key, err)
+		}
+	}
 }

--- a/cmd/gofastr/emitter_quoting_security_test.go
+++ b/cmd/gofastr/emitter_quoting_security_test.go
@@ -241,7 +241,16 @@ func irQuotingSites(payload string) []irSite {
 
 	// ---- blocks ----
 	block := func(site string, blk BlueprintBlock) {
-		add(site, func(b *Blueprint) { b.Screens[0].Body = []BlueprintBlock{blk} })
+		add(site, func(b *Blueprint) {
+			b.Screens[0].Body = []BlueprintBlock{blk}
+			// entity_detail / entity_form(edit) render a specific record and
+			// require an {id} route param to clear validateBlueprint; without it
+			// the validator (correctly) rejects and these injection sites would
+			// be skipped instead of exercised.
+			if blk.Kind == "entity_detail" || (blk.Kind == "entity_form" && strings.EqualFold(blk.Mode, "edit")) {
+				b.Screens[0].Route = "/tickets/{id}"
+			}
+		})
 	}
 	block("block.mode", BlueprintBlock{Kind: "entity_form", Entity: "tickets", Mode: payload})
 	block("block.search", BlueprintBlock{Kind: "entity_list", Entity: "tickets", Search: payload})

--- a/cmd/gofastr/init.go
+++ b/cmd/gofastr/init.go
@@ -72,9 +72,22 @@ func runInit(args []string) {
 		case args[i] == "--no-entity":
 			noEntity = true
 		case strings.HasPrefix(args[i], "--db="):
-			dbDriver = strings.TrimPrefix(args[i], "--db=")
-			if dbDriver == "postgres" {
+			// Accept the docs-canonical spellings (sqlite, postgres) plus the
+			// wire/alias spellings (sqlite3, postgresql) the framework already
+			// honors, and map them to the real driver name. Anything else used
+			// to fall through and silently scaffold SQLite (dbDriver set, dbURL
+			// left as a SQLite file) — a broken app that looked configured.
+			switch strings.ToLower(strings.TrimSpace(strings.TrimPrefix(args[i], "--db="))) {
+			case "sqlite", "sqlite3":
+				dbDriver = "sqlite3"
+				dbURL = "file:" + name + ".db"
+			case "postgres", "postgresql":
+				dbDriver = "postgres"
 				dbURL = "postgres://user:password@localhost:5432/" + name + "?sslmode=disable"
+			default:
+				choice := strings.TrimPrefix(args[i], "--db=")
+				fail("--db=%q is not a recognized database driver. Accepted values: sqlite, postgres (aliases: sqlite3, postgresql).", choice)
+				osExit(1)
 			}
 		}
 	}
@@ -275,7 +288,7 @@ Usage:
 
 Flags:
   --module=<path>  Go module path (default: local/<name>)
-  --db=<driver>    sqlite3 (default) or postgres
+  --db=<driver>    sqlite (default) or postgres (aliases: sqlite3, postgresql)
   --no-entity      Omit the sample entity and database wiring
   --reinit         Refresh AI onboarding files in an existing project
   --force          With --reinit, overwrite customized onboarding files

--- a/cmd/gofastr/init_db_test.go
+++ b/cmd/gofastr/init_db_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runInit accepts --db=<driver> and silently scaffolded SQLite for any value
+// that wasn't "postgres" — so --db=mysql wrote dbDriver="mysql" with a SQLite
+func TestInitRejectsUnknownDBDriver(t *testing.T) {
+	dir := t.TempDir()
+	covT_chdir(t, dir)
+	// osExit unwinds via panic (covT_capExit), and covT_capStdout reads its
+	// temp file only AFTER fn returns — so the read is skipped on the panic
+	// path. Swap os.Stdout ourselves and read inline once covT_capExit has
+	// recovered the panic (it returns normally, so execution continues here).
+	old := os.Stdout
+	f, err := os.CreateTemp(t.TempDir(), "stdout-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = f
+	code := covT_capExit(t, func() { runInit([]string{"app", "--db=mysql"}) })
+	os.Stdout = old
+	_ = f.Close()
+	captured, err := os.ReadFile(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(captured)
+	if code != 1 {
+		t.Fatalf("unknown --db=mysql should exit 1, got %d", code)
+	}
+	// The error must point the author at the accepted spellings.
+	lower := strings.ToLower(out)
+	if !strings.Contains(lower, "sqlite") || !strings.Contains(lower, "postgres") {
+		t.Fatalf("error should list accepted drivers (sqlite, postgres), got: %q", out)
+	}
+	// And it must not have scaffolded a broken project.
+	if _, err := os.Stat(filepath.Join(dir, "app", "main.go")); err == nil {
+		t.Fatalf("unknown --db should not have created the project")
+	}
+}
+
+// Accepted aliases still work: the docs-canonical "sqlite" and "postgres", plus
+// the wire spellings "sqlite3"/"postgresql". Each must scaffold a main.go whose
+// driver wiring matches the chosen database.
+func TestInitAcceptsDBDriverAliases(t *testing.T) {
+	for _, tc := range []struct {
+		flag string
+		want string // substring expected in main.go
+	}{
+		{"--db=sqlite", `runtimeIsolation.Database("sqlite3",`},
+		{"--db=sqlite3", `runtimeIsolation.Database("sqlite3",`},
+		{"--db=postgres", "lib/pq"},
+		{"--db=postgresql", "lib/pq"},
+	} {
+		t.Run(tc.flag, func(t *testing.T) {
+			dir := t.TempDir()
+			covT_chdir(t, dir)
+			out := covT_capStdout(t, func() { runInit([]string{"app", tc.flag}) })
+			main, err := os.ReadFile(filepath.Join(dir, "app", "main.go"))
+			if err != nil {
+				t.Fatalf("runInit %s did not scaffold main.go: %v (out=%q)", tc.flag, err, out)
+			}
+			if !strings.Contains(string(main), tc.want) {
+				t.Fatalf("%s: main.go missing %q\n%s", tc.flag, tc.want, string(main)[:200])
+			}
+		})
+	}
+}

--- a/cmd/gofastr/main.go
+++ b/cmd/gofastr/main.go
@@ -105,7 +105,7 @@ func printHelp() {
     Flags:
       --module=<path>  Set Go module path (default: local/<name>)
       --no-entity      Skip sample entity scaffolding
-      --db=<driver>    Database driver: sqlite3 (default) or postgres
+      --db=<driver>    Database driver: sqlite (default) or postgres (aliases: sqlite3, postgresql)
   new handler <n>       Scaffold a new HTTP handler
   new route <path>      Scaffold a route registration
   generate (gen, g) --from=<yml> Generate code from a deterministic YAML blueprint

--- a/cmd/gofastr/pack.go
+++ b/cmd/gofastr/pack.go
@@ -2497,6 +2497,13 @@ func reverseAuthCard(call *ast.CallExpr) BlueprintBlock {
 		}
 	}
 	footerHref := htmlAttr(rawString(c["Footer"]), "href")
+	if footerHref == "" {
+		// Since v0.61 the emitter renders the auth footer as the URL-checked
+		// ui.Link component instead of a raw anchor; read Href from its config.
+		if link, ok := c["Footer"].(*ast.CallExpr); ok && callSel(link) == "ui.Link" {
+			footerHref = astString(cfgOf(link, 0)["Href"])
+		}
+	}
 	kind, hrefKey := "login_form", "register_href"
 	if strings.Contains(action, "register") {
 		kind, hrefKey = "signup_form", "login_href"

--- a/core-ui/ARCHITECTURE.md
+++ b/core-ui/ARCHITECTURE.md
@@ -609,7 +609,7 @@ NetworkRetryBanner, app code) sees updates without re-reading:
 
 | Field | Updated when |
 | --- | --- |
-| `window.__gofastr.sseStatus.connected` | `true` on EventSource `open`, `false` on `error` |
+| `window.__gofastr.sseStatus.connected` | `true` on EventSource `open`, `false` on `error` and on `pagehide` (the transport closes when the page hides — bfcache entry or unload — and reconnects on `pageshow.persisted`, so a navigated-away page never hoards one of the tab's ~6 per-host connections) |
 | `window.__gofastr.sseStatus.lastEventAt` | every received `island` frame and on `open` (a `Date.now()` ms timestamp) |
 | `window.__gofastr.sseStatus.retryCount` | incremented on each transport error, reset to 0 on `open` |
 

--- a/core-ui/runtime/src/sse.js
+++ b/core-ui/runtime/src/sse.js
@@ -19,10 +19,17 @@
 //   - core looks for the <meta name="gofastr-sse"> tag on
 //     DOMContentLoaded; if present, idle-loads this module.
 //   - reconnects on transport error (3s back-off).
+//   - closes the transport on pagehide and re-establishes it on a
+//     bfcache restore (pageshow.persisted) — see the lifecycle block.
 (() => {
   'use strict';
   window.__gofastr = window.__gofastr || {};
   const NS = window.__gofastr;
+
+  // The live transport and any pending reconnect timer, held at module
+  // scope so the pagehide handler below can tear them down.
+  let source = null;
+  let retryTimer = 0;
 
   // One live status object. Mutated in place — never reassigned — so
   // every reference (banner poll, app listener) sees updates.
@@ -52,7 +59,7 @@
     const sseUrl = document.querySelector('meta[name="gofastr-sse"]')?.getAttribute('content');
     if (!sseUrl) return;
 
-    const source = new EventSource(sseUrl);
+    source = new EventSource(sseUrl);
 
     source.onopen = () => {
       status.connected = true;
@@ -92,6 +99,7 @@
       status.retryCount++;
       emit();
       source.close();
+      source = null;
       // After repeated failures the cause is more likely a dead token
       // than a flapping network — attempt a re-mint (throttled to every
       // other failure past the 2nd, so a genuine outage doesn't hammer
@@ -99,9 +107,36 @@
       // picks it up on this or the next cycle. Reconnect timing is NOT
       // blocked on the re-mint (a hung fetch must not stall recovery).
       if (status.retryCount >= 2 && status.retryCount % 2 === 0) remintSession();
-      setTimeout(connect, 3000);
+      retryTimer = setTimeout(connect, 3000);
     };
   }
+
+  // bfcache lifecycle. On a hard navigation Chrome puts the outgoing
+  // page into the back/forward cache WITHOUT closing its EventSource:
+  // the dead page's stream keeps hoarding one of the tab's ~6 per-host
+  // HTTP/1.1 connections until the cache entry is evicted, so six
+  // SSE-bearing navigations starve the tab and the seventh page never
+  // loads. Close the transport when the page is hidden (pagehide fires
+  // on both bfcache entry and real unload; closing is correct for
+  // either), and re-establish it when the page comes back out of the
+  // cache (pageshow.persisted). connect() re-reads the stream meta, so
+  // a session re-mint that landed before hiding is honored, and its
+  // onopen resets retryCount/lastEventAt and re-announces the status.
+  // The retry timer is cleared so a bfcached page's pending reconnect
+  // can't fire on restore alongside pageshow's own connect.
+  addEventListener('pagehide', () => {
+    clearTimeout(retryTimer);
+    if (source) {
+      source.close();
+      source = null;
+    }
+    // Silent: the page is going away — holders re-learn the state from
+    // onopen's emit after the pageshow reconnect.
+    status.connected = false;
+  });
+  addEventListener('pageshow', (e) => {
+    if (e.persisted && !source) connect();
+  });
 
   // Connect immediately when the module loads — by the time we're
   // executed core has already determined the SSE meta tag is on the

--- a/core-ui/runtime/sse_bfcache_e2e_test.go
+++ b/core-ui/runtime/sse_bfcache_e2e_test.go
@@ -1,0 +1,106 @@
+package runtime
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// TestSSEClosesStreamOnHardNav pins the pagehide lifecycle: when the
+// user hard-navigates away from an SSE-bearing page, the module must
+// close its EventSource so the navigated-away page doesn't keep one of
+// the tab's ~6 per-host HTTP/1.1 connections hoarded from inside the
+// back/forward cache. Without the pagehide close, Chrome retains the
+// dead page's stream socket (never sends FIN) and 6 SSE-bearing
+// navigations starve the tab — the server here observes exactly that:
+// its stream handler never unblocks.
+func TestSSEClosesStreamOnHardNav(t *testing.T) {
+	var active int32
+	mux := http.NewServeMux()
+	js, err := RuntimeJS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux.HandleFunc("/__gofastr/runtime.js", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		_, _ = w.Write([]byte(js))
+	})
+	// Serve the sse module bytes at its demand-load path.
+	if mod, ok := Module("sse"); ok {
+		mux.HandleFunc("/__gofastr/runtime/sse.js", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/javascript")
+			_, _ = w.Write([]byte(mod))
+		})
+	}
+	// The stream hangs open until the peer disconnects; `active` is the
+	// server's live view of how many stream sockets exist.
+	mux.HandleFunc("/__gofastr/sse", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		fl, _ := w.(http.Flusher)
+		fmt.Fprint(w, ": connected\n\n")
+		if fl != nil {
+			fl.Flush()
+		}
+		atomic.AddInt32(&active, 1)
+		defer atomic.AddInt32(&active, -1)
+		<-r.Context().Done()
+	})
+	// Page A carries the SSE meta; page B is a plain document, so the
+	// only stream that can exist after the navigation is A's leftover.
+	mux.HandleFunc("/a", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<!doctype html><html><head>`+
+			`<meta name="gofastr-sse" content="/__gofastr/sse?session=sess-1">`+
+			`</head><body><span id="ready-a">a</span>`+
+			`<script src="/__gofastr/runtime.js"></script></body></html>`)
+	})
+	mux.HandleFunc("/b", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<!doctype html><html><head></head>`+
+			`<body><span id="ready-b">b</span>`+
+			`<script src="/__gofastr/runtime.js"></script></body></html>`)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	ctx := newSeedBrowserCtx(t)
+
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/a"),
+		chromedp.WaitVisible(`#ready-a`, chromedp.ByID),
+	); err != nil {
+		t.Fatalf("chromedp (page A): %v", err)
+	}
+	waitStreams := func(want int32, timeout time.Duration) bool {
+		deadline := time.Now().Add(timeout)
+		for time.Now().Before(deadline) {
+			if atomic.LoadInt32(&active) == want {
+				return true
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		return false
+	}
+	if !waitStreams(1, 15*time.Second) {
+		t.Fatalf("page A never opened its SSE stream (active = %d)", atomic.LoadInt32(&active))
+	}
+
+	// Hard navigation: a full document load of /b, which puts page A into
+	// the back/forward cache. A's stream must close promptly.
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/b"),
+		chromedp.WaitVisible(`#ready-b`, chromedp.ByID),
+	); err != nil {
+		t.Fatalf("chromedp (page B): %v", err)
+	}
+	if !waitStreams(0, 10*time.Second) {
+		t.Fatalf("page A's SSE stream survived the hard navigation: server still sees %d open stream(s)",
+			atomic.LoadInt32(&active))
+	}
+}

--- a/core/middleware/timeout.go
+++ b/core/middleware/timeout.go
@@ -168,6 +168,18 @@ func (tw *timeoutWriter) expire() bool {
 // The handler runs in a goroutine; a buffered response writer prevents
 // concurrent writes to the underlying http.Header map between the handler
 // goroutine and the timeout path.
+//
+// Streaming contract: once the handler flushes or hijacks — flipping the
+// wrapped writer into streaming mode — the deadline stops terminating the
+// response. The middleware then waits for the handler to return instead of
+// handing the finalized response back to net/http underneath it (which
+// would make the handler's next write panic — the bug that killed every
+// SSE stream older than the timeout). The request context still expires
+// with DeadlineExceeded at the deadline, so a streaming handler chooses
+// its own lifetime: honor the deadline and unwind, or (like the SSE bus,
+// issue #159) ignore it and bound the stream itself. Handlers that never
+// start streaming keep the hard guarantee: a hung handler gets its 504 at
+// the deadline.
 func Timeout(d time.Duration) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -199,9 +211,26 @@ func Timeout(d time.Duration) Middleware {
 				}
 				tw.finish()
 			case <-ctx.Done():
-				if tw.expire() {
-					http.Error(w, "Gateway Timeout", http.StatusGatewayTimeout)
+				if !tw.expire() {
+					// The response is already streaming (or hijacked): the
+					// handler owns the connection lifetime and the deadline
+					// no longer applies. Returning here would hand the
+					// response back to net/http, which finalizes it and
+					// nils its internal buffered writer — the still-
+					// streaming handler's next write (e.g. the SSE
+					// heartbeat) would then panic inside net/http. Block
+					// until the handler returns instead. The request
+					// context stays expired (DeadlineExceeded), so
+					// streaming handlers that honor the deadline still
+					// unwind on their own; the SSE bus deliberately
+					// ignores it and bounds its own lifetime (issue #159).
+					<-done
+					if childPanic != nil {
+						panic(childPanic)
+					}
+					return
 				}
+				http.Error(w, "Gateway Timeout", http.StatusGatewayTimeout)
 				// Parent took the timeout branch; the handler goroutine
 				// is still running and may yet panic. Watch for that
 				// late panic and surface it through slog.Default so it

--- a/core/middleware/timeout.go
+++ b/core/middleware/timeout.go
@@ -161,6 +161,58 @@ func (tw *timeoutWriter) expire() bool {
 	return true
 }
 
+// timeoutCtx is the request context handed to the wrapped handler. It
+// replaces context.WithTimeout because a stdlib deadline is irrevocable:
+// once it fires, Err() is frozen at DeadlineExceeded forever, so a client
+// disconnect AFTER the deadline becomes invisible to a still-streaming
+// handler that discriminates DeadlineExceeded (ignore — issue #159) from
+// Canceled (unwind). This context keeps the same observable behavior for
+// non-streaming requests — Done fires at the deadline with
+// Err() == DeadlineExceeded, and earlier parent cancellation propagates —
+// but the deadline is DISARMED when the response has started streaming,
+// leaving the context live so a later disconnect still delivers Canceled.
+//
+// Deadline() deliberately reports no deadline: for a streaming response
+// the deadline may never fire, and advertising one that then doesn't fire
+// makes stdlib helpers misbehave (context.WithTimeout derived from a
+// parent whose advertised deadline is earlier trusts the parent to fire
+// and drops its own timer — a lost timeout). Callers needing a budget
+// still observe Done()/Err() exactly as with context.WithTimeout.
+type timeoutCtx struct {
+	parent context.Context // original *http.Request context (values, cause)
+
+	mu   sync.Mutex
+	done chan struct{}
+	err  error
+}
+
+func newTimeoutCtx(parent context.Context) *timeoutCtx {
+	return &timeoutCtx{parent: parent, done: make(chan struct{})}
+}
+
+func (c *timeoutCtx) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (c *timeoutCtx) Done() <-chan struct{}       { return c.done }
+func (c *timeoutCtx) Value(key any) any           { return c.parent.Value(key) }
+
+func (c *timeoutCtx) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.err
+}
+
+// cancel completes the context with err. First caller wins; later calls
+// are no-ops, so the deadline, parent-cancellation propagation, and
+// end-of-request cleanup can race safely.
+func (c *timeoutCtx) cancel(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.err != nil {
+		return
+	}
+	c.err = err
+	close(c.done)
+}
+
 // Timeout returns middleware that enforces a deadline on request processing.
 // If the downstream handler does not complete within the given duration,
 // a 504 Gateway Timeout response is returned.
@@ -170,21 +222,37 @@ func (tw *timeoutWriter) expire() bool {
 // goroutine and the timeout path.
 //
 // Streaming contract: once the handler flushes or hijacks — flipping the
-// wrapped writer into streaming mode — the deadline stops terminating the
-// response. The middleware then waits for the handler to return instead of
+// wrapped writer into streaming mode — the deadline stops applying to the
+// response. The middleware waits for the handler to return instead of
 // handing the finalized response back to net/http underneath it (which
 // would make the handler's next write panic — the bug that killed every
-// SSE stream older than the timeout). The request context still expires
-// with DeadlineExceeded at the deadline, so a streaming handler chooses
-// its own lifetime: honor the deadline and unwind, or (like the SSE bus,
-// issue #159) ignore it and bound the stream itself. Handlers that never
-// start streaming keep the hard guarantee: a hung handler gets its 504 at
-// the deadline.
+// SSE stream older than the timeout), and the request context stays LIVE
+// past the deadline so a later client disconnect is still delivered as
+// context.Canceled. A streaming handler therefore owns its lifetime: it
+// unwinds on disconnect, on its own bound (like the SSE bus, issue #159),
+// or on a failed write — never because the request deadline lapsed.
+// Handlers that never start streaming keep the hard guarantee: a hung
+// handler gets its 504 at the deadline, with the context completed as
+// DeadlineExceeded.
 func Timeout(d time.Duration) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx, cancel := context.WithTimeout(r.Context(), d)
-			defer cancel()
+			ctx := newTimeoutCtx(r.Context())
+			// End-of-request cleanup: release the propagation callback
+			// and anyone still selecting on ctx.Done(). A context that
+			// already completed (deadline or disconnect) ignores this.
+			defer ctx.cancel(context.Canceled)
+			// Client disconnect (or any parent cancellation) reaches the
+			// handler even after the deadline has been disarmed by a
+			// streaming response. AfterFunc costs no goroutine until the
+			// parent actually completes; stop() releases it when the
+			// request ends first.
+			stop := context.AfterFunc(r.Context(), func() {
+				ctx.cancel(r.Context().Err())
+			})
+			defer stop()
+			timer := time.NewTimer(d)
+			defer timer.Stop()
 
 			tw := newTimeoutWriter(w)
 			done := make(chan struct{})
@@ -204,13 +272,11 @@ func Timeout(d time.Duration) Middleware {
 				next.ServeHTTP(tw, r.WithContext(ctx))
 			}()
 
-			select {
-			case <-done:
-				if childPanic != nil {
-					panic(childPanic)
-				}
-				tw.finish()
-			case <-ctx.Done():
+			// abandon handles "the request is over but the handler is
+			// not": the deadline fired, or the client disconnected while
+			// the handler was still running. cause completes the
+			// handler's context when it hasn't completed already.
+			abandon := func(cause error) {
 				if !tw.expire() {
 					// The response is already streaming (or hijacked): the
 					// handler owns the connection lifetime and the deadline
@@ -219,19 +285,21 @@ func Timeout(d time.Duration) Middleware {
 					// nils its internal buffered writer — the still-
 					// streaming handler's next write (e.g. the SSE
 					// heartbeat) would then panic inside net/http. Block
-					// until the handler returns instead. The request
-					// context stays expired (DeadlineExceeded), so
-					// streaming handlers that honor the deadline still
-					// unwind on their own; the SSE bus deliberately
-					// ignores it and bounds its own lifetime (issue #159).
+					// until the handler returns instead. The handler's ctx
+					// is NOT cancelled here — it stays live so a later
+					// client disconnect still reaches the handler as
+					// Canceled (via the AfterFunc above); the stream's
+					// lifetime belongs to the handler and its own bound
+					// (#159).
 					<-done
 					if childPanic != nil {
 						panic(childPanic)
 					}
 					return
 				}
+				ctx.cancel(cause)
 				http.Error(w, "Gateway Timeout", http.StatusGatewayTimeout)
-				// Parent took the timeout branch; the handler goroutine
+				// Parent abandoned the handler; the handler goroutine
 				// is still running and may yet panic. Watch for that
 				// late panic and surface it through slog.Default so it
 				// doesn't vanish — otherwise debugging "why does this
@@ -247,6 +315,23 @@ func Timeout(d time.Duration) Middleware {
 						)
 					}
 				}()
+			}
+
+			select {
+			case <-done:
+				if childPanic != nil {
+					panic(childPanic)
+				}
+				tw.finish()
+			case <-r.Context().Done():
+				// Client gone before the handler finished (the AfterFunc
+				// has already delivered the parent's error to ctx). Same
+				// exit as the deadline: don't hold the connection open
+				// for a peer that left. The 504 goes to a dead socket —
+				// written for parity, observed by no one.
+				abandon(r.Context().Err())
+			case <-timer.C:
+				abandon(context.DeadlineExceeded)
 			}
 		})
 	}

--- a/core/middleware/timeout_streaming_test.go
+++ b/core/middleware/timeout_streaming_test.go
@@ -1,0 +1,107 @@
+package middleware
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestTimeoutStreamingOutlivesDeadline pins the contract documented in
+// framework/docs/content/reactivity.md ("streams outlive the request
+// timeout", issue #159): once a handler flushes — flipping the timeout
+// writer into streaming mode — the deadline must no longer terminate the
+// response. Before the fix, the middleware's parent goroutine returned to
+// net/http at the deadline, which finalized the response underneath the
+// still-streaming handler; the handler's next write (the SSE heartbeat)
+// then panicked with a nil-pointer deref inside net/http ("panic in
+// timed-out handler ... path=/__gofastr/sse" at exact heartbeat cadence).
+//
+// Needs a real server: httptest.ResponseRecorder never finalizes, so the
+// bug is invisible against a recorder.
+func TestTimeoutStreamingOutlivesDeadline(t *testing.T) {
+	type outcome struct {
+		panicked any
+		writeErr error
+	}
+	outcomeCh := make(chan outcome, 1)
+
+	h := Timeout(40 * time.Millisecond)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var out outcome
+		defer func() {
+			out.panicked = recover()
+			outcomeCh <- out
+		}()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: first\n\n"))
+		w.(http.Flusher).Flush() // streaming starts, well before the deadline
+
+		time.Sleep(150 * time.Millisecond) // deadline fires in here
+
+		// The post-deadline heartbeat write. Before the fix this panicked
+		// inside net/http (response already finalized by the parent).
+		_, out.writeErr = w.Write([]byte("data: second\n\n"))
+		w.(http.Flusher).Flush()
+	}))
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+
+	out := <-outcomeCh
+	if out.panicked != nil {
+		t.Fatalf("post-deadline write panicked: %v", out.panicked)
+	}
+	if out.writeErr != nil {
+		t.Fatalf("post-deadline write failed: %v", out.writeErr)
+	}
+	if readErr != nil {
+		t.Fatalf("reading stream: %v", readErr)
+	}
+	if !strings.Contains(string(body), "data: second") {
+		t.Fatalf("client never received the post-deadline frame; body=%q", body)
+	}
+}
+
+// TestTimeoutHungHandlerStill504s is the control for the streaming
+// exemption: a handler that never flushes and simply hangs must still get
+// its 504 at the deadline — the middleware's slowloris/hung-handler
+// protection — and the client must receive it promptly, not after the
+// handler finally returns.
+func TestTimeoutHungHandlerStill504s(t *testing.T) {
+	release := make(chan struct{})
+	h := Timeout(30 * time.Millisecond)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // hang far past the deadline, no Flush
+		_, _ = w.Write([]byte("too late"))
+	}))
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	defer close(release)
+
+	start := time.Now()
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusGatewayTimeout {
+		t.Fatalf("expected 504, got %d (body=%q)", resp.StatusCode, body)
+	}
+	// The 504 must arrive at the deadline, not when the handler unblocks.
+	if elapsed > 2*time.Second {
+		t.Fatalf("504 took %v; timeout path is blocking on the handler", elapsed)
+	}
+	if strings.Contains(string(body), "too late") {
+		t.Fatalf("handler output leaked past the 504: %q", body)
+	}
+}

--- a/core/middleware/timeout_streaming_test.go
+++ b/core/middleware/timeout_streaming_test.go
@@ -1,7 +1,9 @@
 package middleware
 
 import (
+	"context"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -67,6 +69,85 @@ func TestTimeoutStreamingOutlivesDeadline(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "data: second") {
 		t.Fatalf("client never received the post-deadline frame; body=%q", body)
+	}
+}
+
+// TestTimeoutStreamDisconnectAfterDeadline pins the third leg of the
+// streaming contract: a client disconnect must promptly unwind a streaming
+// handler even when it happens AFTER the request deadline has passed. The
+// handler mimics the SSE stream loop (core-ui/island/stream.go): a one-shot
+// watcher on r.Context() that ignores DeadlineExceeded (issue #159 — the
+// timeout firing on a live client) and unwinds only on context.Canceled (a
+// real disconnect). With context.WithTimeout, the deadline permanently
+// freezes ctx.Err() at DeadlineExceeded, so a later disconnect is invisible
+// and the stream lives to its own bound instead of unwinding.
+func TestTimeoutStreamDisconnectAfterDeadline(t *testing.T) {
+	unwound := make(chan string, 1)
+	h := Timeout(40 * time.Millisecond)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: first\n\n"))
+		w.(http.Flusher).Flush()
+
+		// stream.go's disconnect discrimination, verbatim in shape.
+		reqCtx := r.Context()
+		streamCtx, streamCancel := context.WithCancel(context.Background())
+		defer streamCancel()
+		go func() {
+			<-reqCtx.Done()
+			if reqCtx.Err() == context.Canceled {
+				streamCancel()
+			}
+		}()
+
+		tick := time.NewTicker(25 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-streamCtx.Done():
+				unwound <- "canceled"
+				return
+			case <-tick.C:
+				if _, err := w.Write([]byte(": ping\n\n")); err != nil {
+					// A cancel racing the same tick still counts as clean.
+					select {
+					case <-streamCtx.Done():
+						unwound <- "canceled"
+					default:
+						unwound <- "write-error"
+					}
+					return
+				}
+				w.(http.Flusher).Flush()
+			}
+		}
+	}))
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if _, err := conn.Write([]byte("GET / HTTP/1.1\r\nHost: t\r\n\r\n")); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	// Read the response head + first frame so the stream is known-started.
+	buf := make([]byte, 512)
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := conn.Read(buf); err != nil {
+		t.Fatalf("read response head: %v", err)
+	}
+
+	time.Sleep(120 * time.Millisecond) // deadline (40ms) fires in here; stream survives
+	_ = conn.Close()                   // the disconnect happens AFTER the deadline
+
+	select {
+	case reason := <-unwound:
+		if reason != "canceled" {
+			t.Fatalf("stream unwound via %q, want context.Canceled from the disconnect", reason)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream handler never unwound after post-deadline client disconnect")
 	}
 }
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,7 @@ Self-contained Go programs — `go run ./examples/<name>`:
 | `semantic-demo` | Semantic search with `battery/semantic`. |
 | `embed-demo` | Embeddable surfaces: an app and a customer's site on two origins. |
 | `processmodule-demo` | A process-isolated third-party module speaking the `moduleproto` protocol over stdio — the canonical [process-module](../framework/docs/content/process-modules.md) example and the child the go/no-go gate suite drives end to end. |
+| `site` | The framework's live component gallery and reference docs site — every UI component rendered one per page, plus the hosted examples. Run with `go run ./examples/site` (or `./scripts/dev-watch.sh` for livereload). |
 
 ## Blueprint examples (declarative)
 

--- a/examples/blog/gofastr.yml
+++ b/examples/blog/gofastr.yml
@@ -190,7 +190,7 @@ screens:
         fields: [title, body, status, author_id]
 
   - name: post_detail
-    route: /post-detail
+    route: /posts/{id}
     title: Post Details
     description: View blog post
     body:

--- a/examples/ecommerce/app/app.go
+++ b/examples/ecommerce/app/app.go
@@ -116,11 +116,6 @@ func RegisterGenerated(fwApp *framework.App, site *app.App, db *sql.DB) {
 		// HTML forms, mount auth.CSRF — see `gofastr docs blueprints`
 		// (Auth section) and `gofastr docs auth`.
 	}
-	{
-		_, b := ui.ConfirmAction(ui.ConfirmActionConfig{Name: "delete-products", TriggerLabel: "Delete", Title: "Delete this Products?", Body: "This action will soft-delete the record. It can be restored later.", RPCPath: "/products/{id}"})
-		d := b.Build()
-		widget.Mount(fwApp.Router(), &d)
-	}
 	mountGenerated(fwApp, site, db)
 	fwApp.Router().Handle("POST", "/orders/{id}/confirm", http.HandlerFunc(ConfirmOrder))
 	fwApp.Router().Handle("POST", "/orders/{id}/ship", http.HandlerFunc(ShipOrder))

--- a/examples/ecommerce/app/e2e_test.go
+++ b/examples/ecommerce/app/e2e_test.go
@@ -45,7 +45,7 @@ func TestE2E(t *testing.T) {
 	}
 
 	// Public screens render for anonymous visitors.
-	for _, p := range []string{"/", "/products", "/categories", "/orders", "/reviews", "/new-product", "/product-detail", "/order-detail", "/product-detail/edit", "/order-detail/edit"} {
+	for _, p := range []string{"/", "/products", "/categories", "/orders", "/reviews", "/new-product"} {
 		if code, body := e2eDo(t, http.DefaultClient, "GET", base+p, ""); code != http.StatusOK {
 			t.Errorf("public screen %s = %d, want 200", p, code)
 		} else if len(body) < 120 {

--- a/examples/ecommerce/app/screen_orders_crud.go
+++ b/examples/ecommerce/app/screen_orders_crud.go
@@ -106,11 +106,11 @@ func mountOrdersScreen(fwApp *framework.App, site *app.App, db *sql.DB) {
 }
 
 func mountOrderDetailScreen(fwApp *framework.App, site *app.App, db *sql.DB) {
-	site.Register("/order-detail", &OrderDetailScreen{}, appLayout)
+	site.Register("/orders/:id", &OrderDetailScreen{}, appLayout)
 }
 
 func mountOrdersEditScreen(fwApp *framework.App, site *app.App, db *sql.DB) {
-	site.Register("/order-detail/edit", &OrdersEditScreen{}, appLayout)
+	site.Register("/orders/:id/edit", &OrdersEditScreen{}, appLayout)
 }
 
 func init() {

--- a/examples/ecommerce/app/screen_products_crud.go
+++ b/examples/ecommerce/app/screen_products_crud.go
@@ -141,11 +141,11 @@ func mountProductsScreen(fwApp *framework.App, site *app.App, db *sql.DB) {
 }
 
 func mountProductDetailScreen(fwApp *framework.App, site *app.App, db *sql.DB) {
-	site.Register("/product-detail", &ProductDetailScreen{}, appLayout)
+	site.Register("/products/:id", &ProductDetailScreen{}, appLayout)
 }
 
 func mountProductsEditScreen(fwApp *framework.App, site *app.App, db *sql.DB) {
-	site.Register("/product-detail/edit", &ProductsEditScreen{}, appLayout)
+	site.Register("/products/:id/edit", &ProductsEditScreen{}, appLayout)
 }
 
 func init() {

--- a/examples/ecommerce/app/seed_guard_test.go
+++ b/examples/ecommerce/app/seed_guard_test.go
@@ -1,0 +1,150 @@
+// Runtime regression guards for the generated storefront.
+//
+// These assertions live OUTSIDE the generator-emitted e2e_test.go (which
+// `gofastr generate --force` rewrites from the blueprint) so they survive
+// regeneration. They guard two regressions the blueprint validator now
+// catches at generate time but that must also fail loudly at runtime:
+//
+//  1. Reviews declare a required product_id relation. Before the seed wired
+//     it via `@products.slug=…`, every review row failed CreateOne and the
+//     storefront shipped zero reviews ("seed reviews: skipping row").
+//  2. product_detail's route must carry {id}, or the list's "View" link
+//     (/products/<id>) matches no registered route and renders nothing.
+//
+// Category linkage (products -> categories via @categories.slug=…) is not
+// rendered on the anonymous storefront, so it is verified through the REST
+// API as a logged-in customer: each product carries a resolved category_id,
+// and the distinct set covers every seeded category.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestSeedAndDetailGuards boots a freshly-seeded storefront (isolated SQLite
+// DB) and asserts the seed loaded and the detail route resolves.
+func TestSeedAndDetailGuards(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds + boots the binary")
+	}
+	base := bootSeededStorefront(t)
+
+	// (1) Reviews seeded: a missing required product_id skips every row, so
+	// the list falls back to its empty state. The seeded author must appear.
+	code, body := e2eDo(t, http.DefaultClient, "GET", base+"/reviews", "")
+	if code != http.StatusOK {
+		t.Fatalf("reviews page = %d, want 200", code)
+	}
+	if strings.Contains(body, "No reviews yet") {
+		t.Error("reviews page shows the empty state — seed rows were skipped (product_id @-ref unresolved?)")
+	}
+	if !strings.Contains(body, "Sarah M.") {
+		t.Error("reviews page missing seeded author 'Sarah M.' — reviews seed did not load")
+	}
+
+	// (2) Detail route alive + View link well-formed: pull the first
+	// /products/<id> View link from the catalog (the link the validator now
+	// requires {id} on) and fetch it. A dead link 404s.
+	_, prodBody := e2eDo(t, http.DefaultClient, "GET", base+"/products", "")
+	m := regexp.MustCompile(`/products/([0-9a-fA-F-]{36})`).FindStringSubmatch(prodBody)
+	if m == nil {
+		t.Fatal("products catalog has no /products/<id> View link — list did not render seeded rows or link shape changed")
+	}
+	href := m[0]
+	dcode, dbody := e2eDo(t, http.DefaultClient, "GET", base+href, "")
+	if dcode != http.StatusOK {
+		t.Errorf("product detail %s = %d, want 200 (dead View link?)", href, dcode)
+	}
+	if !strings.Contains(dbody, "Wireless Headphones") && !strings.Contains(dbody, "USB-C Hub") &&
+		!strings.Contains(dbody, "Mechanical Keyboard") && !strings.Contains(dbody, "Webcam HD") {
+		t.Errorf("product detail %s did not render a seeded product", href)
+	}
+
+	// (3) Every category has >=1 product. The storefront does not render the
+	// category column, so read the records through the REST API as a logged-in
+	// customer and check category_id resolved on every product, with the
+	// distinct set spanning all three seeded categories.
+	client := e2eAuthedClient(t, base)
+	rcode, rbody := e2eDo(t, client, "GET", base+"/api/products", "")
+	if rcode != http.StatusOK {
+		t.Fatalf("GET /api/products = %d; body=%.300s", rcode, rbody)
+	}
+	var resp struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(rbody), &resp); err != nil {
+		t.Fatalf("decode products JSON: %v; body=%.300s", err, rbody)
+	}
+	if len(resp.Data) < 4 {
+		t.Errorf("expected >=4 seeded products via REST, got %d", len(resp.Data))
+	}
+	categories := map[string]bool{}
+	for _, p := range resp.Data {
+		cid := p["categoryId"]
+		if cid == nil {
+			t.Errorf("product id=%v has nil categoryId — @categories.slug @-ref unresolved", p["id"])
+			continue
+		}
+		categories[fmt.Sprintf("%v", cid)] = true
+	}
+	if len(categories) < 3 {
+		t.Errorf("seeded products span %d distinct categories, want >=3 (every category should have >=1 product)", len(categories))
+	}
+}
+
+// bootSeededStorefront builds the generated binary and boots it on a free port
+// with a throwaway SQLite database, returning its base URL.
+func bootSeededStorefront(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "app")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	addr := e2eFreeAddr(t)
+	srv := exec.Command(bin)
+	srv.Dir = dir
+	srv.Env = append(os.Environ(), "PORT="+addr, "DATABASE_URL=file:"+filepath.Join(dir, "guard.db"))
+	srv.Stdout, srv.Stderr = nil, nil
+	if err := srv.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Process.Kill(); _, _ = srv.Process.Wait() })
+	base := "http://" + addr
+	e2eWaitReady(t, base)
+	return base
+}
+
+// e2eAuthedClient registers a fresh customer and returns a client whose cookie
+// jar carries the session, so session-gated REST reads succeed.
+func e2eAuthedClient(t *testing.T, base string) *http.Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar: %v", err)
+	}
+	client := &http.Client{Jar: jar}
+	creds := `{"email":"e2e-guard@shop.test","password":"e2e-guard-pw-123"}`
+	if code, body := e2eDo(t, client, "POST", base+"/auth/register", creds); code >= 400 {
+		t.Fatalf("POST /auth/register = %d; body=%.300s", code, body)
+	}
+	if code, body := e2eDo(t, client, "POST", base+"/auth/login", creds); code >= 400 {
+		t.Fatalf("POST /auth/login = %d; body=%.300s", code, body)
+	}
+	return client
+}

--- a/examples/ecommerce/app/stubs.go
+++ b/examples/ecommerce/app/stubs.go
@@ -40,14 +40,14 @@ func seedData() []seedEntity {
 			{"active": true, "description": "Everything for your home", "name": "Home & Garden", "slug": "home-garden", "sort_order": 3},
 		}},
 		{Entity: "products", Rows: []map[string]any{
-			{"description": "Premium noise-cancelling wireless headphones with 30-hour battery life.", "featured": true, "name": "Wireless Headphones", "price": "79.99", "sku": "WH-001", "slug": "wireless-headphones", "status": "active", "stock": 150},
-			{"description": "7-in-1 USB-C hub with HDMI, USB 3.0, SD card reader, and PD charging.", "name": "USB-C Hub", "price": "49.99", "sku": "UCH-002", "slug": "usb-c-hub", "status": "active", "stock": 200},
-			{"description": "Hot-swappable mechanical keyboard with RGB backlighting.", "featured": true, "name": "Mechanical Keyboard", "price": "129.99", "sku": "MK-003", "slug": "mechanical-keyboard", "status": "active", "stock": 75},
-			{"compare_at_price": "59.99", "description": "1080p HD webcam with auto-focus and built-in microphone.", "name": "Webcam HD", "price": "39.99", "sku": "WC-004", "slug": "webcam-hd", "status": "draft", "stock": 300},
+			{"category_id": "@categories.slug=electronics", "description": "Premium noise-cancelling wireless headphones with 30-hour battery life.", "featured": true, "name": "Wireless Headphones", "price": "79.99", "sku": "WH-001", "slug": "wireless-headphones", "status": "active", "stock": 150},
+			{"category_id": "@categories.slug=electronics", "description": "7-in-1 USB-C hub with HDMI, USB 3.0, SD card reader, and PD charging.", "name": "USB-C Hub", "price": "49.99", "sku": "UCH-002", "slug": "usb-c-hub", "status": "active", "stock": 200},
+			{"category_id": "@categories.slug=home-garden", "description": "Hot-swappable mechanical keyboard with RGB backlighting.", "featured": true, "name": "Mechanical Keyboard", "price": "129.99", "sku": "MK-003", "slug": "mechanical-keyboard", "status": "active", "stock": 75},
+			{"category_id": "@categories.slug=clothing", "compare_at_price": "59.99", "description": "1080p HD webcam with auto-focus and built-in microphone.", "name": "Webcam HD", "price": "39.99", "sku": "WC-004", "slug": "webcam-hd", "status": "draft", "stock": 300},
 		}},
 		{Entity: "reviews", Rows: []map[string]any{
-			{"author_name": "Sarah M.", "body": "The noise cancellation is incredible. Battery lasts forever.", "rating": 5, "title": "Best headphones I ever owned", "verified": true},
-			{"author_name": "Mike T.", "body": "Solid build quality for the price. Wish the case was included.", "rating": 4, "title": "Great value", "verified": true},
+			{"author_name": "Sarah M.", "body": "The noise cancellation is incredible. Battery lasts forever.", "product_id": "@products.slug=wireless-headphones", "rating": 5, "title": "Best headphones I ever owned", "verified": true},
+			{"author_name": "Mike T.", "body": "Solid build quality for the price. Wish the case was included.", "product_id": "@products.slug=mechanical-keyboard", "rating": 4, "title": "Great value", "verified": true},
 		}},
 	}
 }

--- a/examples/ecommerce/gofastr.yml
+++ b/examples/ecommerce/gofastr.yml
@@ -399,7 +399,7 @@ screens:
         fields: [name, slug, sku, description, price, stock, status, featured]
 
   - name: product_detail
-    route: /product-detail
+    route: /products/{id}
     title: Product Details
     description: View product details
     body:
@@ -412,7 +412,7 @@ screens:
         fields: [name, slug, sku, description, price, stock, status, featured]
 
   - name: order_detail
-    route: /order-detail
+    route: /orders/{id}
     title: Order Details
     description: View order details
     body:
@@ -465,6 +465,7 @@ seed:
     rows:
       - name: Wireless Headphones
         slug: wireless-headphones
+        category_id: "@categories.slug=electronics"
         sku: WH-001
         description: Premium noise-cancelling wireless headphones with 30-hour battery life.
         price: 79.99
@@ -473,6 +474,7 @@ seed:
         featured: true
       - name: USB-C Hub
         slug: usb-c-hub
+        category_id: "@categories.slug=electronics"
         sku: UCH-002
         description: 7-in-1 USB-C hub with HDMI, USB 3.0, SD card reader, and PD charging.
         price: 49.99
@@ -480,6 +482,7 @@ seed:
         status: active
       - name: Mechanical Keyboard
         slug: mechanical-keyboard
+        category_id: "@categories.slug=home-garden"
         sku: MK-003
         description: Hot-swappable mechanical keyboard with RGB backlighting.
         price: 129.99
@@ -488,6 +491,7 @@ seed:
         featured: true
       - name: Webcam HD
         slug: webcam-hd
+        category_id: "@categories.slug=clothing"
         sku: WC-004
         description: 1080p HD webcam with auto-focus and built-in microphone.
         price: 39.99
@@ -497,11 +501,13 @@ seed:
   - entity: reviews
     rows:
       - author_name: Sarah M.
+        product_id: "@products.slug=wireless-headphones"
         rating: 5
         title: Best headphones I ever owned
         body: The noise cancellation is incredible. Battery lasts forever.
         verified: true
       - author_name: Mike T.
+        product_id: "@products.slug=mechanical-keyboard"
         rating: 4
         title: Great value
         body: Solid build quality for the price. Wish the case was included.

--- a/examples/lms/gofastr.yml
+++ b/examples/lms/gofastr.yml
@@ -566,7 +566,7 @@ screens:
         fields: [title, slug, subtitle, description, category, level, price, is_free]
 
   - name: course_detail
-    route: /course-detail
+    route: /courses/{id}
     title: Course Details
     description: View course details
     body:
@@ -638,6 +638,7 @@ seed:
     rows:
       - title: Introduction to Web Development
         slug: intro-web-dev
+        instructor_id: "@instructors.email=sarah@learnhub.dev"
         subtitle: Learn HTML, CSS, and JavaScript from scratch
         description: A comprehensive beginner course covering the fundamentals of web development. No prior experience required.
         category: Web Development
@@ -649,6 +650,7 @@ seed:
         estimated_duration_weeks: 6
       - title: Advanced Go Programming
         slug: advanced-go
+        instructor_id: "@instructors.email=sarah@learnhub.dev"
         subtitle: Master Go concurrency, generics, and performance
         description: Deep dive into Go's advanced features including goroutines, channels, generics, and profiling.
         category: Backend Development
@@ -660,6 +662,7 @@ seed:
         estimated_duration_weeks: 8
       - title: Cloud Fundamentals
         slug: cloud-fundamentals
+        instructor_id: "@instructors.email=alex@learnhub.dev"
         subtitle: Understanding cloud computing concepts
         description: Free course covering AWS, GCP, and Azure basics. Perfect for beginners exploring cloud computing.
         category: Cloud Computing
@@ -672,12 +675,12 @@ seed:
   - entity: modules
     rows:
       - title: Getting Started with HTML
-        course_id: 1
+        course_id: "@courses.slug=intro-web-dev"
         description: Learn the building blocks of every web page
         position: 1
         status: published
       - title: CSS Styling Fundamentals
-        course_id: 1
+        course_id: "@courses.slug=intro-web-dev"
         description: Make your web pages look beautiful
         position: 2
         status: published

--- a/examples/meridian/screen_login.go
+++ b/examples/meridian/screen_login.go
@@ -20,7 +20,7 @@ func (s *LoginScreen) ScreenType() app.ScreenType { return app.ScreenPage }
 
 func (s *LoginScreen) RenderCtx(ctx context.Context) render.HTML {
 	return html.Div(html.DivConfig{},
-		ui.AuthCard(ui.AuthCardConfig{Title: "Sign in to Meridian", Alert: authError(ctx), Body: ui.Form(ui.FormConfig{Action: "/auth/login", Method: "POST", SubmitLabel: "Sign in"}, render.Raw("<input type=\"hidden\" name=\"next\" value=\"/app\">"), ui.FormField(ui.FormFieldConfig{Label: "Email", For: "auth-email", Required: true, Input: render.Raw("<input id=\"auth-email\" name=\"email\" type=\"email\" autocomplete=\"email\" required>")}), ui.FormField(ui.FormFieldConfig{Label: "Password", For: "auth-password", Required: true, Input: render.Raw("<input id=\"auth-password\" name=\"password\" type=\"password\" autocomplete=\"current-password\" required>")})), Footer: render.Raw("<a href=\"/signup\">Create an account</a>")}),
+		ui.AuthCard(ui.AuthCardConfig{Title: "Sign in to Meridian", Alert: authError(ctx), Body: ui.Form(ui.FormConfig{Action: "/auth/login", Method: "POST", SubmitLabel: "Sign in"}, render.Raw("<input type=\"hidden\" name=\"next\" value=\"/app\">"), ui.FormField(ui.FormFieldConfig{Label: "Email", For: "auth-email", Required: true, Input: render.Raw("<input id=\"auth-email\" name=\"email\" type=\"email\" autocomplete=\"email\" required>")}), ui.FormField(ui.FormFieldConfig{Label: "Password", For: "auth-password", Required: true, Input: render.Raw("<input id=\"auth-password\" name=\"password\" type=\"password\" autocomplete=\"current-password\" required>")})), Footer: ui.Link(ui.LinkConfig{Href: "/signup", Text: "Create an account"})}),
 	)
 }
 

--- a/examples/meridian/screen_signup.go
+++ b/examples/meridian/screen_signup.go
@@ -20,7 +20,7 @@ func (s *SignupScreen) ScreenType() app.ScreenType { return app.ScreenPage }
 
 func (s *SignupScreen) RenderCtx(ctx context.Context) render.HTML {
 	return html.Div(html.DivConfig{},
-		ui.AuthCard(ui.AuthCardConfig{Title: "Create your Meridian account", Alert: authError(ctx), Body: ui.Form(ui.FormConfig{Action: "/auth/register", Method: "POST", SubmitLabel: "Create account"}, render.Raw("<input type=\"hidden\" name=\"next\" value=\"/app\">"), ui.FormField(ui.FormFieldConfig{Label: "Email", For: "auth-email", Required: true, Input: render.Raw("<input id=\"auth-email\" name=\"email\" type=\"email\" autocomplete=\"email\" required>")}), ui.FormField(ui.FormFieldConfig{Label: "Password", For: "auth-password", Required: true, Input: render.Raw("<input id=\"auth-password\" name=\"password\" type=\"password\" autocomplete=\"new-password\" required minlength=\"8\">")})), Footer: render.Raw("<a href=\"/login\">Already have an account? Sign in</a>")}),
+		ui.AuthCard(ui.AuthCardConfig{Title: "Create your Meridian account", Alert: authError(ctx), Body: ui.Form(ui.FormConfig{Action: "/auth/register", Method: "POST", SubmitLabel: "Create account"}, render.Raw("<input type=\"hidden\" name=\"next\" value=\"/app\">"), ui.FormField(ui.FormFieldConfig{Label: "Email", For: "auth-email", Required: true, Input: render.Raw("<input id=\"auth-email\" name=\"email\" type=\"email\" autocomplete=\"email\" required>")}), ui.FormField(ui.FormFieldConfig{Label: "Password", For: "auth-password", Required: true, Input: render.Raw("<input id=\"auth-password\" name=\"password\" type=\"password\" autocomplete=\"new-password\" required minlength=\"8\">")})), Footer: ui.Link(ui.LinkConfig{Href: "/login", Text: "Already have an account? Sign in"})}),
 	)
 }
 

--- a/examples/portfolio/gofastr.yml
+++ b/examples/portfolio/gofastr.yml
@@ -388,7 +388,7 @@ screens:
         fields: [title, slug, body, excerpt, category, status, featured]
 
   - name: post_detail
-    route: /post-detail
+    route: /blog/{id}
     title: Post Details
     description: View blog post
     body:

--- a/examples/project-manager/gofastr.yml
+++ b/examples/project-manager/gofastr.yml
@@ -447,7 +447,7 @@ screens:
         fields: [title, description, priority, task_type, status, assignee_email, due_date]
 
   - name: task_detail
-    route: /task-detail
+    route: /tasks/{id}
     title: Task Details
     description: View task details
     body:
@@ -499,6 +499,32 @@ seed:
         description: Native mobile app for iOS and Android
         status: planning
         color: "#10B981"
+  - entity: boards
+    rows:
+      - name: Web Board
+        project_id: "@projects.key=WEB"
+        description: Kanban board for the website redesign
+        position: 1
+        color: "#3B82F6"
+      - name: Mobile Board
+        project_id: "@projects.key=MOB"
+        description: Backlog board for the mobile app
+        position: 1
+        color: "#10B981"
+  - entity: columns
+    rows:
+      - name: Backlog
+        board_id: "@boards.name=Web Board"
+        position: 1
+      - name: In Progress
+        board_id: "@boards.name=Web Board"
+        position: 2
+      - name: Done
+        board_id: "@boards.name=Web Board"
+        position: 3
+      - name: Mobile Backlog
+        board_id: "@boards.name=Mobile Board"
+        position: 1
   - entity: labels
     rows:
       - name: Bug
@@ -516,24 +542,28 @@ seed:
   - entity: tasks
     rows:
       - title: Design new homepage hero section
+        column_id: "@columns.name=In Progress"
         description: Create a visually striking hero section with animated gradient background
         priority: high
         task_type: feature
         status: in_progress
         estimated_hours: 8
       - title: Fix mobile navigation overflow
+        column_id: "@columns.name=Backlog"
         description: Hamburger menu items overflow on screens smaller than 375px
         priority: urgent
         task_type: bug
         status: todo
         estimated_hours: 2
       - title: Add dark mode toggle
+        column_id: "@columns.name=Backlog"
         description: Implement system-preference-aware dark mode with manual override
         priority: medium
         task_type: improvement
         status: todo
         estimated_hours: 4
       - title: Write API documentation
+        column_id: "@columns.name=Backlog"
         description: Document all REST endpoints with request/response examples
         priority: low
         task_type: task
@@ -542,6 +572,8 @@ seed:
   - entity: comments
     rows:
       - body: The hero section looks great on desktop but needs work on mobile.
+        task_id: "@tasks.title=Design new homepage hero section"
         author_email: designer@team.dev
       - body: Reproduced on iPhone SE. The overflow happens when nav items exceed 5.
+        task_id: "@tasks.title=Fix mobile navigation overflow"
         author_email: dev@team.dev

--- a/examples/real-estate/gofastr.yml
+++ b/examples/real-estate/gofastr.yml
@@ -499,7 +499,7 @@ screens:
         fields: [title, property_type, listing_type, price, address, city, bedrooms, bathrooms, sqft, description]
 
   - name: property_detail
-    route: /property-detail
+    route: /properties/{id}
     title: Property Details
     description: View property details
     body:
@@ -572,11 +572,13 @@ seed:
     rows:
       - name: Emma Sterling
         email: emma@premierrealty.dev
+        agency_id: "@agencies.slug=premier-realty"
         phone: "+1-555-0101"
         bio: 15 years experience in luxury residential real estate.
         active: true
       - name: James Rivera
         email: james@coastalhomes.dev
+        agency_id: "@agencies.slug=coastal-homes"
         phone: "+1-555-0201"
         bio: Specialist in coastal and beachfront properties.
         active: true
@@ -584,6 +586,8 @@ seed:
     rows:
       - title: Modern Downtown Loft
         slug: modern-downtown-loft
+        agency_id: "@agencies.slug=premier-realty"
+        agent_id: "@agents.email=emma@premierrealty.dev"
         description: Stunning 2-bedroom loft in the heart of downtown with floor-to-ceiling windows and city views.
         property_type: apartment
         listing_type: sale
@@ -599,6 +603,8 @@ seed:
         featured: true
       - title: Beachfront Villa
         slug: beachfront-villa
+        agency_id: "@agencies.slug=coastal-homes"
+        agent_id: "@agents.email=james@coastalhomes.dev"
         description: Spectacular 4-bedroom beachfront villa with private pool and ocean views.
         property_type: house
         listing_type: sale
@@ -615,6 +621,8 @@ seed:
         featured: true
       - title: Cozy Studio Near Park
         slug: cozy-studio-near-park
+        agency_id: "@agencies.slug=premier-realty"
+        agent_id: "@agents.email=emma@premierrealty.dev"
         description: Affordable studio apartment walking distance from Golden Gate Park.
         property_type: apartment
         listing_type: rent

--- a/examples/site/e2e_runtime_modules_test.go
+++ b/examples/site/e2e_runtime_modules_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/chromedp/cdproto/network"
+	cdruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
 )
 
@@ -342,15 +343,30 @@ func TestE2E_RuntimeSplit_ToastModuleFailureShowsFallback(t *testing.T) {
                 }
             });
         })()`, nil),
-		chromedp.Sleep(800*time.Millisecond),
 		// The fallback should produce SOME visible toast-shaped node
-		// with the title text the server sent.
-		chromedp.Evaluate(`(() => {
-            // Look for the fallback container by a stable hook.
-            const fallback = document.querySelector('[data-fui-toast-fallback]');
-            if (!fallback) return false;
-            return fallback.textContent.includes('Saved');
-        })()`, &fallbackVisible),
+		// with the title text the server sent. POLL for it rather than
+		// sampling once after a fixed sleep: loadModule inserts module
+		// <script>s with async=false, so they join the document's
+		// in-order script list — and per the HTML spec even the ERROR
+		// event of an in-order script waits for every earlier pending
+		// in-order script to settle. The home page queues several
+		// modules at boot (toasts, sse, widgets, …); on a starved CI
+		// runner any of those fetches can outlive a fixed sleep, which
+		// delays the toasts.js onerror → fallback render past the
+		// sample point. The fallback is delayed, never lost — so wait
+		// on the real signal with a generous budget.
+		chromedp.Evaluate(`new Promise((resolve) => {
+            const t0 = performance.now();
+            const tick = () => {
+                const fallback = document.querySelector('[data-fui-toast-fallback]');
+                if (fallback && fallback.textContent.includes('Saved')) { resolve(true); return; }
+                if (performance.now() - t0 > 10000) { resolve(false); return; }
+                setTimeout(tick, 100);
+            };
+            tick();
+        })`, &fallbackVisible, func(p *cdruntime.EvaluateParams) *cdruntime.EvaluateParams {
+			return p.WithAwaitPromise(true)
+		}),
 	); err != nil {
 		t.Fatalf("chromedp: %v", err)
 	}

--- a/examples/site/get_started_compile_test.go
+++ b/examples/site/get_started_compile_test.go
@@ -1,0 +1,216 @@
+package main
+
+// Executable-docs gate for the /get-started page.
+//
+// The Get Started page is the most-traveled adoption path, and its two Go
+// code blocks (the sample entity declaration and the "add a page" screen)
+// are the first Go a reader pastes. They drifted before: the entity sample
+// used a top-level `CRUD:` field after that field moved onto
+// entity.ExposureConfig, so the sample stopped compiling as Go and nobody
+// noticed — there was no test rendering the page and compiling what it shows.
+//
+// This gate renders GetStartedScreen, extracts every Go code block (the
+// ui.CodeBlock samples — the terminal blocks are shell, not Go), wraps each
+// snippet in a minimal harness that supplies the package context + imports a
+// reader would already have, and compiles it against the local tree via a
+// replace directive. A snippet that drifts from the framework's real API
+// fails CI here, not in a reader's editor.
+//
+// Red-first: this test was committed against the broken `CRUD:` sample and
+// watched fail before the fix landed.
+
+import (
+	"html"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const gsGoFastrModule = "github.com/DonaldMurillo/gofastr"
+
+func TestGetStartedGoBlocksCompile(t *testing.T) {
+	page := string((&GetStartedScreen{}).Render())
+
+	blocks := extractGetStartedGoBlocks(t, page)
+	if len(blocks) == 0 {
+		t.Fatal("no Go code blocks found on /get-started — extraction is broken or the page changed shape")
+	}
+
+	for _, b := range blocks {
+		b := b
+		t.Run(b.label, func(t *testing.T) {
+			src, ok := wrapGetStartedSnippet(b.filename, b.source)
+			if !ok {
+				t.Fatalf("no compile harness for code block %q — add one in wrapGetStartedSnippet", b.filename)
+			}
+			compileGetStartedSnippet(t, src, b.label)
+		})
+	}
+}
+
+type gsCodeBlock struct {
+	filename string // from the CodeBlock chrome header
+	label    string // subtest name (base filename)
+	source   string // tag-stripped Go source, one line per rendered line
+}
+
+// extractGetStartedGoBlocks finds every framed ui.CodeBlock whose filename
+// ends in .go and returns the tag-stripped source. Non-Go blocks (yaml,
+// shell terminal output) are skipped. The CodeBlock chrome emits a stable
+// pair — a <span class="ui-code-block__file">NAME</span> header and a
+// <pre class="ui-code-block__body">…</pre> body — in document order; we pair
+// them by count. If the framework reshapes that chrome the count check fails
+// loudly, which is the intent: the gate must track what the page renders.
+func extractGetStartedGoBlocks(t *testing.T, page string) []gsCodeBlock {
+	t.Helper()
+	fileRe := regexp.MustCompile(`<span class="ui-code-block__file">(.*?)</span>`)
+	preRe := regexp.MustCompile(`(?s)<pre[^>]*class="ui-code-block__body"[^>]*>(.*?)</pre>`)
+	files := fileRe.FindAllStringSubmatch(page, -1)
+	pres := preRe.FindAllStringSubmatch(page, -1)
+	if len(files) != len(pres) {
+		t.Fatalf("code-block chrome shape changed: %d file headers vs %d body <pre> blocks", len(files), len(pres))
+	}
+	var out []gsCodeBlock
+	for i := range files {
+		name := html.UnescapeString(gsStripTags(files[i][1]))
+		if !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		lines := gsSplitLines(pres[i][1])
+		out = append(out, gsCodeBlock{
+			filename: name,
+			label:    filepath.Base(name),
+			source:   strings.Join(lines, "\n"),
+		})
+	}
+	return out
+}
+
+var gsTagRe = regexp.MustCompile(`<[^>]*>`)
+
+func gsStripTags(s string) string { return gsTagRe.ReplaceAllString(s, "") }
+
+// gsSplitLines reverses the CodeBlock line wrapping back into source lines.
+// Each rendered line is wrapped in <span class="ui-code-block__line">…</span>;
+// tokens inside are further <span class="tk-*">text</span> spans (or escaped
+// plain text). Splitting on the line-wrapper open tag, then stripping every
+// remaining tag and unescaping entities, reconstructs the exact Go source —
+// the token palette only adds styling, never alters text.
+func gsSplitLines(body string) []string {
+	const lineOpen = `<span class="ui-code-block__line">`
+	parts := strings.Split(body, lineOpen)
+	lines := make([]string, 0, len(parts))
+	for _, p := range parts[1:] { // [0] is the preamble before the first line
+		line := html.UnescapeString(gsStripTags(p))
+		line = strings.ReplaceAll(line, "\u200b", "") // blank-line zero-width space
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// wrapGetStartedSnippet wraps an extracted snippet in the package context +
+// imports a reader pasting it would already have, keyed by the block's
+// filename. The entity snippet is a bare app.Entity(...) statement, so it
+// needs a host function; the screen snippet is a type + methods, so it just
+// needs a package and imports. Adding a new Go block to the page means adding
+// a case here — the default returns false so a missing harness fails loudly
+// instead of silently compiling the wrong thing.
+func wrapGetStartedSnippet(filename, source string) (string, bool) {
+	switch {
+	case strings.HasSuffix(filename, "entities.go"):
+		// Mirrors entities/entities.go as `gofastr init` writes it: the
+		// declaration lives in package entities next to a boolPtr helper.
+		return "package entities\n\n" +
+			"import (\n" +
+			"\t\"github.com/DonaldMurillo/gofastr/core/schema\"\n" +
+			"\t\"github.com/DonaldMurillo/gofastr/framework\"\n" +
+			"\t\"github.com/DonaldMurillo/gofastr/framework/entity\"\n" +
+			")\n\n" +
+			"func boolPtr(b bool) *bool { return &b }\n\n" +
+			"func registerSample(app *framework.App) {\n" +
+			source + "\n" +
+			"}\n", true
+	case strings.HasSuffix(filename, "about.go"):
+		// A screen is a package main type whose Render returns markup.
+		return "package main\n\n" +
+			"import (\n" +
+			"\t\"github.com/DonaldMurillo/gofastr/core/render\"\n" +
+			"\t\"github.com/DonaldMurillo/gofastr/framework/ui\"\n" +
+			")\n\n" +
+			source + "\n\n" +
+			"func main() {}\n", true
+	default:
+		return "", false
+	}
+}
+
+// compileGetStartedSnippet writes the wrapped source into a throwaway module
+// whose go.mod points the framework at the local working tree via a replace
+// directive (plus a copied go.sum so transitive deps resolve offline), then
+// builds it. Mirrors the mechanism in cmd/gofastr/readme_quickstart_test.go
+// and init_reliability_test.go.
+func compileGetStartedSnippet(t *testing.T, src, label string) {
+	t.Helper()
+	repoRoot := gsRepoRoot(t)
+	goVer, err := gsGoVersion(repoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	goMod := "module getstarted-gate\n\ngo " + goVer + "\n\nrequire " + gsGoFastrModule + " v0.0.0\n\nreplace " + gsGoFastrModule + " => " + repoRoot + "\n"
+	gsWriteFile(t, filepath.Join(dir, "go.mod"), goMod)
+	if err := gsCopyFile(filepath.Join(repoRoot, "go.sum"), filepath.Join(dir, "go.sum")); err != nil {
+		t.Fatalf("copy go.sum: %v", err)
+	}
+	gsWriteFile(t, filepath.Join(dir, "main.go"), src)
+
+	build := exec.Command("go", "build", "-mod=mod", ".")
+	build.Dir = dir
+	build.Env = append(os.Environ(), "GOCACHE="+filepath.Join(t.TempDir(), "gocache"))
+	out, err := build.CombinedOutput()
+	if err != nil {
+		t.Fatalf("/get-started code block %q did not compile against the local tree:\n%v\n--- source ---\n%s\n--- build output ---\n%s",
+			label, err, src, out)
+	}
+}
+
+func gsRepoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func gsGoVersion(repoRoot string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(repoRoot, "go.mod"))
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		f := strings.Fields(line)
+		if len(f) >= 2 && f[0] == "go" {
+			return f[1], nil
+		}
+	}
+	return "", os.ErrNotExist
+}
+
+func gsWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func gsCopyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0o644)
+}

--- a/examples/site/hubs_compile_test.go
+++ b/examples/site/hubs_compile_test.go
@@ -1,0 +1,134 @@
+package main
+
+// Executable-docs gate for the taught area hubs (screens_hubs.go).
+//
+// Every code sample on a taught hub is a contract: a reader pastes it and it
+// must compile against the framework's real API. The /framework hub had
+// drifted before — its entity and access-control samples used the pre-grouped
+// flat EntityConfig shape (Public: / OwnerField: / Access: at the top level)
+// after those fields moved onto ExposureConfig and ScopeConfig — and nothing
+// caught it because no test compiled what the page renders.
+//
+// This gate renders the /framework hub, extracts every Go code block, wraps
+// each fragment in the minimal host context a reader pasting it would already
+// have (a func body for bare statements, plus the imports the snippet names),
+// and compiles it against the local tree. A snippet that drifts fails CI here,
+// not in a reader's editor.
+//
+// It reuses the extraction + compile machinery shared with the /get-started
+// gate (get_started_compile_test.go): extractGetStartedGoBlocks and
+// compileGetStartedSnippet are generic over the ui.CodeBlock chrome — only
+// the per-fragment wrapping is hub-specific, because a hub page repeats
+// filenames (two main.go blocks) so dispatch is by what the snippet says, not
+// the filename it claims.
+//
+// Red-first: this gate was committed against the broken flat EntityConfig
+// samples and watched fail before the grouped-shape fix landed.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFrameworkHubGoBlocksCompile(t *testing.T) {
+	page := string(frameworkHub().Render())
+
+	blocks := extractGetStartedGoBlocks(t, page)
+	if len(blocks) == 0 {
+		t.Fatal("no Go code blocks found on the /framework hub — extraction is broken or the page changed shape")
+	}
+
+	for _, b := range blocks {
+		b := b
+		t.Run(b.label, func(t *testing.T) {
+			src, ok := wrapHubFrameworkSnippet(b.source)
+			if !ok {
+				t.Fatalf("no compile harness for hub code block %q — add one in wrapHubFrameworkSnippet\n--- source ---\n%s", b.filename, b.source)
+			}
+			compileGetStartedSnippet(t, src, b.label)
+		})
+	}
+}
+
+// wrapHubFrameworkSnippet wraps an extracted hub snippet in the package
+// context + imports a reader pasting it would already have, keyed by what the
+// snippet contains (a hub page repeats filenames — two main.go blocks — so the
+// filename alone can't pick the harness). Each branch supplies exactly the
+// declarations the fragment references and no more, so the snippet compiles
+// for the reasons a reader's file would. The default returns false so a new Go
+// block with no harness fails loudly instead of silently compiling the wrong
+// thing.
+func wrapHubFrameworkSnippet(source string) (string, bool) {
+	switch {
+	// Entities + Access-control concepts: a bare app.Entity(...) statement.
+	// Needs a host function holding the *framework.App and framework (EntityConfig
+	// / ExposureConfig / ScopeConfig / AccessControl are aliased at the package
+	// root). core/schema is pulled in only when the snippet references it — the
+	// Entities sample declares a field list, the Access-control one does not, and
+	// an unconditional import would be "imported and not used" for the latter.
+	case strings.Contains(source, "app.Entity("):
+		imports := "\t\"github.com/DonaldMurillo/gofastr/framework\"\n"
+		if strings.Contains(source, "schema.") {
+			imports = "\t\"github.com/DonaldMurillo/gofastr/core/schema\"\n" + imports
+		}
+		return "package main\n\n" +
+			"import (\n" + imports + ")\n\n" +
+			"func registerSample(app *framework.App) {\n" +
+			source + "\n" +
+			"}\n\nfunc main() {}\n", true
+
+	// Auth concept: references db, fwApp, the auth battery, and log.
+	case strings.Contains(source, "authMgr"):
+		return "package main\n\n" +
+			"import (\n" +
+			"\t\"database/sql\"\n" +
+			"\t\"log\"\n" +
+			"\n" +
+			"\t\"github.com/DonaldMurillo/gofastr/battery/auth\"\n" +
+			"\t\"github.com/DonaldMurillo/gofastr/framework\"\n" +
+			")\n\n" +
+			"func setupAuth(db *sql.DB, fwApp *framework.App) {\n" +
+			source + "\n" +
+			"}\n\nfunc main() {}\n", true
+
+	// Migrations concept: references db, app.Registry, framework.AutoMigrate.
+	case strings.Contains(source, "AutoMigrate"):
+		return "package main\n\n" +
+			"import (\n" +
+			"\t\"database/sql\"\n" +
+			"\t\"log\"\n" +
+			"\n" +
+			"\t\"github.com/DonaldMurillo/gofastr/framework\"\n" +
+			")\n\n" +
+			"func migrateAll(db *sql.DB, app *framework.App) {\n" +
+			source + "\n" +
+			"}\n\nfunc main() {}\n", true
+
+	// Components concept: a ui.PageHeader(...) call expression → wrap as a
+	// return value so it is a statement, not a bare expression at func scope.
+	case strings.Contains(source, "ui.PageHeader"):
+		return "package main\n\n" +
+			"import (\n" +
+			"\t\"github.com/DonaldMurillo/gofastr/core/render\"\n" +
+			"\t\"github.com/DonaldMurillo/gofastr/framework/ui\"\n" +
+			")\n\n" +
+			"func pageHeaderSample() render.HTML {\n" +
+			"\treturn " + source + "\n" +
+			"}\n\nfunc main() {}\n", true
+
+	// Theming concept: references a `site` host app's WithTheme + the theme
+	// overrides. `site` is the *core-ui/app.App a host already constructed.
+	case strings.Contains(source, "theme.Default"):
+		return "package main\n\n" +
+			"import (\n" +
+			"\t\"github.com/DonaldMurillo/gofastr/core-ui/app\"\n" +
+			"\t\"github.com/DonaldMurillo/gofastr/framework/ui/theme\"\n" +
+			")\n\n" +
+			"func applyTheme(site *app.App) {\n" +
+			source + "\n" +
+			"}\n\nfunc main() {}\n", true
+
+	default:
+		return "", false
+	}
+}

--- a/examples/site/screens_hubs.go
+++ b/examples/site/screens_hubs.go
@@ -352,7 +352,7 @@ func frameworkHub() *TeachHubScreen {
 				CodeFile: "main.go",
 				CodeLang: "go",
 				Code: `app.Entity("posts", framework.EntityConfig{
-    Public: true,
+    Exposure: &framework.ExposureConfig{Public: true},
     Fields: []schema.Field{
         {Name: "title", Type: schema.String, Required: true},
         {Name: "body", Type: schema.Text},
@@ -385,10 +385,12 @@ fwApp.Use(auth.SessionMiddleware(authMgr))`,
 				CodeFile: "entities.go",
 				CodeLang: "go",
 				Code: `app.Entity("notes", framework.EntityConfig{
-    OwnerField: "user_id", // every read and write is scoped to the signed-in user
-    Access: framework.AccessControl{
-        Read: "notes:read", Create: "notes:write",
-        Update: "notes:write", Delete: "notes:admin",
+    Scope: &framework.ScopeConfig{OwnerField: "user_id"}, // every read and write is scoped to the signed-in user
+    Exposure: &framework.ExposureConfig{
+        Access: framework.AccessControl{
+            Read: "notes:read", Create: "notes:write",
+            Update: "notes:write", Delete: "notes:admin",
+        },
     },
 })`,
 				RefSlug: "access-control",

--- a/examples/site/screens_pages.go
+++ b/examples/site/screens_pages.go
@@ -158,10 +158,10 @@ func gsBody() render.HTML {
 	)
 
 	step2 := step("s2", "02", "Scaffold", "~45s",
-		html.Paragraph(html.TextConfig{}, render.Text("Scaffold a new project. It writes main.go, a sample posts entity in entities/, a home screen in screens/, a versioned migration, DESIGN.md, a gofastr.yml project config, and the agent onboarding files (AGENTS.md + agents/, CLAUDE.md), then initializes git.")),
+		html.Paragraph(html.TextConfig{}, render.Text("Scaffold a new project. It writes main.go, a sample posts entity in entities/entities.go, a home screen in screens.go at the root, a versioned migration, DESIGN.md, gofastr.isolation.yml, and the agent onboarding files (AGENTS.md + agents/, CLAUDE.md), then initializes git.")),
 		termBlock("$ scaffold",
 			render.Text("$ gofastr init blog\n"),
-			ok("→ created blog/: main.go, entities/, screens/, gofastr.yml, DESIGN.md, AGENTS.md, CLAUDE.md\n"),
+			ok("✓ Created project blog in ./blog/: main.go, screens.go, entities/entities.go, gofastr.isolation.yml, DESIGN.md, CLAUDE.md, AGENTS.md\n"),
 			ok("→ next: cd blog && go mod tidy && gofastr dev\n"),
 		),
 		html.Paragraph(html.TextConfig{}, render.Text("Open the scaffolded "), codeText("main.go"), render.Text(". It's short, it's yours, and every registration in it is plain Go. Read it.")),
@@ -176,7 +176,7 @@ func gsBody() render.HTML {
 			ln(render.Text("    "), pn("{"), render.Text("Name"), pn(":"), render.Text(" "), str_(`"body"`), pn(","), render.Text(" Type"), pn(":"), render.Text(" schema."), ty("Text"), pn("},")),
 			ln(render.Text("    "), pn("{"), render.Text("Name"), pn(":"), render.Text(" "), str_(`"published"`), pn(","), render.Text(" Type"), pn(":"), render.Text(" schema."), ty("Bool"), pn("},")),
 			ln(render.Text("  "), pn("},")),
-			ln(render.Text("  CRUD"), pn(":"), render.Text(" boolPtr("), kw("true"), pn("),")),
+			ln(render.Text("  Exposure"), pn(":"), render.Text(" &entity."), ty("ExposureConfig"), pn("{"), render.Text("CRUD"), pn(":"), render.Text(" boolPtr("), kw("true"), pn(")},")),
 			ln(pn("})")),
 		}),
 		html.Paragraph(html.TextConfig{}, render.Text("The matching versioned migration is next to it in the same file. "), codeText("gofastr docs migrations"), render.Text(" covers how those run.")),
@@ -199,8 +199,8 @@ func gsBody() render.HTML {
 	)
 
 	step5 := step("s5", "05", "First page", "~60s",
-		html.Paragraph(html.TextConfig{}, render.Text("Add a second server-rendered page. A screen is a Go struct whose Render returns the markup. The scaffolded home screen in "), codeText("screens/home.go"), render.Text(" is the pattern:")),
-		codeBlock("blog/screens/about.go", []render.HTML{
+		html.Paragraph(html.TextConfig{}, render.Text("Add a second server-rendered page. A screen is a Go struct whose Render returns the markup. The scaffolded home screen in "), codeText("screens.go"), render.Text(" is the pattern:")),
+		codeBlock("blog/about.go", []render.HTML{
 			ln(kw("type"), render.Text(" "), ty("AboutScreen"), render.Text(" "), kw("struct"), pn("{}")),
 			ln(render.Text("")),
 			ln(kw("func"), render.Text(" (s "), pn("*"), ty("AboutScreen"), pn(")"), render.Text(" "), fn_("ScreenTitle"), pn("()"), render.Text(" "), ty("string"), pn(" {"), render.Text(" "), kw("return"), render.Text(" "), str_(`"About"`), pn(" }")),
@@ -208,7 +208,7 @@ func gsBody() render.HTML {
 			ln(render.Text("  "), kw("return"), render.Text(" ui."), fn_("PageHeader"), pn("("), render.Text("ui."), ty("PageHeaderConfig"), pn("{"), render.Text("Title"), pn(":"), render.Text(" "), str_(`"About"`), pn("})")),
 			ln(pn("}")),
 		}),
-		html.Paragraph(html.TextConfig{}, render.Text("Register it in "), codeText("main.go"), render.Text(" next to the home screen: "), codeText(`site.Register("/about", &screens.AboutScreen{}, nil)`), render.Text(". Save, and the dev server serves it.")),
+		html.Paragraph(html.TextConfig{}, render.Text("Register it in "), codeText("main.go"), render.Text(" next to the home screen: "), codeText(`site.Register("/about", &AboutScreen{}, nil)`), render.Text(". Save, and the dev server serves it.")),
 		callout("Tip", "Run `gofastr docs` to browse all embedded docs offline, including entity-declarations, query-dsl, and hooks."),
 	)
 

--- a/framework/docs/content/cli.md
+++ b/framework/docs/content/cli.md
@@ -12,7 +12,10 @@ each command to the doc that covers it.
 - `gofastr init <name>` — a new project: framework UI, `DESIGN.md`, a
   sample entity (`--no-entity` to skip), git, and the agent onboarding
   files. `--module=<path>` sets the Go module; `--db=sqlite|postgres`
-  picks the driver. A released CLI pins the generated `go.mod` to its
+  picks the driver (default `sqlite`; `sqlite3` and `postgresql` are
+  accepted aliases, anything else is an error). `init . --reinit` refreshes the
+  AI-agent onboarding files in place (`--force` overwrites your edits);
+  no Go code or git changes. A released CLI pins the generated `go.mod` to its
   matching GoFastr version. A local development build prints the exact
   `go get …@vX.Y.Z` step because it cannot infer a release safely.
 - `gofastr new handler <name>` / `gofastr new route <path>` — scaffold
@@ -21,7 +24,8 @@ each command to the doc that covers it.
   and the per-battery detail files under `agents/`.
 - `gofastr theme edit` — a local theme configurator: every token as a control,
   the whole component gallery as a live preview, write-back to `theme/theme.go`.
-- `gofastr theme init` — scaffold a typed `theme/theme.go` you own.
+- `gofastr theme init` — scaffold a typed `theme/theme.go` you own
+  (`--out=<path>` writes elsewhere; `--force` overwrites).
 
 ## Blueprints
 
@@ -29,8 +33,11 @@ each command to the doc that covers it.
   (exit 0 = valid; includes the unscoped-PII lint).
 - `gofastr generate --from=<yml>` — one-shot scaffold of the whole app
   as owned Go ([tutorial](tutorial-blueprint-app.md)). `generate --add`
-  / `generate entity <name>` scaffold *new* files into an existing app;
-  owned files are never touched.
+  / `generate entity <name>` / `generate screen <name>` scaffold *new*
+  files into an existing app; owned files are never touched.
+  `generate --config=<codegen.yml>` runs the configurable codegen engine
+  ([codegen](codegen.md)); `generate --watch` re-runs on every change.
+  `generate all` is the full-project path (same engine as `--from`).
 - `gofastr pack [app-dir]` — snapshot a generated app into a
   best-effort `gofastr.yml`. Lossy; not an inverse of `generate`.
 
@@ -40,13 +47,18 @@ each command to the doc that covers it.
   for what you changed (after the reload, never blocking it), and the dev
   MCP tools for your coding agent ([dev-livereload](dev-livereload.md)).
   `--dir` sets the watch root, `--pkg` the main package under it,
-  `--addr`/`-p` the port.
+  `--addr`/`-p` the port; `--no-a11y` skips the accessibility lint on
+  each rebuild.
 - `gofastr build` — codegen + `go vet` + accessibility lint + the embed
-  server-action gate + `go build` (`--no-a11y` skips the lint, `--pkg`
-  selects the main package, `--no-embed-check` skips the embed gate, and
-  `--allow-unverified-embeds` keeps proven violations fatal while
-  downgrading a surface the analyzer cannot follow — see
-  [embed](embed.md)).
+  server-action gate + contract verification + `go build`. Only
+  error-severity contract findings stop the build (`gofastr verify` is
+  the full report; an existing app adopts the gate with a baseline — see
+  [contracts](contracts.md)). Flags: `--no-a11y` skips the a11y lint,
+  `--no-embed-check` skips the embed gate, `--no-contracts` skips the
+  contract gate, `--no-generate` skips codegen, `--pkg` selects the main
+  package, and `-o`/`--output` names the binary (default `bin/server`).
+  `--allow-unverified-embeds` keeps proven embed violations fatal while
+  downgrading a surface the analyzer cannot follow ([embed](embed.md)).
 - `gofastr test` — run the project's tests.
 - `gofastr docs [topic]` — these docs, offline, versioned with the
   binary (`--list` every topic, `--grep <term>` to search).
@@ -61,8 +73,9 @@ each command to the doc that covers it.
 - `gofastr generate sdk` — Go + JS/TS clients your app can host behind
   a live docs page ([sdk](sdk.md)).
 - `gofastr upgrade` — move to a newer release: lists every migration
-  note between your `go.mod` version and the target and points at
-  affected lines; `--apply` runs the steps ([upgrading](upgrading.md)).
+  note between your `go.mod` version and the target (`--to vX.Y.Z`;
+  without it the newest tagged release is resolved via the proxy) and
+  points at affected lines; `--apply` runs the steps ([upgrading](upgrading.md)).
 
 ## Verify
 
@@ -83,6 +96,9 @@ each command to the doc that covers it.
 - `gofastr verify --strict --baseline-write` — record today's findings as
   accepted debt so only NEW ones fail. How an existing codebase adopts the
   gate.
+- `gofastr verify --rule <id> --fix` — apply one rule's fixes at a time
+  so edits stay reviewable; `--analyzer <name>` scopes to one analyzer,
+  `--config <file>` picks a non-default config, `--no-vet` skips `go vet`.
 
 ## Audit
 

--- a/framework/docs/content/comparison.md
+++ b/framework/docs/content/comparison.md
@@ -28,7 +28,7 @@ by writing hooks (Go or JS) that run *inside* PocketBase's lifecycle.
 **The difference in kind:** PocketBase is a host you configure.
 GoFastr is Go source you own — written by hand against the framework,
 or scaffolded by the optional blueprint as a flat `package main`
-(`main.go`, `app.go`, `screens.go`, `entities/`) — that you commit,
+(`main.go`, `app.go`, `screens_register.go` + `screen_*.go`, `entities/`) — that you commit,
 diff in code review, debug with a debugger, and refactor like any
 other package. There's no runtime
 schema store and no canonical file you have to keep living inside: you

--- a/framework/docs/content/deploy.md
+++ b/framework/docs/content/deploy.md
@@ -25,7 +25,7 @@ gofastr build
 gofastr build --pkg ./cmd/server
 ```
 
-> **Go version.** `go.mod` declares `go 1.26`. The framework core only needs
+> **Go version.** `go.mod` declares `go 1.26.5`. The framework core only needs
 > Go 1.24 (generic type aliases); the 1.26 floor comes from the optional
 > `battery/print/chromepdf` PDF dependency (`chromedp/cdproto`). If you don't
 > use that battery, an older Go works in practice — but the declared floor is

--- a/framework/docs/content/overview.md
+++ b/framework/docs/content/overview.md
@@ -51,11 +51,13 @@ app.Entity("posts", framework.EntityConfig{
 app.Start(":8080")
 ```
 
-See [Entity declarations](/docs/entity-declarations). Generated code is regular
-Go at the module root (`main.go`, `app.go`, `screens.go`, `entities/`) — read
-it, edit it, commit it. When the framework is in your way, drop back to `core/`.
-You can also scaffold a set of entities from a `gofastr.yml` with the
-[code generator](/docs/codegen); the running app never needs the file.
+See [Entity declarations](/docs/entity-declarations). The `app.Entity` call
+above is a runtime registration — it wires the table, routes, and tools in
+memory and writes no files. `gofastr init` scaffolds the project that hosts it:
+`main.go`, `screens.go`, and `entities/entities.go` at the module root, all plain
+Go you read, edit, and commit. When the framework is in your way, drop back to
+`core/`. You can also scaffold a whole app from a `gofastr.yml` blueprint with
+the [code generator](/docs/codegen); the running app never needs the file.
 
 (Only `core/middleware` pulls in a dependency — OpenTelemetry, for tracing.
 Everything else in `core/` is stdlib-only.)
@@ -136,8 +138,11 @@ SQLite and Postgres, dialect-aware.
 
 - **[Agent-readiness](/docs/agent-ready)** — per-entity MCP tools, auto
   `llm.md`, and the discovery endpoints your app serves.
-- **[Embed](/docs/embed)** — local semantic search, no API key.
-  **[Audit deps](/docs/audit-deps)** — flag packages an agent shouldn't import.
+- **[Embed](/docs/embed)** — hand a screen to a site you don't control: one
+  `<script>` tag, an origin allowlist, a themed iframe.
+  **[Semantic search](/docs/semantic-search)** — local vector retrieval, no API
+  key. **[Audit deps](/docs/audit-deps)** — flag packages an agent shouldn't
+  import.
 - **[Kiln](/docs/kiln)** — experimental build-mode binary: an agent edits an
   in-memory model over HTTP.
 

--- a/framework/docs/content/project-structure.md
+++ b/framework/docs/content/project-structure.md
@@ -17,7 +17,7 @@ myapp/
 │   └── entities.go     # app.Entity(...) registrations (sample: posts)
 ├── migrations/         # versioned SQL (reversible)
 ├── static/             # assets served as-is
-├── gofastr.yml         # the scaffold input — OPTIONAL, deletable once the code is yours
+├── gofastr.isolation.yml  # process-isolation config (local DB per worktree)
 ├── go.mod
 └── AGENTS.md, CLAUDE.md, DESIGN.md, agents/   # agent onboarding
 ```
@@ -36,7 +36,8 @@ description — written in Go (`entities/entities.go`, the `gofastr init`
 default) or declared in a [`gofastr.yml` blueprint](blueprints.md). When you
 generate from a blueprint (`gofastr generate --from=gofastr.yml`), it scaffolds
 owned Go straight into this root layout — a flat `package main` (`main.go`,
-`app.go`, `screens.go`, …) plus the `entities/` package — that you read, edit,
+`app.go`, `screens_register.go` plus one `screen_<name>.go` per screen, …) plus
+the `entities/` package — that you read, edit,
 and commit. The blueprint is optional and one-time, not a source of truth:
 `generate` is one-shot (it refuses to overwrite an existing project unless you
 pass `--force`), so once the code is yours you own and edit it directly, and
@@ -61,7 +62,7 @@ layer:
 myapp/
 ├── main.go
 ├── entities/            # declarations stay here
-├── app.go, screens.go   # generated screens + wiring stay here (package main)
+├── app.go, screens_register.go, screen_*.go  # generated screens + wiring (package main)
 ├── internal/
 │   ├── billing/         # billing hooks, webhooks, invoice logic
 │   ├── projects/        # project-specific endpoints + rules
@@ -103,7 +104,7 @@ A domain package under `internal/` can mix framework entities and hand-written
   mechanical when you actually need it.
 - **Treating the scaffold as untouchable.** There's no `gen/` quarantine dir and
   no `DO NOT EDIT` header — the generated `entities/` package and root
-  `app.go`/`screens.go`/… are owned `package main` Go. Edit them directly.
+  `app.go`/`screens_register.go`/`screen_*.go`/… are owned `package main` Go.
   `gofastr generate` is one-shot: it scaffolds once and refuses to overwrite an
   existing project (pass `--force` to regenerate the whole set).
 - **Layer-based packages (`services/`, `repositories/`).** In Go this scatters

--- a/framework/docs/content/tutorial-blueprint-app.md
+++ b/framework/docs/content/tutorial-blueprint-app.md
@@ -29,8 +29,7 @@ Every command below is copy-paste runnable. Each step ends with a
 - the `gofastr` CLI:
 
 ```bash
-# until the next tagged release — see the version note above
-go install github.com/DonaldMurillo/gofastr/cmd/gofastr@main
+go install github.com/DonaldMurillo/gofastr/cmd/gofastr@latest
 ```
 
 ## 1. Blueprint → running app

--- a/framework/docs/content/ui-getting-started.md
+++ b/framework/docs/content/ui-getting-started.md
@@ -2,7 +2,7 @@
 
 Running `gofastr init` scaffolds a themed, product-specific app built from framework primitives. This doc walks through the setup steps in order — you'll have a working app after each one.
 
-The module is published — `go mod tidy` resolves it from the Go module proxy. Pin a tagged version (e.g. `v0.4.0`) rather than tracking `main`.
+The module is published — `go mod tidy` resolves it from the Go module proxy. Pin a tagged release rather than tracking `main` (`go get github.com/DonaldMurillo/gofastr@latest` resolves the newest).
 
 ---
 
@@ -24,14 +24,14 @@ Only add a `replace` directive pointing at a local checkout if you are
 hacking on the framework itself and want your app to pick up unreleased
 changes.
 
-Visit <http://localhost:8080> — you should see a placeholder home page served by `screens/home.go`. The CRUD entity at `/posts` works too.
+Visit <http://localhost:8080> — you should see a placeholder home page served by `screens.go`. The CRUD entity at `/posts` works too.
 
 Scaffold layout:
 
 ```
 myapp/
   main.go            # wires entities + adaptive framework theme + UI host
-  screens/home.go    # the home page you'll edit
+  screens.go         # the home page you'll edit
   DESIGN.md          # product intent, hierarchy, composition, and mobile direction
   entities/entities.go # Go-declared CRUD entities (try /posts)
   migrations/

--- a/framework/docs/docs_test.go
+++ b/framework/docs/docs_test.go
@@ -10,11 +10,13 @@ import (
 
 // MinExpectedTopics is the manifest floor: if a doc is accidentally
 // deleted in a rebase, the embed FS is silently smaller and the count
-// regresses. Bumping this constant in the same commit that adds a new
-// doc enforces "every doc removal requires an explicit decision."
+// regresses below this floor. Set to the EXACT current doc count so a
+// single deletion fails the test — not a wide cushion that hides drift.
 //
-// Bump it up when adding docs. Be reluctant to decrement.
-const MinExpectedTopics = 65
+// Adding a doc raises the count above the floor and still passes; no
+// bump is needed. Lower this only when intentionally removing a doc,
+// and re-count first: ls framework/docs/content/*.md | wc -l
+const MinExpectedTopics = 92
 
 func TestEmbedManifestFloor(t *testing.T) {
 	topics, err := List()

--- a/framework/experimental/harness/control/ws/ws.go
+++ b/framework/experimental/harness/control/ws/ws.go
@@ -217,8 +217,22 @@ func (c *Conn) run(parentCtx context.Context) {
 	}
 	defer c.mux.Detach(c.session, c.clientID)
 
+	// Subscribe to the bus BEFORE entering the read loop. The 101
+	// response already went out in ServeHTTP, so a command frame may
+	// be buffered and ready the moment readFrame runs; if that
+	// command were dispatched before the subscription registered, the
+	// turn's events would broadcast to zero subscribers and be lost —
+	// Bus.broadcast delivers only to current subscribers and the live
+	// path has no replay. Subscribing synchronously here makes
+	// subscribe-before-dispatch a guarantee instead of a scheduling
+	// accident (the old `go subscribePump` lost the whole turn
+	// whenever a loaded runner delayed the pump goroutine).
+	var events <-chan control.EventEnvelope
+	if eng := c.mux.EngineFor(c.session); eng != nil {
+		events = eng.Bus.Subscribe(ctx)
+	}
 	// Engine→client pump.
-	go c.subscribePump(ctx)
+	go c.eventPump(ctx, events)
 
 	// Client→engine read loop.
 	for {
@@ -270,12 +284,13 @@ func (c *Conn) handleText(ctx context.Context, payload []byte) {
 	}
 }
 
-func (c *Conn) subscribePump(ctx context.Context) {
-	eng := c.mux.EngineFor(c.session)
-	if eng == nil {
+// eventPump forwards bus events to the client. The subscription is
+// created synchronously by run() before the read loop starts — see
+// the ordering comment there; do not move the Subscribe call in here.
+func (c *Conn) eventPump(ctx context.Context, ch <-chan control.EventEnvelope) {
+	if ch == nil {
 		return
 	}
-	ch := eng.Bus.Subscribe(ctx)
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/pgtest/pgtest.go
+++ b/internal/pgtest/pgtest.go
@@ -5,7 +5,9 @@
 // Resolution order (memoised once per process):
 //  1. TEST_POSTGRES_DSN env var — point CI at an existing server.
 //  2. testcontainers postgres:16-alpine — spun up on demand (needs Docker).
-//  3. neither reachable → tests call t.Skip via DB/DSN.
+//  3. neither reachable → t.Skip locally; under CI (PGTEST_REQUIRED=1 or
+//     GITHUB_ACTIONS=true) escalate to t.Fatal so the ~30 real-PG suites can't
+//     silently degrade to SQLite-only behind a green build.
 //
 // Each DB(t) hands back a connection scoped to a unique schema (search_path),
 // so concurrent tests don't collide, with cleanup registered on t.
@@ -67,13 +69,31 @@ func resolve() (string, error) {
 	return baseDSN, resolveErr
 }
 
-// BaseDSN returns the resolved base DSN (the maintenance/default database), or
-// skips the test if Postgres is unreachable. Use for EnsureDatabase / CLI
-// round-trips that need a raw connection string.
+// required reports whether a reachable Postgres is mandatory for this run.
+// True when PGTEST_REQUIRED is set to any non-empty value (the explicit opt-in
+// the CI workflow sets) or when running under GitHub Actions (GITHUB_ACTIONS).
+// When true the harness escalates the no-Postgres t.Skip to a t.Fatal so the
+// ~30 real-PG suites cannot silently degrade to SQLite-only behind a green
+// build. Local dev (neither set) keeps the cheap skip — no Docker, no failure.
+func required() bool {
+	if strings.TrimSpace(os.Getenv("PGTEST_REQUIRED")) != "" {
+		return true
+	}
+	return os.Getenv("GITHUB_ACTIONS") == "true"
+}
+
+// BaseDSN returns the resolved base DSN (the maintenance/default database).
+// When Postgres is unreachable it skips locally but fails the test under CI
+// (see required); this is the single choke point every pgtest entry point
+// (DB, FreshDatabaseDSN, UnusedDSN) flows through. Use BaseDSN directly for
+// EnsureDatabase / CLI round-trips that need a raw connection string.
 func BaseDSN(t *testing.T) string {
 	t.Helper()
 	dsn, err := resolve()
 	if err != nil {
+		if required() {
+			t.Fatalf("pgtest: Postgres is required (PGTEST_REQUIRED/GITHUB_ACTIONS) but unreachable — real-PG suites would otherwise silently skip. resolve error: %v", err)
+		}
 		t.Skipf("Postgres unavailable: %v", err)
 	}
 	if logged.CompareAndSwap(false, true) {

--- a/internal/pgtest/pgtest_test.go
+++ b/internal/pgtest/pgtest_test.go
@@ -1,0 +1,30 @@
+package pgtest
+
+import "testing"
+
+// TestPGHarnessRequired is the canary that keeps the dual-dialect claim honest
+// in CI. When a real Postgres is required (PGTEST_REQUIRED set, or running
+// under GITHUB_ACTIONS) it fails the build unless the harness can stand up a
+// live, queryable Postgres — not merely that resolve() returned a string.
+// Outside that (local dev, no Docker) it skips, preserving the cheap local
+// experience.
+//
+// This is the named, always-run assertion that complements the fail-closed
+// choke point in BaseDSN: even if every other pgtest caller were removed, this
+// test alone makes "Postgres ran in CI" an enforced fact rather than prose.
+func TestPGHarnessRequired(t *testing.T) {
+	if !required() {
+		t.Skip("pgtest not required (set PGTEST_REQUIRED=1 or run on CI to enforce)")
+	}
+	// DB(t) routes through BaseDSN(t), which already fatals under required()
+	// when Postgres is unreachable. The round-trip below proves the returned
+	// connection is genuinely usable.
+	db := DB(t)
+	var n int
+	if err := db.QueryRow("SELECT 1").Scan(&n); err != nil {
+		t.Fatalf("pgtest canary: harness DB unusable (SELECT 1): %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("pgtest canary: SELECT 1 returned %d, want 1", n)
+	}
+}


### PR DESCRIPTION
Closes the full verified-bug list from the 2026-08-04 nine-analyst holistic assessment (7 Claude lenses + GLM + Sol, post-v0.61.0). Every fix landed test-first; the full suite (`test-all.sh`, chromedp and kiln/integration included) is green with Docker up.

## Security
- **Flat `soft_delete:`/`multi_tenant:` and `app.auth.enabled` fail closed.** `boolValue` read YAML-1.1 truthies (`yes`/`on`) as false — the permissive state for all three (tenant scoping off / hard deletes / auth off, app public). They now decode through `protectiveBool` like the grouped `scope.*` keys; `validate` and `generate` both reject the spelling naming the key. Sweep classified every remaining `boolValue` call site (report in the commit).

## Generator correctness
- **Detail screens must carry `{id}`**: new validator rule; seven param-less detail routes across six bundled blueprints produced dead View links nothing ever clicked. Blueprints fixed, ecommerce app regenerated byte-identical, and a hand-owned e2e guard now follows a real View href to a 200.
- **Dead ConfirmAction mount removed** from soft-delete output (wrong path, never referenced); minimal soft-delete-only apps still compile.
- **Directory-mode `generate --from=<dir>` kept dropping every `seed:` block** (`mergeBlueprints` skipped the field).
- **Seeds actually seed**: ecommerce reviews/categories, lms courses/modules, project-manager boards→columns→tasks→comments chains — all previously skipped silently on boot, now wired with `@entity.field=value` refs.
- **`gofastr pack` reads the v0.61 `ui.Link` auth footer** — the reverse reader only understood the old raw anchor, which broke the meridian round-trip (caught by the full suite during this round).
- **`init --db=` validates its value** — unknown drivers no longer silently scaffold SQLite.

## Release hygiene
- **The intermittent ws failure that turned the v0.61.0 tag red is root-caused and fixed**: the event pump subscribed to the bus after the read loop was already accepting commands, so a fast-dispatched turn broadcast to zero subscribers and the whole turn vanished. Subscription now precedes the read loop (happens-before); clean under `-count=100 -race` and concurrent stress.
- **Real-PG suites fail closed in CI**: `PGTEST_REQUIRED` escalates the no-Docker skip to a failure at the single `BaseDSN` choke point, and `TestPGHarnessRequired` round-trips `SELECT 1` through a real container. (Ground truth first: PG *does* run in CI today via testcontainers — this guards the fact.)

## Docs & site truth
- Get Started + framework hub pages taught the pre-v0.54 flat `EntityConfig` and a scaffold layout `init` never writes; fixed, and **every Go code block on both pages is now extracted and compiled in CI** (both gates were red on the broken samples first).
- Doc sweep, each item verified against source: scaffold layouts in four docs, install pins unified on `@latest`, cli.md gains `build`'s contracts gate + real `--db` values + missing flags, README cursor-paging path, Embed/semantic-search mixup, exact docs-count floor, `examples/site` row in examples/README.
- Meridian auth footers match the generator (`ui.Link`), byte-verified and screenshotted light+dark — closes #185. Remaining `ScreenSEO()` drift left for the issue's separate track.

## What to watch on CI
- `internal/pgtest` flips from `[no test files]` to running `TestPGHarnessRequired`.
- No PG suite may newly SKIP — under the required flag that's now a hard fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Late additions (found while getting CI green)

Chasing the browser-e2e failures uncovered a three-bug masking chain, all fixed here:

1. **Timeout middleware killed every SSE stream older than 30s** — at the deadline the parent returned to net/http under the still-streaming handler, so the next heartbeat write nil-panicked (`panic in timed-out handler ... /__gofastr/sse` at exactly 15s cadence). The middleware violated the documented "streams outlive the request timeout" contract.
2. Fixing that exposed a second defect in the fix's first cut: `context.WithTimeout` freezes `Err()` at `DeadlineExceeded`, so post-deadline client disconnects never reached the stream's `Canceled`-vs-`DeadlineExceeded` discrimination (#159). `Timeout` now uses a purpose-built context: identical non-streaming semantics (hung handlers still 504 at the deadline), deadline disarmed once the response streams/hijacks, and `context.AfterFunc` on the original request context delivers later disconnects as `Canceled`. Three contract tests pin the triangle.
3. With streams no longer force-killed, the **real** bug surfaced: `sse.js` never closed its EventSource on navigation. Chrome bfcaches outgoing pages with their sockets open (no FIN — proven by netstat + goroutine dumps), so six hard navigations exhaust the tab's per-host connection budget and the seventh page never loads. The `signal-animate` e2e had only ever passed *because* bug 1 was severing those sockets. The transport now closes on `pagehide` and reconnects on `pageshow.persisted`; red-first runtime test asserts the server sees the stream close within a second of navigation.

Also: the pre-existing `TestE2E_RuntimeSplit_ToastModuleFailureShowsFallback` flake (fixed-sleep sampling racing spec-mandated in-order script error events) now polls the real signal, and `gofastr pack` learned to read the v0.61 `ui.Link` auth footer (the reverse reader only understood the old raw anchor — caught by the meridian round-trip gate).
