### PR TITLE
test(cli): give the blueprint browser e2e its own cold-start budget

### DIFF
--- a/cmd/gofastr/blueprint_test.go
+++ b/cmd/gofastr/blueprint_test.go
@@ -1335,7 +1335,20 @@ func runBrowserUIE2E(t *testing.T, baseURL, wantEntityTitle string) {
 	defer allocCancel()
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	defer browserCancel()
-	ctx, cancel := context.WithTimeout(browserCtx, 20*time.Second)
+
+	// chromedp starts Chrome lazily on the first Run, so a single timeout
+	// would have to cover BOTH the cold start and the page work — and it
+	// caps WSURLReadTimeout above, making that 90s ineffective. This test
+	// cold-starts Chrome right after generating and building a whole app,
+	// which is when the runner is slowest, so the two budgets are separate:
+	// a generous one to get the browser up, then the work budget.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	defer startCancel()
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("browser UI e2e failed: chrome did not start within 90s: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)
 	defer cancel()
 
 	var hasRuntime, hasActions, hasIsland, hasWidget bool


### PR DESCRIPTION
`browser e2e · gofastr-cli (blocking)` failed on main (run 31054242992) and on PR #195's first attempt, both with `chrome failed to start`.

**Not a flake, and not the app.** Every HTTP assertion before the browser step passed on both failing runs — the generated app booted and served create/get/update/patch/list correctly. The failure is purely the browser launch.

**Root cause.** chromedp starts Chrome lazily on the first `Run`, so `runBrowserUIE2E` had a single 20s context covering both the cold start and the page work — and that context capped the `WSURLReadTimeout(90*time.Second)` set just above it, so the generous setting never applied. 20s was the lowest browser timeout in the repo (siblings use 30–120s; the two other tests in this same CI job use 120s and 30s), and this test cold-starts Chrome immediately after generating and building an entire app, which is exactly when the runner is slowest.

**Fix.** Startup gets its own 90s budget via an explicit `chromedp.Run(startCtx)` before the assertions, which then get 60s. The failure message also now distinguishes "chrome did not start" from an assertion failure.

Verified locally: `go test ./cmd/gofastr/ -run TestBlueprintCLIGeneratesEntireWorkingAppE2E -count=1` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)