### PR TITLE
Post-v0.63.0 carryover: proven idempotency leak, broker scoping, issues #136 + #194

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,13 @@ on:
     # tag on a commit with no CI run finds zero check runs and the
     # release gate times out red.
   pull_request:
+  # Merge queue: GitHub tests the queued commit (main + this PR, as it will
+  # actually land) and merges that exact commit, so its check runs attach to
+  # the SHA the release gate polls. Without the queue, every change runs this
+  # pipeline twice — once on the PR's ephemeral merge commit, once on the
+  # identical tree after it lands on main. This trigger is inert until the
+  # queue is enabled on main; enabling it removes the duplicate.
+  merge_group:
   # The `security` job needs a time trigger, not just a code trigger: an
   # advisory can land against a dependency nobody touched. GO-2026-5158
   # (otel baggage, reachable from core/middleware.Tracing) shipped in a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,82 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING: `IdempotencyStore.Finish` takes the request fingerprint.** The
+  signature is now
+  `Finish(ctx, key, fingerprint string, resp *IdempotentResponse) error`, and
+  the write is bound to the claim that produced it. Custom stores must accept
+  the fingerprint and refuse to write a row that no longer carries it. The
+  unbound signature was rejected rather than kept behind an optional interface
+  because a store that ignores the fingerprint can serve one principal's
+  response to another, and that must not be the quiet default.
+- **A brokered call can never lift owner scoping.** A process module's reverse
+  entity call is now marked at the boundary and `CrossOwnerRead` is refused for
+  it unconditionally, instead of being predicted from the policy captured when
+  the delegation was minted. The re-dispatch runs the full middleware chain and
+  re-resolves authority, so the old check could pass judgement on a context the
+  query never used. This matches what the broker already documented — a
+  delegated user who legitimately holds `CrossOwnerRead` in their own session
+  cannot exercise it through a module — but it is a behavior change for a host
+  that relied on the carve-out silently not applying.
+
+### Fixed
+
+- **An idempotent request could be answered with another caller's response.**
+  When a handler outran the in-flight TTL and a second request re-claimed the
+  same `Idempotency-Key`, the first handler's `Finish` wrote its response into
+  the second's row while leaving that row's fingerprint in place — so the
+  retry passed the fingerprint check and was served a body it never asked for.
+  With `Principal` set to a tenant id, as the configuration documents, that
+  crosses users. Proven by execution before it was fixed. The expired-claim
+  re-claim also deleted by key alone, so two racing re-claims could destroy a
+  fresh claim and run the handler twice; it now deletes only a still-expired
+  row.
+- **A process module could read entities outside its approved grant.** Every
+  key of a module's filter object was forwarded into the CRUD list query, so
+  `include=` eager-loaded a second entity the grant never named — with no row
+  scoping at all when that entity declares no owner and no tenant — and
+  `trashed=true` surfaced soft-deleted rows. Filter keys are now allow-listed
+  against the resolved entity's declared, non-hidden, queryable fields, which
+  is what the code claimed to do. Delegation handles are also bound to the
+  module they were issued to, and handle minting fails loudly on an entropy
+  error instead of silently producing a constant.
+- **`/api/llm.md` listed every entity to any signed-in caller.** The index was
+  rendered once at startup and gated on a session, while the per-entity
+  document it links to runs the full scope chain — the schema is the
+  disclosure, not the rows. It is now rendered per request and filtered to the
+  entities that caller can list.
+- **`SearchInput` and `FilterToolbar` put their `Action` into a form without
+  the URL guard** every sibling form applies, so a `javascript:` action
+  survived to submit. `FilterToolbar` only appeared safe because an unrelated
+  button panicked first, which `HideReset` skipped.
+- **Panic and timeout logs carried raw request paths.** `URL.Path` is
+  percent-decoded, so a `%0d%0a` in the request forged log lines through the
+  recovery and timeout sinks, which never scrubbed; the access-log sink
+  scrubbed but never bounded, so an oversized path was logged whole. Both
+  halves now hold at all three.
+- **An unknown filter parameter could pin a CPU.** The "did you mean" suggestion
+  ran an edit-distance pass over an unbounded, unauthenticated query-parameter
+  name; the suggestion is now skipped past a sane length and the plain error is
+  returned.
+- **One panicking metrics collector no longer drops the whole scrape** — each
+  runs isolated, matching how the hook runner already treats third-party
+  callbacks.
+- **Magic-link tokens are erased with the user.** `EraseUserData` gained a
+  declarative identity seam: a battery can key an eraser on a resolved
+  identity, such as the user's email, instead of the user id. Magic-link
+  tokens are keyed by email and so survived an erasure — a link minted before
+  it and redeemed after created a fresh account for the erased address. Shipped
+  as a documented limitation in v0.63.0; it is closed now. 2FA secrets and
+  OAuth links are erased too.
+- **`SegmentedControl` posts the selected value.** `RPCPath` attached the RPC
+  attribute and fired the request with an empty body, so the handler fell
+  through to its default and confidently rendered the wrong selection. Any form
+  control dispatching an RPC now serializes its enclosing form; an explicit
+  body still wins, and a control outside a form is unchanged. The same gap in
+  the tool-call dispatcher is fixed with it.
+
 ## [0.63.0] - 2026-08-05
 
 ### Added

--- a/battery/auth/erase.go
+++ b/battery/auth/erase.go
@@ -8,7 +8,7 @@ import "github.com/DonaldMurillo/gofastr/framework/datexport"
 // erasure is complete. The framework centralizes all raw write behind one
 // SafeIdent-guarded path; these registrations are purely declarative.
 //
-// Two erasers are registered under the canonical table names:
+// These erasers are registered under the canonical table names:
 //
 //   - auth_sessions: EraseDelete by user_id. A user's sessions are pure
 //     credential state — they are hard-deleted, revoking every active session
@@ -24,12 +24,12 @@ import "github.com/DonaldMurillo/gofastr/framework/datexport"
 //     "<user table>_oauth_links" convention. A surviving link re-attaches the
 //     erased account on the next provider sign-in.
 //
-// KNOWN GAP — magic_link_tokens is keyed by EMAIL, not user id, so the
-// declarative eraser (which receives only the user id) cannot reach it. A
-// magic link minted before an erasure and redeemed after it creates a fresh
-// account for that address. Hosts that use magic links should expire
-// outstanding tokens for the address alongside the erasure. Tracked
-// separately; do not assume erasure revokes an in-flight magic link.
+//   - magic_link_tokens: EraseDelete by EMAIL. The token table is keyed by
+//     email, not user id, so the eraser declares IdentityEmail and the
+//     framework resolves the user's email from the user table at erase time
+//     (see the IdentityEmail registration below) and binds it instead of the
+//     user id. This closes the gap where a magic link minted before an erasure
+//     and redeemed after it re-created the erased account.
 //
 // API tokens (auth_api_tokens) are named credentials, not per-user rows —
 // the table has no user column — so a host that scopes tokens to users
@@ -43,8 +43,9 @@ import "github.com/DonaldMurillo/gofastr/framework/datexport"
 //
 // The table names are host-configured (commonly "users"/"auth_users" for the
 // user table). These registrations cover the canonical names; a host that
-// renamed either must datexport.RegisterEraser the actual name, or the
-// canonical entry is skipped with a note at erase time and that table is
+// renamed either must datexport.RegisterEraser the actual name (and, for a
+// renamed user table, re-register the IdentityEmail resolver against it), or
+// the canonical entry is skipped with a note at erase time and that table is
 // excluded from the erasure.
 
 func init() {
@@ -63,5 +64,21 @@ func init() {
 	datexport.RegisterEraser(datexport.DataEraser{
 		Name: "users_oauth_links", Source: "auth", Table: "users_oauth_links",
 		Column: "user_id", Mode: datexport.EraseDelete,
+	})
+	// IdentityEmail resolves the erased user's email from the user table
+	// (auth_users.id → email) ONCE per erasure, before the tx. The
+	// magic-link token table is keyed by email, so its eraser declares
+	// IdentityEmail and the framework binds the resolved email instead of
+	// the user id — closing the gap where an in-flight magic link survived
+	// an erasure and re-created the account. The token table is created
+	// lazily by NewSQLMagicLinkTokenStore; a host on the in-memory store has
+	// no such table, so this eraser is a no-op (skipped at erase time).
+	datexport.RegisterIdentityResolver(datexport.IdentityEmail, datexport.DataIdentityResolver{
+		Table: "auth_users", IDColumn: "id", ValueColumn: "email",
+	})
+	datexport.RegisterEraser(datexport.DataEraser{
+		Name: "magic_link_tokens", Source: "auth", Table: "magic_link_tokens",
+		Column: "email", Mode: datexport.EraseDelete,
+		Identity: datexport.IdentityEmail,
 	})
 }

--- a/battery/auth/erase_test.go
+++ b/battery/auth/erase_test.go
@@ -57,3 +57,41 @@ func TestAuthErasersCoverCredentialTables(t *testing.T) {
 		}
 	}
 }
+
+// magic_link_tokens is keyed by EMAIL, not user id, so a plain user-id eraser
+// cannot reach it. battery/auth closes the gap declaratively: it registers an
+// IdentityEmail resolver (auth_users.id → email) and a magic_link_tokens eraser
+// that declares IdentityEmail. App.EraseUserData then resolves the email at
+// erase time and deletes the user's outstanding tokens, so a pre-erasure magic
+// link can no longer re-create the erased account.
+func TestAuthErasersCoverMagicLinkTokens(t *testing.T) {
+	// The email identity resolver is registered against the user table.
+	r, ok := datexport.ResolveIdentity(datexport.IdentityEmail)
+	if !ok {
+		t.Fatal("IdentityEmail resolver not registered")
+	}
+	if r.Table != "auth_users" || r.IDColumn != "id" || r.ValueColumn != "email" {
+		t.Errorf("IdentityEmail resolver = %+v, want {Table:auth_users, IDColumn:id, ValueColumn:email}", r)
+	}
+
+	// The magic-link token eraser declares the email identity (email column).
+	var ml *datexport.DataEraser
+	for _, e := range datexport.AllErasers() {
+		if e.Name == "magic_link_tokens" && e.Source == "auth" {
+			cp := e
+			ml = &cp
+		}
+	}
+	if ml == nil {
+		t.Fatal("magic_link_tokens eraser not registered")
+	}
+	if ml.Table != "magic_link_tokens" || ml.Column != "email" {
+		t.Errorf("magic_link_tokens = {Table:%q, Column:%q}, want {magic_link_tokens, email}", ml.Table, ml.Column)
+	}
+	if ml.Mode != datexport.EraseDelete {
+		t.Errorf("magic_link_tokens mode = %v, want EraseDelete", ml.Mode)
+	}
+	if ml.Identity != datexport.IdentityEmail {
+		t.Errorf("magic_link_tokens Identity = %v, want IdentityEmail", ml.Identity)
+	}
+}

--- a/battery/print/chromepdf/ssrf_ipliteral_chromium_test.go
+++ b/battery/print/chromepdf/ssrf_ipliteral_chromium_test.go
@@ -59,7 +59,17 @@ func TestResolverRulesBlockIPLiteral(t *testing.T) {
 	defer cancelAlloc()
 	ctx, cancel := chromedp.NewContext(allocCtx)
 	defer cancel()
-	ctx, cancelT := context.WithTimeout(ctx, 45*time.Second)
+
+	// chromedp starts Chrome lazily on the first Run: give the cold
+	// start its own budget so the work budget below is not also a
+	// launch budget (and so it does not cap WSURLReadTimeout).
+	startCtx, startCancel := context.WithTimeout(ctx, 90*time.Second)
+	defer startCancel()
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
+	ctx, cancelT := context.WithTimeout(ctx, 60*time.Second)
 	defer cancelT()
 
 	// A document that fetches the internal address, exactly as a malicious

--- a/cmd/gofastr/dev_e2e_test.go
+++ b/cmd/gofastr/dev_e2e_test.go
@@ -218,6 +218,18 @@ func devE2EBrowserCtx(t *testing.T) context.Context {
 	t.Cleanup(allocCancel)
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the returned context then only has to cover
+	// the assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
 	ctx, cancel := context.WithTimeout(browserCtx, 120*time.Second)
 	t.Cleanup(cancel)
 	return ctx

--- a/cmd/gofastr/dev_live_test.go
+++ b/cmd/gofastr/dev_live_test.go
@@ -467,7 +467,19 @@ location.reload = function() { window.__reloadCalled = true; };
 	defer allocCancel()
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	defer browserCancel()
-	ctx, cancel := context.WithTimeout(browserCtx, 30*time.Second)
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the work context then only has to cover the
+	// assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	defer startCancel()
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)
 	defer cancel()
 
 	// Load page.

--- a/cmd/gofastr/generate_sdkjs_browser_test.go
+++ b/cmd/gofastr/generate_sdkjs_browser_test.go
@@ -111,6 +111,18 @@ func TestGeneratedJSSDK_BrowserRoundTrip(t *testing.T) {
 	defer allocCancel()
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	defer browserCancel()
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the work context then only has to cover the
+	// assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	defer startCancel()
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
 	ctx, cancel := context.WithTimeout(browserCtx, 120*time.Second)
 	defer cancel()
 

--- a/cmd/gofastr/theme_edit_browser_test.go
+++ b/cmd/gofastr/theme_edit_browser_test.go
@@ -133,6 +133,18 @@ func themeEditBrowserCtx(t *testing.T) context.Context {
 	t.Cleanup(allocCancel)
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the returned context then only has to cover
+	// the assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)
 	t.Cleanup(cancel)
 	return ctx

--- a/core-ui/ARCHITECTURE.md
+++ b/core-ui/ARCHITECTURE.md
@@ -104,7 +104,7 @@ server side and the runtime does the work.
 
 | Attribute | Purpose |
 |---|---|
-| `data-fui-rpc="<path>"` | Click / form-submit fires a request to `<path>` |
+| `data-fui-rpc="<path>"` | Click on the element (or submit of a `<form data-fui-rpc>`) fires a request to `<path>`. Body precedence: an explicit `data-fui-rpc-body` JSON wins; otherwise a `<form>` node serializes itself, and any other form control (radio/select/input/textarea) serializes its ENCLOSING form via `node.form` so the control's own `name=value` round-trips (`framework/ui.SegmentedControl` `RPCPath` relies on this — place the control inside a `<form>`); a control with no enclosing form and no explicit body posts an empty body. GET folds the serialized form into the query string; a multipart form (or one with a file input) posts `FormData`, everything else posts JSON. |
 | `data-fui-rpc-method="GET\|POST\|…"` | HTTP method (default POST) |
 | `data-fui-rpc-signal="<name>"` | The response body is treated as a signal value and broadcast to bound nodes |
 | `data-fui-rpc-close` | Containing widget closes on 2xx |

--- a/core-ui/runtime/compute_e2e_test.go
+++ b/core-ui/runtime/compute_e2e_test.go
@@ -228,6 +228,18 @@ func newComputeBrowserCtx(t *testing.T) context.Context {
 	t.Cleanup(allocCancel)
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the returned context then only has to cover
+	// the assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)
 	t.Cleanup(cancel)
 	return ctx

--- a/core-ui/runtime/input_trigger_e2e_test.go
+++ b/core-ui/runtime/input_trigger_e2e_test.go
@@ -76,7 +76,19 @@ func TestInputTrigger_SelectFiresRPC(t *testing.T) {
 	t.Cleanup(allocCancel)
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
-	ctx, cancel := context.WithTimeout(browserCtx, 30*time.Second)
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the work context then only has to cover the
+	// assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)
 	t.Cleanup(cancel)
 
 	if err := chromedp.Run(ctx,

--- a/core-ui/runtime/nav_match_prefix_e2e_test.go
+++ b/core-ui/runtime/nav_match_prefix_e2e_test.go
@@ -72,7 +72,19 @@ func navPrefixBrowser(t *testing.T) context.Context {
 	t.Cleanup(allocCancel)
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
-	ctx, cancel := context.WithTimeout(browserCtx, 30*time.Second)
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the returned context then only has to cover
+	// the assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)
 	t.Cleanup(cancel)
 	return ctx
 }

--- a/core-ui/runtime/poll_e2e_test.go
+++ b/core-ui/runtime/poll_e2e_test.go
@@ -84,6 +84,18 @@ func newPollBrowserCtx(t *testing.T) context.Context {
 	t.Cleanup(allocCancel)
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the returned context then only has to cover
+	// the assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)
 	t.Cleanup(cancel)
 	return ctx

--- a/core-ui/runtime/runtime_forms_e2e_test.go
+++ b/core-ui/runtime/runtime_forms_e2e_test.go
@@ -129,7 +129,19 @@ func newFormBrowserCtx(t *testing.T) context.Context {
 	t.Cleanup(allocCancel)
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
-	ctx, cancel := context.WithTimeout(browserCtx, 30*time.Second)
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the returned context then only has to cover
+	// the assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)
 	t.Cleanup(cancel)
 	return ctx
 }

--- a/core-ui/runtime/seed_e2e_test.go
+++ b/core-ui/runtime/seed_e2e_test.go
@@ -63,10 +63,21 @@ func newSeedBrowserCtx(t *testing.T) context.Context {
 	t.Cleanup(allocCancel)
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
-	// Windows runners can spend longer connecting to a freshly started
-	// browser when the package has already exercised several E2E fixtures.
-	// Keep the operation deadline aligned with the allocator's generous
-	// websocket startup budget instead of failing during browser startup.
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the returned context then only has to cover
+	// the assertions. Windows runners can spend longer connecting to a freshly
+	// started browser when the package has already exercised several E2E
+	// fixtures, so this cold-start budget matches the allocator's generous
+	// websocket startup budget.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
 	ctx, cancel := context.WithTimeout(browserCtx, 90*time.Second)
 	t.Cleanup(cancel)
 	return ctx

--- a/core-ui/runtime/segmented_rpc_e2e_test.go
+++ b/core-ui/runtime/segmented_rpc_e2e_test.go
@@ -1,0 +1,342 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// segmentedRadio emits the exact <input type="radio"> markup the
+// framework/ui.SegmentedControl component renders for one option (see
+// framework/ui/segmented.go). Keeping the runtime-level fixture
+// byte-equivalent to the component output means this test exercises the
+// real dispatch path without crossing the core-ui → framework layer line;
+// framework/ui/segmented_test.go pins that the component emits these
+// attributes. rpc.js is the unit under test here, not the component.
+const segmentedRadio = `
+<input type="radio" name="%s" value="%s" class="ui-segmented__input" id="%s--%s"
+       data-fui-rpc="%s" data-fui-rpc-method="POST"%s>`
+
+func segmentedPage(form bool, extraInputAttrs, signalSpan string) string {
+	var signalAttr string
+	if signalSpan != "" {
+		signalAttr = ` data-fui-rpc-signal="` + signalSpan + `"`
+	}
+	radio := func(val string) string {
+		return fmt.Sprintf(segmentedRadio, "plan", val, "plan", val, "/plan/set", signalAttr+extraInputAttrs)
+	}
+	open, closeTag := "<div>", "</div>"
+	if form {
+		open, closeTag = `<form id="picker">`, `</form>`
+	}
+	echo := "single"
+	if signalSpan == "" {
+		echo = ""
+	}
+	return fmt.Sprintf(`<!doctype html><html><head><title>seg</title></head><body>
+%s
+  <div class="ui-segmented" role="radiogroup" aria-label="Plan" data-count="2">
+    <label class="ui-segmented__option" for="plan--single" data-position="0">%s<span>Single machine</span></label>
+    <label class="ui-segmented__option" for="plan--unlimited" data-position="1">%s<span>Unlimited machines</span></label>
+  </div>
+%s
+<p>Chosen: <span id="echo" data-fui-signal="plan-echo" data-fui-signal-mode="text">%s</span></p>
+<span id="ready">ready</span>
+<script src="/__gofastr/runtime.js"></script>
+</body></html>`, open, radio("single"), radio("unlimited"), closeTag, echo)
+}
+
+// planSetHandler records the decoded JSON body and replies with the chosen
+// plan value — falling back to the SAME confident default a real handler
+// uses when the field is missing. Before the fix the body is empty, so the
+// handler reads plan="" and renders "single" even after the operator clicks
+// "Unlimited machines": the bug is not a missing request, it is a request
+// that arrives without the selection, producing a confidently wrong answer.
+func planSetHandler(t *testing.T, mu *sync.Mutex, recorded *map[string]string, hits *int) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var m map[string]string
+		if len(raw) > 0 {
+			_ = json.Unmarshal(raw, &m)
+		}
+		mu.Lock()
+		*hits++
+		*recorded = m
+		mu.Unlock()
+		chosen := m["plan"]
+		if chosen == "" {
+			chosen = "single" // the confidently-wrong default the empty-body bug produces
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprint(w, chosen)
+	}
+}
+
+// TestSegmentedControl_RPCPostsSelectedValue is the core proof for #194: a
+// SegmentedControl radio inside a <form> with RPCPath must POST a body
+// carrying the CHOSEN segment's name=value so the handler renders the right
+// value, not the default. The old rpc.js only serialized a FORM node, so a
+// radio dispatched with an empty body and the handler fell through to its
+// default — clicking "Unlimited machines" rendered "single".
+func TestSegmentedControl_RPCPostsSelectedValue(t *testing.T) {
+	js, err := RuntimeJS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mu sync.Mutex
+	var recorded map[string]string
+	hits := 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/__gofastr/runtime.js", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Write([]byte(js))
+	})
+	handleRuntimeModules(t, mux)
+	mux.HandleFunc("/plan/set", planSetHandler(t, &mu, &recorded, &hits))
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, segmentedPage(true, "", "plan-echo"))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	ctx := newSeedBrowserCtx(t)
+	var echo string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`#ready`, chromedp.ByID),
+		// Click the "Unlimited machines" radio. The browser checks it before
+		// the click event fires, so new FormData(radio.form) carries plan=unlimited.
+		chromedp.Click(`#plan--unlimited`, chromedp.ByID),
+		chromedp.Sleep(800*time.Millisecond),
+		chromedp.Text(`#echo`, &echo, chromedp.ByID),
+	); err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits != 1 {
+		t.Fatalf("plan RPC hit %d time(s), want 1", hits)
+	}
+	got := recorded["plan"]
+	if got != "unlimited" {
+		t.Errorf("server received plan=%q, want \"unlimited\" — the radio's selection did not round-trip in the body (recorded=%v)", got, recorded)
+	}
+	// The echo is the user-visible symptom: before the fix the empty body made
+	// the handler render its default, so the operator saw "single" after
+	// clicking "Unlimited machines". Assert the CHOSEN value renders.
+	if echo != "unlimited" {
+		t.Errorf("echo rendered %q, want \"unlimited\" — the server echoed its default because the selection never arrived", echo)
+	}
+}
+
+// TestSegmentedControl_RPCExplicitBodyWins pins the precedence contract:
+// an explicit data-fui-rpc-body must still win over form serialization so
+// existing callers that hand-craft a JSON body are not regressed. This test
+// passes before AND after the fix — it is a regression guard for the
+// precedence the fix must preserve.
+func TestSegmentedControl_RPCExplicitBodyWins(t *testing.T) {
+	js, err := RuntimeJS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mu sync.Mutex
+	var recorded map[string]string
+	hits := 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/__gofastr/runtime.js", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Write([]byte(js))
+	})
+	handleRuntimeModules(t, mux)
+	mux.HandleFunc("/plan/set", planSetHandler(t, &mu, &recorded, &hits))
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		// data-fui-rpc-body on the radio; the form also carries a plan field
+		// whose value differs, so the assertion can tell which source won.
+		fmt.Fprint(w, segmentedPage(true, ` data-fui-rpc-body='{"plan":"override"}'`, ""))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	ctx := newSeedBrowserCtx(t)
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`#ready`, chromedp.ByID),
+		chromedp.Click(`#plan--unlimited`, chromedp.ByID),
+		chromedp.Sleep(800*time.Millisecond),
+	); err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits != 1 {
+		t.Fatalf("plan RPC hit %d time(s), want 1", hits)
+	}
+	if recorded["plan"] != "override" {
+		t.Errorf("plan=%q, want \"override\" — explicit data-fui-rpc-body must win over form serialization", recorded["plan"])
+	}
+}
+
+// TestSegmentedControl_RPCNoFormDoesNotError pins requirement #3: a form
+// control with NO enclosing form (node.form === null) and no explicit body
+// keeps today's behaviour — the request fires with an empty body and the
+// runtime must not throw serializing a null form. This passes before AND
+// after the fix; it guards against the fix introducing a FormData(null) throw.
+func TestSegmentedControl_RPCNoFormDoesNotError(t *testing.T) {
+	js, err := RuntimeJS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mu sync.Mutex
+	var recorded map[string]string
+	hits := 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/__gofastr/runtime.js", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Write([]byte(js))
+	})
+	handleRuntimeModules(t, mux)
+	mux.HandleFunc("/plan/set", planSetHandler(t, &mu, &recorded, &hits))
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		// No <form> wrapper: node.form is null on every radio. A page-level
+		// error recorder runs BEFORE the runtime so a FormData(null) throw is
+		// observable — hit==1 alone would not distinguish "no body" from "threw
+		// before fetch".
+		fmt.Fprint(w, `<!doctype html><html><head><title>seg-noform</title></head><body>
+<script>window.__pageErrors=[];window.addEventListener('error',function(e){window.__pageErrors.push(e.message||String(e));});</script>
+<div class="ui-segmented" role="radiogroup" aria-label="Plan" data-count="2">
+  <label class="ui-segmented__option" for="plan--single" data-position="0">
+    <input type="radio" name="plan" value="single" class="ui-segmented__input" id="plan--single" data-fui-rpc="/plan/set" data-fui-rpc-method="POST" data-fui-rpc-signal="plan-echo" checked>
+    <span>Single machine</span>
+  </label>
+  <label class="ui-segmented__option" for="plan--unlimited" data-position="1">
+    <input type="radio" name="plan" value="unlimited" class="ui-segmented__input" id="plan--unlimited" data-fui-rpc="/plan/set" data-fui-rpc-method="POST" data-fui-rpc-signal="plan-echo">
+    <span>Unlimited machines</span>
+  </label>
+</div>
+<span id="echo" data-fui-signal="plan-echo" data-fui-signal-mode="text">single</span>
+<span id="ready">ready</span>
+<script src="/__gofastr/runtime.js"></script>
+</body></html>`)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	ctx := newSeedBrowserCtx(t)
+	var pageErrs []string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`#ready`, chromedp.ByID),
+		chromedp.Click(`#plan--unlimited`, chromedp.ByID),
+		chromedp.Sleep(700*time.Millisecond),
+		chromedp.Evaluate(`window.__pageErrors`, &pageErrs),
+	); err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits != 1 {
+		t.Fatalf("plan RPC hit %d time(s), want 1 — a form control with no enclosing form must still dispatch (empty body), not error", hits)
+	}
+	if len(pageErrs) > 0 {
+		t.Errorf("unexpected page error(s) dispatching a form-control RPC with no form: %v", pageErrs)
+	}
+	// No form → legacy empty body. The recorded map has no plan; that is
+	// today's documented behaviour, NOT a regression.
+	if plan, ok := recorded["plan"]; ok && plan != "" {
+		t.Errorf("no-form control posted plan=%q unexpectedly; a control with no enclosing form must keep the legacy empty body", plan)
+	}
+}
+
+// TestKiln_RPCFormControlCarriesValue covers the SIBLING dispatcher
+// (_dispatchKiln) for the same class of bug: a data-kiln-tool form control
+// inside a <form> must carry its value, not post ” (data-kiln-args). The
+// kiln path only serializes a FORM node today, so a radio posts an empty
+// JSON body. Explicit data-kiln-args still wins; this uses a bare control
+// so the new form-serialization branch is the one under test.
+func TestKiln_RPCFormControlCarriesValue(t *testing.T) {
+	js, err := RuntimeJS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mu sync.Mutex
+	var recorded map[string]string
+	hits := 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/__gofastr/runtime.js", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Write([]byte(js))
+	})
+	handleRuntimeModules(t, mux)
+	mux.HandleFunc("/kiln/tool/set-plan", func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var m map[string]string
+		if len(raw) > 0 {
+			_ = json.Unmarshal(raw, &m)
+		}
+		mu.Lock()
+		hits++
+		recorded = m
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{}`)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		// kiln-app body class satisfies _kilnOK so _dispatchKiln runs.
+		fmt.Fprint(w, `<!doctype html><html><head><title>kiln</title></head><body class="kiln-app">
+<form id="picker">
+  <div class="ui-segmented" role="radiogroup" aria-label="Plan" data-count="2">
+    <label class="ui-segmented__option" for="plan--single" data-position="0">
+      <input type="radio" name="plan" value="single" class="ui-segmented__input" id="plan--single" data-kiln-tool="set-plan" checked>
+      <span>Single machine</span>
+    </label>
+    <label class="ui-segmented__option" for="plan--unlimited" data-position="1">
+      <input type="radio" name="plan" value="unlimited" class="ui-segmented__input" id="plan--unlimited" data-kiln-tool="set-plan">
+      <span>Unlimited machines</span>
+    </label>
+  </div>
+</form>
+<span id="ready">ready</span>
+<script src="/__gofastr/runtime.js"></script>
+</body></html>`)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	ctx := newSeedBrowserCtx(t)
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`#ready`, chromedp.ByID),
+		chromedp.Click(`#plan--unlimited`, chromedp.ByID),
+		chromedp.Sleep(700*time.Millisecond),
+	); err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits != 1 {
+		t.Fatalf("kiln tool hit %d time(s), want 1", hits)
+	}
+	if recorded["plan"] != "unlimited" {
+		t.Errorf("kiln tool received plan=%q, want \"unlimited\" — a data-kiln-tool form control must serialize its form, not post '' (recorded=%v)", recorded["plan"], recorded)
+	}
+}

--- a/core-ui/runtime/src/rpc.js
+++ b/core-ui/runtime/src/rpc.js
@@ -41,6 +41,15 @@
       const obj = {};
       new FormData(node).forEach((v, k) => { obj[k] = v; });
       body = JSON.stringify(obj);
+    } else if (!body && node.form) {
+      // A form control that belongs to a form (radio/select/input/textarea
+      // with node.form set) carries its value by serializing the enclosing
+      // form — the same class as the data-fui-rpc fix below. Explicit
+      // data-kiln-args wins (read above); a control with no form keeps the
+      // legacy '' body rather than erroring.
+      const obj = {};
+      new FormData(node.form).forEach((v, k) => { obj[k] = v; });
+      body = JSON.stringify(obj);
     }
     await _kilnPost(node, body);
   }
@@ -130,14 +139,20 @@
     let body = node.getAttribute('data-fui-rpc-body');
     let resolvedPath = path;
     let bodyIsFormData = false;
-    if (!body && node.tagName === 'FORM') {
-      const fd = new FormData(node);
+    // A form control that belongs to a form (every radio/input/select/
+    // textarea with node.form set) carries its value exactly like a FORM
+    // node: serialize the enclosing form so the handler sees name=value.
+    // An explicit data-fui-rpc-body (read above) still wins; a control with
+    // no enclosing form and no explicit body keeps the legacy empty body.
+    const formSource = node.tagName === 'FORM' ? node : (node.form || null);
+    if (!body && formSource) {
+      const fd = new FormData(formSource);
       if (method === 'GET') {
         const params = new URLSearchParams();
         fd.forEach((v, k) => { if (v != null) params.append(k, String(v)); });
         const qs = params.toString();
         if (qs) resolvedPath = path + (path.includes('?') ? '&' : '?') + qs;
-      } else if (node.enctype === 'multipart/form-data' || node.querySelector('input[type="file"]')) {
+      } else if (formSource.enctype === 'multipart/form-data' || formSource.querySelector('input[type="file"]')) {
         body = fd;
         bodyIsFormData = true;
       } else {

--- a/core-ui/runtime/tabs_aria_e2e_test.go
+++ b/core-ui/runtime/tabs_aria_e2e_test.go
@@ -63,7 +63,19 @@ func TestTabClickUpdatesAriaSelected(t *testing.T) {
 	t.Cleanup(allocCancel)
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
-	ctx, cancel := context.WithTimeout(browserCtx, 30*time.Second)
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the work context then only has to cover the
+	// assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)
 	t.Cleanup(cancel)
 
 	var sel0, sel1, active string

--- a/core-ui/widget/slot_surface_dom_test.go
+++ b/core-ui/widget/slot_surface_dom_test.go
@@ -41,7 +41,19 @@ func newBareBrowserCtx(t *testing.T) context.Context {
 	t.Cleanup(allocCancel)
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
-	ctx, cancel := context.WithTimeout(browserCtx, 30*time.Second)
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the returned context then only has to cover
+	// the assertions. (Same fix as cmd/gofastr's blueprint e2e.)
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)
 	t.Cleanup(cancel)
 	return ctx
 }

--- a/core/middleware/idempotency.go
+++ b/core/middleware/idempotency.go
@@ -38,7 +38,7 @@ const IdempotencyKeyHeader = "Idempotency-Key"
 //     unless IdempotencyConfig.FailOpen is true.
 type IdempotencyStore interface {
 	Begin(ctx context.Context, key, fingerprint string) (replay *IdempotentResponse, ok bool, err error)
-	Finish(ctx context.Context, key string, resp *IdempotentResponse) error
+	Finish(ctx context.Context, key, fingerprint string, resp *IdempotentResponse) error
 }
 
 // IdempotentResponse is the cached snapshot of a completed write.
@@ -266,7 +266,7 @@ func Idempotency(cfg IdempotencyConfig) Middleware {
 			// only correct action is to make the loss observable — silently
 			// dropping it is the bug this fixes.
 			finish := func(resp *IdempotentResponse) {
-				if err := cfg.Store.Finish(finishCtx, storeKey, resp); err != nil {
+				if err := cfg.Store.Finish(finishCtx, storeKey, fp, resp); err != nil {
 					cfg.Logger.Error("idempotency: Finish failed (claim stranded; retries of this key will 409 until TTL)",
 						"key", key, "error", err)
 				}
@@ -499,13 +499,21 @@ func (s *memoryIdempotencyStore) Begin(_ context.Context, key, fingerprint strin
 	return nil, false, nil
 }
 
-func (s *memoryIdempotencyStore) Finish(_ context.Context, key string, resp *IdempotentResponse) error {
+func (s *memoryIdempotencyStore) Finish(_ context.Context, key, fingerprint string, resp *IdempotentResponse) error {
 	now := time.Now()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	e, ok := s.entries[key]
 	if !ok {
+		return nil
+	}
+	// Only the owner of the in-flight claim may mutate or release it. If the
+	// claim expired and was re-assigned to a different fingerprint while this
+	// handler was still running, Finish must be a no-op: writing would clobber
+	// the new owner's claim and replay this caller's response to them on retry
+	// — a cross-user disclosure. See TestIdemFinishOnlyWritesOwnClaim.
+	if e.fingerprint != fingerprint {
 		return nil
 	}
 	if resp == nil {

--- a/core/middleware/idempotency_security_test.go
+++ b/core/middleware/idempotency_security_test.go
@@ -305,12 +305,19 @@ func runFinishOwnClaim(t *testing.T, s IdempotencyStore) {
 // fresh claim, so the assertion never false-fails on correct code. The memory
 // store serializes under a mutex and is immune by construction; it is covered
 // here as the property x surface pairing.
+//
+// The in-flight TTL here is deliberately LONG. The seeded row is already
+// expired, so the reclaim path still runs, but a winner's fresh claim cannot
+// legitimately expire mid-race — with a short TTL a slow, loaded runner lets a
+// later racer correctly re-claim an expired row, which is the TTL working and
+// is indistinguishable from the bug. A long TTL makes a second fresh claim
+// proof that the DELETE removed a live one.
 
 func TestIdemReclaimKeepsFreshRow(t *testing.T) {
 	t.Run("memory", func(t *testing.T) {
 		ms := &memoryIdempotencyStore{
-			ttl:         time.Second,
-			inFlightTTL: 30 * time.Millisecond,
+			ttl:         time.Minute,
+			inFlightTTL: 30 * time.Second,
 			entries:     map[string]*idemEntry{},
 		}
 		ctx := context.Background()
@@ -327,7 +334,7 @@ func TestIdemReclaimKeepsFreshRow(t *testing.T) {
 		runReclaimOneWinner(t, ms, "k-f4", reseed)
 	})
 	t.Run("sql", func(t *testing.T) {
-		db, s := newWALSQLIdemStore(t, 30*time.Millisecond)
+		db, s := newWALSQLIdemStore(t, 30*time.Second)
 		ctx := context.Background()
 		// Run one Begin up front so the per-minute reap has already fired and
 		// won't delete our seeded expired row before the racers reach the

--- a/core/middleware/idempotency_security_test.go
+++ b/core/middleware/idempotency_security_test.go
@@ -2,10 +2,12 @@ package middleware
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -98,7 +100,7 @@ type brokenStore struct{}
 func (brokenStore) Begin(context.Context, string, string) (*IdempotentResponse, bool, error) {
 	return nil, false, errors.New("store down")
 }
-func (brokenStore) Finish(context.Context, string, *IdempotentResponse) error {
+func (brokenStore) Finish(context.Context, string, string, *IdempotentResponse) error {
 	return nil
 }
 
@@ -165,7 +167,7 @@ func (s *recordingStore) Begin(ctx context.Context, key, fp string) (*Idempotent
 	return nil, false, nil
 }
 
-func (s *recordingStore) Finish(ctx context.Context, key string, resp *IdempotentResponse) error {
+func (s *recordingStore) Finish(ctx context.Context, key, fingerprint string, resp *IdempotentResponse) error {
 	s.mu.Lock()
 	s.finishCalled = true
 	s.finishCtxErr = ctx.Err()
@@ -217,4 +219,197 @@ func TestIdempotency_FinishUsesUncancelledContext(t *testing.T) {
 	if store.finishCtxErr != nil {
 		t.Fatalf("Finish must use uncancelled context to record cleanup; ctx.Err at call time=%v", store.finishCtxErr)
 	}
+}
+
+// ----- F1: Finish must only write the claim Begin created -------------------
+//
+// SECURITY (cross-user disclosure): Begin claims a key with a fingerprint, but
+// the in-flight claim can expire while the handler is still running. A second
+// caller then re-claims the SAME key under a DIFFERENT fingerprint. If Finish
+// persists by key alone (ignoring which fingerprint owns the row), the first
+// caller's late Finish staples its response onto the second caller's row — and
+// because Begin never rewrites the fingerprint column, the second caller's
+// retry matches the fingerprint and is served the FIRST caller's body. That is a
+// cross-user leak whenever Principal returns a user/tenant id.
+//
+// The fix is a breaking signature change — Finish now takes the fingerprint and
+// a store MUST refuse to write a row whose fingerprint does not match. The
+// optional-interface alternative was rejected: it leaves every third-party
+// IdempotencyStore silently vulnerable, which is the wrong default for a leak of
+// this kind. Memory and SQL both honour it below.
+
+func TestIdemFinishOnlyWritesOwnClaim(t *testing.T) {
+	t.Run("memory", func(t *testing.T) {
+		s := &memoryIdempotencyStore{
+			ttl:         time.Second,
+			inFlightTTL: 50 * time.Millisecond,
+			entries:     map[string]*idemEntry{},
+		}
+		runFinishOwnClaim(t, s)
+	})
+	t.Run("sql", func(t *testing.T) {
+		_, s := openSQLIdemStore(t)
+		s.inFlightTTL = 50 * time.Millisecond // tiny in-flight window so the claim expires mid-handler
+		runFinishOwnClaim(t, s)
+	})
+}
+
+func runFinishOwnClaim(t *testing.T, s IdempotencyStore) {
+	t.Helper()
+	ctx := context.Background()
+	const key = "k-f1"
+	const fpA = "fp-userA"
+	const fpB = "fp-userB"
+	const secretA = `{"secret":"USER-A-PRIVATE-ORDER"}`
+
+	// 1. User A claims the key (in-flight, short TTL).
+	if _, ok, err := s.Begin(ctx, key, fpA); err != nil || ok {
+		t.Fatalf("A fresh claim: ok=%v err=%v", ok, err)
+	}
+	// 2. A's claim expires while its handler is still running.
+	time.Sleep(80 * time.Millisecond)
+	// 3. User B — same key, DIFFERENT body/fingerprint — re-claims the stale row.
+	if _, ok, err := s.Begin(ctx, key, fpB); err != nil || ok {
+		t.Fatalf("B re-claim of A's expired claim: ok=%v err=%v", ok, err)
+	}
+	// 4. A's handler finally returns and tries to persist A's response.
+	respA := &IdempotentResponse{
+		Status: http.StatusOK,
+		Header: http.Header{"X-Owner": []string{"user-A"}},
+		Body:   []byte(secretA),
+	}
+	if err := s.Finish(ctx, key, fpA, respA); err != nil {
+		t.Fatalf("A Finish: %v", err)
+	}
+	// 5. B's retry must NEVER receive A's response body. Assert on the BODY — a
+	// status-only check would miss the disclosure (A's status can be 200 too).
+	replay, ok, err := s.Begin(ctx, key, fpB)
+	if ok && replay != nil && string(replay.Body) == secretA {
+		t.Fatalf("F1 cross-user disclosure: B's retry was served A's body %q (status=%d, err=%v)",
+			secretA, replay.Status, err)
+	}
+}
+
+// ----- F4: expired-claim reclaim must not delete a fresh claim --------------
+//
+// When Begin finds an expired row it deletes the stale claim and re-claims. The
+// DELETE once matched on key alone, with no expiry predicate. Under contention
+// two callers can both observe the expired row: the first deletes it and inserts
+// a FRESH claim; the second's key-only DELETE then destroys that FRESH claim and
+// it re-inserts — so BOTH believe they own the key and BOTH run the handler.
+// That is the double-execution the middleware exists to prevent, and it defeats
+// the ErrInFlight fallback. The DELETE is now expiry-gated
+// (WHERE key = $1 AND expires_at <= $2).
+//
+// This is a race-invariant guard: with the fix exactly ONE caller ever obtains a
+// fresh claim, so the assertion never false-fails on correct code. The memory
+// store serializes under a mutex and is immune by construction; it is covered
+// here as the property x surface pairing.
+
+func TestIdemReclaimKeepsFreshRow(t *testing.T) {
+	t.Run("memory", func(t *testing.T) {
+		ms := &memoryIdempotencyStore{
+			ttl:         time.Second,
+			inFlightTTL: 30 * time.Millisecond,
+			entries:     map[string]*idemEntry{},
+		}
+		ctx := context.Background()
+		_, _, _ = ms.Begin(ctx, "warmup", "fp-w") // consume the first-call reap
+		reseed := func() {
+			ms.mu.Lock()
+			ms.entries["k-f4"] = &idemEntry{
+				fingerprint: "fp-seed",
+				expires:     time.Now().Add(-time.Second),
+				createdAt:   time.Now().Add(-2 * time.Second),
+			}
+			ms.mu.Unlock()
+		}
+		runReclaimOneWinner(t, ms, "k-f4", reseed)
+	})
+	t.Run("sql", func(t *testing.T) {
+		db, s := newWALSQLIdemStore(t, 30*time.Millisecond)
+		ctx := context.Background()
+		// Run one Begin up front so the per-minute reap has already fired and
+		// won't delete our seeded expired row before the racers reach the
+		// reclaim path (the steady-state condition this fix targets).
+		if _, _, err := s.Begin(ctx, "warmup", "fp-warmup"); err != nil {
+			t.Fatalf("warmup Begin: %v", err)
+		}
+		reseed := func() {
+			if _, err := db.Exec("DELETE FROM idempotency_keys WHERE key = ?", "k-f4"); err != nil {
+				t.Fatalf("reseed delete: %v", err)
+			}
+			now := time.Now()
+			if _, err := db.Exec(
+				"INSERT INTO idempotency_keys (key, fingerprint, expires_at, created_at) VALUES (?, ?, ?, ?)",
+				"k-f4", "fp-seed", now.Add(-time.Second), now.Add(-2*time.Second),
+			); err != nil {
+				t.Fatalf("reseed insert: %v", err)
+			}
+		}
+		runReclaimOneWinner(t, s, "k-f4", reseed)
+	})
+}
+
+func runReclaimOneWinner(t *testing.T, s IdempotencyStore, key string, reseed func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	// The F4 window (SELECT sees an expired row, then a concurrent INSERT lands,
+	// then this caller's key-only DELETE removes the fresh claim) is narrow, so a
+	// single race rarely trips. We run many reseeded iterations per invocation to
+	// make a regression reliably observable while keeping the guard deterministic
+	// on correct code: with the fix every iteration yields exactly one winner, so
+	// the assertion can never false-fail.
+	const racers = 60
+	const iters = 60
+	var maxFresh int64
+	for range iters {
+		reseed()
+		var fresh int64
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for i := range racers {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				<-start
+				fp := fmt.Sprintf("fp-%d", i)
+				_, ok, err := s.Begin(ctx, key, fp)
+				if err == nil && !ok {
+					atomic.AddInt64(&fresh, 1)
+				}
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+		if f := atomic.LoadInt64(&fresh); f > maxFresh {
+			maxFresh = f
+		}
+		if maxFresh > 1 {
+			break
+		}
+	}
+	t.Logf("F4 race: maxFresh=%d over up to %d iterations x %d racers (want <=1)", maxFresh, iters, racers)
+	if maxFresh > 1 {
+		t.Fatalf("F4: %d callers obtained a fresh claim for one key in a single iteration — the reclaim path deleted a fresh claim", maxFresh)
+	}
+}
+
+// newWALSQLIdemStore opens a file-backed sqlite DB in WAL mode with several
+// connections so concurrent Begins genuinely interleave. The in-memory store
+// used elsewhere is pinned to one connection and cannot reproduce the race.
+func newWALSQLIdemStore(t *testing.T, inFlightTTL time.Duration) (*sql.DB, *SQLIdempotencyStore) {
+	t.Helper()
+	dsn := filepath.Join(t.TempDir(), "idem_f4.db") + "?_pragma=journal_mode(WAL)"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	s, err := NewSQLIdempotencyStore(db, WithSQLIdempotencyInFlightTTL(inFlightTTL))
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	return db, s
 }

--- a/core/middleware/idempotency_silent_test.go
+++ b/core/middleware/idempotency_silent_test.go
@@ -19,7 +19,7 @@ type finishErrorStore struct{}
 func (finishErrorStore) Begin(context.Context, string, string) (*IdempotentResponse, bool, error) {
 	return nil, true, nil // first writer; middleware must call Finish
 }
-func (finishErrorStore) Finish(context.Context, string, *IdempotentResponse) error {
+func (finishErrorStore) Finish(context.Context, string, string, *IdempotentResponse) error {
 	return errors.New("finish failed: db down")
 }
 

--- a/core/middleware/idempotency_sql.go
+++ b/core/middleware/idempotency_sql.go
@@ -186,11 +186,15 @@ func (s *SQLIdempotencyStore) Begin(ctx context.Context, key, fingerprint string
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
 		// Existing row was expired (or reaped between the failed insert
-		// and this read). Delete any stale row then retry the claim
-		// once — second insert wins now that the conflict is gone.
+		// and this read). Delete the stale row then retry the claim once —
+		// the second insert wins now that the conflict is gone. The DELETE is
+		// expiry-gated so a concurrent re-claimer can never remove a FRESH
+		// claim another caller just inserted (which would let both run the
+		// handler — the double-execution idempotency exists to prevent). See
+		// TestIdemReclaimKeepsFreshRow.
 		if _, deleteErr := s.db.ExecContext(ctx,
-			fmt.Sprintf("DELETE FROM %s WHERE key = %s", s.table, s.placeholder(1)),
-			key,
+			fmt.Sprintf("DELETE FROM %s WHERE key = %s AND expires_at <= %s", s.table, s.placeholder(1), s.placeholder(2)),
+			key, now,
 		); deleteErr != nil {
 			return nil, false, fmt.Errorf("idempotency: delete expired claim: %w", deleteErr)
 		}
@@ -227,11 +231,11 @@ func (s *SQLIdempotencyStore) Begin(ctx context.Context, key, fingerprint string
 }
 
 // Finish implements IdempotencyStore.
-func (s *SQLIdempotencyStore) Finish(ctx context.Context, key string, resp *IdempotentResponse) error {
+func (s *SQLIdempotencyStore) Finish(ctx context.Context, key, fingerprint string, resp *IdempotentResponse) error {
 	if resp == nil {
 		_, err := s.db.ExecContext(ctx,
-			fmt.Sprintf("DELETE FROM %s WHERE key = %s", s.table, s.placeholder(1)),
-			key,
+			fmt.Sprintf("DELETE FROM %s WHERE key = %s AND fingerprint = %s", s.table, s.placeholder(1), s.placeholder(2)),
+			key, fingerprint,
 		)
 		return err
 	}
@@ -241,10 +245,10 @@ func (s *SQLIdempotencyStore) Finish(ctx context.Context, key string, resp *Idem
 	}
 	expires := time.Now().Add(s.ttl)
 	_, err = s.db.ExecContext(ctx, fmt.Sprintf(
-		"UPDATE %s SET status = %s, headers = %s, body = %s, expires_at = %s WHERE key = %s",
+		"UPDATE %s SET status = %s, headers = %s, body = %s, expires_at = %s WHERE key = %s AND fingerprint = %s",
 		s.table,
-		s.placeholder(1), s.placeholder(2), s.placeholder(3), s.placeholder(4), s.placeholder(5),
-	), resp.Status, string(hdrJSON), resp.Body, expires, key)
+		s.placeholder(1), s.placeholder(2), s.placeholder(3), s.placeholder(4), s.placeholder(5), s.placeholder(6),
+	), resp.Status, string(hdrJSON), resp.Body, expires, key, fingerprint)
 	return err
 }
 

--- a/core/middleware/idempotency_sql_test.go
+++ b/core/middleware/idempotency_sql_test.go
@@ -47,7 +47,7 @@ func TestSQLIdempotency_FreshClaimAndReplay(t *testing.T) {
 		Header: http.Header{"X-Custom": []string{"v"}},
 		Body:   []byte(`{"id":1}`),
 	}
-	if err := s.Finish(ctx, "k1", cached); err != nil {
+	if err := s.Finish(ctx, "k1", "fp1", cached); err != nil {
 		t.Fatalf("finish: %v", err)
 	}
 
@@ -65,7 +65,7 @@ func TestSQLIdempotency_FingerprintMismatch(t *testing.T) {
 	_, s := openSQLIdemStore(t)
 	ctx := context.Background()
 	_, _, _ = s.Begin(ctx, "k", "fp1")
-	_ = s.Finish(ctx, "k", &IdempotentResponse{Status: 200, Header: http.Header{}, Body: []byte("ok")})
+	_ = s.Finish(ctx, "k", "fp1", &IdempotentResponse{Status: 200, Header: http.Header{}, Body: []byte("ok")})
 
 	_, _, err := s.Begin(ctx, "k", "different-fp")
 	if !errors.Is(err, ErrFingerprintMismatch) {
@@ -77,7 +77,7 @@ func TestSQLIdempotency_FinishNilReleasesClaim(t *testing.T) {
 	_, s := openSQLIdemStore(t)
 	ctx := context.Background()
 	_, _, _ = s.Begin(ctx, "k", "fp")
-	if err := s.Finish(ctx, "k", nil); err != nil {
+	if err := s.Finish(ctx, "k", "fp", nil); err != nil {
 		t.Fatalf("finish nil: %v", err)
 	}
 	// Subsequent call should be a fresh claim, not in-flight.
@@ -95,7 +95,7 @@ func TestSQLIdempotency_ExpiryAllowsFreshClaim(t *testing.T) {
 	}
 	ctx := context.Background()
 	_, _, _ = s.Begin(ctx, "k", "fp")
-	_ = s.Finish(ctx, "k", &IdempotentResponse{Status: 200, Header: http.Header{}, Body: []byte("ok")})
+	_ = s.Finish(ctx, "k", "fp", &IdempotentResponse{Status: 200, Header: http.Header{}, Body: []byte("ok")})
 	time.Sleep(40 * time.Millisecond)
 	resp, ok, err := s.Begin(ctx, "k", "fp")
 	if err != nil || ok || resp != nil {

--- a/core/middleware/idempotency_test.go
+++ b/core/middleware/idempotency_test.go
@@ -284,7 +284,7 @@ func TestMemoryStore_TTLExpiry(t *testing.T) {
 	if _, _, err := s.Begin(nil, "k", "fp"); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.Finish(nil, "k", resp); err != nil {
+	if err := s.Finish(nil, "k", "fp", resp); err != nil {
 		t.Fatal(err)
 	}
 	got, ok, err := s.Begin(nil, "k", "fp")
@@ -379,7 +379,7 @@ type failingStore struct{ err error }
 func (f failingStore) Begin(_ context.Context, _, _ string) (*IdempotentResponse, bool, error) {
 	return nil, false, f.err
 }
-func (f failingStore) Finish(_ context.Context, _ string, _ *IdempotentResponse) error { return nil }
+func (f failingStore) Finish(_ context.Context, _, _ string, _ *IdempotentResponse) error { return nil }
 
 // TestIdempotencyRequiresPrincipal pins that the middleware cannot be
 // wired into a shared key namespace by omission.

--- a/core/middleware/logging.go
+++ b/core/middleware/logging.go
@@ -36,7 +36,7 @@ func LoggingFn(getLogger func() *slog.Logger) Middleware {
 			}
 			logger.Info("request",
 				"method", safeLogMethod(r.Method),
-				"path", safeLogPath(r.URL.Path),
+				"path", truncate(safeLogPath(r.URL.Path), maxRecoveryPathLen),
 				"status", wrapped.statusCode,
 				"duration", duration.String(),
 			)
@@ -109,7 +109,7 @@ func SampledLoggingFn(sampleN int, slowThreshold time.Duration, getLogger func()
 			if wrapped.statusCode >= 400 || duration > slowThreshold {
 				logger.Info("request",
 					"method", safeLogMethod(r.Method),
-					"path", safeLogPath(r.URL.Path),
+					"path", truncate(safeLogPath(r.URL.Path), maxRecoveryPathLen),
 					"status", wrapped.statusCode,
 					"duration", duration.String(),
 					"sampled", false,
@@ -122,7 +122,7 @@ func SampledLoggingFn(sampleN int, slowThreshold time.Duration, getLogger func()
 			if n%uint64(sampleN) == 1 {
 				logger.Info("request",
 					"method", safeLogMethod(r.Method),
-					"path", safeLogPath(r.URL.Path),
+					"path", truncate(safeLogPath(r.URL.Path), maxRecoveryPathLen),
 					"status", wrapped.statusCode,
 					"duration", duration.String(),
 					"sampled", true,
@@ -132,18 +132,26 @@ func SampledLoggingFn(sampleN int, slowThreshold time.Duration, getLogger func()
 	}
 }
 
-// safeLogMethod percent-encodes control bytes (and DEL) in the HTTP
-// method so an attacker who got a CRLF / ESC sequence into r.Method
-// can't forge a fake log entry or smuggle a terminal-control payload
-// into an operator's tail/less session.
-func safeLogMethod(m string) string {
-	if !strings.ContainsAny(m, "\x00\r\n\t\v\f\b\x1b") {
-		return m
+// scrubControlBytes percent-encodes ASCII control bytes (the C0 range) and
+// DEL in a request-derived value — URL path, method, or a panic that embeds
+// a request string — so an attacker can't forge a fake log entry or smuggle
+// a terminal-control payload into an operator's tail/less session. slog's
+// JSON handler escapes these for valid JSON, but a JSON-escaped \r\n is still
+// visible to text grep, and naive log shippers render the injected payload on
+// its own line.
+//
+// r.URL.Path is percent-DECODED, so a %0d%0a in the raw request is a real
+// CRLF by the time it reaches any sink here. The fast-path probe includes
+// DEL (0x7f): without it, a path carrying only DEL bypassed the encoder and
+// was logged raw.
+func scrubControlBytes(s string) string {
+	if !strings.ContainsAny(s, "\x00\r\n\t\v\f\b\x1b\x7f") {
+		return s
 	}
 	var b strings.Builder
-	b.Grow(len(m))
-	for i := 0; i < len(m); i++ {
-		c := m[i]
+	b.Grow(len(s))
+	for i := range s {
+		c := s[i]
 		if c < 0x20 || c == 0x7f {
 			fmt.Fprintf(&b, "%%%02x", c)
 			continue
@@ -153,28 +161,11 @@ func safeLogMethod(m string) string {
 	return b.String()
 }
 
-// safeLogPath re-encodes control characters in a URL path so an
-// attacker can't forge a fake log entry by injecting CRLF (or other
-// terminal-escape sequences). slog's JSON handler already escapes
-// these for valid JSON, but a JSON-escaped \r\n is still visible to
-// text grep — and naive log shippers / console viewers can be tricked
-// into rendering the injected payload on its own line.
-func safeLogPath(p string) string {
-	if !strings.ContainsAny(p, "\x00\r\n\t\v\f\b\x1b") {
-		return p
-	}
-	var b strings.Builder
-	b.Grow(len(p))
-	for i := 0; i < len(p); i++ {
-		c := p[i]
-		if c < 0x20 || c == 0x7f {
-			fmt.Fprintf(&b, "%%%02x", c)
-			continue
-		}
-		b.WriteByte(c)
-	}
-	return b.String()
-}
+// safeLogMethod percent-encodes control bytes (and DEL) in the HTTP method.
+func safeLogMethod(m string) string { return scrubControlBytes(m) }
+
+// safeLogPath percent-encodes control characters in a URL path.
+func safeLogPath(p string) string { return scrubControlBytes(p) }
 
 // DiscardLogging returns middleware that tracks request timing but
 // writes no log output. Useful for benchmarks and high-throughput

--- a/core/middleware/logging_security_test.go
+++ b/core/middleware/logging_security_test.go
@@ -1,10 +1,12 @@
 package middleware
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -104,8 +106,118 @@ func TestLogging_LongPathTruncated(t *testing.T) {
 	srv.ServeHTTP(rr, req)
 
 	logOutput := buf.String()
-	// If the full path appears, it's unbounded
+	// If the full path appears, the logging sink does not bound the path
+	// length — disk exhaustion via long URLs. (Recovery/timeout already
+	// truncated; logging did not — see TestLogSinksScrubAndBound.)
 	if strings.Contains(logOutput, strings.Repeat("A", 10000)) {
-		t.Logf("SECURITY: [logging] full 10KB path logged. Consider truncating paths in log output. Attack: disk exhaustion via long URLs.")
+		t.Errorf("SECURITY: [logging] full 10KB path logged unbounded. Attack: disk exhaustion via long URLs.")
+	}
+}
+
+// captureHandler is a minimal slog.Handler that stores the last record's
+// attributes verbatim (no JSON/text escaping), so a test can detect raw
+// control bytes that a real JSON handler would have escaped away.
+type captureHandler struct {
+	mu    sync.Mutex
+	attrs map[string]string
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.attrs == nil {
+		h.attrs = map[string]string{}
+	}
+	r.Attrs(func(a slog.Attr) bool { h.attrs[a.Key] = a.Value.String(); return true })
+	return nil
+}
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *captureHandler) get(key string) string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.attrs[key]
+}
+func (h *captureHandler) reset() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.attrs = map[string]string{}
+}
+
+// TestLogSinksScrubAndBound pins the two halves of the log-injection
+// property across EVERY sink that logs a request-derived value: control
+// bytes must be scrubbed (r.URL.Path is percent-DECODED, so %0d%0a is a real
+// CRLF) and the path must be length-bounded. Logging scrubbed but never
+// truncated; recovery/timeout truncated but never scrubbed — each sink held
+// only one half. This loops the property × surface so a new sink can't drift
+// the same way.
+func TestLogSinksScrubAndBound(t *testing.T) {
+	prev := slog.Default()
+	cap := &captureHandler{}
+	slog.SetDefault(slog.New(cap))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	sinks := []struct {
+		name    string
+		handler http.Handler
+		async   bool // timeout logs from a watcher goroutine after ServeHTTP returns
+	}{
+		{"logging", Logging()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})), false},
+		{"recovery", Recovery()(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			panic("boom")
+		})), false},
+		{"timeout", Timeout(50 * time.Millisecond)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done() // wait for the deadline, then panic late
+			panic("late")
+		})), true},
+	}
+
+	// Distinct attack bytes: CR, LF, NUL, DEL.
+	for _, sk := range sinks {
+		t.Run(sk.name, func(t *testing.T) {
+			for _, b := range []byte{'\r', '\n', 0x00, 0x7f} {
+				cap.reset()
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.URL.Path = "/test" + string(b) + "END"
+				req.Method = "GE" + string(b) + "T"
+				sk.handler.ServeHTTP(httptest.NewRecorder(), req)
+
+				if sk.async {
+					// The timed-out-handler log fires from a watcher goroutine.
+					deadline := time.Now().Add(2 * time.Second)
+					for time.Now().Before(deadline) && cap.get("path") == "" {
+						time.Sleep(5 * time.Millisecond)
+					}
+				}
+
+				if got := cap.get("path"); got == "" {
+					t.Fatalf("byte=%#x: no path attribute captured", b)
+				} else if strings.ContainsRune(got, rune(b)) {
+					t.Errorf("byte=%#x: raw control byte reached path log attr %q", b, got)
+				}
+				if got := cap.get("method"); strings.ContainsRune(got, rune(b)) {
+					t.Errorf("byte=%#x: raw control byte reached method log attr %q", b, got)
+				}
+			}
+
+			// Length bound: a 10 KB path must not land in full.
+			cap.reset()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.URL.Path = "/" + strings.Repeat("A", 10000)
+			sk.handler.ServeHTTP(httptest.NewRecorder(), req)
+			if sk.async {
+				deadline := time.Now().Add(2 * time.Second)
+				for time.Now().Before(deadline) && cap.get("path") == "" {
+					time.Sleep(5 * time.Millisecond)
+				}
+			}
+			if strings.Contains(cap.get("path"), strings.Repeat("A", 10000)) {
+				t.Errorf("10KB path logged unbounded: %d bytes", len(cap.get("path")))
+			}
+		})
 	}
 }

--- a/core/middleware/metrics.go
+++ b/core/middleware/metrics.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"sort"
@@ -224,11 +225,28 @@ func MetricsHandler(m *Metrics) http.Handler {
 		m.mu.Unlock()
 		sort.Slice(snapshot, func(i, j int) bool { return snapshot[i].name < snapshot[j].name })
 		for _, c := range snapshot {
-			c.fn(&sb)
+			runCollectorSafely(&sb, c.name, c.fn)
 		}
 
 		w.Write([]byte(sb.String()))
 	})
+}
+
+// runCollectorSafely runs one metrics collector with a per-call recover,
+// mirroring hook.runHookSafely. A third-party CollectorFunc that panics is
+// isolated (logged once) instead of aborting the whole /metrics scrape: the
+// exposition buffer is shared across the loop, so without this guard one bad
+// collector would drop every family's metrics for that scrape.
+func runCollectorSafely(w io.Writer, name string, fn CollectorFunc) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("metrics collector panic isolated",
+				"collector", name,
+				"error", truncate(fmt.Sprint(r), maxRecoveryPanicLen),
+			)
+		}
+	}()
+	fn(w)
 }
 
 // metricsResponseWriter captures the response status code so the recording

--- a/core/middleware/metrics_security_test.go
+++ b/core/middleware/metrics_security_test.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -74,5 +76,38 @@ func TestMetricsBoundsMethodCardinality(t *testing.T) {
 	}
 	if keys > 4 {
 		t.Fatalf("counter cardinality unbounded: %d keys after 1008 distinct methods", keys)
+	}
+}
+
+// TestMetricsCollectorPanicIsolated pins panic isolation at the collector
+// extension point. A third-party CollectorFunc runs with no recover, and the
+// buffer is flushed only AFTER the loop — so one panicking collector dropped
+// the whole /metrics scrape. The property (mirroring hook.runHookSafely):
+// a bad collector is isolated, logged once, and the remaining families still
+// land on the scrape.
+func TestMetricsCollectorPanicIsolated(t *testing.T) {
+	m := NewMetrics()
+	m.RegisterCollector("good", func(w io.Writer) {
+		fmt.Fprintln(w, "good_metric 42")
+	})
+	m.RegisterCollector("bad", func(w io.Writer) {
+		panic("collector explosion")
+	})
+	m.RegisterCollector("also_good", func(w io.Writer) {
+		fmt.Fprintln(w, "also_good_metric 7")
+	})
+
+	rec := httptest.NewRecorder()
+	MetricsHandler(m).ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("scrape status = %d, want 200 (a panicking collector must not fail the scrape)", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "good_metric 42") {
+		t.Errorf("SECURITY: [availability] a good collector was lost when a sibling panicked:\n%s", body)
+	}
+	if !strings.Contains(body, "also_good_metric 7") {
+		t.Errorf("SECURITY: [availability] collector AFTER the panicking one was lost:\n%s", body)
 	}
 }

--- a/core/middleware/recovery.go
+++ b/core/middleware/recovery.go
@@ -49,9 +49,9 @@ func RecoveryFn(getLogger func() *slog.Logger) Middleware {
 						}
 					}
 					logger.Error("panic recovered",
-						"error", truncate(fmt.Sprint(err), maxRecoveryPanicLen),
-						"path", truncate(r.URL.Path, maxRecoveryPathLen),
-						"method", r.Method,
+						"error", scrubControlBytes(truncate(fmt.Sprint(err), maxRecoveryPanicLen)),
+						"path", safeLogPath(truncate(r.URL.Path, maxRecoveryPathLen)),
+						"method", safeLogMethod(r.Method),
 						"stack", truncate(string(debug.Stack()), maxRecoveryStackLen),
 					)
 					http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/core/middleware/timeout.go
+++ b/core/middleware/timeout.go
@@ -309,9 +309,9 @@ func Timeout(d time.Duration) Middleware {
 					<-done
 					if childPanic != nil {
 						slog.Error("panic in timed-out handler",
-							"error", truncate(fmt.Sprint(childPanic), maxRecoveryPanicLen),
-							"path", truncate(r.URL.Path, maxRecoveryPathLen),
-							"method", r.Method,
+							"error", scrubControlBytes(truncate(fmt.Sprint(childPanic), maxRecoveryPanicLen)),
+							"path", safeLogPath(truncate(r.URL.Path, maxRecoveryPathLen)),
+							"method", safeLogMethod(r.Method),
 						)
 					}
 				}()

--- a/examples/backoffice/e2e_test.go
+++ b/examples/backoffice/e2e_test.go
@@ -45,6 +45,18 @@ func backofficeBrowser(t *testing.T) context.Context {
 	t.Cleanup(allocCancel)
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the returned context then only has to cover
+	// the assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)
 	t.Cleanup(cancel)
 	// Auto-accept any window.confirm (the data-fui-confirm delete dialog).

--- a/examples/meridian/e2e_ui_test.go
+++ b/examples/meridian/e2e_ui_test.go
@@ -75,6 +75,18 @@ func e2eBrowser(t *testing.T) context.Context {
 	t.Cleanup(allocCancel)
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the returned context then only has to cover
+	// the assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)
 	t.Cleanup(cancel)
 	return ctx

--- a/framework/app_banner_auth_test.go
+++ b/framework/app_banner_auth_test.go
@@ -60,3 +60,29 @@ func TestBannerPublicOpenAPIUnmarked(t *testing.T) {
 		}
 	}
 }
+
+// TestStartupBannerVersionedEntityPathAndLabel: an entity mounted under a
+// versioned route group (App.GroupEntity) must advertise its version-prefixed
+// mount path and carry the "(version)" label, not the bare "/table" path a
+// single-version entity gets. A user curling the banner URL for /v2/widgets
+// must reach it; printing "/widgets" would advertise a 404.
+func TestStartupBannerVersionedEntityPathAndLabel(t *testing.T) {
+	app := NewApp(WithoutDefaultMiddleware())
+	g := app.Group("/v2")
+	app.GroupEntity(g, "widgets", EntityConfig{
+		Fields:   []schema.Field{{Name: "title", Type: schema.String}},
+		Exposure: &ExposureConfig{CRUD: boolPtr(false)},
+	}.WithTimestamps(false))
+	var out bytes.Buffer
+	app.startupOutput = &out
+
+	app.printStartupBanner("127.0.0.1:8080", "test", false, false, "")
+	got := out.String()
+
+	if !strings.Contains(got, "widgets (/v2)") {
+		t.Errorf("versioned entity label missing; banner:\n%s", got)
+	}
+	if !strings.Contains(got, "127.0.0.1:8080/v2/widgets") {
+		t.Errorf("versioned mount path missing; banner:\n%s", got)
+	}
+}

--- a/framework/app_config_timeouts_test.go
+++ b/framework/app_config_timeouts_test.go
@@ -1,0 +1,54 @@
+package framework
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestMCPAppConfigReflectsRunningServerTimeouts pins the second half of
+// effectiveServerTimeoutsMs: once App.Start has built the http.Server, the
+// app_config introspection tool must report the deadlines the LIVE server
+// actually uses — defaults plus HTTPServerTimeouts overrides and
+// DisableRequestTimeout zeroing — not the pre-start default constants the
+// pre-Start path falls back to. An operator asking "why did my handler get
+// cut?" via MCP gets the resolved values, not guesses.
+func TestMCPAppConfigReflectsRunningServerTimeouts(t *testing.T) {
+	app := NewApp(
+		WithMCPIntrospection(),
+		WithHTTPServerTimeouts(HTTPServerTimeoutsConfig{
+			ReadHeaderTimeout: new(4 * time.Second),
+			ReadTimeout:       new(7 * time.Second),
+			WriteTimeout:      new(8 * time.Second),
+			IdleTimeout:       new(9 * time.Second),
+		}),
+	)
+	_, stop := startOnRandomPort(t, app)
+	defer stop()
+
+	res, err := app.MCP.CallTool(context.Background(), "app_config", map[string]any{})
+	if err != nil {
+		t.Fatalf("CallTool app_config: %v", err)
+	}
+	m, ok := res.(map[string]any)
+	if !ok {
+		t.Fatalf("app_config result = %T, want map[string]any", res)
+	}
+	to, ok := m["http_server_timeouts_ms"].(map[string]int64)
+	if !ok {
+		t.Fatalf("http_server_timeouts_ms = %T, want map[string]int64", m["http_server_timeouts_ms"])
+	}
+	// Every value must match the override, proving the tool read the running
+	// http.Server rather than reporting the pre-start defaults.
+	want := map[string]int64{
+		"read_header_ms": (4 * time.Second).Milliseconds(),
+		"read_ms":        (7 * time.Second).Milliseconds(),
+		"write_ms":       (8 * time.Second).Milliseconds(),
+		"idle_ms":        (9 * time.Second).Milliseconds(),
+	}
+	for k, w := range want {
+		if to[k] != w {
+			t.Errorf("%s = %d, want %d (resolved live-server deadline)", k, to[k], w)
+		}
+	}
+}

--- a/framework/crud/llmmd.go
+++ b/framework/crud/llmmd.go
@@ -1,6 +1,7 @@
 package crud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -274,8 +275,20 @@ func EntityLLMMD(ent *entity.Entity) string {
 }
 
 // RegistryLLMMD generates a top-level LLM-friendly markdown index that
-// lists every registered entity with a link to its detailed llm.md page.
+// lists every registered entity with a link to its detailed llm.md page. It
+// lists every entity — callers that serve this to a request (the /api/llm.md
+// index) MUST filter per request via [registryLLMMD] so the index does not
+// disclose entities the caller cannot read.
 func RegistryLLMMD(registry entity.Registry, appName string) string {
+	return registryLLMMD(registry, appName, nil)
+}
+
+// registryLLMMD renders the index, keeping only entities for which keep
+// returns true (a nil keep keeps all). The /api/llm.md handler passes a
+// per-request keep that mirrors List's read-scope predicate (owner, tenant,
+// RBAC) so an authenticated caller with no grant for an entity gets 403 on
+// its rows AND never sees its name, base path or flags in the index.
+func registryLLMMD(registry entity.Registry, appName string, keep func(*entity.Entity) bool) string {
 	var b strings.Builder
 	title := appName
 	if title == "" {
@@ -294,6 +307,9 @@ func RegistryLLMMD(registry entity.Registry, appName string) string {
 	b.WriteString("| Resource | Base Path | Endpoints | Description |\n")
 	b.WriteString("|----------|-----------|-----------|-------------|\n")
 	for _, ent := range entities {
+		if keep != nil && !keep(ent) {
+			continue
+		}
 		table := ent.GetTable()
 		basePath := "/" + table
 		llmLink := "/" + table + "/llm.md"
@@ -384,18 +400,47 @@ func LLMMDHandlerFor(ch *CrudHandler) http.Handler {
 // RegistryLLMMDHandler returns an http.Handler that serves the top-level
 // LLM-friendly markdown index for all registered entities. Auth-required
 // for the same reason as [LLMMDHandler].
+//
+// The index is rendered per request, filtered to the entities THIS caller
+// can list — the same read-scope predicate each entity's List route runs
+// (see canListEntity). Serving a construction-time-precomputed document
+// instead disclosed every entity's name, base path, endpoint count and
+// soft-delete/multi-tenant flags to an authenticated caller who would get
+// 403 on the rows. The index is the disclosure, not the row.
 func RegistryLLMMDHandler(registry entity.Registry, appName string) http.Handler {
-	md := RegistryLLMMD(registry, appName)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-store")
-		if _, ok := handler.GetUser(r.Context()); !ok {
+		ctx := r.Context()
+		if _, ok := handler.GetUser(ctx); !ok {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
+		md := registryLLMMD(registry, appName, func(ent *entity.Entity) bool {
+			return canListEntity(ctx, ent)
+		})
 		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
 		w.Header().Set("Content-Length", strconv.Itoa(len(md)))
 		w.Write([]byte(md))
 	})
+}
+
+// canListEntity reports whether ctx passes every read-scope gate that the
+// entity's List route runs, as a boolean (no HTTP response). It reuses the
+// SAME in-process predicates List's requireScope delegates to —
+// requireOwnerContext, requireTenantContext and CanRead — so the index
+// filter cannot drift from the read path. A caller who would receive 401/403
+// on an entity's rows is hidden from its index entry too. The baseline
+// session gate (requireAuthenticated) is enforced once at the handler entry,
+// so it is not re-checked here.
+func canListEntity(ctx context.Context, ent *entity.Entity) bool {
+	ch := &CrudHandler{Entity: ent}
+	if err := ch.requireOwnerContext(ctx); err != nil {
+		return false
+	}
+	if err := ch.requireTenantContext(ctx); err != nil {
+		return false
+	}
+	return ch.CanRead(ctx)
 }
 
 // fieldTypeLabel returns a human-readable label for a schema field type.

--- a/framework/crud/llmmd_authz_security_test.go
+++ b/framework/crud/llmmd_authz_security_test.go
@@ -66,3 +66,59 @@ func ordersHandlerWithReadPermission(t *testing.T) *CrudHandler {
 	})
 	return &CrudHandler{Entity: ent}
 }
+
+// TestLLMMDIndexHidesUngrantedEntities is the registry-index twin of the
+// per-entity llm.md disclosure above. RegistryLLMMDHandler served a
+// construction-time-precomputed document listing EVERY registered entity
+// (name, base path, endpoint count, soft-delete/multi-tenant flags) to any
+// authenticated caller, while each entity's List runs the full scope chain.
+// An authenticated caller with no orders:read grant got 403 on the rows and
+// 200 on the index — the index itself is the disclosure. The fix renders the
+// index per request, filtered to the entities this caller can actually list
+// (the same read-scope predicate List runs).
+func TestLLMMDIndexHidesUngrantedEntities(t *testing.T) {
+	orders := entity.Define("orders", entity.EntityConfig{Fields: []schema.Field{
+		{Name: "total", Type: schema.Int},
+	}, Exposure: &entity.ExposureConfig{Access: entity.AccessControl{Read: "orders:read"}}})
+	products := entity.Define("products", entity.EntityConfig{Fields: []schema.Field{
+		{Name: "name", Type: schema.String},
+	}, Exposure: &entity.ExposureConfig{}}) // no read permission → any caller can list
+	reg := stubRegistry{byName: map[string]*entity.Entity{
+		"orders":   orders,
+		"products": products,
+	}}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/llm.md", nil)
+	req = reqWithRolesOnly(req, "u1") // signed in, holds no orders:read grant
+	RegistryLLMMDHandler(reg, "Test API").ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("index refused an authenticated caller: %d %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "products") {
+		t.Error("SECURITY: index hid an entity the caller CAN read (products)")
+	}
+	if strings.Contains(body, "orders") {
+		t.Error("SECURITY: [disclosure] index listed orders — name/base path/flags of an entity the caller cannot read")
+	}
+}
+
+// TestLLMMDIndexShowsGrantedEntity confirms a caller who holds the grant still
+// sees the entity, so the filter is a scope predicate, not a blanket suppress.
+func TestLLMMDIndexShowsGrantedEntity(t *testing.T) {
+	orders := entity.Define("orders", entity.EntityConfig{Fields: []schema.Field{
+		{Name: "total", Type: schema.Int},
+	}, Exposure: &entity.ExposureConfig{Access: entity.AccessControl{Read: "orders:read"}}})
+	reg := stubRegistry{byName: map[string]*entity.Entity{"orders": orders}}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/llm.md", nil)
+	req = reqWithGrant(req, "u1", "orders:read")
+	RegistryLLMMDHandler(reg, "Test API").ServeHTTP(rec, req)
+
+	if !strings.Contains(rec.Body.String(), "orders") {
+		t.Error("index hid orders from a caller who holds orders:read")
+	}
+}

--- a/framework/crud/owner.go
+++ b/framework/crud/owner.go
@@ -98,12 +98,43 @@ var errOwnerRequired = errors.New("owner context required for owner-scoped entit
 // in-process callers (typed repos, jobs, scripts) bypass that path.
 var errTenantRequired = errors.New("tenant context required for multi-tenant entity")
 
+// brokeredCallKey marks a context as a process-module broker re-dispatch.
+// A module never brokers data in a cross-owner frame (design #37 §5), so a
+// brokered call must never exercise CrossOwnerRead — even when the
+// re-resolved caller legitimately holds it in their own session. The
+// unexported key type means no HTTP-derived context can carry it: it is set
+// ONLY by the broker (framework/processmodule_broker.go resolveCaller) via
+// WithBrokeredCall, exactly mirroring owner.crossOwnerKey / AllowCrossOwner.
+type brokeredCallKey struct{}
+
+// WithBrokeredCall stamps ctx as originating from the process-module
+// broker's CRUD re-dispatch. crossOwnerReadGranted returns false
+// unconditionally when it is present, so owner scoping holds by
+// construction for every brokered call regardless of the re-resolved
+// caller's permissions. SECURITY: set ONLY from the broker's resolveCaller.
+func WithBrokeredCall(ctx context.Context) context.Context {
+	return context.WithValue(ctx, brokeredCallKey{}, true)
+}
+
+// IsBrokeredCall reports whether ctx was stamped by the process-module
+// broker. Exported so the broker test surface can pin the root-cause marker.
+func IsBrokeredCall(ctx context.Context) bool {
+	v, _ := ctx.Value(brokeredCallKey{}).(bool)
+	return v
+}
+
 // crossOwnerReadGranted reports whether the request context holds the
 // entity's declared CrossOwnerRead permission. Returns false when the
-// entity does not opt in (empty permission) or when access.Can denies
-// (including the fail-closed "no policy in context" case). READ-ONLY by
-// construction: only ApplyOwnerScope / ApplyOwnerScopeCount consult it.
+// entity does not opt in (empty permission), when access.Can denies
+// (including the fail-closed "no policy in context" case), and — the F3
+// root-cause fix — unconditionally when the call was brokered through a
+// process module, so a delegated caller who holds CrossOwnerRead cannot
+// exercise it through a module. READ-ONLY by construction: only
+// ApplyOwnerScope / ApplyOwnerScopeCount consult it.
 func (ch *CrudHandler) crossOwnerReadGranted(ctx context.Context) bool {
+	if IsBrokeredCall(ctx) {
+		return false
+	}
 	perm := ch.Entity.Config.Scope.CrossOwnerRead
 	return perm != "" && access.Can(ctx, access.Permission(perm))
 }

--- a/framework/datexport/registry.go
+++ b/framework/datexport/registry.go
@@ -60,6 +60,29 @@ const (
 	EraseAnonymize
 )
 
+// IdentityKind selects which principal an eraser matches against. The default
+// (zero value, IdentityUserID) matches the erased user's id — the original
+// behavior every existing registration relies on. A non-default identity is
+// resolved ONCE at erase time via a registered [DataIdentityResolver], and the
+// resolved value is bound for the eraser's Column instead of the user id.
+//
+// This is the seam that reaches tables keyed by an identity OTHER than the
+// user id: battery/auth's magic_link_tokens is keyed by EMAIL, so it declares
+// IdentityEmail and the framework resolves email from the user table at erase
+// time. See framework/erase_data.go → identity resolution.
+type IdentityKind int
+
+const (
+	// IdentityUserID matches Column against the erased user's id. It is the
+	// zero value so every DataEraser that leaves Identity unset keeps the
+	// original behavior.
+	IdentityUserID IdentityKind = iota
+	// IdentityEmail matches Column against the erased user's email, resolved
+	// from the user table at erase time. battery/auth registers the resolver
+	// against auth_users (id → email).
+	IdentityEmail
+)
+
 // DataEraser declares the right-to-be-forgotten behavior for one physical
 // table that lives outside the entity registry — the erase-plane mirror of
 // DataExporter. The framework's App.EraseUserData walks both the entity
@@ -78,6 +101,11 @@ const (
 //     Tombstone. Each is SafeIdent-checked before SQL.
 //   - Tombstone (EraseAnonymize only) is the replacement written to every
 //     ScrubColumn. Empty defaults to "[erased]".
+//   - Identity selects which principal Column is matched against. The default
+//     (IdentityUserID, the zero value) matches the erased user's id — the
+//     original behavior. A non-default Identity (e.g. IdentityEmail) is
+//     resolved once at erase time through the matching DataIdentityResolver,
+//     and the resolved value is bound for Column instead of the user id.
 type DataEraser struct {
 	Name         string
 	Source       string
@@ -86,12 +114,37 @@ type DataEraser struct {
 	Mode         EraseMode
 	ScrubColumns []string
 	Tombstone    string
+	Identity     IdentityKind
+}
+
+// DataIdentityResolver declares how the framework resolves a non-user-id
+// identity at erase time — declaratively, so the framework stays the single
+// place raw SQL is built (decision E3). The framework runs, ONCE per erasure
+// and BEFORE the write transaction opens,
+//
+//	SELECT ValueColumn FROM Table WHERE IDColumn = <erased user id>
+//
+// and binds the result for every eraser declaring the resolver's
+// IdentityKind. Table, IDColumn, and ValueColumn are SafeIdent-checked before
+// SQL; the erased user id is a $n bound argument.
+//
+// battery/auth registers IdentityEmail against auth_users (id → email) so the
+// magic-link token table — keyed by email, not user id — becomes reachable by
+// App.EraseUserData. A resolver whose Table is absent at erase time, or whose
+// SELECT finds no row (the user row is already gone on an idempotent re-run),
+// means the identity cannot be resolved: erasers declaring it are SKIPPED with
+// a note rather than failed (nothing left to match).
+type DataIdentityResolver struct {
+	Table       string
+	IDColumn    string
+	ValueColumn string
 }
 
 var (
-	mu      sync.RWMutex
-	entries = []*DataExporter{}
-	erasers = []*DataEraser{}
+	mu        sync.RWMutex
+	entries   = []*DataExporter{}
+	erasers   = []*DataEraser{}
+	resolvers = map[IdentityKind]DataIdentityResolver{}
 )
 
 // Register adds a data exporter. Safe to call from init(). An exporter whose
@@ -168,6 +221,7 @@ func cloneEraser(e DataEraser) *DataEraser {
 	return &DataEraser{
 		Name: e.Name, Source: e.Source, Table: e.Table, Column: e.Column,
 		Mode: e.Mode, ScrubColumns: scrub, Tombstone: e.Tombstone,
+		Identity: e.Identity,
 	}
 }
 
@@ -194,10 +248,53 @@ func AllErasers() []DataEraser {
 		out = append(out, DataEraser{
 			Name: ex.Name, Source: ex.Source, Table: ex.Table, Column: ex.Column,
 			Mode: ex.Mode, ScrubColumns: append([]string(nil), ex.ScrubColumns...),
-			Tombstone: ex.Tombstone,
+			Tombstone: ex.Tombstone, Identity: ex.Identity,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// RegisterIdentityResolver registers how a non-user-id identity is resolved at
+// erase time. Safe to call from init(); a re-registration for the same kind
+// replaces it (last-writer-wins), mirroring RegisterEraser. battery/auth
+// registers IdentityEmail from init() so any app importing battery/auth can
+// reach email-keyed tables (magic_link_tokens) via App.EraseUserData.
+func RegisterIdentityResolver(kind IdentityKind, r DataIdentityResolver) {
+	mu.Lock()
+	defer mu.Unlock()
+	resolvers[kind] = r
+}
+
+// UnregisterIdentityResolver removes a resolver by kind. Returns true if one
+// was present.
+func UnregisterIdentityResolver(kind IdentityKind) bool {
+	mu.Lock()
+	defer mu.Unlock()
+	_, ok := resolvers[kind]
+	delete(resolvers, kind)
+	return ok
+}
+
+// ResolveIdentity looks up the resolver declared for kind. The second return
+// is false when no resolver is registered — App.EraseUserData treats an eraser
+// that declares such an identity as a FAIL-LOUD misconfiguration (the erasure
+// would be incomplete).
+func ResolveIdentity(kind IdentityKind) (DataIdentityResolver, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	r, ok := resolvers[kind]
+	return r, ok
+}
+
+// AllIdentityResolvers returns a copy of the registered resolvers.
+func AllIdentityResolvers() map[IdentityKind]DataIdentityResolver {
+	mu.RLock()
+	defer mu.RUnlock()
+	out := make(map[IdentityKind]DataIdentityResolver, len(resolvers))
+	for k, v := range resolvers {
+		out[k] = v
+	}
 	return out
 }
 
@@ -208,4 +305,7 @@ func Reset(_ *testing.T) {
 	defer mu.Unlock()
 	entries = nil
 	erasers = nil
+	for k := range resolvers {
+		delete(resolvers, k)
+	}
 }

--- a/framework/dbctx_context_test.go
+++ b/framework/dbctx_context_test.go
@@ -1,0 +1,64 @@
+package framework
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestWithDBContextNilDBIsNoOp pins the UI-only-app contract: stamping a nil
+// *sql.DB into the context would put a nil pointer under a truthy key, so
+// WithDBContext returns the context UNCHANGED and DBFromContext reports "no
+// DB". A screen on a no-database app must never receive a nil *sql.DB it
+// would dereference.
+func TestWithDBContextNilDBIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	out := WithDBContext(ctx, nil)
+	if out != ctx {
+		t.Fatal("WithDBContext(ctx, nil) returned a derived context; it must be a no-op")
+	}
+	if db, ok := DBFromContext(out); ok || db != nil {
+		t.Fatalf("DBFromContext = %v, ok=%v after a nil stamp; want nil, false", db, ok)
+	}
+}
+
+// TestWithDBContextRoundTrips verifies the positive path: a real *sql.DB
+// stamped in is retrievable downstream — the package-portable alternative to a
+// global handle.
+func TestWithDBContextRoundTrips(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Skipf("sqlite3 driver not available: %v", err)
+	}
+	defer db.Close()
+
+	ctx := WithDBContext(context.Background(), db)
+	got, ok := DBFromContext(ctx)
+	if !ok || got != db {
+		t.Fatalf("DBFromContext = %v, ok=%v; want the stamped db, true", got, ok)
+	}
+}
+
+// TestAppDBContextMiddlewarePassThroughWithoutDB: an app built without WithDB
+// returns a pass-through middleware (the bare next handler, unwrapped) so a
+// request never carries a nil DB in context. This is the default-middleware
+// opt-out path — apps that wire their own chain still get a safe no-op.
+func TestAppDBContextMiddlewarePassThroughWithoutDB(t *testing.T) {
+	app := NewApp(WithoutDefaultMiddleware()) // no WithDB
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if _, ok := DBFromContext(r.Context()); ok {
+			t.Error("DBFromContext returned ok on a no-DB app's request")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := app.DBContextMiddleware()(next)
+	wrapped.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	if !called {
+		t.Fatal("pass-through middleware did not invoke the handler")
+	}
+}

--- a/framework/docs/content/data-export.md
+++ b/framework/docs/content/data-export.md
@@ -216,8 +216,9 @@ log.Printf("erased %d rows for user_42", report.TotalErased())
 2. **Battery plane.** Every registered `datexport.DataEraser` runs. A battery
    declares each table it owns and how to erase it: hard-delete, or anonymize
    (overwrite named columns with a tombstone and keep the row). `battery/auth`
-   registers `auth_sessions` (delete by `user_id`) and `auth_users` (delete by
-   `id`).
+   registers `auth_sessions` (delete by `user_id`), `auth_users` (delete by
+   `id`), and `magic_link_tokens` (delete by `email` via the `IdentityEmail`
+   resolver — see [Identity-keyed tables](#identity-keyed-tables-non-user-id-match) below).
 3. **Audit plane (built-in).** The audit table is retained — it is the
    compliance record of who did what — but the user's `actor_id` is
    anonymized: every row where `actor_id = userID` is set to `[erased]`. See
@@ -303,6 +304,53 @@ datexport.RegisterEraser(datexport.DataEraser{
 `EraseAnonymize`, both `ScrubColumns` and `Column` are overwritten with
 `Tombstone`. As with export: a registered table that is absent from the live
 DB is skipped with a note; an unregistered raw table is silently excluded.
+
+### Identity-keyed tables (non-user-id match)
+
+Most tables are reached by the user id — `Column` holds the user id directly.
+Some tables are keyed by a *different* identity: `battery/auth`'s
+`magic_link_tokens` is keyed by **email**, not user id, so a plain user-id match
+cannot reach it. Before this seam, a magic link minted before an erasure and
+redeemed after it found no user and *created a new account* for the erased
+address — an account-restoration path straight through a completed erasure.
+
+An eraser declares the identity with `Identity`; the framework resolves it ONCE
+at erase time (before the write transaction opens) through a registered
+`DataIdentityResolver` and binds the resolved value for `Column` instead of the
+user id:
+
+```go
+// Resolve email from the user table: SELECT email FROM auth_users WHERE id = $1
+datexport.RegisterIdentityResolver(datexport.IdentityEmail, datexport.DataIdentityResolver{
+    Table: "auth_users", IDColumn: "id", ValueColumn: "email",
+})
+
+datexport.RegisterEraser(datexport.DataEraser{
+    Name: "magic_link_tokens", Source: "auth", Table: "magic_link_tokens",
+    Column: "email", Mode: datexport.EraseDelete,
+    Identity: datexport.IdentityEmail, // default IdentityUserID matches by user id
+})
+```
+
+Resolution stays **declarative** — the framework remains the single place raw
+SQL is built (`SafeIdent`-guarded identifiers, `$n`-bound values); a battery
+never runs arbitrary SQL. Two guarantees:
+
+- **No resolver for a declared identity → fail loud.** An erasure that cannot
+  reach a declared table is incomplete, and silently-incomplete is the failure
+  mode this primitive exists to prevent.
+- **Resolver finds no row → skip, don't fail.** On an idempotent re-run the
+  user row is already gone, so the identity cannot be resolved. That means
+  "nothing left to match": the eraser is skipped (named in `report.Skipped`),
+  the rest of the erasure reports zero, and no error is returned.
+
+`battery/auth` registers the `IdentityEmail` resolver and the `magic_link_tokens`
+eraser from `init()`, so any app importing `battery/auth` closes the gap
+automatically. The token table is created lazily by
+`NewSQLMagicLinkTokenStore`; on the in-memory token store there is no such table
+and the eraser is a no-op. A host that renames the user table must re-register
+the resolver against the actual name, mirroring how a renamed eraser table is
+re-registered.
 
 ### SQL safety
 

--- a/framework/docs/content/idempotency.md
+++ b/framework/docs/content/idempotency.md
@@ -125,9 +125,21 @@ the client can retry against a recovered server.
 ```go
 type IdempotencyStore interface {
     Begin(ctx, key, fingerprint string) (*IdempotentResponse, bool, error)
-    Finish(ctx, key string, resp *IdempotentResponse) error
+    Finish(ctx, key, fingerprint string, resp *IdempotentResponse) error
 }
 ```
+
+`Finish` is fingerprint-bound: it must only persist into (or release) the row
+that `Begin` created under that exact fingerprint. An in-flight claim can expire
+while its handler is still running and be re-claimed by a *different* caller
+under a *different* fingerprint; if `Finish` wrote by key alone, the first
+caller's late `Finish` would staple its response onto the second caller's row —
+and because `Begin` never rewrites the fingerprint column, the second caller's
+retry would match the fingerprint and be served the **first caller's body**.
+That is a cross-user disclosure whenever `Principal` returns a user/tenant id,
+so the fingerprint is a required parameter, not an optional one: a third-party
+store that ignores it is silently vulnerable. The bundled memory and SQL stores
+both scope their `UPDATE`/`DELETE` by `key AND fingerprint`.
 
 Two stores are bundled:
 
@@ -149,7 +161,10 @@ behind a 503 (current default).
 
 For clustered deployments without a database, drop a Redis adapter
 behind the same interface — only `Begin` and `Finish` need
-implementing.
+implementing. `Finish` receives the fingerprint the claim was created
+with; a custom store MUST scope its write and its release to the row
+matching that fingerprint (see the note above), or a late `Finish` from
+an expired claim can overwrite another principal's row.
 
 `Begin` returns one of:
 
@@ -161,8 +176,8 @@ implementing.
   by default (503) and falls through to the handler only when
   `FailOpen: true` is set.
 
-`Finish(ctx, key, nil)` releases the claim without caching — used on
-non-success responses.
+`Finish(ctx, key, fingerprint, nil)` releases the claim without caching —
+used on non-success responses.
 
 `Finish` is invoked with a fresh `context.WithTimeout(context.Background(),
 5*time.Second)`, NOT the request context. A client disconnect mid-
@@ -173,6 +188,12 @@ next reap cycle.
 
 - **Don't forget `Principal`.** Without it the cache is global and a
   client-chosen `Idempotency-Key` collides across users.
+- **Don't ignore the fingerprint in a custom `Finish`.** `Finish` is
+  fingerprint-bound for a reason: a claim can expire mid-handler and be
+  re-claimed by another principal, and a `Finish` that writes by key alone
+  then overwrites that principal's row and serves the first caller's body
+  on retry. Scope the write (`UPDATE … WHERE key AND fingerprint`) and the
+  release (`DELETE … WHERE key AND fingerprint`) — the bundled stores do.
 - **Don't put state-mutating side effects in middleware that runs
   before `Idempotency`.** The cached response only covers downstream
   handlers; anything that happened earlier in the chain runs every

--- a/framework/erase_data.go
+++ b/framework/erase_data.go
@@ -96,6 +96,7 @@ type EraseReport struct {
 	Entities  []EraseTableResult // owner-scoped entity tables (always delete)
 	Batteries []EraseTableResult // registered erasers (delete or anonymize)
 	Audit     *EraseTableResult  // built-in audit anonymization; nil if the audit table is absent
+	Skipped   []string           // erasers skipped because their identity could not be resolved (idempotent re-run)
 }
 
 // TotalErased returns the sum of every RowsAffected across all planes. In
@@ -148,10 +149,110 @@ func (a *App) EraseUserData(ctx context.Context, userID string, opts ...EraseOpt
 	ents := a.collectEraseEntitySources()
 	erasers := datexport.AllErasers()
 
-	if cfg.dryRun {
-		return a.eraseDryRun(ctx, dialect, userID, cfg, ents, erasers)
+	// Resolve every non-user-id identity ONCE, before the write transaction
+	// opens (a single-connection pool deadlocks on a read inside the tx). An
+	// eraser declaring an identity with no resolver fails loud here; an
+	// identity whose value cannot be resolved is skipped, not failed.
+	resolved, skipped, err := a.resolveEraserIdentities(ctx, dialect, userID, erasers)
+	if err != nil {
+		return EraseReport{}, err
 	}
-	return a.eraseWrite(ctx, dialect, userID, cfg, ents, erasers)
+
+	if cfg.dryRun {
+		rep, derr := a.eraseDryRun(ctx, dialect, userID, cfg, ents, resolved)
+		if derr == nil {
+			rep.Skipped = skipped
+		}
+		return rep, derr
+	}
+	rep, werr := a.eraseWrite(ctx, dialect, userID, cfg, ents, resolved)
+	if werr == nil {
+		rep.Skipped = skipped
+	}
+	return rep, werr
+}
+
+// resolvedEraser pairs a registered eraser with the value its match column is
+// bound against. For IdentityUserID (the default) the value IS the user id;
+// for a non-default identity it is the value resolved once at erase time
+// through the matching DataIdentityResolver.
+type resolvedEraser struct {
+	eraser datexport.DataEraser
+	value  string
+}
+
+// resolveEraserIdentities resolves the bound match value for every eraser,
+// ONCE, before the write transaction opens (a single-connection pool deadlocks
+// on a read inside the tx). It is the identity-resolver seam:
+//
+//   - IdentityUserID (the default): the value is the user id, unchanged. Every
+//     existing registration behaves exactly as before.
+//   - A non-default identity with NO registered resolver: FAIL LOUD. An erasure
+//     that cannot reach a declared table is incomplete, and silently-incomplete
+//     is the failure mode this primitive exists to prevent.
+//   - A non-default identity whose resolver runs but finds no row (the user row
+//     is already gone on an idempotent re-run) or whose table is absent (host
+//     renamed it): the eraser is SKIPPED (added to skipped, not returned)
+//     rather than failed. An unresolvable identity means "nothing left to
+//     match".
+func (a *App) resolveEraserIdentities(ctx context.Context, dialect migrate.Dialect, userID string, erasers []datexport.DataEraser) (resolved []resolvedEraser, skipped []string, err error) {
+	for _, e := range erasers {
+		if e.Identity == datexport.IdentityUserID {
+			resolved = append(resolved, resolvedEraser{eraser: e, value: userID})
+			continue
+		}
+		r, ok := datexport.ResolveIdentity(e.Identity)
+		if !ok {
+			return nil, nil, fmt.Errorf("framework: erase %q declares identity %d but no resolver is registered — erasure would be incomplete", e.Name, e.Identity)
+		}
+		val, found, rerr := a.resolveIdentityValue(ctx, dialect, userID, r)
+		if rerr != nil {
+			return nil, nil, fmt.Errorf("framework: erase %q: resolve identity: %w", e.Name, rerr)
+		}
+		if !found {
+			skipped = append(skipped, e.Name)
+			continue
+		}
+		resolved = append(resolved, resolvedEraser{eraser: e, value: val})
+	}
+	return resolved, skipped, nil
+}
+
+// resolveIdentityValue runs the declarative resolver —
+//
+//	SELECT ValueColumn FROM Table WHERE IDColumn = userID
+//
+// against a.DB, NOT inside the transaction, and reports whether a row matched.
+// An absent resolver table is treated as "not found" (skip, not fail): the host
+// may have renamed the user table, mirroring how an absent eraser table is
+// skipped. Table/IDColumn/ValueColumn are MustIdent-guarded (decision E3); the
+// user id is a $n bound argument. A NULL or blank value is treated as
+// unresolvable (the eraser is skipped) — an empty identity cannot usefully
+// match rows.
+func (a *App) resolveIdentityValue(ctx context.Context, dialect migrate.Dialect, userID string, r datexport.DataIdentityResolver) (string, bool, error) {
+	exists, err := tableExists(ctx, a.DB, r.Table, dialect)
+	if err != nil {
+		return "", false, fmt.Errorf("probe resolver table %q: %w", r.Table, err)
+	}
+	if !exists {
+		return "", false, nil
+	}
+	qt := query.QuoteIdent(query.MustIdent(r.Table))
+	qID := query.QuoteIdent(query.MustIdent(r.IDColumn))
+	qVal := query.QuoteIdent(query.MustIdent(r.ValueColumn))
+	var val sql.NullString
+	err = a.DB.QueryRowContext(ctx,
+		fmt.Sprintf("SELECT %s FROM %s WHERE %s = $1", qVal, qt, qID), userID).Scan(&val)
+	if err == sql.ErrNoRows {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	if !val.Valid || val.String == "" {
+		return "", false, nil
+	}
+	return val.String, true, nil
 }
 
 // collectEraseEntitySources enumerates every owner-scoped PHYSICAL table in
@@ -274,18 +375,20 @@ func childrenOf(parent string, parents map[string][]string) []string {
 // eraseWrite performs the real erasure inside one transaction. Existence
 // probes run against a.DB BEFORE BeginTx so a single-connection SQLite pool
 // does not deadlock (the tx would otherwise hold the only connection while
-// the probe waited for one).
-func (a *App) eraseWrite(ctx context.Context, dialect migrate.Dialect, userID string, cfg eraseConfig, ents []eraseEntitySource, erasers []datexport.DataEraser) (EraseReport, error) {
+// the probe waited for one). Erasers arrive already identity-resolved (see
+// resolveEraserIdentities): each carries the value its match column is bound
+// against — the user id, or a resolved identity like email.
+func (a *App) eraseWrite(ctx context.Context, dialect migrate.Dialect, userID string, cfg eraseConfig, ents []eraseEntitySource, erasers []resolvedEraser) (EraseReport, error) {
 	report := EraseReport{DryRun: false}
 
-	liveErasers := make([]datexport.DataEraser, 0, len(erasers))
+	liveErasers := make([]resolvedEraser, 0, len(erasers))
 	for _, e := range erasers {
-		exists, err := tableExists(ctx, a.DB, e.Table, dialect)
+		exists, err := tableExists(ctx, a.DB, e.eraser.Table, dialect)
 		if err != nil {
-			return report, fmt.Errorf("framework: erase probe %q: %w", e.Table, err)
+			return report, fmt.Errorf("framework: erase probe %q: %w", e.eraser.Table, err)
 		}
 		if !exists {
-			fmt.Fprintf(os.Stderr, "framework: erase: table %q absent, skipping\n", e.Table)
+			fmt.Fprintf(os.Stderr, "framework: erase: table %q absent, skipping\n", e.eraser.Table)
 			continue
 		}
 		liveErasers = append(liveErasers, e)
@@ -303,8 +406,8 @@ func (a *App) eraseWrite(ctx context.Context, dialect migrate.Dialect, userID st
 		}
 	}
 	for _, e := range liveErasers {
-		if err := requireColumn(ctx, a.DB, e.Table, e.Column, dialect); err != nil {
-			return report, fmt.Errorf("framework: erase %q: %w", e.Name, err)
+		if err := requireColumn(ctx, a.DB, e.eraser.Table, e.eraser.Column, dialect); err != nil {
+			return report, fmt.Errorf("framework: erase %q: %w", e.eraser.Name, err)
 		}
 	}
 
@@ -330,28 +433,29 @@ func (a *App) eraseWrite(ctx context.Context, dialect migrate.Dialect, userID st
 		})
 	}
 
-	// Battery plane: registered erasers.
+	// Battery plane: registered erasers, each matched against its resolved
+	// value (user id, or a resolved identity like email).
 	for _, e := range liveErasers {
-		switch e.Mode {
+		switch e.eraser.Mode {
 		case datexport.EraseDelete:
-			n, derr := eraseDelete(ctx, tx, e.Table, e.Column, userID)
+			n, derr := eraseDelete(ctx, tx, e.eraser.Table, e.eraser.Column, e.value)
 			if derr != nil {
-				return report, fmt.Errorf("framework: erase %q: %w", e.Name, derr)
+				return report, fmt.Errorf("framework: erase %q: %w", e.eraser.Name, derr)
 			}
 			report.Batteries = append(report.Batteries, EraseTableResult{
-				Name: e.Name, Source: e.Source, Table: e.Table, Mode: "delete", RowsAffected: n,
+				Name: e.eraser.Name, Source: e.eraser.Source, Table: e.eraser.Table, Mode: "delete", RowsAffected: n,
 			})
 		case datexport.EraseAnonymize:
-			ts := e.Tombstone
+			ts := e.eraser.Tombstone
 			if ts == "" {
 				ts = "[erased]"
 			}
-			n, derr := eraseAnonymize(ctx, tx, e, userID, ts)
+			n, derr := eraseAnonymize(ctx, tx, e.eraser, e.value, ts)
 			if derr != nil {
-				return report, fmt.Errorf("framework: erase %q: %w", e.Name, derr)
+				return report, fmt.Errorf("framework: erase %q: %w", e.eraser.Name, derr)
 			}
 			report.Batteries = append(report.Batteries, EraseTableResult{
-				Name: e.Name, Source: e.Source, Table: e.Table, Mode: "anonymize", RowsAffected: n,
+				Name: e.eraser.Name, Source: e.eraser.Source, Table: e.eraser.Table, Mode: "anonymize", RowsAffected: n,
 			})
 		}
 	}
@@ -377,7 +481,10 @@ func (a *App) eraseWrite(ctx context.Context, dialect migrate.Dialect, userID st
 
 // eraseDryRun counts every row that WOULD be affected without writing. No
 // transaction (read-only); absent tables contribute nothing and are skipped.
-func (a *App) eraseDryRun(ctx context.Context, dialect migrate.Dialect, userID string, cfg eraseConfig, ents []eraseEntitySource, erasers []datexport.DataEraser) (EraseReport, error) {
+// Erasers arrive already identity-resolved (see resolveEraserIdentities): each
+// is counted against its resolved value, taking the SAME resolution path as a
+// real erase.
+func (a *App) eraseDryRun(ctx context.Context, dialect migrate.Dialect, userID string, cfg eraseConfig, ents []eraseEntitySource, erasers []resolvedEraser) (EraseReport, error) {
 	report := EraseReport{DryRun: true}
 
 	for _, s := range ents {
@@ -393,26 +500,26 @@ func (a *App) eraseDryRun(ctx context.Context, dialect migrate.Dialect, userID s
 		})
 	}
 	for _, e := range erasers {
-		exists, err := tableExists(ctx, a.DB, e.Table, dialect)
+		exists, err := tableExists(ctx, a.DB, e.eraser.Table, dialect)
 		if err != nil {
-			return report, fmt.Errorf("framework: erase probe %q: %w", e.Table, err)
+			return report, fmt.Errorf("framework: erase probe %q: %w", e.eraser.Table, err)
 		}
 		if !exists {
 			continue
 		}
-		if err := requireColumn(ctx, a.DB, e.Table, e.Column, dialect); err != nil {
-			return report, fmt.Errorf("framework: erase %q: %w", e.Name, err)
+		if err := requireColumn(ctx, a.DB, e.eraser.Table, e.eraser.Column, dialect); err != nil {
+			return report, fmt.Errorf("framework: erase %q: %w", e.eraser.Name, err)
 		}
 		mode := "delete"
-		if e.Mode == datexport.EraseAnonymize {
+		if e.eraser.Mode == datexport.EraseAnonymize {
 			mode = "anonymize"
 		}
-		n, err := eraseCount(ctx, a.DB, e.Table, e.Column, userID)
+		n, err := eraseCount(ctx, a.DB, e.eraser.Table, e.eraser.Column, e.value)
 		if err != nil {
-			return report, fmt.Errorf("framework: erase %q: %w", e.Name, err)
+			return report, fmt.Errorf("framework: erase %q: %w", e.eraser.Name, err)
 		}
 		report.Batteries = append(report.Batteries, EraseTableResult{
-			Name: e.Name, Source: e.Source, Table: e.Table, Mode: mode, RowsAffected: n,
+			Name: e.eraser.Name, Source: e.eraser.Source, Table: e.eraser.Table, Mode: mode, RowsAffected: n,
 		})
 	}
 	auditExists, err := tableExists(ctx, a.DB, cfg.auditTable, dialect)

--- a/framework/erase_data_test.go
+++ b/framework/erase_data_test.go
@@ -729,3 +729,260 @@ func countRows(t *testing.T, db *sql.DB, table string) int {
 	}
 	return n
 }
+
+// ---- Identity resolution (email-keyed tables) ------------------------------
+//
+// App.EraseUserData matches by USER id, but some tables are keyed by another
+// identity — battery/auth's magic_link_tokens is keyed by EMAIL. The
+// IdentityKind seam lets an eraser declare a non-user-id identity that the
+// framework resolves ONCE at erase time (before the tx) and binds for the
+// match column. These scenarios prove the seam end to end using the magic-link
+// schema shape: a token table (token PK, email, expires_at) plus an auth_users
+// table the email resolver reads (id → email).
+
+// newIdentityEraseApp builds a minimal App (no entities) over an in-memory
+// SQLite DB. The caller creates the raw tables, seeds rows, and registers the
+// erasers/resolvers under test.
+func newIdentityEraseApp(t *testing.T) (*App, *sql.DB) {
+	t.Helper()
+	db := openSQLiteMem(t)
+	return NewApp(WithDB(db)), db
+}
+
+// createMagicLinkTables makes the auth_users + magic_link_tokens tables in the
+// exact schema the auth battery ships (email-keyed tokens).
+func createMagicLinkTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+	ctx := context.Background()
+	for _, ddl := range []string{
+		`CREATE TABLE auth_users (id TEXT PRIMARY KEY, email TEXT UNIQUE NOT NULL)`,
+		`CREATE TABLE magic_link_tokens (token TEXT PRIMARY KEY, email TEXT NOT NULL, expires_at BIGINT NOT NULL)`,
+	} {
+		if _, err := db.ExecContext(ctx, ddl); err != nil {
+			t.Fatalf("create magic-link tables: %v", err)
+		}
+	}
+}
+
+// registerMagicLinkEraseScenario wires an ISOLATED registry: the email
+// identity resolver (auth_users.id → email), the auth_users eraser (so erasing
+// the user drops the user row — making the idempotency check meaningful), and
+// the magic_link_tokens eraser keyed by email (the gap this closes).
+func registerMagicLinkEraseScenario(t *testing.T) {
+	t.Helper()
+	datexport.Reset(t)
+	datexport.RegisterIdentityResolver(datexport.IdentityEmail, datexport.DataIdentityResolver{
+		Table: "auth_users", IDColumn: "id", ValueColumn: "email",
+	})
+	datexport.RegisterEraser(datexport.DataEraser{
+		Name: "auth_users", Source: "auth", Table: "auth_users",
+		Column: "id", Mode: datexport.EraseDelete,
+	})
+	datexport.RegisterEraser(datexport.DataEraser{
+		Name: "magic_link_tokens", Source: "auth", Table: "magic_link_tokens",
+		Column: "email", Mode: datexport.EraseDelete,
+		Identity: datexport.IdentityEmail,
+	})
+}
+
+// A user's magic-link tokens are erased via the email identity, while another
+// user's tokens survive. This is the gap the seam exists to close: pre-seam the
+// token table was unreachable (keyed by email; the eraser receives only the
+// user id) and the tokens silently survived — letting a pre-erasure magic link
+// re-create the account after erasure.
+func TestEraseUserData_EmailIdentityErasesMagicLinkTokens(t *testing.T) {
+	app, db := newIdentityEraseApp(t)
+	defer db.Close()
+	createMagicLinkTables(t, db)
+	ctx := context.Background()
+	exec := func(q string, args ...any) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, q, args...); err != nil {
+			t.Fatalf("seed: %v\nquery: %s", err, q)
+		}
+	}
+	exec(`INSERT INTO auth_users (id, email) VALUES ('u1','u1@x.test'),('u2','u2@x.test')`)
+	exec(`INSERT INTO magic_link_tokens (token, email, expires_at) VALUES
+		('t1','u1@x.test',0),('t1b','u1@x.test',0),('t2','u2@x.test',0)`)
+	registerMagicLinkEraseScenario(t)
+
+	rep, err := app.EraseUserData(ctx, "u1")
+	if err != nil {
+		t.Fatalf("EraseUserData u1: %v", err)
+	}
+
+	// u1's tokens are gone; u2's survive.
+	if got := countWhere(t, db, "magic_link_tokens", "email", "u1@x.test"); got != 0 {
+		t.Errorf("u1 magic-link tokens after erase = %d, want 0", got)
+	}
+	if got := countWhere(t, db, "magic_link_tokens", "email", "u2@x.test"); got != 1 {
+		t.Errorf("u2 magic-link tokens after erase = %d, want 1 (other user intact)", got)
+	}
+	// The user row is erased too (auth_users eraser, IdentityUserID).
+	if got := countWhere(t, db, "auth_users", "id", "u1"); got != 0 {
+		t.Errorf("auth_users u1 after erase = %d, want 0", got)
+	}
+	if got := countWhere(t, db, "auth_users", "id", "u2"); got != 1 {
+		t.Errorf("auth_users u2 after erase = %d, want 1", got)
+	}
+	// The magic-link plane reports the two erased rows.
+	var ml int
+	for _, b := range rep.Batteries {
+		if b.Name == "magic_link_tokens" {
+			ml = b.RowsAffected
+		}
+	}
+	if ml != 2 {
+		t.Errorf("report magic_link_tokens RowsAffected = %d, want 2", ml)
+	}
+}
+
+// A second erasure is idempotent. After the first erase the user row is gone,
+// so the email identity CANNOT be resolved — the magic-link eraser is SKIPPED
+// (not failed), the user-id erasers match zero rows, and the report carries
+// zero with no error. An unresolvable identity is "nothing left to match", not
+// a failure.
+func TestEraseUserData_EmailIdentityIdempotentSecondRun(t *testing.T) {
+	app, db := newIdentityEraseApp(t)
+	defer db.Close()
+	createMagicLinkTables(t, db)
+	ctx := context.Background()
+	exec := func(q string, args ...any) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, q, args...); err != nil {
+			t.Fatalf("seed: %v\nquery: %s", err, q)
+		}
+	}
+	exec(`INSERT INTO auth_users (id, email) VALUES ('u1','u1@x.test')`)
+	exec(`INSERT INTO magic_link_tokens (token, email, expires_at) VALUES ('t1','u1@x.test',0)`)
+	registerMagicLinkEraseScenario(t)
+
+	if _, err := app.EraseUserData(ctx, "u1"); err != nil {
+		t.Fatalf("first erase u1: %v", err)
+	}
+
+	rep, err := app.EraseUserData(ctx, "u1")
+	if err != nil {
+		t.Fatalf("second erase u1 (idempotent): %v", err)
+	}
+	if got := rep.TotalErased(); got != 0 {
+		t.Errorf("idempotent re-erase TotalErased = %d, want 0", got)
+	}
+	// The magic-link eraser was skipped because its email identity could not
+	// be resolved (the user row is gone).
+	skipped := false
+	for _, s := range rep.Skipped {
+		if s == "magic_link_tokens" {
+			skipped = true
+		}
+	}
+	if !skipped {
+		t.Errorf("report.Skipped = %v, want it to contain magic_link_tokens", rep.Skipped)
+	}
+}
+
+// Dry-run takes the SAME resolution path as a real erase — it resolves the
+// email, counts the token rows that would be deleted, and leaves the DB
+// untouched.
+func TestEraseUserData_EmailIdentityDryRunCounts(t *testing.T) {
+	app, db := newIdentityEraseApp(t)
+	defer db.Close()
+	createMagicLinkTables(t, db)
+	ctx := context.Background()
+	exec := func(q string, args ...any) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, q, args...); err != nil {
+			t.Fatalf("seed: %v\nquery: %s", err, q)
+		}
+	}
+	exec(`INSERT INTO auth_users (id, email) VALUES ('u1','u1@x.test')`)
+	exec(`INSERT INTO magic_link_tokens (token, email, expires_at) VALUES
+		('t1','u1@x.test',0),('t1b','u1@x.test',0)`)
+	registerMagicLinkEraseScenario(t)
+
+	rep, err := app.EraseUserData(ctx, "u1", WithEraseDryRun())
+	if err != nil {
+		t.Fatalf("dry-run u1: %v", err)
+	}
+	if !rep.DryRun {
+		t.Errorf("rep.DryRun = false, want true")
+	}
+	var ml int
+	for _, b := range rep.Batteries {
+		if b.Name == "magic_link_tokens" {
+			ml = b.RowsAffected
+		}
+	}
+	if ml != 2 {
+		t.Errorf("dry-run magic_link_tokens RowsAffected = %d, want 2", ml)
+	}
+	// DB untouched: both tokens and the user row still present.
+	if got := countWhere(t, db, "magic_link_tokens", "email", "u1@x.test"); got != 2 {
+		t.Errorf("dry-run deleted tokens: %d remain, want 2 (DB unchanged)", got)
+	}
+	if got := countWhere(t, db, "auth_users", "id", "u1"); got != 1 {
+		t.Errorf("dry-run deleted user row: %d remain, want 1 (DB unchanged)", got)
+	}
+}
+
+// An eraser that declares a non-user-id identity with NO registered resolver
+// must FAIL LOUD — an unresolvable declared identity means the erasure is
+// incomplete, and silently-incomplete is the failure mode this primitive
+// exists to prevent. Both real and dry-run paths must fail.
+func TestEraseUserData_IdentityWithoutResolverFailsLoud(t *testing.T) {
+	app, db := newIdentityEraseApp(t)
+	defer db.Close()
+	createMagicLinkTables(t, db)
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `INSERT INTO auth_users (id, email) VALUES ('u1','u1@x.test')`); err != nil {
+		t.Fatal(err)
+	}
+	datexport.Reset(t)
+	// NO IdentityEmail resolver registered — the eraser declares an identity
+	// the framework cannot resolve at all.
+	datexport.RegisterEraser(datexport.DataEraser{
+		Name: "magic_link_tokens", Source: "auth", Table: "magic_link_tokens",
+		Column: "email", Mode: datexport.EraseDelete,
+		Identity: datexport.IdentityEmail,
+	})
+
+	if _, err := app.EraseUserData(ctx, "u1"); err == nil {
+		t.Fatal("erasure with a declared identity but no resolver succeeded (must fail loud)")
+	}
+	if _, err := app.EraseUserData(ctx, "u1", WithEraseDryRun()); err == nil {
+		t.Fatal("dry-run with a declared identity but no resolver succeeded (must fail loud)")
+	}
+}
+
+// The resolved value is BOUND, not interpolated into SQL. An email containing
+// a single quote (o'brien@x.test) must erase correctly — neither breaking the
+// statement nor injecting past the match. Interpolating it would syntax-error
+// the DELETE or delete more than intended.
+func TestEraseUserData_EmailIdentityBindsQuotedValue(t *testing.T) {
+	app, db := newIdentityEraseApp(t)
+	defer db.Close()
+	createMagicLinkTables(t, db)
+	ctx := context.Background()
+	exec := func(q string, args ...any) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, q, args...); err != nil {
+			t.Fatalf("seed: %v\nquery: %s", err, q)
+		}
+	}
+	exec(`INSERT INTO auth_users (id, email) VALUES ('u1',$1),('u2',$2)`, "o'brien@x.test", "u2@x.test")
+	exec(`INSERT INTO magic_link_tokens (token, email, expires_at) VALUES ($1,$3,0),($2,$4,0)`,
+		"tok-u1", "tok-u2", "o'brien@x.test", "u2@x.test")
+	registerMagicLinkEraseScenario(t)
+
+	if _, err := app.EraseUserData(ctx, "u1"); err != nil {
+		t.Fatalf("EraseUserData u1 (quoted email): %v", err)
+	}
+	// The quoted-email token is gone; the other user's token survives (no
+	// injection widened the delete).
+	if got := countWhere(t, db, "magic_link_tokens", "email", "o'brien@x.test"); got != 0 {
+		t.Errorf("o'brien token after erase = %d, want 0 (quote must not break the bind)", got)
+	}
+	if got := countWhere(t, db, "magic_link_tokens", "email", "u2@x.test"); got != 1 {
+		t.Errorf("u2 token after erase = %d, want 1 (quote must not inject past the match)", got)
+	}
+}

--- a/framework/filter/filter.go
+++ b/framework/filter/filter.go
@@ -425,6 +425,17 @@ func nearestField(key string, fieldNames []string) string {
 			break
 		}
 	}
+	// The key arrives straight off the request URL (a query-param NAME,
+	// unauthenticated, no body). Levenshtein's cost is len(key) ×
+	// Σ len(fieldNames), so an attacker can push ~1 MiB of key at a 30-field
+	// entity for a per-GET CPU spike. A real field name is short — skip the
+	// suggestion entirely past a small bound and return the plain
+	// unknown-field error. (Build-time/argv callers in contracts and the CLI
+	// pass trusted, tiny identifiers and never hit this.)
+	const maxSuggestionKeyLen = 64
+	if len(base) > maxSuggestionKeyLen {
+		return ""
+	}
 	best, bestDist, ties := "", 1<<30, 0
 	// Allow more slack for longer names; a 1-char typo in "status" and a
 	// 2-char transposition should both resolve.

--- a/framework/filter/injection_security_test.go
+++ b/framework/filter/injection_security_test.go
@@ -1,11 +1,13 @@
 package filter
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DonaldMurillo/gofastr/core/query"
 	"github.com/DonaldMurillo/gofastr/core/schema"
@@ -311,5 +313,44 @@ func TestSearchSQLPayloadParameterized(t *testing.T) {
 				t.Errorf("SECURITY: [filter_search] payload %q leaked into SQL: %q", p, sql)
 			}
 		}
+	}
+}
+
+// TestUnknownFilterKeyIsBounded pins the cost ceiling on the "did you mean"
+// suggestion path. The unrecognized filter key is a query-param NAME straight
+// off the request URL — unauthenticated, no body — and nearestField runs
+// fuzzy.Levenshtein over it against every field name, so cost is
+// len(key) × Σ len(fieldNames) (~225ms/MiB measured over 30 fields). With
+// Go's default 1 MiB MaxHeaderBytes that is a per-GET CPU spike an
+// unauthenticated caller can trigger at will. A real field name is short, so
+// the suggestion is skipped past a small bound and the plain unknown-field
+// error returns instantly.
+func TestUnknownFilterKeyIsBounded(t *testing.T) {
+	fields := make([]schema.Field, 30)
+	for i := range fields {
+		fields[i] = schema.Field{Name: fmt.Sprintf("field_%02d", i), Type: schema.String}
+	}
+	// 8 MiB key: uncapped Levenshtein over 30 fields is ~1.7s here; after the
+	// len-bound guard it is microseconds. A 500ms budget separates the two by
+	// ~300×, so it holds across any realistic CI machine speed.
+	bigKey := strings.Repeat("x", 8<<20)
+	q := url.Values{}
+	q.Set(bigKey, "1")
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := ParseFiltersValues(q, fields)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an unknown-filter error for the oversized key, got nil")
+		}
+		if strings.Contains(err.Error(), "did you mean") {
+			t.Errorf("oversized key still computed a suggestion: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("unknown-filter parse did not return promptly — uncapped Levenshtein over an 8 MiB key")
 	}
 }

--- a/framework/metrics_collectors_test.go
+++ b/framework/metrics_collectors_test.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"context"
 	"database/sql"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/DonaldMurillo/gofastr/core/middleware"
+	"github.com/DonaldMurillo/gofastr/framework/event"
 )
 
 // TestAppMetrics_NilWithoutWithMetrics pins that the accessor returns nil
@@ -57,6 +59,45 @@ func TestAppMetrics_DBPoolCollector(t *testing.T) {
 		"db_pool_wait_count_total ",
 		"# TYPE db_pool_wait_duration_seconds_total counter",
 		"db_pool_wait_duration_seconds_total ",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in /metrics:\n%s", want, body)
+		}
+	}
+}
+
+// TestAppMetrics_OutboxCollectorAutoWired pins the framework-owned outbox
+// surface: an app built with WithOutbox + WithMetrics exposes the
+// per-consumer outbox gauges on the single /metrics endpoint the moment any
+// caller takes the metrics handle (a battery's Init in a real app;
+// app.Metrics() here stands in for that). No second handler to mount, no
+// cross-package wiring — RegisterCollector("outbox", …) fires from Metrics()
+// itself. The DB-pool collector must still land alongside it, so the two
+// framework-owned collectors coexist on one scrape.
+func TestAppMetrics_OutboxCollectorAutoWired(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Skip("sqlite3 driver not available")
+	}
+	t.Cleanup(func() { db.Close() })
+
+	app := NewApp(WithDB(db), WithMetrics(),
+		WithOutbox(),
+		WithOutboxConsumer("witness", event.EntityCreated,
+			func(context.Context, event.Event) error { return nil }),
+	)
+	m := app.Metrics()
+	if m == nil {
+		t.Fatal("Metrics() returned nil with WithMetrics + WithOutbox enabled")
+	}
+
+	rec := httptest.NewRecorder()
+	middleware.MetricsHandler(m).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := rec.Body.String()
+
+	for _, want := range []string{
+		"# TYPE outbox_pending gauge",           // framework-owned outbox collector
+		"# TYPE db_pool_open_connections gauge", // coexisting DB-pool collector
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("missing %q in /metrics:\n%s", want, body)

--- a/framework/oauth_resource_metadata_test.go
+++ b/framework/oauth_resource_metadata_test.go
@@ -1,0 +1,101 @@
+package framework
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestOAuthProtectedResource_OptionalFields pins that the RFC 9728 metadata
+// document at /.well-known/oauth-protected-resource reflects every optional
+// field a host configures — jwks_uri, resource_name, resource_documentation,
+// resource_policy_uri, resource_tos_uri, plus the authorization_servers and
+// scopes_supported lists. Each is emitted only when set, so a regression that
+// dropped one would silently publish an incomplete discovery doc that a client
+// following the spec could not recover from.
+func TestOAuthProtectedResource_OptionalFields(t *testing.T) {
+	cfg := OAuthProtectedResourceConfig{
+		Resource:               "https://api.example.test",
+		AuthorizationServers:   []string{"https://auth.example.test"},
+		ScopesSupported:        []string{"read", "write"},
+		BearerMethodsSupported: []string{"header", "body"},
+		JWKSURI:                "https://api.example.test/.well-known/jwks.json",
+		ResourceName:           "Example API",
+		ResourceDocumentation:  "https://api.example.test/docs",
+		ResourcePolicyURI:      "https://api.example.test/privacy",
+		ResourceTOSURI:         "https://api.example.test/tos",
+	}
+	app, cleanup := startApp(t, NewApp(WithOAuthProtectedResource(cfg)))
+	defer cleanup()
+
+	rec := httptest.NewRecorder()
+	app.router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	stringFields := map[string]string{
+		"resource":               cfg.Resource,
+		"jwks_uri":               cfg.JWKSURI,
+		"resource_name":          cfg.ResourceName,
+		"resource_documentation": cfg.ResourceDocumentation,
+		"resource_policy_uri":    cfg.ResourcePolicyURI,
+		"resource_tos_uri":       cfg.ResourceTOSURI,
+	}
+	for key, want := range stringFields {
+		if got, _ := doc[key].(string); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+	// Slice fields come back from JSON as []any; compare element-wise.
+	checkSlice := func(key string, want []string) {
+		t.Helper()
+		got, _ := doc[key].([]any)
+		if len(got) != len(want) {
+			t.Errorf("%s = %v, want %v", key, got, want)
+			return
+		}
+		for i, w := range want {
+			if g, _ := got[i].(string); g != w {
+				t.Errorf("%s[%d] = %q, want %q", key, i, g, w)
+			}
+		}
+	}
+	checkSlice("authorization_servers", cfg.AuthorizationServers)
+	checkSlice("scopes_supported", cfg.ScopesSupported)
+	checkSlice("bearer_methods_supported", cfg.BearerMethodsSupported)
+}
+
+// TestOAuthProtectedResource_BearerDefaultsToHeader pins the documented
+// default: a host that leaves BearerMethodsSupported empty still publishes
+// ["header"] (RFC 6750's primary method), not an empty or absent field.
+func TestOAuthProtectedResource_BearerDefaultsToHeader(t *testing.T) {
+	app, cleanup := startApp(t, NewApp(WithOAuthProtectedResource(OAuthProtectedResourceConfig{
+		Resource: "https://api.example.test",
+	})))
+	defer cleanup()
+
+	rec := httptest.NewRecorder()
+	app.router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	got, _ := doc["bearer_methods_supported"].([]any)
+	if len(got) != 1 || got[0] != "header" {
+		t.Errorf("bearer_methods_supported = %v, want [header] (the RFC 6750 default)", got)
+	}
+	// Optional fields absent when unset — they must not appear as empty strings.
+	for _, key := range []string{"jwks_uri", "resource_name", "resource_documentation", "resource_policy_uri", "resource_tos_uri", "authorization_servers", "scopes_supported"} {
+		if _, present := doc[key]; present {
+			t.Errorf("unset optional field %q should be absent, got %v", key, doc[key])
+		}
+	}
+}

--- a/framework/processmodule_broker.go
+++ b/framework/processmodule_broker.go
@@ -74,12 +74,15 @@ type Broker struct {
 // exactly what the reverse path needs to (a) re-attach the caller's identity
 // to the CRUD re-dispatch (Cookie/Authorization re-injected via crud.Redispatch
 // reading mcp.WithRequest) and (b) run the CrossOwnerRead carve-out on the
-// delegated caller (roles + policy). parentCallID is diagnostic correlation.
+// delegated caller (roles + policy). module binds the handle to the module
+// that minted it (F6) so an app-global handle table cannot be replayed under
+// a different module's reverse handler. parentCallID is diagnostic correlation.
 type delegationEntry struct {
 	cookie        string
 	authorization string
 	roles         []string
 	policy        *access.RolePolicy
+	module        string
 	parentCallID  uint64
 	expires       time.Time
 }
@@ -165,13 +168,23 @@ func mustHandle(p *moduleproto.Peer, method string, h moduleproto.Handler) {
 // A nil r is the ambient (caller-less) path — MintDelegation is still legal
 // but returns an empty handle the broker treats as ambient.
 func (b *Broker) MintDelegation(r *http.Request, parentCallID uint64) (string, func()) {
-	handle := randomHandle()
+	handle, err := randomHandle()
+	if err != nil {
+		// Entropy failure is fatal: rand.Read failing means the handle would
+		// be the identical all-zero string for every call, and the handle IS
+		// the delegation credential. Fail loud — mirrors
+		// battery/auth/apitoken.go ("Entropy failure is fatal"). The panic
+		// is contained by the host's recovery middleware (→ 503/500); no
+		// handle is minted, so no delegation occurs.
+		panic(fmt.Sprintf("processmodule broker: mint delegation handle: %v", err))
+	}
 	entry := delegationEntry{parentCallID: parentCallID, expires: b.now().Add(b.handleTTL)}
 	if r != nil {
 		entry.cookie = r.Header.Get("Cookie")
 		entry.authorization = r.Header.Get("Authorization")
 		entry.roles = access.GetRoles(r.Context())
 		entry.policy = access.PolicyFromContext(r.Context())
+		entry.module = delegationModuleFromCtx(r.Context())
 	}
 	b.mu.Lock()
 	if b.handles == nil {
@@ -186,10 +199,39 @@ func (b *Broker) MintDelegation(r *http.Request, parentCallID uint64) (string, f
 	}
 }
 
-func randomHandle() string {
+// randomHandle returns a 128-bit opaque delegation handle. The error from
+// crypto/rand is propagated (never swallowed): on failure every handle would
+// otherwise collapse to the same all-zero string, and the handle is the
+// delegation credential. Callers MUST treat a non-nil error as fatal.
+func randomHandle() (string, error) {
 	var buf [16]byte
-	_, _ = rand.Read(buf[:])
-	return hex.EncodeToString(buf[:])
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", fmt.Errorf("read delegation entropy: %w", err)
+	}
+	return hex.EncodeToString(buf[:]), nil
+}
+
+// delegationModuleKey carries the module name a delegation handle is being
+// minted for (F6). It is stamped on the mint request's context by the
+// supervisor's proxy and tool dispatch (the only legitimate minters) and read
+// by MintDelegation so resolveCaller can refuse a handle minted for one
+// module when it is echoed under a different module's reverse handler. The
+// unexported key type means no value can be set except via withDelegationModule.
+type delegationModuleKey struct{}
+
+// withDelegationModule stamps ctx with the module name a delegation handle is
+// being minted for. The supervisor's proxy (serveProxy) and tool dispatch
+// (dispatchToolCall) call this immediately before MintDelegation.
+func withDelegationModule(ctx context.Context, module string) context.Context {
+	return context.WithValue(ctx, delegationModuleKey{}, module)
+}
+
+func delegationModuleFromCtx(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	m, _ := ctx.Value(delegationModuleKey{}).(string)
+	return m
 }
 
 // ----- entity ops -----
@@ -263,9 +305,12 @@ func parseEntityCall(op entityOp, params json.RawMessage) (entityName string, ca
 //     present non-grantable scope means tampering — deny;
 //  3. delegation resolve: look up the handle (ambient when empty), denying on
 //     unknown/expired/released;
-//  4. CrossOwnerRead carve-out, delegated-caller half: if the target entity
-//     opts into CrossOwnerRead and the re-attached caller holds it, deny — a
-//     module never brokers data in a cross-owner frame.
+//  4. CrossOwnerRead carve-out, delegated-caller half (belt-and-suspenders):
+//     the root-cause guarantee is the brokeredCall marker on the re-dispatch
+//     context (crossOwnerReadGranted returns false for it). This gate is the
+//     explicit deny: it evaluates the carve-out against the delegated
+//     caller's snapshot policy, falling back to the broker's app-wide policy,
+//     and DENIES when neither is available (the pre-fix no-op).
 //
 // It returns the resolved entity (for the re-dispatch path) and the
 // re-dispatch context with the caller's identity re-attached.
@@ -300,13 +345,30 @@ func (b *Broker) gate(ctx context.Context, entityName, verb string, view ModuleG
 		return nil, nil, err
 	}
 
-	// (4) CrossOwnerRead delegated-caller half. The entity's CrossOwnerRead
-	// permission is host-trusted config; if the re-attached caller holds it,
-	// the re-dispatch would lift owner scoping — so the broker refuses to
-	// broker the call at all. This is the load-bearing carve-out.
-	if cor := ent.Config.Scope.CrossOwnerRead; cor != "" && entry != nil && entry.policy != nil {
-		checkCtx := access.WithPolicy(access.WithRoles(ctx, entry.roles), entry.policy)
-		if access.Can(checkCtx, access.Permission(cor)) {
+	// (4) CrossOwnerRead delegated-caller half — belt-and-suspenders. The
+	// root-cause guarantee is the brokeredCall marker resolveCaller stamps on
+	// the re-dispatch context: crossOwnerReadGranted returns false for it, so
+	// owner scoping holds by construction regardless of the re-resolved
+	// caller's permissions. This gate is the explicit, visible deny. It
+	// evaluates against the delegated caller's snapshot policy when present,
+	// falling back to the broker's app-wide policy; when neither is available
+	// the carve-out is unevaluatable and we DENY rather than silently permit
+	// (the pre-fix behavior, which no-op'd on a nil entry.policy).
+	if cor := ent.Config.Scope.CrossOwnerRead; cor != "" {
+		policy := b.policy
+		roles := []string{moduleRole(view.Name)}
+		if entry != nil {
+			if entry.policy != nil {
+				policy = entry.policy
+			}
+			if len(entry.roles) > 0 {
+				roles = entry.roles
+			}
+		}
+		if policy == nil {
+			return nil, nil, brokerDeny("CrossOwnerRead is not brokerable through a module (no policy to evaluate)")
+		}
+		if access.Can(access.WithPolicy(access.WithRoles(ctx, roles), policy), access.Permission(cor)) {
 			return nil, nil, brokerDeny("CrossOwnerRead is not brokerable through a module")
 		}
 	}
@@ -318,7 +380,9 @@ func (b *Broker) gate(ctx context.Context, entityName, verb string, view ModuleG
 // synthetic module/<name> role + the broker's app-wide policy are attached so
 // the CRUD permission gate can consult the module's grants; owner/tenant
 // gates then fail closed (no owner id). A non-empty handle is looked up; an
-// unknown/expired/released handle denies.
+// unknown/expired/released handle, or one bound to a different module (F6),
+// denies. Every returned context is stamped brokeredCall (F3) so the CRUD
+// owner gate never lifts scope for a brokered call.
 func (b *Broker) resolveCaller(ctx context.Context, caller moduleproto.CallerRef, view ModuleGrantView) (context.Context, *delegationEntry, error) {
 	if caller.Delegation == "" {
 		// Ambient. Attach the synthetic role; the design's safe-by-construction
@@ -328,7 +392,7 @@ func (b *Broker) resolveCaller(ctx context.Context, caller moduleproto.CallerRef
 		if b.policy != nil {
 			rctx = access.WithPolicy(rctx, b.policy)
 		}
-		return rctx, nil, nil
+		return crud.WithBrokeredCall(rctx), nil, nil
 	}
 	b.mu.Lock()
 	entry, ok := b.handles[caller.Delegation]
@@ -342,12 +406,21 @@ func (b *Broker) resolveCaller(ctx context.Context, caller moduleproto.CallerRef
 		b.mu.Unlock()
 		return nil, nil, brokerDeny("expired delegation handle")
 	}
+	// F6: a handle is bound to the module that minted it (entry.module). A
+	// handle minted for one module must not resolve under another module's
+	// reverse handler. entry.module is "" for minters not yet wired through
+	// withDelegationModule; those stay unbound (not rejected) for back-compat.
+	if entry.module != "" && entry.module != view.Name {
+		return nil, nil, brokerDeny("delegation handle bound to module %q, not %q", entry.module, view.Name)
+	}
 	// Re-attach the originating request so crud.Redispatch re-injects the
 	// caller's Cookie/Authorization and the full middleware chain re-resolves
 	// the identity (design §5 caveat b).
 	snap := snapshotRequest(entry)
 	rctx := mcp.WithRequest(ctx, snap)
-	return rctx, &entry, nil
+	// F3: stamp the re-dispatch as brokered so crossOwnerReadGranted refuses
+	// to lift owner scoping no matter what the re-resolved caller holds.
+	return crud.WithBrokeredCall(rctx), &entry, nil
 }
 
 // dispatchEntity performs the op-shaped CRUD re-dispatch through the router
@@ -363,6 +436,14 @@ func (b *Broker) dispatchEntity(op entityOp, ent *entity.Entity, ctx context.Con
 		if err := unmarshalParams(params, &p); err != nil {
 			return nil, err
 		}
+		// F2: a child cannot smuggle control keys (include/trashed/where/…)
+		// or undeclared names through p.Filter into the CRUD query. Drop
+		// every key that is not a declared, non-Hidden, non-NoQuery field.
+		filtered, err := sanitizeFilter(ent, p.Filter)
+		if err != nil {
+			return nil, paramErr("filter: %v", err)
+		}
+		p.Filter = filtered
 		path := base + entityQuerySuffix(p)
 		res, err := crud.Redispatch(ctx, b.router, http.MethodGet, path, nil)
 		if err != nil {
@@ -528,8 +609,10 @@ func snapshotRequest(entry delegationEntry) *http.Request {
 }
 
 // entityQuerySuffix expands the structured query params into the CRUD list
-// query string the filter/sort/select/limit/offset DSL expects. The filter
-// shape is the host's flat field_suffix map (mirrors crud/mcp.go listTool).
+// query string the filter/sort/select/limit/offset DSL expects. p.Filter MUST
+// be allow-listed by the caller (dispatchEntity runs it through sanitizeFilter)
+// before reaching here — expandRaw forwards every key verbatim, so an
+// unfiltered filter would let a child inject control keys (include/trashed/…).
 func entityQuerySuffix(p moduleproto.EntityQueryParams) string {
 	q := url.Values{}
 	expandRaw(q, p.Filter)
@@ -555,7 +638,10 @@ func entityQuerySuffix(p moduleproto.EntityQueryParams) string {
 }
 
 // expandRaw sets one query param per top-level key of a JSON object filter.
-// Non-object filters are ignored (the host's filter DSL is a flat map).
+// Non-object filters are ignored (the host's filter DSL is a flat map). It is
+// an UNFILTERED primitive — every key is forwarded verbatim — so the caller
+// MUST allow-list first (see sanitizeFilter, which mirrors the crud/mcp.go
+// listTool field allow-list). Do NOT call expandRaw on an untrusted filter.
 func expandRaw(q url.Values, raw json.RawMessage) {
 	if len(raw) == 0 {
 		return
@@ -567,6 +653,64 @@ func expandRaw(q url.Values, raw json.RawMessage) {
 	for k, v := range m {
 		q.Set(k, fmt.Sprint(v))
 	}
+}
+
+// sanitizeFilter reduces a child-supplied filter object to the keys that name
+// a declared, non-Hidden, non-NoQuery field of ent — optionally suffixed with
+// a comparison operator the filter DSL recognizes (_gt/_gte/_lt/_lte/_like/_in).
+// Control keys (include/trashed/where/limit/sort/fields/q/…), Hidden/NoQuery
+// field names, and undeclared names are dropped so they can never reach the
+// CRUD list query string. This is the F2 fix: it mirrors the allow-list
+// crud/mcp.go listTool builds, which expandRaw alone does not. Non-object
+// filters pass through unchanged (expandRaw ignores them anyway).
+func sanitizeFilter(ent *entity.Entity, raw json.RawMessage) (json.RawMessage, error) {
+	if ent == nil || len(raw) == 0 {
+		return raw, nil
+	}
+	var m map[string]any
+	if json.Unmarshal(raw, &m) != nil {
+		return raw, nil // non-object: expandRaw ignores it; pass through
+	}
+	allowed := queryableFieldKeys(ent)
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if allowed[k] {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// queryableFieldKeys returns the set of filter keys the CRUD list parser
+// accepts for ent's declared, non-Hidden, non-NoQuery fields: each field's
+// column Name and WireName alias, each with the optional comparison suffixes
+// the filter DSL recognizes. Mirrors crud/mcp.go listTool's mcpFieldKey loop.
+func queryableFieldKeys(ent *entity.Entity) map[string]bool {
+	allowed := make(map[string]bool)
+	if ent == nil {
+		return allowed
+	}
+	for _, f := range ent.GetFields() {
+		if f.Hidden || f.NoQuery {
+			continue
+		}
+		for _, k := range []string{f.Name, f.WireName} {
+			if k == "" {
+				continue
+			}
+			for _, suffix := range []string{"", "_gt", "_gte", "_lt", "_lte", "_like", "_in"} {
+				allowed[k+suffix] = true
+			}
+		}
+	}
+	return allowed
 }
 
 func sortParam(raw json.RawMessage) string {

--- a/framework/processmodule_broker_security_test.go
+++ b/framework/processmodule_broker_security_test.go
@@ -1,0 +1,215 @@
+package framework
+
+// Adversarial security tests for the process-module capability broker
+// (design #37 §5). One file, one property family per finding (F2/F3/F6).
+// These pin the production fix; see processmodule_broker.go for the design
+// notes. Naming + shape follow .claude/skills/adversarial-tests/SKILL.md.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/moduleproto"
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/access"
+	"github.com/DonaldMurillo/gofastr/framework/crud"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// ---------------------------------------------------------------------------
+// F2 — a module cannot reach entities outside its grant via caller-supplied
+// CONTROL KEYS smuggled through the child filter. expandRaw used to forward
+// every top-level key of p.Filter into the CRUD list query, so a child could
+// inject include/trashed/where/limit (and any undeclared name). The fix
+// allow-lists p.Filter against the entity's declared, non-Hidden, non-NoQuery
+// fields (mirrors crud/mcp.go listTool).
+// ---------------------------------------------------------------------------
+
+// TestBrokerFilterCannotSetControlKeys asserts the property on every distinct
+// attack shape in one table: control keys, a valid field, a suffixed valid
+// field, a NoQuery field, a Hidden field, and an undeclared name.
+func TestBrokerFilterCannotSetControlKeys(t *testing.T) {
+	ent := brokerEntity("docs", "docs", func(c *entity.EntityConfig) {
+		c.Fields = []schema.Field{
+			{Name: "id", Type: schema.String},
+			{Name: "status", Type: schema.String},
+			{Name: "created_at", Type: schema.String},
+			{Name: "ssn", Type: schema.String, NoQuery: true},   // visible but never filterable
+			{Name: "secret", Type: schema.String, Hidden: true}, // existence must stay hidden
+		}
+	})
+
+	// One filter exercising every attack class at once.
+	raw := json.RawMessage(`{
+		"include":"author","trashed":true,"where":"x","limit":1,
+		"page":2,"sort":"id","fields":"id","q":"pw","offset":3,
+		"cursor":"c","direction":"asc","stream":1,"per_page":5,
+		"status":"open","created_at_gte":"2026-01-01",
+		"ssn":"111-22-3333","secret":"x","bogus":"y"
+	}`)
+
+	got, err := sanitizeFilter(ent, raw)
+	if err != nil {
+		t.Fatalf("sanitizeFilter errored: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(got, &m); err != nil {
+		t.Fatalf("sanitizeFilter output not a JSON object: %v (out=%s)", err, got)
+	}
+
+	// Every control key + non-queryable + undeclared name MUST be dropped.
+	banned := []string{
+		"include", "trashed", "where", "limit", "page", "sort", "fields",
+		"q", "offset", "cursor", "direction", "stream", "per_page",
+		"ssn", "secret", "bogus",
+	}
+	for _, k := range banned {
+		if _, ok := m[k]; ok {
+			t.Errorf("F2 leak: key %q reached the CRUD query (should be dropped)", k)
+		}
+	}
+	// Declared, non-Hidden, non-NoQuery field keys (with comparison suffix)
+	// are the ONLY keys that survive.
+	if m["status"] != "open" {
+		t.Errorf("declared field %q was dropped: got %v", "status", m["status"])
+	}
+	if m["created_at_gte"] != "2026-01-01" {
+		t.Errorf("suffixed field %q was dropped: got %v", "created_at_gte", m["created_at_gte"])
+	}
+	if len(m) != 2 {
+		t.Errorf("sanitizeFilter left %d keys, want exactly 2: %v", len(m), m)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// F3 — a brokered re-dispatch NEVER lifts owner scope, even when the
+// re-resolved caller legitimately holds CrossOwnerRead. The root-cause fix
+// stamps every brokered re-dispatch context with crud.WithBrokeredCall so
+// crossOwnerReadGranted returns false by construction; the gate at broker.gate
+// is belt-and-suspenders (now with a b.policy fallback + fail-closed deny).
+// ---------------------------------------------------------------------------
+
+func TestBrokerNeverLiftsOwnerScope(t *testing.T) {
+	// Entity is owner-scoped AND opts into CrossOwnerRead.
+	mkReg := func() *Registry {
+		return brokerRegistry(brokerEntity("logs", "logs", func(c *entity.EntityConfig) {
+			c.Scope.CrossOwnerRead = "logs:read:all"
+		}))
+	}
+	policy := access.NewRolePolicy()
+	if err := policy.Grant("super", "logs:read", "logs:read:all"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sub-case 1: the delegated caller legitimately holds CrossOwnerRead and
+	// the mint-time snapshot captured a policy. The gate denies BEFORE
+	// re-dispatch; the router is never reached.
+	t.Run("caller_holds_crossowner_denies", func(t *testing.T) {
+		var hit atomic.Bool
+		b := NewBroker(fakeSuccessRouter(&hit), mkReg(), nil, "")
+		handle, release := brokerMint(t, b, policy, "alice", []string{"super"})
+		defer release()
+		h := b.entityHandler(ModuleGrantView{Name: "m", Grants: []access.Permission{"logs:read"}}, opQuery)
+		_, err := callReverse(t, h, moduleproto.EntityQueryParams{
+			Entity: "logs",
+			Caller: moduleproto.CallerRef{Delegation: handle},
+		})
+		wantDenied(t, err)
+		wantNotHit(t, &hit)
+	})
+
+	// Sub-case 2: the mint-time snapshot carries NO policy (entry.policy ==
+	// nil) and the broker has no app-wide policy (b.policy == nil). Today
+	// this unevaluatable carve-out silently permitted the re-dispatch to
+	// resolve the caller with CrossOwnerRead; it must now DENY fail-closed.
+	t.Run("mint_time_policy_nil_fail_closed", func(t *testing.T) {
+		var hit atomic.Bool
+		b := NewBroker(fakeSuccessRouter(&hit), mkReg(), nil, "") // no WithBrokerPolicy
+		req := httptest.NewRequest(http.MethodGet, "/x", nil)
+		req.Header.Set("Cookie", "sid=alice")
+		mctx := access.WithRoles(req.Context(), []string{"super"}) // NO policy
+		handle, release := b.MintDelegation(req.WithContext(mctx), 1)
+		defer release()
+		h := b.entityHandler(ModuleGrantView{Name: "m", Grants: []access.Permission{"logs:read"}}, opQuery)
+		_, err := callReverse(t, h, moduleproto.EntityQueryParams{
+			Entity: "logs",
+			Caller: moduleproto.CallerRef{Delegation: handle},
+		})
+		wantDenied(t, err)
+		wantNotHit(t, &hit)
+	})
+
+	// Sub-case 3: a brokered call that PROCEEDS (no CrossOwnerRead on the
+	// entity) must still stamp the re-dispatch context with the brokeredCall
+	// marker — the root-cause guarantee that owner scope holds by
+	// construction for every brokered call.
+	t.Run("redispatch_context_stamped", func(t *testing.T) {
+		var sawMarker atomic.Bool
+		router := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if crud.IsBrokeredCall(r.Context()) {
+				sawMarker.Store(true)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":[],"total":0}`))
+		})
+		reg := brokerRegistry(brokerEntity("notes", "notes", nil))
+		b := NewBroker(router, reg, nil, "")
+		handle, release := brokerMint(t, b, access.NewRolePolicy(), "alice", nil)
+		defer release()
+		h := b.entityHandler(ModuleGrantView{Name: "m", Grants: []access.Permission{"notes:read"}}, opQuery)
+		_, err := callReverse(t, h, moduleproto.EntityQueryParams{
+			Entity: "notes",
+			Caller: moduleproto.CallerRef{Delegation: handle},
+		})
+		wantOK(t, err)
+		if !sawMarker.Load() {
+			t.Fatal("F3: re-dispatch context was not stamped brokeredCall — owner scope is not guaranteed by construction")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// F6 — delegation handles are app-global (one Broker.handles map shared by
+// every module). A handle minted for module A must be refused when it is
+// echoed back under module B's reverse handler. The fix binds each handle to
+// the minting module and rejects on mismatch in resolveCaller.
+// ---------------------------------------------------------------------------
+
+func TestBrokerHandleBoundToModule(t *testing.T) {
+	reg := brokerRegistry(brokerEntity("docs", "docs", nil))
+	var hit atomic.Bool
+	b := NewBroker(fakeSuccessRouter(&hit), reg, nil, "")
+
+	// Mint a handle bound to moduleA (stamp the module on the mint context,
+	// exactly as the supervisor's proxy/tools paths do).
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Cookie", "sid=alice")
+	mintCtx := withDelegationModule(req.Context(), "moduleA")
+	handle, release := b.MintDelegation(req.WithContext(mintCtx), 1)
+	defer release()
+
+	// moduleB presents moduleA's handle → refused, router never reached.
+	hB := b.entityHandler(ModuleGrantView{Name: "moduleB", Grants: []access.Permission{"docs:read"}}, opQuery)
+	_, err := callReverse(t, hB, moduleproto.EntityQueryParams{
+		Entity: "docs",
+		Caller: moduleproto.CallerRef{Delegation: handle},
+	})
+	wantDenied(t, err)
+	wantNotHit(t, &hit)
+
+	// Sanity: the SAME handle under moduleA's own handler is accepted — this
+	// is a cross-module bind, not a blanket rejection.
+	hit.Store(false)
+	hA := b.entityHandler(ModuleGrantView{Name: "moduleA", Grants: []access.Permission{"docs:read"}}, opQuery)
+	_, err = callReverse(t, hA, moduleproto.EntityQueryParams{
+		Entity: "docs",
+		Caller: moduleproto.CallerRef{Delegation: handle},
+	})
+	wantOK(t, err)
+	if !hit.Load() {
+		t.Fatal("handle bound to moduleA must resolve under moduleA's handler (false positive would over-restrict)")
+	}
+}

--- a/framework/processmodule_proxy.go
+++ b/framework/processmodule_proxy.go
@@ -105,6 +105,10 @@ func (s *ProcessModuleSupervisor) serveProxy(name, routeID string, w http.Respon
 	// in-memory table cannot leak across a long-lived connection.
 	callID := proxyCallID.Add(1)
 	requestID := fmt.Sprintf("%s-%d", name, callID)
+	// F6: bind the delegation handle to THIS module (name) so it cannot be
+	// replayed under another module's reverse handler — the handle table is
+	// app-global.
+	r = r.WithContext(withDelegationModule(r.Context(), name))
 	handle, release := s.broker.MintDelegation(r, callID)
 	defer release()
 

--- a/framework/processmodule_tools.go
+++ b/framework/processmodule_tools.go
@@ -309,14 +309,16 @@ func (s *ProcessModuleSupervisor) dispatchToolCall(ctx context.Context, moduleNa
 		return nil, ErrModuleToolNotReady
 	}
 
-	// Mint a delegation handle from the calling agent's context so a
-	// reverse host.* call re-attaches THIS caller's authority to the CRUD
-	// re-dispatch (design §5.1 ↔ §5). The agent's authority arrives in ctx
-	// (roles / policy / user); MintDelegation snapshots them. An anonymous
-	// agent (no user) mints an ambient handle — the broker's owner/tenant
-	// gates then refuse owner-scoped reads by construction.
+	// Mint a delegation handle bound to THIS module (F6) so a reverse host.*
+	// call cannot replay it under another module's handler. The agent's
+	// authority arrives in ctx (roles / policy / user); MintDelegation
+	// snapshots them, but they are NOT re-attached on the reverse path
+	// (snapshotRequest copies only Cookie/Authorization, which tool calls
+	// lack) — so a tool-sourced reverse call re-dispatches anonymously and
+	// requireScope refuses owner-scoped reads by construction. See the F7
+	// note on requestFromToolCtx.
 	callID := moduleToolCallID.Add(1)
-	mintReq := requestFromToolCtx(ctx)
+	mintReq := requestFromToolCtx(withDelegationModule(ctx, moduleName))
 	handle, release := s.broker.MintDelegation(mintReq, callID)
 	defer release()
 
@@ -345,12 +347,15 @@ func (s *ProcessModuleSupervisor) dispatchToolCall(ctx context.Context, moduleNa
 }
 
 // requestFromToolCtx builds a minimal *http.Request carrying the calling
-// agent's context so [Broker.MintDelegation] can snapshot roles + policy
-// (it reads them off r.Context()). MCP tool calls arrive with no
-// Cookie/Authorization header — the agent's authority is role/policy
-// based, not session-cookie based — so cookie/auth stay empty and the
-// broker re-attaches via roles+policy, which is the correct model for an
-// agent-originated tool invocation.
+// agent's context so [Broker.MintDelegation] can snapshot the module binding
+// (F6) off r.Context(). MCP tool calls arrive with no Cookie/Authorization
+// header — the agent's authority is role/policy based, not session-cookie
+// based — so cookie/auth stay empty. The broker's re-dispatch therefore
+// re-resolves to an ANONYMOUS caller: snapshotRequest copies only
+// Cookie/Authorization and resolveCaller never re-attaches the stashed
+// roles/policy. requireScope then refuses owner-scoped reads by construction.
+// That is the SAFE behavior — do NOT "fix" it by re-attaching the agent's
+// roles/policy, which would let a tool-sourced reverse call read cross-owner.
 func requestFromToolCtx(ctx context.Context) *http.Request {
 	r := &http.Request{
 		Method: http.MethodPost,

--- a/framework/registry_relation_conflict_test.go
+++ b/framework/registry_relation_conflict_test.go
@@ -1,0 +1,85 @@
+package framework
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// TestRegistry_RejectsConflictingRelationsAcrossVersions pins the F9
+// invariant — two versions of one entity share a physical table, so a
+// relation on the same column/key MUST reference the same target. The gate
+// fires for EVERY relation type, not only BelongsTo: a HasOne, a
+// ManyToMany, or a name-deduped logical relation that diverges across
+// versions is rejected at registration with a message naming the conflict.
+// Each subtest registers a v1, then a conflicting v2, and expects the
+// registration to panic.
+func TestRegistry_RejectsConflictingRelationsAcrossVersions(t *testing.T) {
+	widgetCfg := func(rels []entity.Relation) EntityConfig {
+		return EntityConfig{
+			Table:     "widgets",
+			Fields:    []schema.Field{{Name: "title", Type: schema.String}},
+			Relations: rels,
+			Exposure:  &ExposureConfig{CRUD: boolPtr(false)},
+		}.WithTimestamps(false)
+	}
+
+	// registerV1 then registerV2; expect v2 to panic with the F9 message.
+	expectConflictPanic := func(t *testing.T, v1, v2 []entity.Relation) {
+		t.Helper()
+		app := NewApp(WithoutDefaultMiddleware())
+		g1 := app.Group("/v1")
+		app.GroupEntity(g1, "widgets", widgetCfg(v1))
+
+		g2 := app.Group("/v2")
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("v2 registration did not panic on the relation conflict")
+			}
+			msg, ok := r.(string)
+			if !ok {
+				t.Fatalf("panic value = %T, want string", r)
+			}
+			if !strings.Contains(msg, "incompatible definitions across versions") {
+				t.Errorf("panic message lacks the F9 relation-conflict text: %q", msg)
+			}
+		}()
+		app.GroupEntity(g2, "widgets", widgetCfg(v2))
+	}
+
+	t.Run("HasOne_name_dedup", func(t *testing.T) {
+		// No ForeignKey → the relation dedups by logical Name; the display
+		// column is the Name too. A HasOne named "profile" pointing at two
+		// different targets across versions is a conflict.
+		expectConflictPanic(t,
+			[]entity.Relation{{Type: entity.RelHasOne, Name: "profile", Entity: "profiles"}},
+			[]entity.Relation{{Type: entity.RelHasOne, Name: "profile", Entity: "avatars"}},
+		)
+	})
+
+	t.Run("ManyToMany_fk_target", func(t *testing.T) {
+		// ForeignKey + ForeignKeyTarget set → describeRelation renders the
+		// target(key) form. A ManyToMany on the same key diverging in target
+		// entity is a conflict.
+		expectConflictPanic(t,
+			[]entity.Relation{{Type: entity.RelManyToMany, Name: "tags", Entity: "tags", ForeignKey: "tag_id", ForeignKeyTarget: "id"}},
+			[]entity.Relation{{Type: entity.RelManyToMany, Name: "tags", Entity: "labels", ForeignKey: "tag_id", ForeignKeyTarget: "id"}},
+		)
+	})
+
+	t.Run("extra_relation_skipped_then_conflict", func(t *testing.T) {
+		// v2 carries an extra relation v1 never declared (dedup key not in
+		// v1's map → skipped) AND a colliding one. The skip must not mask the
+		// collision: the colliding relation still trips the gate.
+		expectConflictPanic(t,
+			[]entity.Relation{{Type: entity.RelHasMany, Name: "comments", Entity: "comments", ForeignKey: "post_id"}},
+			[]entity.Relation{
+				{Type: entity.RelHasMany, Name: "likes", Entity: "likes", ForeignKey: "like_id"},             // not in v1 → skipped
+				{Type: entity.RelHasMany, Name: "comments", Entity: "other_comments", ForeignKey: "post_id"}, // collides
+			},
+		)
+	})
+}

--- a/framework/seed_hook_error_test.go
+++ b/framework/seed_hook_error_test.go
@@ -1,0 +1,46 @@
+package framework
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestWithSeedNilIsNoOp pins that a nil seed hook is silently ignored rather
+// than appended: a caller that conditionally passes a nil (e.g.
+// app.WithSeed(maybeHook())) must not end up with a nil entry that panics when
+// runSeedHooks fires the chain.
+func TestWithSeedNilIsNoOp(t *testing.T) {
+	app := NewApp(WithoutDefaultMiddleware())
+	before := len(app.seedHooks)
+	ret := app.WithSeed(nil)
+	if ret != app {
+		t.Fatal("WithSeed did not return the App for chaining")
+	}
+	if len(app.seedHooks) != before {
+		t.Fatalf("WithSeed(nil) appended %d nil hook(s)", len(app.seedHooks)-before)
+	}
+}
+
+// TestSeedHookErrorAbortsChain pins that a WithSeed func returning a non-nil
+// error stops the chain and surfaces that error, so a failing app-level seed
+// fails boot loudly instead of running later hooks against partial data.
+func TestSeedHookErrorAbortsChain(t *testing.T) {
+	app := NewApp(WithoutDefaultMiddleware())
+	boom := errors.New("seed boom")
+	ranFirst := false
+	ranSecond := false
+	app.WithSeed(func(context.Context) error { ranFirst = true; return boom })
+	app.WithSeed(func(context.Context) error { ranSecond = true; return nil })
+
+	err := app.runSeedHooks()
+	if !ranFirst {
+		t.Fatal("first seed hook did not run")
+	}
+	if ranSecond {
+		t.Fatal("second seed hook ran after the first failed — the chain must abort")
+	}
+	if !errors.Is(err, boom) {
+		t.Fatalf("runSeedHooks returned %v, want %v", err, boom)
+	}
+}

--- a/framework/static/pwa_static_chrome_e2e_test.go
+++ b/framework/static/pwa_static_chrome_e2e_test.go
@@ -57,6 +57,18 @@ func TestPWAStaticChromeE2E(t *testing.T) {
 	defer allocCancel()
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	defer browserCancel()
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the work context then only has to cover the
+	// assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	defer startCancel()
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
 	ctx, cancel := context.WithTimeout(browserCtx, 120*time.Second)
 	defer cancel()
 

--- a/framework/typed_hooks_after_error_test.go
+++ b/framework/typed_hooks_after_error_test.go
@@ -1,0 +1,60 @@
+package framework
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+// TestTypedHook_AfterCreateErrorPropagates is the AfterCreate mirror of the
+// existing BeforeCreate rollback test. A typed AfterCreate hook returning an
+// error must surface that error to the caller (the row is already committed,
+// but the response must not read as success) — the crud layer wraps and
+// returns it (crud_ops.go doCreate → ExecuteHooks(AfterCreate) → return).
+// Without this, a typed AfterCreate hook that rejects (e.g. post-commit
+// validation) would silently succeed from the caller's perspective.
+func TestTypedHook_AfterCreateErrorPropagates(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, db *sql.DB, _ Dialect) {
+		app, ch := hookApp(t, db)
+		ran := false
+		OnAfterCreate(app, "posts", func(ctx context.Context, p *hookTestPost) error {
+			ran = true
+			return errors.New("typed after-create reject")
+		})
+		_, err := ch.CreateOne(context.Background(), map[string]any{"title": "x"})
+		if !ran {
+			t.Fatal("AfterCreate hook did not run")
+		}
+		if err == nil {
+			t.Fatal("AfterCreate hook error did not propagate to CreateOne")
+		}
+	})
+}
+
+// TestTypedHook_AfterUpdateErrorPropagates is the AfterUpdate mirror: a typed
+// AfterUpdate hook returning an error surfaces to UpdateOne, so a post-update
+// rejection is observable rather than swallowed.
+func TestTypedHook_AfterUpdateErrorPropagates(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, db *sql.DB, _ Dialect) {
+		app, ch := hookApp(t, db)
+		created, err := ch.CreateOne(context.Background(), map[string]any{"title": "orig"})
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		id := created["id"].(string)
+
+		ran := false
+		OnAfterUpdate(app, "posts", func(ctx context.Context, p *hookTestPost) error {
+			ran = true
+			return errors.New("typed after-update reject")
+		})
+		_, err = ch.UpdateOne(context.Background(), id, map[string]any{"title": "new"})
+		if !ran {
+			t.Fatal("AfterUpdate hook did not run")
+		}
+		if err == nil {
+			t.Fatal("AfterUpdate hook error did not propagate to UpdateOne")
+		}
+	})
+}

--- a/framework/ui/filtertoolbar.go
+++ b/framework/ui/filtertoolbar.go
@@ -6,6 +6,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
+	"github.com/DonaldMurillo/gofastr/core-ui/urlsafe"
 	"github.com/DonaldMurillo/gofastr/core/render"
 	"github.com/DonaldMurillo/gofastr/framework/i18nui"
 )
@@ -159,6 +160,15 @@ func FilterToolbar(cfg FilterToolbarConfig) render.HTML {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	// Action flows to both the <form action> and the reset LinkButton, so
+	// clean it once here through the same urlsafe.CleanAnchor allow-list
+	// ui.Form uses. A javascript:/vbscript:/data: action never becomes a
+	// live form action and never reaches LinkButton's scheme check (which
+	// would otherwise panic); a rejected value degrades to the inert "#".
+	action := urlsafe.CleanAnchor(cfg.Action)
+	if action == "" {
+		action = "#"
+	}
 
 	label := cfg.Label
 	if label == "" {
@@ -215,7 +225,7 @@ func FilterToolbar(cfg FilterToolbarConfig) render.HTML {
 		}
 		actionsKids = append(actionsKids, LinkButton(LinkButtonConfig{
 			Label:   resetLabel,
-			Href:    cfg.Action,
+			Href:    action,
 			Variant: ButtonGhost,
 			Class:   "ui-filter-toolbar__reset",
 		}))
@@ -227,7 +237,7 @@ func FilterToolbar(cfg FilterToolbarConfig) render.HTML {
 	formAttrs := html.Attrs{
 		"class":      cls("ui-filter-toolbar", cfg.Class),
 		"method":     "GET",
-		"action":     cfg.Action,
+		"action":     action,
 		"role":       "search",
 		"aria-label": label,
 	}

--- a/framework/ui/image_placeholder_chromium_test.go
+++ b/framework/ui/image_placeholder_chromium_test.go
@@ -59,7 +59,17 @@ func TestPlaceholderPaintsWhileSourceIsPending(t *testing.T) {
 	defer cancelAlloc()
 	ctx, cancel := chromedp.NewContext(allocCtx)
 	defer cancel()
-	ctx, cancelTimeout := context.WithTimeout(ctx, 40*time.Second)
+
+	// chromedp starts Chrome lazily on the first Run: give the cold
+	// start its own budget so the work budget below is not also a
+	// launch budget (and so it does not cap WSURLReadTimeout).
+	startCtx, startCancel := context.WithTimeout(ctx, 90*time.Second)
+	defer startCancel()
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
+	ctx, cancelTimeout := context.WithTimeout(ctx, 60*time.Second)
 	defer cancelTimeout()
 
 	var shot []byte

--- a/framework/ui/searchinput.go
+++ b/framework/ui/searchinput.go
@@ -6,6 +6,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
+	"github.com/DonaldMurillo/gofastr/core-ui/urlsafe"
 	"github.com/DonaldMurillo/gofastr/core/render"
 	"github.com/DonaldMurillo/gofastr/framework/i18nui"
 )
@@ -105,12 +106,18 @@ func SearchInput(cfg SearchInputConfig) render.HTML {
 	innerWrapper := render.Tag("label",
 		map[string]string{"class": cls, "for": cfg.ID},
 		inner...)
-
-	// Wrap in <form role="search"> when Action is provided.
+	// Wrap in <form role="search"> when Action is provided. The action
+	// runs through the same urlsafe.CleanAnchor allow-list as ui.Form so a
+	// javascript:/vbscript:/data: Action never becomes a live form action;
+	// a rejected value degrades to the inert "#" ui.Form uses.
 	if cfg.Action != "" {
+		action := urlsafe.CleanAnchor(cfg.Action)
+		if action == "" {
+			action = "#"
+		}
 		return searchInputStyle.WrapHTML(render.Tag("form", map[string]string{
 			"role":   "search",
-			"action": cfg.Action,
+			"action": action,
 			"method": method,
 			"class":  "ui-search-input__form",
 		}, innerWrapper))

--- a/framework/ui/segmented.go
+++ b/framework/ui/segmented.go
@@ -55,8 +55,13 @@ type SegmentedControlConfig struct {
 	// the SegmentedControl is not inside a <label> or FormField).
 	Label string
 
-	// RPCPath, when set, attaches data-fui-rpc to each radio so a
-	// change submits to the server. Method is POST.
+	// RPCPath, when set, attaches data-fui-rpc to each radio so a change
+	// POSTs to the server carrying the selected segment's name=value. The
+	// runtime serializes the form the radio belongs to (node.form), so place
+	// the SegmentedControl inside a <form> for the selection to round-trip —
+	// a radio with no enclosing form posts an empty body and the handler
+	// cannot see which segment was chosen. An explicit data-fui-rpc-body on a
+	// radio still wins over form serialization. Method is POST.
 	RPCPath string
 
 	// RPCSignal, when set, broadcasts the response as the given

--- a/framework/ui/segmented_test.go
+++ b/framework/ui/segmented_test.go
@@ -118,6 +118,45 @@ func TestSegmentedControlRPC(t *testing.T) {
 	}
 }
 
+// TestSegmentedControlRPCCarriesSelectionContract is the Go half of #194:
+// when RPCPath is set, EVERY option's <input> must carry name + value +
+// data-fui-rpc together. The runtime serializes new FormData(radio.form) for a
+// form control (core-ui/runtime/segmented_rpc_e2e_test.go proves that path),
+// which only carries the chosen segment if the radio has a name and value to
+// submit. A radio missing name/value would post an empty selection even after
+// the rpc.js fix — this pins the markup half of the contract.
+func TestSegmentedControlRPCCarriesSelectionContract(t *testing.T) {
+	out := string(SegmentedControl(SegmentedControlConfig{
+		Name:      "view",
+		Label:     "View mode",
+		RPCPath:   "/views/set",
+		RPCSignal: "current-view",
+		Options: []SegmentedOption{
+			{Label: "Day", Value: "day"},
+			{Label: "Week", Value: "week"},
+			{Label: "Month", Value: "month"},
+		},
+	}))
+	for _, val := range []string{"day", "week", "month"} {
+		tag := inputTagFor(out, val)
+		if tag == "" {
+			t.Errorf("option value=%q missing its <input> tag", val)
+			continue
+		}
+		for _, want := range []string{
+			`name="view"`,               // the form-submit name the handler reads
+			`value="` + val + `"`,       // the segment's submit value
+			`data-fui-rpc="/views/set"`, // the dispatch trigger
+			`data-fui-rpc-signal="current-view"`,
+			`data-fui-rpc-method="POST"`,
+		} {
+			if !strings.Contains(tag, want) {
+				t.Errorf("radio value=%q missing %q in tag: %s", val, want, tag)
+			}
+		}
+	}
+}
+
 func TestSegmentedControlDisabled(t *testing.T) {
 	out := string(SegmentedControl(SegmentedControlConfig{
 		Name:  "x",

--- a/framework/ui/srcset_datauri_chromium_test.go
+++ b/framework/ui/srcset_datauri_chromium_test.go
@@ -42,7 +42,17 @@ func TestSrcsetDataURICommaInBrowser(t *testing.T) {
 	defer cancelAlloc()
 	ctx, cancel := chromedp.NewContext(allocCtx)
 	defer cancel()
-	ctx, cancelTimeout := context.WithTimeout(ctx, 30*time.Second)
+
+	// chromedp starts Chrome lazily on the first Run: give the cold
+	// start its own budget so the work budget below is not also a
+	// launch budget (and so it does not cap WSURLReadTimeout).
+	startCtx, startCancel := context.WithTimeout(ctx, 90*time.Second)
+	defer startCancel()
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
+	ctx, cancelTimeout := context.WithTimeout(ctx, 60*time.Second)
 	defer cancelTimeout()
 
 	var currentSrc string
@@ -88,7 +98,17 @@ func TestSrcsetDataURIPayloadIsNotASecondCandidate(t *testing.T) {
 	defer cancelAlloc()
 	ctx, cancel := chromedp.NewContext(allocCtx)
 	defer cancel()
-	ctx, cancelTimeout := context.WithTimeout(ctx, 30*time.Second)
+
+	// chromedp starts Chrome lazily on the first Run: give the cold
+	// start its own budget so the work budget below is not also a
+	// launch budget (and so it does not cap WSURLReadTimeout).
+	startCtx, startCancel := context.WithTimeout(ctx, 90*time.Second)
+	defer startCancel()
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
+	ctx, cancelTimeout := context.WithTimeout(ctx, 60*time.Second)
 	defer cancelTimeout()
 
 	var currentSrc string

--- a/framework/ui/ui_link_form_security_test.go
+++ b/framework/ui/ui_link_form_security_test.go
@@ -779,3 +779,69 @@ func extractAttr(htmlStr, attrName string) string {
 	}
 	return htmlStr[start : start+end]
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  Form action sinks — SearchInput + FilterToolbar (sibling drift of ui.Form)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// TestFormActionSinksRejectUnsafeURL pins the URL-scheme allow-list on the
+// two <form action> sinks that previously put cfg.Action straight into a
+// hand-rolled render.Tag while the sibling ui.Form ran it through
+// urlsafe.CleanAnchor. Property × surface: loop the same attack shapes over
+// BOTH components. FilterToolbar runs with HideReset so the form action is
+// the only sink exercised (its reset LinkButton already had a guard).
+func TestFormActionSinksRejectUnsafeURL(t *testing.T) {
+	unsafe := []string{
+		"javascript:alert(1)",
+		"vbscript:msgbox(1)",
+		"data:text/html,<script>alert(1)</script>",
+		"//evil.com/x",
+	}
+	sinks := []struct {
+		name   string
+		render func(action string) render.HTML
+	}{
+		{"SearchInput", func(a string) render.HTML {
+			return ui.SearchInput(ui.SearchInputConfig{Name: "q", ID: "q", Action: a})
+		}},
+		{"FilterToolbar", func(a string) render.HTML {
+			return ui.FilterToolbar(ui.FilterToolbarConfig{
+				Action: a, HideReset: true,
+				Sort: []ui.SortOption{{Value: "x", Label: "X"}},
+			})
+		}},
+	}
+	for _, s := range sinks {
+		t.Run(s.name, func(t *testing.T) {
+			for _, action := range unsafe {
+				h := string(s.render(action))
+				if strings.Contains(h, action) {
+					t.Errorf("SECURITY: %s rendered unsafe form action %q verbatim:\n%s", s.name, action, h)
+				}
+				if scheme := schemeOf(action); scheme != "" && strings.Contains(h, scheme+":") {
+					t.Errorf("SECURITY: %s kept dangerous scheme %q in output:\n%s", s.name, scheme, h)
+				}
+			}
+			// A valid relative action must round-trip unchanged — the guard
+			// is a scheme allow-list, not a blanket reject.
+			h := string(s.render("/search"))
+			if !strings.Contains(h, `action="/search"`) {
+				t.Errorf("%s dropped a valid relative action:\n%s", s.name, h)
+			}
+		})
+	}
+}
+
+// schemeOf returns the lowercased scheme prefix of u ("" for relative /
+// protocol-relative URLs), used only to narrow the unsafe-action assertion.
+func schemeOf(u string) string {
+	i := strings.Index(u, ":")
+	if i <= 0 {
+		return ""
+	}
+	// protocol-relative ("//host") has no scheme.
+	if strings.HasPrefix(u, "//") {
+		return ""
+	}
+	return strings.ToLower(u[:i])
+}

--- a/framework/ui_e2e_test.go
+++ b/framework/ui_e2e_test.go
@@ -260,7 +260,17 @@ func newE2EChrome(t *testing.T) context.Context {
 	t.Cleanup(allocCancel)
 	browser, browserCancel := chromedp.NewContext(alloc)
 	t.Cleanup(browserCancel)
-	ctx, cancel := context.WithTimeout(browser, 30*time.Second)
+
+	// chromedp starts Chrome lazily on the first Run: give the cold start its
+	// own budget so the work budget below is not also a launch budget (and so
+	// it does not cap WSURLReadTimeout).
+	startCtx, startCancel := context.WithTimeout(browser, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(browser, 60*time.Second)
 	t.Cleanup(cancel)
 	return ctx
 }

--- a/framework/uihost/embed_e2e_test.go
+++ b/framework/uihost/embed_e2e_test.go
@@ -248,6 +248,18 @@ func newEmbedBrowserCtx(t *testing.T) context.Context {
 	t.Cleanup(allocCancel)
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the returned context then only has to cover
+	// the assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)
 	t.Cleanup(cancel)
 	return ctx

--- a/framework/uihost/partial_redirect_e2e_test.go
+++ b/framework/uihost/partial_redirect_e2e_test.go
@@ -115,7 +115,17 @@ func newE2EChromeForUIHost(t *testing.T) context.Context {
 	t.Cleanup(allocCancel)
 	browser, browserCancel := chromedp.NewContext(alloc)
 	t.Cleanup(browserCancel)
-	ctx, cancel := context.WithTimeout(browser, 30*time.Second)
+
+	// chromedp starts Chrome lazily on the first Run: give the cold start its
+	// own budget so the work budget below is not also a launch budget (and so
+	// it does not cap WSURLReadTimeout).
+	startCtx, startCancel := context.WithTimeout(browser, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(browser, 60*time.Second)
 	t.Cleanup(cancel)
 	return ctx
 }

--- a/framework/uihost/pwa_chrome_e2e_test.go
+++ b/framework/uihost/pwa_chrome_e2e_test.go
@@ -68,6 +68,18 @@ func TestPWAChromeE2E(t *testing.T) {
 	defer allocCancel()
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	defer browserCancel()
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
+	// under its own budget first; the work context then only has to cover the
+	// assertions.
+	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
+	defer startCancel()
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
 	ctx, cancel := context.WithTimeout(browserCtx, 120*time.Second)
 	defer cancel()
 

--- a/framework/wellknown_naming_test.go
+++ b/framework/wellknown_naming_test.go
@@ -1,0 +1,80 @@
+package framework
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestMCPServerCard_NameDerivedFromConfig pins that the MCP server-card and
+// catalog endpoints derive their identifiers from AppConfig.Name the way the
+// spec requires: the reverse-DNS card name sanitizes the app name into the
+// ^[a-zA-Z0-9._-]+$ pattern (spaces/underscores/dots collapse to dashes),
+// while the catalog displayName carries the raw human name. A regression that
+// emitted the raw name into the reverse-DNS field would break spec-validating
+// clients.
+func TestMCPServerCard_NameDerivedFromConfig(t *testing.T) {
+	const appName = "My Cool App_v2.io"
+	app, cleanup := startApp(t, NewApp(WithConfig(AppConfig{Name: appName}), WithMCP()))
+	defer cleanup()
+
+	// Server card: name must be the sanitized reverse-DNS identifier.
+	rec := httptest.NewRecorder()
+	app.router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/mcp/server-card", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("server-card status %d", rec.Code)
+	}
+	var card map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &card); err != nil {
+		t.Fatalf("server-card JSON: %v", err)
+	}
+	if got := card["name"]; got != "io.gofastr/my-cool-app-v2-io" {
+		t.Errorf("card name = %q, want io.gofastr/my-cool-app-v2-io (sanitized)", got)
+	}
+
+	// Catalog: displayName carries the raw app name, the identifier the
+	// sanitized one.
+	rec = httptest.NewRecorder()
+	app.router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/.well-known/mcp/catalog.json", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("catalog status %d", rec.Code)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("catalog JSON: %v", err)
+	}
+	entries, _ := doc["entries"].([]any)
+	if len(entries) == 0 {
+		t.Fatalf("catalog has no entries: %v", doc)
+	}
+	first := entries[0].(map[string]any)
+	if got := first["displayName"]; got != appName {
+		t.Errorf("catalog displayName = %q, want %q", got, appName)
+	}
+	if got := first["identifier"]; got != "urn:air:io.gofastr/my-cool-app-v2-io" {
+		t.Errorf("catalog identifier = %q, want urn:air:io.gofastr/my-cool-app-v2-io", got)
+	}
+}
+
+// TestMCPServerCard_NameFallsBackForAllInvalidChars pins the other arm of
+// mcpCardName: an app name with NO spec-valid characters (everything gets
+// stripped) must fall back to "app" rather than emitting an empty identifier
+// — io.gofastr/<empty> would be a malformed, spec-rejecting card.
+func TestMCPServerCard_NameFallsBackForAllInvalidChars(t *testing.T) {
+	app, cleanup := startApp(t, NewApp(WithConfig(AppConfig{Name: "🎉✨"}), WithMCP()))
+	defer cleanup()
+
+	rec := httptest.NewRecorder()
+	app.router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/mcp/server-card", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("server-card status %d", rec.Code)
+	}
+	var card map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &card); err != nil {
+		t.Fatalf("server-card JSON: %v", err)
+	}
+	if got := card["name"]; got != "io.gofastr/app" {
+		t.Errorf("card name = %q, want io.gofastr/app (all-invalid name must fall back)", got)
+	}
+}

--- a/kiln/integration/browser_test.go
+++ b/kiln/integration/browser_test.go
@@ -142,7 +142,18 @@ func newChrome(t *testing.T) (context.Context, context.CancelFunc) {
 	t.Cleanup(allocCancel)
 	browser, browserCancel := chromedp.NewContext(alloc)
 	t.Cleanup(browserCancel)
-	ctx, timeoutCancel := context.WithTimeout(browser, 30*time.Second)
+
+	// chromedp starts Chrome lazily on the first Run, so one timeout would
+	// have to cover BOTH the cold start and the page work — and it caps the
+	// WSURLReadTimeout above, making that ineffective. Start the browser
+	// under its own budget first; the returned context covers only the work.
+	startCtx, startCancel := context.WithTimeout(browser, 90*time.Second)
+	t.Cleanup(startCancel)
+	if err := chromedp.Run(startCtx); err != nil {
+		t.Fatalf("chrome did not start within 90s: %v", err)
+	}
+
+	ctx, timeoutCancel := context.WithTimeout(browser, 60*time.Second)
 	return ctx, timeoutCancel
 }
 

--- a/scripts/coverage-floors.sh
+++ b/scripts/coverage-floors.sh
@@ -50,14 +50,6 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# framework/ (nomatch:/processmodule) sat at 95.5 through v0.62.0. v0.63.0
-# added EraseUserData (~530 lines), configurable server timeouts, the metrics
-# accessor, and secret rotation to the package; measured 95.1 after covering
-# the new behavior, with the residue in error-injection paths
-# (commit/RowsAffected failures) that need a fault driver to reach. The floor
-# is 94.5 — 0.6 of slack rather than the usual 2 — because this bucket should
-# tighten again, not drift.
-#
 # pkg<space>floor[<space>filter].
 #   filter absent           → whole-package coverage.
 #   filter "match:REGEX"    → only statements in files whose path matches REGEX.
@@ -66,7 +58,7 @@ cd "$(dirname "$0")/.."
 FLOORS="
 ./core/migrate/ 98.0
 ./core/schema/ 97.0
-./framework/ 94.5 nomatch:/processmodule
+./framework/ 95.5 nomatch:/processmodule
 ./framework/ 84.0 match:/processmodule
 ./framework/contracts/ 72.0
 ./framework/contracts/analyzers/ 70.5


### PR DESCRIPTION
Everything left over from v0.63.0, plus issues #136 and #194. TDD throughout — the security findings each have a test that failed for the right reason first.

Closes #194.

## The one that matters

**An idempotent request could be answered with another caller's response.** When a handler outran the in-flight TTL and a second request re-claimed the same `Idempotency-Key`, the first handler's `Finish` wrote its response into the second's row while leaving that row's fingerprint intact — so the retry passed the fingerprint check and was served a body it never asked for. With `Principal` set to a tenant id, which the configuration documents as a legal choice, that crosses users.

This was **proven by execution** against SQLite through the exported API before it was fixed, not argued:

```
RESULT: user B was served status=200 header=map[X-Owner:[user-A]] body={"secret":"USER-A-PRIVATE-ORDER"}
```

`IdempotencyStore.Finish` now takes the request fingerprint and binds the write to its own claim. That is **BREAKING** for custom stores. I chose it over an optional interface deliberately: a store that ignores the fingerprint can serve one principal's response to another, and that must not be the quiet default for third-party code.

## Also fixed

- **A process module could read entities outside its grant.** Every key of a module's filter object was forwarded into the CRUD list query — though the comment claimed it mirrored `listTool`, which allow-lists — so `include=` eager-loaded an entity no grant named, with no row scoping at all when that entity declares neither owner nor tenant. Now allow-listed for real.
- **`CrossOwnerRead` was judged against a context the query never used** — the mint-time policy snapshot, while the re-dispatch re-resolves authority through the full chain. Brokered calls are now unconditionally owner-scoped, which is what `broker.go` already documented.
- **Five sinks whose siblings already carried the guard**: `/api/llm.md`'s entity index was session-gated while its per-entity sibling runs the full scope chain; `SearchInput`/`FilterToolbar` form actions skipped the URL guard; recovery and timeout logs carried percent-decoded paths; an unknown filter key ran unbounded edit distance; a panicking metrics collector dropped the whole scrape.
- **Magic-link tokens are erased with the user** — the limitation documented in v0.63.0. Erasers can now key on a resolved identity (email) rather than the user id, via a declarative resolver; batteries still never run SQL. 2FA secrets and OAuth links registered too.
- **#194** — `SegmentedControl.RPCPath` posted an empty body, so the handler fell through to its default and rendered a confidently wrong selection. Any form control now serializes its enclosing form; the tool-call dispatcher had the same gap.

## Coverage floor earned back

`framework` returns to **95.5** (measures 95.72). v0.63.0 lowered it to 94.5 because that release added surface faster than tests; this restores it with tests that pin observable behaviour, and leaves fault-injection-only branches honestly uncovered rather than faking a driver.

## Issue #136

Its inventory was mostly stale — four items already closed, including the grouped-entity MCP `BasePath` claim, which is **refuted** (both paths set it). I've posted a re-sweep record on the issue listing what was fixed, what remains genuinely never-looked, and two things that need a decision rather than a patch: the untrusted-module sandbox tier has no production call site, and MCP resources are enumerable to callers the gate refuses.

**Method caveat, stated because this issue is about audit coverage:** both halves of the pass ran on the same model tier, so they share blind spots and their agreement is weak evidence. `go vet` and `govulncheck` were clean but speak to none of these findings. Nothing here clears any surface.

## Verification

`./scripts/test-all.sh` → exit 0, 192 packages. Coverage floors hold. `go vet` clean. Branch protection updated separately to the ten-check manifest with `strict` and `enforce_admins` on.

`merge_group` is wired in `ci.yml` to kill the duplicate PR→main run, but the queue itself can't be enabled — the `merge_queue` ruleset is rejected on this repo's plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added identity-aware data erasure, including email-based cleanup of magic-link tokens.
  - Segmented controls now submit selected form values through RPC requests.
  - Registry documentation now reflects caller access permissions.
  - Added database and outbox metrics to the shared metrics endpoint.

- **Bug Fixes**
  - Improved idempotent request handling during retries and concurrent claims.
  - Prevented unsafe form actions, cross-owner access, delegation misuse, and unauthorized broker calls.
  - Sanitized and bounded request-path logging.
  - Isolated metrics collector failures.
  - Reduced expensive filter suggestions for oversized inputs.

- **Documentation**
  - Documented updated idempotency and RPC form-submission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->