### PR TITLE
Assessment remediation: green-gated releases and fail-closed boot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ permissions:
 on:
   push:
     branches: [main]
+    # Tag pushes get their own run so the release workflow has blocking
+    # check runs on the exact tag SHA to gate on — v0.61.0 published off a
+    # red commit because tags never triggered CI.
+    tags: ['v*']
   pull_request:
   # The `security` job needs a time trigger, not just a code trigger: an
   # advisory can land against a dependency nobody touched. GO-2026-5158

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,42 @@ jobs:
         with:
           ref: ${{ steps.tag.outputs.tag }}
 
+      # A release must not ship a red commit. v0.61.0 published while its
+      # blocking build·vet·test check had FAILED, because nothing here ever
+      # consulted CI. Waits for every "(blocking)" check run on the exact
+      # tag SHA (ci.yml now runs on v* tags) and refuses to publish unless
+      # all of them — at least the three known jobs — completed green.
+      - name: Require green blocking CI on the tag commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          sha=$(git rev-parse "${TAG}^{commit}")
+          echo "gating release of $TAG on blocking check runs at $sha"
+          deadline=$((SECONDS + 3600))
+          while :; do
+            runs=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${sha}/check-runs" --paginate \
+              --jq '[.check_runs[] | select(.name | test("\\(blocking\\)"))]')
+            total=$(jq 'length' <<<"$runs")
+            green=$(jq '[.[] | select(.status=="completed" and .conclusion=="success")] | length' <<<"$runs")
+            red=$(jq -r '[.[] | select(.status=="completed" and .conclusion!=null and .conclusion!="success")] | map(.name) | join(", ")' <<<"$runs")
+            if [ -n "$red" ]; then
+              echo "::error::blocking checks failed on $sha: $red — a release must not ship a red commit. Fix, retag (or re-run CI), then re-run via workflow_dispatch."
+              exit 1
+            fi
+            if [ "$total" -ge 3 ] && [ "$green" -eq "$total" ]; then
+              echo "all $total blocking checks green on $sha"
+              break
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::timed out waiting for blocking checks on $sha ($green/$total green). Re-run via workflow_dispatch once CI finishes."
+              exit 1
+            fi
+            echo "waiting: $green/$total blocking checks green"
+            sleep 30
+          done
+
       - name: Create release if missing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,33 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Changed
+
+- **Generated apps fail closed at boot.** `gofastr init`'s scaffold used to
+  log `Migration warning` on a failed `migrator.Up` and start the server
+  anyway; it now exits, so a deploy whose committed migration did not apply
+  fails the rollout instead of surfacing as later request errors. Blueprint
+  seeding is fail-fast for the same reason: a seed row that fails (or an
+  entity with no handler) aborts startup naming the entity, where it used to
+  be logged and skipped — and never retried, since the idempotency check
+  marks a partially-seeded entity as done. Regenerate to pick both up.
+
 ### Fixed
+
+- **A release tag now requires green CI on the exact tagged commit.** CI runs
+  on `v*` tag pushes, and the release workflow refuses to publish until every
+  blocking check on the tag SHA has completed successfully — it previously
+  checked only that a changelog section existed, which is how v0.61.0
+  published while its build·vet·test check was red.
+- **The Postgres CI canary cannot skip in required mode.** The URL-shape
+  guards in `pgtest.DB` / `FreshDatabaseDSN` / `UnusedDSN` ran after the
+  fail-closed choke point and still skipped, so a non-URL `TEST_POSTGRES_DSN`
+  — the documented override — silently turned the canary green.
+- **The backend-adoption eval runs again.** The Gin and stdlib baseline lanes
+  required `gofastr/sqlite/stdlib@v1.14.44` — mattn's version carried onto a
+  path that is not a module during the driver swap — so lane setup failed
+  before any trial. They now pin `modernc.org/sqlite`, and a test fails when
+  any baseline requirement stops resolving.
 
 - **Flat blueprint booleans that gate access are strict.** The entity-level
   `soft_delete:` and `multi_tenant:` keys and `app.auth.enabled` now demand a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.62.0] - 2026-08-05
+
 ### Changed
 
 - **Generated apps fail closed at boot.** `gofastr init`'s scaffold used to

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ Honest expectations:
 
 ## Supported versions
 
-GoFastr is pre-1.0. Only the **latest minor release** (currently `0.61.x`)
+GoFastr is pre-1.0. Only the **latest minor release** (currently `0.62.x`)
 receives security fixes. Older `0.x` lines are not patched — upgrade to
 the latest release to stay supported.
 

--- a/cmd/gofastr/blueprint.go
+++ b/cmd/gofastr/blueprint.go
@@ -3914,9 +3914,10 @@ func renderBlueprintMain(bp Blueprint) string {
 		// the time this hook runs the admin already exists and the owner-
 		// scoped rows below can resolve it as their owner. Registering the
 		// data seed before RegisterGenerated would run it before the admin
-		// exists, leaving owner-scoped rows silently unseeded. Rows are
-		// idempotent (skip entities that already have rows) and a row that
-		// fails validation is logged and skipped rather than aborting startup.
+		// exists, leaving owner-scoped rows silently unseeded. Seeding is
+		// idempotent (skip entities that already have rows) and fail-fast: a
+		// row that fails aborts startup, because the CountAll gate would
+		// mark the entity seeded and the dropped row would never retry.
 		sb.WriteString("\tfwApp.WithSeed(func(ctx context.Context) error {\n")
 		if ownerSeed {
 			sb.WriteString("\t\t// Resolve the bootstrap admin (created by the earlier-registered\n")
@@ -3929,12 +3930,12 @@ func renderBlueprintMain(bp Blueprint) string {
 		}
 		sb.WriteString("\t\tfor _, s := range seedData() {\n")
 		sb.WriteString("\t\t\tch, err := fwApp.CrudHandler(s.Entity)\n")
-		sb.WriteString("\t\t\tif err != nil {\n\t\t\t\tcontinue\n\t\t\t}\n")
+		sb.WriteString("\t\t\tif err != nil {\n\t\t\t\treturn fmt.Errorf(\"seed %s: no handler: %w\", s.Entity, err)\n\t\t\t}\n")
 		sb.WriteString("\t\t\tif n, err := ch.CountAll(ctx, framework.ListOptions{}); err == nil && n > 0 {\n\t\t\t\tcontinue\n\t\t\t}\n")
 		sb.WriteString("\t\t\tfor _, row := range s.Rows {\n")
 		sb.WriteString("\t\t\t\tresolveSeedRefs(ctx, fwApp, row)\n")
 		sb.WriteString("\t\t\t\tif _, err := ch.CreateOne(ctx, row); err != nil {\n")
-		sb.WriteString("\t\t\t\t\tlog.Printf(\"seed %s: skipping row: %v\", s.Entity, err)\n")
+		sb.WriteString("\t\t\t\t\treturn fmt.Errorf(\"seed %s: %w\", s.Entity, err)\n")
 		sb.WriteString("\t\t\t\t}\n")
 		sb.WriteString("\t\t\t}\n")
 		sb.WriteString("\t\t}\n")

--- a/cmd/gofastr/blueprint_seed_failfast_test.go
+++ b/cmd/gofastr/blueprint_seed_failfast_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A seed row that fails CreateOne must abort startup, not be logged and
+// skipped: the CountAll idempotency gate marks the entity non-empty after a
+// partial insert, so a dropped row never retries — the app then reports
+// ready on every boot with bootstrap data silently missing. WithSeed errors
+// abort App.Start, so returning the error is the whole fix.
+func TestSeedHookReturnsRowErrors(t *testing.T) {
+	main := renderBlueprintMain(websitesBlueprint())
+	if strings.Contains(main, "skipping row") {
+		t.Fatalf("seed hook logs-and-skips failed rows — fail-open boot:\n%s", main)
+	}
+	if !strings.Contains(main, `return fmt.Errorf("seed %s: %w", s.Entity, err)`) {
+		t.Fatalf("seed hook does not return CreateOne errors:\n%s", main)
+	}
+}
+
+// A missing CRUD handler (entity renamed, registration drifted) must abort
+// for the same reason — `continue` silently unseeds the whole entity.
+func TestSeedHookReturnsHandlerErrors(t *testing.T) {
+	main := renderBlueprintMain(websitesBlueprint())
+	if !strings.Contains(main, `return fmt.Errorf("seed %s: no handler: %w", s.Entity, err)`) {
+		t.Fatalf("seed hook swallows a missing CRUD handler instead of failing the boot:\n%s", main)
+	}
+}

--- a/cmd/gofastr/init.go
+++ b/cmd/gofastr/init.go
@@ -448,8 +448,11 @@ func main() {
 	// Run migrations
 	migrator := migrate.New(db, migrate.WithTableName("_migrations"), migrate.WithDialect(%[6]s))
 	entities.RegisterMigrations(migrator)
+	// A migration that cannot apply is a failed deploy, not a warning: the
+	// server must not report ready over a schema the committed migrations
+	// never reached.
 	if err := migrator.Up(context.Background()); err != nil {
-		log.Printf("Migration warning: %%v", err)
+		log.Fatalf("migrations: %%v", err)
 	}
 
 	addr, err := runtimeIsolation.Addr(getEnv("PORT", "localhost:8080"))

--- a/cmd/gofastr/init_failfast_test.go
+++ b/cmd/gofastr/init_failfast_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A failed versioned migration must abort boot. The scaffold used to log
+// "Migration warning" and call Start anyway, so a deploy whose committed
+// migration did not apply still reported a ready server — the fault then
+// surfaces as a later request error instead of a failed rollout. The ready
+// banner's own comment promises it fires only after migrations succeeded.
+func TestInitMainFailsClosedOnMigrationError(t *testing.T) {
+	bin := buildGofastrBin(t)
+	work := t.TempDir()
+	cmd := exec.Command(bin, "init", "migrfail", "--module=example.com/migrfail")
+	cmd.Dir = work
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("gofastr init: %v\n%s", err, out)
+	}
+	src, err := os.ReadFile(filepath.Join(work, "migrfail", "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mainSrc := string(src)
+	if strings.Contains(mainSrc, "Migration warning") {
+		t.Fatalf("generated main.go warns and boots on a failed migration (fail-open):\n%s", mainSrc)
+	}
+	if !strings.Contains(mainSrc, `log.Fatalf("migrations: %v", err)`) {
+		t.Fatalf("generated main.go does not abort on migrator.Up error:\n%s", mainSrc)
+	}
+}

--- a/cmd/gofastr/release_gate_test.go
+++ b/cmd/gofastr/release_gate_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func workflowSource(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("..", "..", ".github", "workflows", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// v0.61.0 was published from a commit whose blocking CI check had FAILED:
+// ci.yml never ran on tag pushes and release.yml's only gate was a changelog
+// section existing. These two tests pin the closed hole. First: pushing a
+// v* tag must start the CI workflow, so the tag SHA gets its own blocking
+// check runs for the release gate to consult.
+func TestCIRunsOnReleaseTags(t *testing.T) {
+	ci := workflowSource(t, "ci.yml")
+	if !strings.Contains(ci, "tags: ['v*']") {
+		t.Fatal("ci.yml does not trigger on v* tag pushes — a tag SHA gets no check runs of its own and the release gate has nothing to consult")
+	}
+}
+
+// Second: release.yml must refuse to create the GitHub release until every
+// blocking check run on the exact tag commit has completed successfully.
+func TestReleaseGatesOnGreenBlockingChecks(t *testing.T) {
+	rel := workflowSource(t, "release.yml")
+	for _, want := range []string{
+		"check-runs",             // queries the tag commit's check runs
+		`\\(blocking\\)`,         // filters to the blocking jobs
+		"blocking checks failed", // red conclusion aborts the release
+	} {
+		if !strings.Contains(rel, want) {
+			t.Fatalf("release.yml does not gate on the tag SHA's blocking check runs (missing %q) — a tag cut from a red commit publishes anyway", want)
+		}
+	}
+}

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.61.0
+through: v0.62.0
 
 releases:
   - version: v0.3.0
@@ -663,3 +663,11 @@ releases:
       - change: Every package now carries a stability tier
         breaking: false
         guidance: "Informational. docs/public-api.md says what Stable, Provisional, Experimental, Internal and Excluded promise. Nothing is Stable before v1.0.0 — the supported framework surface is Provisional, meaning documented and covered by the deprecation window in `gofastr docs stability`, not frozen. No import paths changed."
+
+  - version: v0.62.0
+    title: Green-gated releases and fail-closed generated boot
+    notes:
+      - change: Generated apps abort startup on failed migrations or seed rows
+        breaking: false
+        guidance: "Behavioral: `gofastr init` scaffolds now exit on a migrator.Up error instead of logging 'Migration warning' and starting, and blueprint seed hooks return the first failing row's error (WithSeed errors abort Start). A deploy that previously came up over an unapplied schema, or with seed rows silently dropped, now fails the rollout with the entity named. Regenerate to pick both up, and fix the migration or seed data rather than restoring warn-and-boot."
+        detect: "Migration warning|seed %s: skipping row"

--- a/evals/backend-adoption/internal/evalrunner/deps_test.go
+++ b/evals/backend-adoption/internal/evalrunner/deps_test.go
@@ -1,0 +1,32 @@
+package evalrunner
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// Every module@version a baseline lane writes into its workspace go.mod must
+// resolve, or the Gin and stdlib lanes die in setup and the eval cannot run
+// at all. This rotted silently once: the sqlite driver swap carried mattn's
+// v1.14.44 onto gofastr's own sqlite/stdlib path — which is not a module —
+// and nothing noticed for days because evals/ is only ever compiled in CI.
+// Distinguishes a bad pin (fail) from an unreachable proxy (skip).
+func TestBaselineRequirementsResolve(t *testing.T) {
+	if testing.Short() {
+		t.Skip("hits the module proxy")
+	}
+	for _, mod := range baselineRequirements() {
+		out, err := exec.Command("go", "list", "-m", mod).CombinedOutput()
+		if err == nil {
+			continue
+		}
+		s := string(out)
+		for _, badPin := range []string{"unknown revision", "invalid version", "not a known dependency", "malformed module path", "no matching versions"} {
+			if strings.Contains(s, badPin) {
+				t.Fatalf("baseline requirement %s does not resolve — the eval's non-GoFastr lanes are unrunnable:\n%s", mod, s)
+			}
+		}
+		t.Skipf("module proxy unreachable, cannot verify %s: %v\n%s", mod, err, s)
+	}
+}

--- a/evals/backend-adoption/internal/evalrunner/runner.go
+++ b/evals/backend-adoption/internal/evalrunner/runner.go
@@ -17,6 +17,25 @@ import (
 
 const ginVersion = "v1.11.0"
 
+// Pinned modules the non-GoFastr lanes get in go.mod. Shared with the
+// resolvability test: a version that stops resolving (as happened when the
+// sqlite driver swap carried the old mattn version onto a path that isn't a
+// module) makes every baseline lane — and so the whole eval — unrunnable.
+const (
+	sqliteRequirement = "modernc.org/sqlite@v1.55.0"
+	cryptoRequirement = "golang.org/x/crypto@v0.52.0"
+)
+
+// baselineRequirements are every module@version a baseline lane writes into
+// its workspace go.mod.
+func baselineRequirements() []string {
+	return []string{
+		"github.com/gin-gonic/gin@" + ginVersion,
+		sqliteRequirement,
+		cryptoRequirement,
+	}
+}
+
 type Config struct {
 	RepoRoot    string
 	ArtifactDir string
@@ -264,8 +283,8 @@ files as needed, but do not replace GoFastr with another web framework.
 		}
 		if output, err := commandOutput(ctx, workspace, "go", "mod", "edit",
 			"-require=github.com/gin-gonic/gin@"+ginVersion,
-			"-require=github.com/DonaldMurillo/gofastr/sqlite/stdlib@v1.14.44",
-			"-require=golang.org/x/crypto@v0.52.0"); err != nil {
+			"-require="+sqliteRequirement,
+			"-require="+cryptoRequirement); err != nil {
 			return fmt.Errorf("add Gin requirement: %w\n%s", err, output)
 		}
 		if err := writeNeutralGuidance(workspace); err != nil {
@@ -282,8 +301,8 @@ hashing. Do not replace Gin with another web framework.
 			return fmt.Errorf("go mod init: %w\n%s", err, output)
 		}
 		if output, err := commandOutput(ctx, workspace, "go", "mod", "edit",
-			"-require=github.com/DonaldMurillo/gofastr/sqlite/stdlib@v1.14.44",
-			"-require=golang.org/x/crypto@v0.52.0"); err != nil {
+			"-require="+sqliteRequirement,
+			"-require="+cryptoRequirement); err != nil {
 			return fmt.Errorf("add focused requirements: %w\n%s", err, output)
 		}
 		if err := writeNeutralGuidance(workspace); err != nil {

--- a/examples/ecommerce/app/main.go
+++ b/examples/ecommerce/app/main.go
@@ -73,7 +73,7 @@ func main() {
 		for _, s := range seedData() {
 			ch, err := fwApp.CrudHandler(s.Entity)
 			if err != nil {
-				continue
+				return fmt.Errorf("seed %s: no handler: %w", s.Entity, err)
 			}
 			if n, err := ch.CountAll(ctx, framework.ListOptions{}); err == nil && n > 0 {
 				continue
@@ -81,7 +81,7 @@ func main() {
 			for _, row := range s.Rows {
 				resolveSeedRefs(ctx, fwApp, row)
 				if _, err := ch.CreateOne(ctx, row); err != nil {
-					log.Printf("seed %s: skipping row: %v", s.Entity, err)
+					return fmt.Errorf("seed %s: %w", s.Entity, err)
 				}
 			}
 		}

--- a/framework/docs/content/blueprints.md
+++ b/framework/docs/content/blueprints.md
@@ -694,8 +694,11 @@ and `main.go` applies it via `App.WithSeed` after auto-migration. Seeding is
 before the rows that reference it) and **idempotent** (an entity whose table
 already has rows is skipped). Rows go through the CRUD `CreateOne` path, so
 validation, id generation, and timestamps apply; `decimal` values are coerced
-to the decimal-string form the validator expects. A row that fails validation
-is logged and skipped rather than aborting startup.
+to the decimal-string form the validator expects. Seeding is **fail-fast**: a
+row that fails validation (or an entity with no registered handler) aborts
+startup with the entity named in the error. The idempotency check would
+otherwise mark a partially-seeded entity as done, so a silently dropped row
+would never retry — the app would report ready with bootstrap data missing.
 
 When any entity declares `owner_field` (per-user scoping) **and** an admin
 account is bootstrapped (`app.admin.seed_email` / `seed_password`), the seed

--- a/internal/pgtest/pgtest.go
+++ b/internal/pgtest/pgtest.go
@@ -102,6 +102,18 @@ func BaseDSN(t *testing.T) string {
 	return dsn
 }
 
+// skipOrFail is the same fail-closed rule BaseDSN applies, extended to the
+// URL-shape checks that run after it: skip locally, fail under required
+// mode. Without it, a non-URL TEST_POSTGRES_DSN — the override
+// CONTRIBUTING.md advertises — turns the CI canary into a silent skip.
+func skipOrFail(t *testing.T, format string, args ...any) {
+	t.Helper()
+	if required() {
+		t.Fatalf(format, args...)
+	}
+	t.Skipf(format, args...)
+}
+
 // DB returns a *sql.DB scoped to a fresh, uniquely-named schema (via
 // search_path) on the shared Postgres, or skips if Postgres is unreachable.
 // The schema and connection are dropped/closed on t.Cleanup.
@@ -116,7 +128,7 @@ func DB(t *testing.T) *sql.DB {
 	// default schema.
 	dsn, err := dsnWithSearchPath(base, schema)
 	if err != nil {
-		t.Skipf("pgtest.DB needs a URL-form base DSN, got %q (%v)", RedactDSN(base), err)
+		skipOrFail(t, "pgtest.DB needs a URL-form base DSN, got %q (%v)", RedactDSN(base), err)
 	}
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
@@ -163,7 +175,7 @@ func FreshDatabaseDSN(t *testing.T) string {
 	base := BaseDSN(t)
 	u, err := url.Parse(base)
 	if err != nil || u.Scheme == "" {
-		t.Skipf("pgtest.FreshDatabaseDSN needs a URL-form base DSN, got %q", RedactDSN(base))
+		skipOrFail(t, "pgtest.FreshDatabaseDSN needs a URL-form base DSN, got %q", RedactDSN(base))
 	}
 	admin, err := sql.Open("postgres", base)
 	if err != nil {
@@ -196,7 +208,7 @@ func UnusedDSN(t *testing.T) (string, func()) {
 	base := BaseDSN(t)
 	u, err := url.Parse(base)
 	if err != nil || u.Scheme == "" {
-		t.Skipf("pgtest.UnusedDSN needs a URL-form base DSN, got %q", RedactDSN(base))
+		skipOrFail(t, "pgtest.UnusedDSN needs a URL-form base DSN, got %q", RedactDSN(base))
 	}
 	name := fmt.Sprintf("created_%d_%d", os.Getpid(), schemaSeq.Add(1))
 	u.Path = "/" + name

--- a/internal/pgtest/pgtest_required_test.go
+++ b/internal/pgtest/pgtest_required_test.go
@@ -1,0 +1,33 @@
+package pgtest
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// Required mode must stay fail-closed PAST BaseDSN. With TEST_POSTGRES_DSN
+// set to a keyword/value (non-URL) string, resolve() succeeds — env DSNs are
+// taken as-is — and the URL-shape checks in DB/FreshDatabaseDSN/UnusedDSN
+// then skip. Under PGTEST_REQUIRED that turns the CI canary into a silent
+// skip through the exact override CONTRIBUTING.md advertises, which is the
+// false-green the canary exists to prevent. This drives the canary in a
+// subprocess and demands a FAILURE, not a skip.
+func TestRequiredModeRejectsNonURLDSN(t *testing.T) {
+	if testing.Short() {
+		t.Skip("compiles and runs the package in a subprocess")
+	}
+	cmd := exec.Command("go", "test", "-count=1", "-run", "TestPGHarnessRequired$", ".")
+	cmd.Env = append(os.Environ(),
+		"PGTEST_REQUIRED=1",
+		"TEST_POSTGRES_DSN=host=localhost port=5432 dbname=pgtest sslmode=disable",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("required-mode canary skipped (passed) on a non-URL DSN instead of failing:\n%s", out)
+	}
+	if !strings.Contains(string(out), "URL-form") {
+		t.Fatalf("canary failed for a different reason than the URL-shape guard:\n%s", out)
+	}
+}


### PR DESCRIPTION
Implements the verified fix list from the 2026-08-05 three-model assessment (Claude + GLM + Sol, post-PR #186). Every fix landed red-test-first.

## Commits

- `128ded7b` **ci: refuse to release a tag whose blocking checks are not green.** v0.61.0 published from a commit whose blocking build·vet·test check had failed — ci.yml never ran on tags and release.yml only checked that a changelog section existed. CI now triggers on `v*` tags, and the release job polls the tag SHA's `(blocking)` check runs: any red aborts, publishing waits for at least the three known blocking jobs to complete green. `release_gate_test.go` pins both halves.
- `e195ae89` **fix(cli): generated apps fail closed on migration and seed errors.** The init scaffold logged `Migration warning` on a failed `migrator.Up` and started the server anyway. Blueprint seeding logged failed rows and returned nil — and the CountAll idempotency gate then marked the entity seeded, so a dropped row never retried. Both abort startup now (`WithSeed` errors already abort `Start`). Ecommerce regenerated to satisfy its byte-parity gate: a 2-line diff. blueprints.md updated to describe fail-fast.
- `04d48976` **fix(pgtest): required mode fails, not skips, on a non-URL DSN.** The URL-shape guards in `DB`/`FreshDatabaseDSN`/`UnusedDSN` ran after the fail-closed choke point and still skipped, so the documented `TEST_POSTGRES_DSN` override could silently turn the CI canary green. A subprocess test drives the canary with a keyword/value DSN and demands a failure.
- `61e2eecf` **fix(evals): pin a resolvable sqlite module in the baseline lanes.** The Gin/stdlib lanes required `gofastr/sqlite/stdlib@v1.14.44` — mattn's version carried onto a non-module path during the modernc driver swap — so lane setup failed before any trial. Now `modernc.org/sqlite@v1.55.0` via shared consts, plus a resolvability test so a dead pin fails instead of rotting silently.
- `1a1600fc` **docs(changelog)** — Changed (generated-app boot behavior) + Fixed entries.

## Verification

- Six new tests, each confirmed failing before its fix (seed row/handler emit, init migration branch, both workflow pins, pgtest subprocess, baseline resolvability).
- Full `cmd/gofastr` suite (179s), meridian + ecommerce blueprint gates (ecommerce's parity gate + seed guard boot the regenerated fail-fast app), `internal/pgtest`, and `evalrunner` all pass; workflows YAML-validated; `go vet`/`gofmt` clean.
- Note: this branch and #189 both add entries under Unreleased in CHANGELOG.md — whichever merges second needs a trivial conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)