### PR TITLE
CI: dedupe the release re-run, per-SHA Go cache, shard browser e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,13 @@ permissions:
 on:
   push:
     branches: [main]
-    # Tag pushes get their own run so the release workflow has blocking
-    # check runs on the exact tag SHA to gate on — v0.61.0 published off a
-    # red commit because tags never triggered CI.
-    tags: ['v*']
+    # No v* tag trigger: a release tag points at a merge commit on main,
+    # and check runs attach to the commit SHA, so the main-push run
+    # already carries the blocking checks the release gate (release.yml)
+    # polls for. A tag trigger re-ran the identical pipeline on the same
+    # SHA — v0.62.0 ran twice, concurrently. Fail-closed is preserved: a
+    # tag on a commit with no CI run finds zero check runs and the
+    # release gate times out red.
   pull_request:
   # The `security` job needs a time trigger, not just a code trigger: an
   # advisory can land against a dependency nobody touched. GO-2026-5158

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,32 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
-          cache: true
+          # setup-go's built-in cache keys on go.sum alone: the entry is
+          # saved once per dependency bump, then restored read-only by every
+          # later run — test results for code that changed since are never
+          # persisted, so the test step re-executed every package on every
+          # run (observed: the v0.62.0 tag run re-ran 7.5 min of tests on a
+          # SHA whose main-push twin was concurrently running the identical
+          # suite). The explicit per-SHA cache below replaces it.
+          cache: false
+
+      - name: Go module + build/test cache (per-SHA)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          # Keyed on the commit so every run SAVES a fresh snapshot (cache
+          # entries are immutable — an existing key is never updated), and
+          # restore-keys hands the next run the newest prior snapshot. That
+          # is what lets Go's content-addressed test cache skip every
+          # package whose sources + transitive deps are unchanged since the
+          # last run — the affected-tests mechanism the Test step's comment
+          # relies on. GOCACHE self-trims stale entries; GitHub's 10 GB
+          # per-repo LRU evicts old SHAs.
+          key: go-test-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            go-test-${{ runner.os }}-
 
       - name: Install Chrome (stable chromedp suites run here too)
         uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1
@@ -120,11 +145,11 @@ jobs:
       - name: Test (deterministic packages)
         # -timeout=20m, -p 2 to keep httptest/chromedp sockets off the
         # ephemeral-port ceiling. Intentionally NO -count=1: Go's
-        # content-addressed test cache (persisted across runs by
-        # setup-go's GOCACHE) then skips re-executing any package whose
-        # sources + transitive deps + test inputs are byte-identical to a
-        # prior PASS — the free, correct-by-construction analog of Nx's
-        # affected/cache. Do NOT re-add -count=1 here to "force fresh
+        # content-addressed test cache (persisted across runs by the
+        # per-SHA cache step above) then skips re-executing any package
+        # whose sources + transitive deps + test inputs are byte-identical
+        # to a prior PASS — the free, correct-by-construction analog of
+        # Nx's affected/cache. Do NOT re-add -count=1 here to "force fresh
         # runs"; the flaky chromedp suites keep it in browser-e2e, which
         # is where forcing a fresh run per push actually matters.
         # Excluded here and run in browser-e2e instead:
@@ -232,7 +257,24 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
-          cache: true
+          # See the test job: setup-go's go.sum-keyed cache goes stale
+          # between dependency bumps. This job restores the test job's
+          # per-SHA cache instead.
+          cache: false
+
+      - name: Go module + build cache (restore only)
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          # Restore-only: every suite here runs -count=1, so the cache buys
+          # compile time, not test skips — and saving this job's
+          # near-duplicate GOCACHE would crowd the repo's 10 GB cache LRU
+          # for no extra hits.
+          key: go-test-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            go-test-${{ runner.os }}-
 
       - name: Install Chrome
         uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ permissions:
 #      deterministic results on the runners. This is the merge gate.
 #
 #   2. `browser-e2e` (BLOCKING since 2026-06-10) — the slow chromedp
-#      suites, run serialized and isolated:
+#      suites, one matrix shard per suite so each runs isolated on its
+#      own runner (they contend for Chrome/sockets when sharing one):
 #        - examples/site, including the axe gate in its own isolated
 #          invocation (it flakes when sharing a go-test run with the
 #          other chromedp tests — CLAUDE.md).
@@ -245,14 +246,65 @@ jobs:
         run: make mod-verify
 
   browser-e2e:
-    name: "browser e2e (blocking)"
+    # One matrix shard per chromedp suite. These suites were serialized in
+    # a single job because they contend for Chrome/sockets when they share
+    # a runner (CLAUDE.md documents the flake classes); separate runners
+    # don't contend, so the matrix keeps every suite exactly as isolated
+    # while running them concurrently — wall clock drops from the ~28m
+    # serial sum to the slowest shard (site-axe, ~13m). fail-fast is off
+    # so one red suite still lets the rest report, matching the old
+    # per-step `if: !cancelled()` behavior. Each shard is its own check
+    # run; release.yml's gate counts checks whose name contains
+    # "(blocking)", so the suffix must stay in `name`.
+    name: "browser e2e · ${{ matrix.suite }} (blocking)"
     runs-on: ubuntu-latest
-    # Per-step go-test timeouts sum to 105m (15+15+15+25+10+10+10+5); the
-    # job budget must exceed that so the !cancelled() always-report steps
-    # can run.
-    timeout-minutes: 110
+    # Budget = the largest per-suite go-test timeout (meridian, 25m) plus
+    # setup; the timeouts on each `run` are unchanged from the serialized
+    # steps they replace.
+    timeout-minutes: 35
     env:
       CGO_ENABLED: "1"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: site
+            run: go test -count=1 -timeout=15m -skip 'TestAxe' ./examples/site/
+          - suite: site-axe
+            # 15m, not 10 — the gate scans every page under BOTH color
+            # schemes (≈3.5min locally; CI runners are slower). Its own
+            # shard: CLAUDE.md documents the axe suite flaking when it
+            # shares a go-test run with the other chromedp tests.
+            run: go test -count=1 -timeout=15m -run 'TestAxe_AllPagesAreClean' ./examples/site/
+          - suite: kiln-integration
+            run: go test -count=1 -timeout=15m ./kiln/integration/
+          - suite: gofastr-cli
+            # Every cmd/gofastr test that drives a real Chrome — the
+            # blueprint app E2E plus the two dev livereload browser tests.
+            # Kept out of the deterministic step so the websocket connect
+            # isn't starved by parallel package load.
+            run: go test -count=1 -timeout=10m -run 'TestBlueprintCLIGeneratesEntireWorkingAppE2E|TestE2E_HotReload_BrowserAutoRefreshes|TestLivereloadSameBuildIDDoesNotReload' ./cmd/gofastr/
+          - suite: core-ui-runtime
+            # The runtime hydration suite launches a real Chrome per test
+            # binary; under the deterministic job's -p 2 package
+            # parallelism the chromedp websocket connect starves and times
+            # out ("websocket url timeout reached" — CLAUDE.md documents
+            # this package as flaky under parallel load, run isolated).
+            run: go test -count=1 -timeout=10m ./core-ui/runtime/
+          - suite: core-ui-widget
+            # Same class as core-ui/runtime — documented flaky when
+            # sharing a go-test run with other chromedp suites.
+            run: go test -count=1 -timeout=5m ./core-ui/widget/
+          - suite: meridian
+            # The 16-surface rendered canary (desktop/mobile × light/dark
+            # × marketing/auth/app/admin) captures in software on the
+            # two-core runner: bounded 30s attempts × up to 6 retries per
+            # surface need a budget well past the local ~2m runtime.
+            run: go test -count=1 -timeout=25m ./examples/meridian/
+          - suite: ui-quality-evals
+            # Its capture tests drive a real headless Chrome; kept out of
+            # the deterministic -p 2 run for the same contention reason.
+            run: go test -count=1 -timeout=10m ./evals/ui-quality/...
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -287,57 +339,5 @@ jobs:
       - name: Install the gofastr binary
         run: go install ./cmd/gofastr
 
-      # Each suite gets its own serialized `go test` invocation:
-      # CLAUDE.md documents that the axe suite flakes when sharing a
-      # go-test run with the other chromedp tests, and the suites
-      # contend for Chrome/network resources when parallel.
-
-      - name: examples/site e2e (without axe)
-        run: go test -count=1 -timeout=15m -skip 'TestAxe' ./examples/site/
-
-      - name: examples/site axe (isolated)
-        # 15m, not 10 — the gate scans every page under BOTH color
-        # schemes (≈3.5min locally; CI runners are slower).
-        if: ${{ !cancelled() }}
-        run: go test -count=1 -timeout=15m -run 'TestAxe_AllPagesAreClean' ./examples/site/
-
-      - name: kiln/integration
-        if: ${{ !cancelled() }}
-        run: go test -count=1 -timeout=15m ./kiln/integration/
-
-      - name: cmd/gofastr browser e2e (blueprint + dev livereload)
-        if: ${{ !cancelled() }}
-        # Serialized, isolated run of every cmd/gofastr test that drives a
-        # real Chrome — the blueprint app E2E plus the two dev livereload
-        # browser tests. Kept out of the deterministic step so the
-        # websocket connect isn't starved by parallel package load.
-        run: go test -count=1 -timeout=10m -run 'TestBlueprintCLIGeneratesEntireWorkingAppE2E|TestE2E_HotReload_BrowserAutoRefreshes|TestLivereloadSameBuildIDDoesNotReload' ./cmd/gofastr/
-
-      - name: core-ui/runtime e2e (isolated)
-        if: ${{ !cancelled() }}
-        # The runtime hydration suite launches a real Chrome per test
-        # binary; under the deterministic job's -p 2 package parallelism
-        # the chromedp websocket connect starves and times out
-        # ("websocket url timeout reached" — CLAUDE.md documents this
-        # package as flaky under parallel load, run isolated).
-        run: go test -count=1 -timeout=10m ./core-ui/runtime/
-
-      - name: core-ui/widget e2e (isolated)
-        if: ${{ !cancelled() }}
-        # Same class as core-ui/runtime — documented flaky when sharing
-        # a go-test run with other chromedp suites.
-        run: go test -count=1 -timeout=5m ./core-ui/widget/
-
-      - name: examples/meridian visual canary (isolated)
-        if: ${{ !cancelled() }}
-        # The 16-surface rendered canary (desktop/mobile × light/dark ×
-        # marketing/auth/app/admin) captures in software on the two-core
-        # runner: bounded 30s attempts × up to 6 retries per surface need a
-        # budget well past the local ~2m runtime.
-        run: go test -count=1 -timeout=25m ./examples/meridian/
-
-      - name: evals/ui-quality evalrunner (isolated)
-        if: ${{ !cancelled() }}
-        # Its capture tests drive a real headless Chrome; kept out of the
-        # deterministic -p 2 run for the same contention reason.
-        run: go test -count=1 -timeout=10m ./evals/ui-quality/...
+      - name: Run suite
+        run: ${{ matrix.run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,16 @@ jobs:
       # A release must not ship a red commit. v0.61.0 published while its
       # blocking build·vet·test check had FAILED, because nothing here ever
       # consulted CI. Waits for every "(blocking)" check run on the exact
-      # tag SHA (ci.yml now runs on v* tags) and refuses to publish unless
-      # all of them — at least the three known jobs — completed green.
+      # tag SHA and refuses to publish unless all of them — at least three
+      # — completed green. Check runs attach to the commit, and a release
+      # tag points at a merge commit on main, so the checks this finds are
+      # the ones from that commit's main-push CI run; ci.yml deliberately
+      # has no v* trigger (it would re-run the identical pipeline on the
+      # same SHA). If the tag points at a commit that never ran CI — or
+      # whose run was cancelled — zero checks turn up and the wait below
+      # times out red: retag on a commit with green CI, or re-run the
+      # failed jobs of that commit's existing CI run (check runs update in
+      # place on the same SHA), then re-run this via workflow_dispatch.
       - name: Require green blocking CI on the tag commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Changed
+
+- **Release tags no longer re-run CI.** A release tag points at a merge
+  commit on main, so the release gate now consults the blocking check runs
+  that commit's main-push CI run already produced; the tag-triggered
+  duplicate of the identical pipeline is gone. A tag on a commit with no CI
+  run still fails the gate. CI itself got faster: the Go build/test cache
+  persists per commit, so packages whose sources and dependencies are
+  unchanged skip re-execution, and each browser e2e suite runs on its own
+  runner — the browser-e2e wall clock drops from the ~28-minute serial sum
+  to the slowest suite (~13 minutes).
+
 ## [0.62.0] - 2026-08-05
 
 ### Changed

--- a/cmd/gofastr/release_gate_test.go
+++ b/cmd/gofastr/release_gate_test.go
@@ -17,14 +17,21 @@ func workflowSource(t *testing.T, name string) string {
 }
 
 // v0.61.0 was published from a commit whose blocking CI check had FAILED:
-// ci.yml never ran on tag pushes and release.yml's only gate was a changelog
-// section existing. These two tests pin the closed hole. First: pushing a
-// v* tag must start the CI workflow, so the tag SHA gets its own blocking
-// check runs for the release gate to consult.
-func TestCIRunsOnReleaseTags(t *testing.T) {
+// release.yml's only gate was a changelog section existing. These two tests
+// pin the closed hole. First: the release gate consults check runs on the
+// tag's commit SHA, and those come from the main-push CI run (a release tag
+// points at a merge commit on main), so ci.yml must run on main pushes —
+// and must NOT also trigger on v* tags, which re-ran the identical pipeline
+// on the same SHA (v0.62.0 ran twice, concurrently). A tag on a commit with
+// no CI run finds zero check runs and the gate times out red, so dropping
+// the tag trigger keeps the gate fail-closed.
+func TestMainPushCICoversReleaseTags(t *testing.T) {
 	ci := workflowSource(t, "ci.yml")
-	if !strings.Contains(ci, "tags: ['v*']") {
-		t.Fatal("ci.yml does not trigger on v* tag pushes — a tag SHA gets no check runs of its own and the release gate has nothing to consult")
+	if !strings.Contains(ci, "branches: [main]") {
+		t.Fatal("ci.yml does not run on main pushes — the merge commit a release tag points at gets no check runs and the release gate has nothing to consult")
+	}
+	if strings.Contains(ci, "tags:") {
+		t.Fatal("ci.yml triggers on tag pushes — that duplicates the main-push run on the same SHA; the release gate already consults those checks")
 	}
 }
 

--- a/scripts/coverage-floors.sh
+++ b/scripts/coverage-floors.sh
@@ -3,8 +3,12 @@
 # can't drift silently. This script is the single source of truth for
 # the floors.
 #
-# Methodology: own-package coverage (`go test -coverprofile ./<pkg>/`,
-# `-count=1`), the cheapest reproducible measurement. A floor may gate a
+# Methodology: own-package coverage (`go test -coverprofile ./<pkg>/`),
+# the cheapest reproducible measurement. No -count=1: coverage runs are
+# served from Go's content-addressed test cache when a package's sources
+# and deps are unchanged — same inputs, same percentage — so repeat runs
+# (locally and in CI, which persists GOCACHE per-SHA) skip re-execution. A
+# floor may gate a
 # whole package OR a file-filtered *bucket* within one — see below. The
 # audited packages sit below a literal 100% by design: defensive
 # fail-closed guards that are unreachable today are kept (not rewritten to
@@ -76,7 +80,7 @@ profile_for() {
   key=$(echo "$pkg" | tr -c 'A-Za-z0-9' '_')
   local prof="$profdir/$key.out"
   if [ ! -f "$prof" ]; then
-    if ! go test -coverprofile="$prof" -count=1 "$pkg" >"$profdir/$key.log" 2>&1; then
+    if ! go test -coverprofile="$prof" "$pkg" >"$profdir/$key.log" 2>&1; then
       cat "$profdir/$key.log"
       return 1
     fi
@@ -113,7 +117,7 @@ while read -r pkg floor filter; do
 
   if [ -z "$filter" ]; then
     # Whole-package fast path.
-    if ! out=$(go test -cover -count=1 "$pkg" 2>&1); then
+    if ! out=$(go test -cover "$pkg" 2>&1); then
       echo "$out"; echo "FAIL  $label — tests failed (no coverage measurement)"; fail=1; continue
     fi
     cov=$(echo "$out" | grep -Eo 'coverage: [0-9.]+%' | tail -1 | grep -Eo '[0-9.]+')


### PR DESCRIPTION
Three changes to the CI/release pipeline, one commit each (plus a changelog roll). Grounded in the v0.62.0 release runs from 2026-08-05.

## 1. Per-SHA Go build/test cache (`3daffd92`)

setup-go's built-in cache keys on go.sum alone: the GOCACHE snapshot is saved once per dependency bump, then restored read-only by every later run. Test results for code changed since that bump were never persisted, so the deterministic test step re-executed every package on every run — the v0.62.0 tag run re-ran 7.5 minutes of tests on a SHA whose main-push twin was concurrently running the identical suite.

An explicit `actions/cache` keyed on `github.sha` with a prefix restore-key replaces it: every run restores the newest prior snapshot and saves its own, so Go's content-addressed test cache skips each package whose sources and transitive deps are unchanged. This is the affected-tests mechanism the test step's comment already relied on, now actually operative. browser-e2e restores without saving (its suites run `-count=1`; the cache only buys compile time). `coverage-floors.sh` drops `-count=1` for the same reason — `-cover` and `-coverprofile` runs are cached on identical inputs (verified locally: second run reports `(cached)` with the same percentage).

## 2. Release tags no longer re-run CI (`9f13df29`)

A release tag points at a merge commit on main, and check runs attach to the commit SHA — so the release gate in release.yml finds the main-push run's blocking checks without a tag-triggered duplicate. v0.62.0 ran the full pipeline twice, concurrently, on the same SHA.

Fail-closed is unchanged: a tag on a commit that never ran CI (or whose run was cancelled) turns up zero check runs and the gate times out red; the remedy is retag-on-green or re-run that commit's CI jobs, then `workflow_dispatch`. The guard test that pinned the tag trigger (`TestCIRunsOnReleaseTags`) now pins the inverse contract (`TestMainPushCICoversReleaseTags`): main pushes must run CI, tag pushes must not.

## 3. browser-e2e as a matrix, one shard per suite (`3ca829b8`)

The eight chromedp suites were serialized in one job because they contend for Chrome and sockets when sharing a runner. Separate runners don't contend, so a matrix keeps each suite exactly as isolated while running them concurrently. Wall clock drops from the ~28m serial sum to the slowest shard (site-axe, ~13m). Per-suite go-test timeouts are unchanged; `fail-fast: false` matches the old `if: !cancelled()` per-step behavior; every shard keeps "(blocking)" in its name, which is what the release gate's check filter matches — the gate's `total >= 3` condition holds with 10 blocking checks instead of 3.

## Expected effect

- A typical PR run: ~29m → bounded by the axe shard (~14m), less when the diff is narrow and the test cache hits.
- Release day: three full pipelines → one PR run plus a mostly-cached main-push run; the release publishes when that run is green instead of waiting on its own duplicate.

First runs on this PR restore no prior `go-test-*` cache (the key prefix is new), so the full speedup shows from the second push onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)