### PR TITLE
fix(ci): empty GitHub expression broke the release workflow at startup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,12 @@ jobs:
             tag="$GITHUB_REF_NAME"
           fi
           # Git allows command-substitution syntax in tag names, and a
-          # ${{ }} expression is spliced into the shell source BEFORE bash
+          # GitHub expression is spliced into the shell source BEFORE bash
           # parses it. Pin the shape here, once, and pass the value through
           # env everywhere else so no step interpolates it into source.
+          # (Do not write an empty GitHub expression anywhere in this file,
+          # even in a shell comment: expressions are parsed file-wide and an
+          # empty one fails the whole workflow at startup.)
           case "$tag" in
             v[0-9]*.[0-9]*.[0-9]*) ;;
             *) echo "::error::refusing tag $tag — a release tag must look like v1.2.3"; exit 1 ;;

--- a/cmd/gofastr/release_gate_test.go
+++ b/cmd/gofastr/release_gate_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -419,5 +420,34 @@ func writeFixture(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// GitHub parses ${…} expressions file-wide, including inside what looks like
+// a shell comment in a run: block. An EMPTY expression is invalid syntax and
+// fails the whole workflow at startup with no jobs — which is exactly how a
+// comment explaining expression injection took the release workflow down.
+// Every expression in a workflow must have a body.
+func TestWorkflowsHaveNoEmptyExpressions(t *testing.T) {
+	dir := filepath.Join("..", "..", ".github", "workflows")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read workflows dir: %v", err)
+	}
+	empty := regexp.MustCompile(`\$\{\{\s*\}\}`)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yml") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		for i, line := range strings.Split(string(body), "\n") {
+			if empty.MatchString(line) {
+				t.Errorf("%s:%d has an empty GitHub expression — the workflow will fail at startup: %s",
+					e.Name(), i+1, strings.TrimSpace(line))
+			}
+		}
 	}
 }


### PR DESCRIPTION
The comment added in #195 explaining tag-name injection contained a literal empty GitHub expression. Expressions are parsed file-wide — including inside what reads as a shell comment in a `run:` block — and an empty one is invalid syntax, so every push produced a release run that failed instantly with zero jobs. A `v0.63.0` tag pushed against that workflow would not have published.

Caught by watching main's runs after merging #195: two release runs (the branch push and the merge) failed with "This run likely failed because of a workflow file issue."

Reworded the comment, and added `TestWorkflowsHaveNoEmptyExpressions` over every workflow file. Verified red first — reintroducing the empty expression fails the test naming `release.yml:55`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)