### PR TITLE
fix: required markers inline (#188) and sidebar shell banner chrome (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Fixed
 
+- **Required markers sit on the label line.** `ui.Select`, `ui.RadioGroup`,
+  and `ui.CheckboxGroup` joined the `*` as a sibling of their
+  `<label>`/`<legend>` inside a grid container, so it rendered as its own row
+  under the label text — unlike `ui.FormField`, which keeps it inline. The
+  marker now renders inside the label/legend, and the select and toggle
+  stylesheets carry its red color and spacing themselves instead of relying
+  on `ui-form-field`'s scoped rule happening to be on the page. (#188)
+- **The sidebar shell's header has banner chrome.** A `WithSidebar` +
+  `WithHeader` layout rendered its banner with no height, background, or
+  bottom border: `ui.SiteHeader` is `block-size: 100%`, which resolves
+  against a parent `LayoutBaseCSS` never sized. The shell header now takes
+  its height from the `--ui-layout-header-height` token (default 56px), and
+  the `.layout-body` underneath subtracts that height so pages stop
+  scrolling by exactly the header's size. (#187)
+
 - **Flat blueprint booleans that gate access are strict.** The entity-level
   `soft_delete:` and `multi_tenant:` keys and `app.auth.enabled` now demand a
   real `true`/`false`, exactly like their grouped `scope.*` twins. A YAML-1.1

--- a/core-ui/app/layout_css.go
+++ b/core-ui/app/layout_css.go
@@ -83,6 +83,26 @@ func LayoutBaseCSS() string {
 /* The markdown content block keeps its own measure on long-form pages. */
 .layout--contained main > div > [data-fui-comp="ui-markdown"] { max-width: 72ch; }
 
+/* Sidebar shell banner: the contained layout styles its header above, but a
+   WithSidebar + WithHeader shell needs its own chrome — ui.SiteHeader is
+   block-size: 100%, which resolves against a parent with no height, so
+   without this rule the banner collapses to text height over the bare page
+   background. --ui-layout-header-height follows the --ui-layout-* override
+   convention (see --ui-layout-container-width). */
+.layout--has-sidebar > header {
+  display: flex;
+  align-items: stretch;
+  block-size: var(--ui-layout-header-height, 56px);
+  background-color: var(--color-surface, #fff);
+  border-bottom: 1px solid var(--color-border, #e4e4e7);
+}
+/* .layout-body is min-height: 100vh, so a banner above it makes every page
+   scroll by exactly the header height with nothing in the overflow; the
+   body under a sidebar-shell banner subtracts it. */
+.layout--has-sidebar > header + .layout-body {
+  min-height: calc(100vh - var(--ui-layout-header-height, 56px));
+}
+
 /* Sidebar shell: a padded content area beside the nav. */
 .layout--has-sidebar main, .layout--has-sidebar .layout-content {
   display: flex;

--- a/core-ui/app/layout_css_test.go
+++ b/core-ui/app/layout_css_test.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+// A WithSidebar + WithHeader shell renders <header role="banner"> as a direct
+// child of the layout--has-sidebar wrapper, but LayoutBaseCSS only styles the
+// CONTAINED layout's header. Without a rule for the sidebar shell the banner
+// has no height, no background, and no bottom border: ui.SiteHeader is
+// block-size: 100%, which resolves against a parent with no height, so the
+// bar collapses to text height over the bare page background. (#187)
+func TestSidebarShellHeaderHasBannerChrome(t *testing.T) {
+	css := LayoutBaseCSS()
+	if !strings.Contains(css, ".layout--has-sidebar > header") {
+		t.Fatal("LayoutBaseCSS has no .layout--has-sidebar > header rule — a WithSidebar+WithHeader banner collapses to text height")
+	}
+	if !strings.Contains(css, "var(--ui-layout-header-height") {
+		t.Fatal("sidebar header height must come from the --ui-layout-header-height token so hosts can override it without overriding the rule")
+	}
+}
+
+// .layout-body is min-height: 100vh, so adding a banner makes every page
+// taller than the viewport by exactly the header height — every screen
+// scrolls with nothing in the overflow. The body under a sidebar-shell
+// header must subtract the header height. (#187)
+func TestSidebarHeaderOffsetsBodyMinHeight(t *testing.T) {
+	css := LayoutBaseCSS()
+	if !strings.Contains(css, ".layout--has-sidebar > header + .layout-body") ||
+		!strings.Contains(css, "calc(100vh - var(--ui-layout-header-height") {
+		t.Fatal("LayoutBaseCSS does not offset .layout-body min-height under the sidebar-shell header — every page scrolls by the header height")
+	}
+}

--- a/framework/docs/content/theming.md
+++ b/framework/docs/content/theming.md
@@ -336,8 +336,10 @@ You can also scope them — set one inside a `ui.Themed` section, or on
 a specific wrapper class, to change a single instance. Each
 component's source lists its knobs next to the CSS that reads them
 (for example `ui.Container`: `--ui-container-default/narrow/wide`;
-`ui.DocLayout`: `--ui-doc-layout-rail/gap/max-width`) — grep
-`framework/ui` for `--ui-` to see the full list.
+`ui.DocLayout`: `--ui-doc-layout-rail/gap/max-width`; the layout
+shells: `--ui-layout-container-width/gutter/header-height`, read by
+`app.LayoutBaseCSS`) — grep `framework/ui` and `core-ui/app` for
+`--ui-` to see the full list.
 
 ## Why you can't just override component CSS
 

--- a/framework/ui/select.go
+++ b/framework/ui/select.go
@@ -106,17 +106,20 @@ func Select(cfg SelectConfig) render.HTML {
 		selAttrs[k] = v
 	}
 
-	labelHTML := render.Tag("label", map[string]string{
-		"for":   id,
-		"class": "ui-select__label",
-	}, render.Text(cfg.Label))
+	// The marker lives INSIDE the <label>: the component root is a grid,
+	// so a sibling span would become its own row under the label text.
+	labelChildren := []render.HTML{render.Text(cfg.Label)}
 	if cfg.Required {
-		labelHTML = render.Join(labelHTML,
+		labelChildren = append(labelChildren,
 			html.Span(html.TextConfig{
 				Class:      "ui-form-field__required",
 				ExtraAttrs: html.Attrs{"aria-hidden": "true"},
 			}, render.Text(" *")))
 	}
+	labelHTML := render.Tag("label", map[string]string{
+		"for":   id,
+		"class": "ui-select__label",
+	}, labelChildren...)
 
 	children := []render.HTML{
 		labelHTML,
@@ -150,6 +153,10 @@ func selectCSS(_ style.Theme) string {
   font-weight: 500;
   font-size: var(--text-sm, 0.9rem);
   color: var(--color-text, #18181B);
+}
+[data-fui-comp="ui-select"] .ui-form-field__required {
+  color: var(--color-danger, #DC2626);
+  margin-inline-start: var(--spacing-xs, 2px);
 }
 [data-fui-comp="ui-select"] .ui-select__input {
   font: inherit;

--- a/framework/ui/select_test.go
+++ b/framework/ui/select_test.go
@@ -1,0 +1,41 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/style"
+)
+
+func requiredSelect() string {
+	return string(Select(SelectConfig{
+		Name:     "policy",
+		Label:    "Policy",
+		Required: true,
+		Options:  []SelectOption{{Value: "a", Text: "A"}},
+	}))
+}
+
+// The component root is display: grid, so a marker rendered as a SIBLING of
+// the <label> becomes its own grid row — "Policy" on one line, "*" on the
+// next. Inside the label it shares the line, matching ui.FormField.
+func TestSelectMarkerRendersInsideLabel(t *testing.T) {
+	h := requiredSelect()
+	marker := strings.Index(h, "ui-form-field__required")
+	if marker == -1 {
+		t.Fatalf("Required: true rendered no marker:\n%s", h)
+	}
+	if marker > strings.Index(h, "</label>") {
+		t.Fatalf("required marker is a sibling of the <label>, so the grid gives it its own row:\n%s", h)
+	}
+}
+
+// The marker's red color + spacing rule in formFieldCSS is scoped to
+// [data-fui-comp="ui-form-field"]; a page that mounts a Select but never a
+// FormField would render the marker unstyled. The component styles what it
+// emits.
+func TestSelectCSSStylesTheMarker(t *testing.T) {
+	if !strings.Contains(selectCSS(style.Theme{}), ".ui-form-field__required") {
+		t.Fatal("selectCSS has no rule for .ui-form-field__required — the marker is unstyled unless ui-form-field happens to be on the page")
+	}
+}

--- a/framework/ui/styles_primitives.go
+++ b/framework/ui/styles_primitives.go
@@ -418,6 +418,10 @@ func toggleCSS(_ style.Theme) string {
   padding: 0;
   margin-bottom: var(--spacing-xs, 4px);
 }
+.ui-toggle-group .ui-form-field__required {
+  color: var(--color-danger, #DC2626);
+  margin-inline-start: var(--spacing-xs, 2px);
+}
 .ui-toggle-group .ui-toggle-group__help {
   margin: 0;
   font-size: var(--text-sm, 0.85rem);

--- a/framework/ui/toggle.go
+++ b/framework/ui/toggle.go
@@ -223,15 +223,17 @@ func RadioGroup(cfg RadioGroupConfig) render.HTML {
 		cls += " " + cfg.Class
 	}
 
-	legend := render.Tag("legend", map[string]string{"class": "ui-toggle-group__legend"},
-		render.Text(cfg.Legend))
+	// The marker lives INSIDE the <legend>: the fieldset is a grid, so a
+	// sibling span would become its own row under the legend text.
+	legendChildren := []render.HTML{render.Text(cfg.Legend)}
 	if cfg.Required {
-		legend = render.Join(legend,
+		legendChildren = append(legendChildren,
 			html.Span(html.TextConfig{
 				Class:      "ui-form-field__required",
 				ExtraAttrs: html.Attrs{"aria-hidden": "true"},
 			}, render.Text(" *")))
 	}
+	legend := render.Tag("legend", map[string]string{"class": "ui-toggle-group__legend"}, legendChildren...)
 
 	children := []render.HTML{legend}
 	for i, opt := range cfg.Options {
@@ -325,15 +327,17 @@ func CheckboxGroup(cfg CheckboxGroupConfig) render.HTML {
 		cls += " " + cfg.Class
 	}
 
-	legend := render.Tag("legend", map[string]string{"class": "ui-toggle-group__legend"},
-		render.Text(cfg.Legend))
+	// The marker lives INSIDE the <legend>: the fieldset is a grid, so a
+	// sibling span would become its own row under the legend text.
+	legendChildren := []render.HTML{render.Text(cfg.Legend)}
 	if cfg.Required {
-		legend = render.Join(legend,
+		legendChildren = append(legendChildren,
 			html.Span(html.TextConfig{
 				Class:      "ui-form-field__required",
 				ExtraAttrs: html.Attrs{"aria-hidden": "true"},
 			}, render.Text(" *")))
 	}
+	legend := render.Tag("legend", map[string]string{"class": "ui-toggle-group__legend"}, legendChildren...)
 
 	children := []render.HTML{legend}
 	for i, opt := range cfg.Options {

--- a/framework/ui/toggle_test.go
+++ b/framework/ui/toggle_test.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"strings"
 	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/style"
 )
 
 func TestCheckboxRequiresName(t *testing.T) {
@@ -85,4 +87,42 @@ func TestToggleCustomIDOverridesName(t *testing.T) {
 func TestToggleRequiredAttribute(t *testing.T) {
 	h := Checkbox(ToggleConfig{Name: "n", Label: "x", Required: true})
 	mustContain(t, h, "required")
+}
+
+// Same defect class as ui.Select (#188): .ui-toggle-group is display: grid,
+// so a marker joined as a SIBLING of the <legend> gets its own grid row.
+func TestRadioGroupMarkerInsideLegend(t *testing.T) {
+	h := string(RadioGroup(RadioGroupConfig{
+		Name: "plan", Legend: "Plan", Required: true,
+		Options: []RadioGroupOption{{Value: "a", Label: "A"}},
+	}))
+	marker := strings.Index(h, "ui-form-field__required")
+	if marker == -1 {
+		t.Fatalf("Required: true rendered no marker:\n%s", h)
+	}
+	if marker > strings.Index(h, "</legend>") {
+		t.Fatalf("required marker is a sibling of the <legend>, so the grid gives it its own row:\n%s", h)
+	}
+}
+
+func TestCheckboxGroupMarkerInsideLegend(t *testing.T) {
+	h := string(CheckboxGroup(CheckboxGroupConfig{
+		Name: "tags", Legend: "Tags", Required: true,
+		Options: []CheckboxGroupOption{{Value: "a", Label: "A"}},
+	}))
+	marker := strings.Index(h, "ui-form-field__required")
+	if marker == -1 {
+		t.Fatalf("Required: true rendered no marker:\n%s", h)
+	}
+	if marker > strings.Index(h, "</legend>") {
+		t.Fatalf("required marker is a sibling of the <legend>, so the grid gives it its own row:\n%s", h)
+	}
+}
+
+// The marker's styling lives in formFieldCSS scoped to ui-form-field; the
+// toggle groups emit the class, so their stylesheet must style it too.
+func TestToggleCSSStylesTheMarker(t *testing.T) {
+	if !strings.Contains(toggleCSS(style.Theme{}), ".ui-form-field__required") {
+		t.Fatal("toggleCSS has no rule for .ui-form-field__required — group markers are unstyled unless ui-form-field happens to be on the page")
+	}
 }


### PR DESCRIPTION
Fixes #187 and #188.

## Commits

- `d017ec51` **fix(ui): render required markers inside the label and legend** — #188. `ui.Select` joined the `*` span as a sibling of the `<label>`; the component root is `display: grid`, so the marker rendered as its own row. The same sibling-join exists in `RadioGroup` and `CheckboxGroup` legends (`.ui-toggle-group` is also a grid), so both are fixed too. The marker's red/spacing rule only existed scoped inside `ui-form-field`'s stylesheet — a page without a FormField rendered the marker unstyled — so `selectCSS` and `toggleCSS` now style the class they emit.
- `0f4bdf84` **fix(core-ui): give the sidebar shell header its banner chrome** — #187. Adopts the CSS shape proposed in the issue: `.layout--has-sidebar > header` sized by the new `--ui-layout-header-height` token (default 56px, following the `--ui-layout-*` convention), plus the `+ .layout-body` rule subtracting the header height from `min-height: 100vh` so pages stop scrolling by exactly that amount. theming.md's `--ui-*` knob list now mentions the layout-shell tokens.
- `96c56f60` **docs(changelog)** — both entries under Unreleased → Fixed.

## Verification

- Six new tests, each confirmed failing before the fix: marker-inside-label/legend for Select/RadioGroup/CheckboxGroup, marker-styled-by-own-stylesheet for select and toggle, and two `LayoutBaseCSS` assertions for the header rule and the body offset.
- Screenshotted a `WithSidebar` + `WithHeader` app with a required Select, RadioGroup, and FormField at 1280px and 375px: banner renders with height/surface/border, all three markers sit inline in red, sidebar collapses to the drawer on mobile. Meridian never composes this layout pair, which is how #187 shipped unseen.
- `go vet` and the ui / core-ui/app / uihost / html / style / registry suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)