### PR TITLE
Address CodeRabbit's review of #198, including a real bug in that PR's cold-start fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,15 @@ MCP tools `framework_docs_list` / `framework_docs_get` /
    end-to-end — marketing, app, auth, admin, mobile, light + dark. Meridian
    is the design-system completeness canary: a surface there that needs
    CSS the components don't provide is a gap to fix upstream, never a patch.
+10. **Read the PR's line-level review comments before merging.** After
+    opening a PR and after every push to it, run
+    `gh api repos/DonaldMurillo/gofastr/pulls/<N>/comments` — the
+    line-level review lives there, NOT in `gh pr view --json comments`,
+    which returns only issue-level comments. A review bot showing `pass`
+    in `gh pr checks` means it RAN, not that it found nothing: PR #198
+    showed `CodeRabbit pass` while holding 12 unread comments, six of
+    them Major. Triage every finding on merit and say which you rejected
+    and why — silence is not triage.
 
 ## Common operations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,8 +99,10 @@ MCP tools `framework_docs_list` / `framework_docs_get` /
    CSS the components don't provide is a gap to fix upstream, never a patch.
 10. **Read the PR's line-level review comments before merging.** After
     opening a PR and after every push to it, run
-    `gh api repos/DonaldMurillo/gofastr/pulls/<N>/comments` — the
-    line-level review lives there, NOT in `gh pr view --json comments`,
+    `gh api --paginate repos/DonaldMurillo/gofastr/pulls/<N>/comments` — the
+    `--paginate` is load-bearing: without it the fetch silently stops at the
+    first page, so a multi-page review (exactly the miss this rule exists to
+    catch) looks empty. The line-level review lives there, NOT in
     which returns only issue-level comments. A review bot showing `pass`
     in `gh pr checks` means it RAN, not that it found nothing: PR #198
     showed `CodeRabbit pass` while holding 12 unread comments, six of

--- a/battery/print/chromepdf/ssrf_ipliteral_chromium_test.go
+++ b/battery/print/chromepdf/ssrf_ipliteral_chromium_test.go
@@ -60,13 +60,19 @@ func TestResolverRulesBlockIPLiteral(t *testing.T) {
 	ctx, cancel := chromedp.NewContext(allocCtx)
 	defer cancel()
 
-	// chromedp starts Chrome lazily on the first Run: give the cold
-	// start its own budget so the work budget below is not also a
-	// launch budget (and so it does not cap WSURLReadTimeout).
-	startCtx, startCancel := context.WithTimeout(ctx, 90*time.Second)
-	defer startCancel()
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(ctx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancelT := context.WithTimeout(ctx, 60*time.Second)

--- a/cmd/gofastr/blueprint_test.go
+++ b/cmd/gofastr/blueprint_test.go
@@ -1336,16 +1336,19 @@ func runBrowserUIE2E(t *testing.T, baseURL, wantEntityTitle string) {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	defer browserCancel()
 
-	// chromedp starts Chrome lazily on the first Run, so a single timeout
-	// would have to cover BOTH the cold start and the page work — and it
-	// caps WSURLReadTimeout above, making that 90s ineffective. This test
-	// cold-starts Chrome right after generating and building a whole app,
-	// which is when the runner is slowest, so the two budgets are separate:
-	// a generous one to get the browser up, then the work budget.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	defer startCancel()
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("browser UI e2e failed: chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)

--- a/cmd/gofastr/dev_e2e_test.go
+++ b/cmd/gofastr/dev_e2e_test.go
@@ -219,15 +219,19 @@ func devE2EBrowserCtx(t *testing.T) context.Context {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the returned context then only has to cover
-	// the assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 120*time.Second)

--- a/cmd/gofastr/dev_live_test.go
+++ b/cmd/gofastr/dev_live_test.go
@@ -468,15 +468,19 @@ location.reload = function() { window.__reloadCalled = true; };
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	defer browserCancel()
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the work context then only has to cover the
-	// assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	defer startCancel()
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)

--- a/cmd/gofastr/generate_sdkjs_browser_test.go
+++ b/cmd/gofastr/generate_sdkjs_browser_test.go
@@ -112,15 +112,19 @@ func TestGeneratedJSSDK_BrowserRoundTrip(t *testing.T) {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	defer browserCancel()
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the work context then only has to cover the
-	// assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	defer startCancel()
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 120*time.Second)

--- a/cmd/gofastr/theme_edit_browser_test.go
+++ b/cmd/gofastr/theme_edit_browser_test.go
@@ -134,15 +134,19 @@ func themeEditBrowserCtx(t *testing.T) context.Context {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the returned context then only has to cover
-	// the assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)

--- a/core-ui/runtime/compute_e2e_test.go
+++ b/core-ui/runtime/compute_e2e_test.go
@@ -229,15 +229,19 @@ func newComputeBrowserCtx(t *testing.T) context.Context {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the returned context then only has to cover
-	// the assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)

--- a/core-ui/runtime/input_trigger_e2e_test.go
+++ b/core-ui/runtime/input_trigger_e2e_test.go
@@ -77,15 +77,19 @@ func TestInputTrigger_SelectFiresRPC(t *testing.T) {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the work context then only has to cover the
-	// assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)

--- a/core-ui/runtime/nav_match_prefix_e2e_test.go
+++ b/core-ui/runtime/nav_match_prefix_e2e_test.go
@@ -73,15 +73,19 @@ func navPrefixBrowser(t *testing.T) context.Context {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the returned context then only has to cover
-	// the assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)

--- a/core-ui/runtime/poll_e2e_test.go
+++ b/core-ui/runtime/poll_e2e_test.go
@@ -85,15 +85,19 @@ func newPollBrowserCtx(t *testing.T) context.Context {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the returned context then only has to cover
-	// the assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)

--- a/core-ui/runtime/runtime_forms_e2e_test.go
+++ b/core-ui/runtime/runtime_forms_e2e_test.go
@@ -130,15 +130,19 @@ func newFormBrowserCtx(t *testing.T) context.Context {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the returned context then only has to cover
-	// the assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)

--- a/core-ui/runtime/seed_e2e_test.go
+++ b/core-ui/runtime/seed_e2e_test.go
@@ -64,18 +64,19 @@ func newSeedBrowserCtx(t *testing.T) context.Context {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the returned context then only has to cover
-	// the assertions. Windows runners can spend longer connecting to a freshly
-	// started browser when the package has already exercised several E2E
-	// fixtures, so this cold-start budget matches the allocator's generous
-	// websocket startup budget.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 90*time.Second)

--- a/core-ui/runtime/tabs_aria_e2e_test.go
+++ b/core-ui/runtime/tabs_aria_e2e_test.go
@@ -64,15 +64,19 @@ func TestTabClickUpdatesAriaSelected(t *testing.T) {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the work context then only has to cover the
-	// assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)

--- a/core-ui/widget/slot_surface_dom_test.go
+++ b/core-ui/widget/slot_surface_dom_test.go
@@ -42,15 +42,19 @@ func newBareBrowserCtx(t *testing.T) context.Context {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the returned context then only has to cover
-	// the assertions. (Same fix as cmd/gofastr's blueprint e2e.)
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)

--- a/core/middleware/idempotency_security_test.go
+++ b/core/middleware/idempotency_security_test.go
@@ -399,9 +399,18 @@ func runReclaimOneWinner(t *testing.T, s IdempotencyStore, key string, reseed fu
 				case errors.Is(err, ErrInFlight), errors.Is(err, ErrFingerprintMismatch):
 					// Expected: lost the race to another claimant, or a
 					// sibling won under a different fingerprint.
-				default:
+				case err == nil && ok:
 					// ok==true (replay) is impossible against a seeded
-					// in-flight row; any other error is a store fault.
+					// in-flight row. The store-fault default below sends
+					// err — which is nil here — so the post-loop nil check
+					// never fired and a replay passed silently. Surface a
+					// non-nil error so the race is actually caught.
+					select {
+					case unexpected <- fmt.Errorf("unexpected replay: Begin returned ok=true (a response) against a seeded in-flight row"):
+					default:
+					}
+				default:
+					// Any other error is a store fault.
 					select {
 					case unexpected <- err:
 					default:

--- a/core/middleware/idempotency_security_test.go
+++ b/core/middleware/idempotency_security_test.go
@@ -364,16 +364,26 @@ func runReclaimOneWinner(t *testing.T, s IdempotencyStore, key string, reseed fu
 
 	// The F4 window (SELECT sees an expired row, then a concurrent INSERT lands,
 	// then this caller's key-only DELETE removes the fresh claim) is narrow, so a
-	// single race rarely trips. We run many reseeded iterations per invocation to
-	// make a regression reliably observable while keeping the guard deterministic
-	// on correct code: with the fix every iteration yields exactly one winner, so
-	// the assertion can never false-fail.
+	// single race rarely trips. We run many reseeded iterations to make a
+	// regression reliably observable.
+	//
+	// The invariant on CORRECT code is exactly ONE fresh claimant per reseeded
+	// iteration: the reclaim DELETE is expiry-gated, so it can never remove a
+	// fresh claim another caller just inserted, which means a second re-claimer's
+	// retry-INSERT conflicts and surfaces ErrInFlight instead. Asserting
+	// fresh==1 (not merely fresh<=1) is what makes the test non-vacuous: the old
+	// guard only failed when fresh>1, so if contention stopped EVERY claimant
+	// from reaching the reclaim path (fresh==0) the test passed without
+	// exercising the property at all.
+	//
+	// Per-finding: any Begin error other than the two expected race outcomes
+	// (ErrInFlight, ErrFingerprintMismatch) is a store fault and must fail.
 	const racers = 60
 	const iters = 60
-	var maxFresh int64
-	for range iters {
+	for iter := range iters {
 		reseed()
 		var fresh int64
+		unexpected := make(chan error, racers)
 		var wg sync.WaitGroup
 		start := make(chan struct{})
 		for i := range racers {
@@ -383,23 +393,37 @@ func runReclaimOneWinner(t *testing.T, s IdempotencyStore, key string, reseed fu
 				<-start
 				fp := fmt.Sprintf("fp-%d", i)
 				_, ok, err := s.Begin(ctx, key, fp)
-				if err == nil && !ok {
+				switch {
+				case err == nil && !ok:
 					atomic.AddInt64(&fresh, 1)
+				case errors.Is(err, ErrInFlight), errors.Is(err, ErrFingerprintMismatch):
+					// Expected: lost the race to another claimant, or a
+					// sibling won under a different fingerprint.
+				default:
+					// ok==true (replay) is impossible against a seeded
+					// in-flight row; any other error is a store fault.
+					select {
+					case unexpected <- err:
+					default:
+					}
 				}
 			}(i)
 		}
 		close(start)
 		wg.Wait()
-		if f := atomic.LoadInt64(&fresh); f > maxFresh {
-			maxFresh = f
+		close(unexpected)
+		var firstUnexpected error
+		for e := range unexpected {
+			if firstUnexpected == nil {
+				firstUnexpected = e
+			}
 		}
-		if maxFresh > 1 {
-			break
+		if firstUnexpected != nil {
+			t.Fatalf("F4 iter %d: unexpected Begin error (only ErrInFlight/ErrFingerprintMismatch expected): %v", iter, firstUnexpected)
 		}
-	}
-	t.Logf("F4 race: maxFresh=%d over up to %d iterations x %d racers (want <=1)", maxFresh, iters, racers)
-	if maxFresh > 1 {
-		t.Fatalf("F4: %d callers obtained a fresh claim for one key in a single iteration — the reclaim path deleted a fresh claim", maxFresh)
+		if f := atomic.LoadInt64(&fresh); f != 1 {
+			t.Fatalf("F4 iter %d: expected exactly ONE fresh claimant (the reclaim path must run AND must not delete a fresh claim), got %d", iter, f)
+		}
 	}
 }
 

--- a/core/middleware/logging.go
+++ b/core/middleware/logging.go
@@ -35,7 +35,7 @@ func LoggingFn(getLogger func() *slog.Logger) Middleware {
 				}
 			}
 			logger.Info("request",
-				"method", safeLogMethod(r.Method),
+				"method", truncate(safeLogMethod(r.Method), maxRecoveryMethodLen),
 				"path", truncate(safeLogPath(r.URL.Path), maxRecoveryPathLen),
 				"status", wrapped.statusCode,
 				"duration", duration.String(),
@@ -108,7 +108,7 @@ func SampledLoggingFn(sampleN int, slowThreshold time.Duration, getLogger func()
 			// Always log errors and slow requests
 			if wrapped.statusCode >= 400 || duration > slowThreshold {
 				logger.Info("request",
-					"method", safeLogMethod(r.Method),
+					"method", truncate(safeLogMethod(r.Method), maxRecoveryMethodLen),
 					"path", truncate(safeLogPath(r.URL.Path), maxRecoveryPathLen),
 					"status", wrapped.statusCode,
 					"duration", duration.String(),
@@ -121,7 +121,7 @@ func SampledLoggingFn(sampleN int, slowThreshold time.Duration, getLogger func()
 			n := atomic.AddUint64(&counter, 1)
 			if n%uint64(sampleN) == 1 {
 				logger.Info("request",
-					"method", safeLogMethod(r.Method),
+					"method", truncate(safeLogMethod(r.Method), maxRecoveryMethodLen),
 					"path", truncate(safeLogPath(r.URL.Path), maxRecoveryPathLen),
 					"status", wrapped.statusCode,
 					"duration", duration.String(),
@@ -132,6 +132,22 @@ func SampledLoggingFn(sampleN int, slowThreshold time.Duration, getLogger func()
 	}
 }
 
+// c0AndDelSet is the complete set of bytes scrubControlBytes percent-encodes:
+// every C0 control byte (0x00–0x1F) plus DEL (0x7F). It MUST cover exactly
+// the range the encoder loop encodes (c < 0x20 || c == 0x7f): the fast-path
+// ContainsAny returns its input unchanged when none of these are present, so
+// a single missing byte means a string carrying ONLY that byte bypasses the
+// encoder and is logged raw. The earlier hand-written probe omitted most of
+// the C0 range (SOH, EOT, FS, …) and those leaked.
+var c0AndDelSet = func() string {
+	var b [33]byte
+	for i := range 32 {
+		b[i] = byte(i)
+	}
+	b[32] = 0x7f
+	return string(b[:])
+}()
+
 // scrubControlBytes percent-encodes ASCII control bytes (the C0 range) and
 // DEL in a request-derived value — URL path, method, or a panic that embeds
 // a request string — so an attacker can't forge a fake log entry or smuggle
@@ -141,11 +157,11 @@ func SampledLoggingFn(sampleN int, slowThreshold time.Duration, getLogger func()
 // its own line.
 //
 // r.URL.Path is percent-DECODED, so a %0d%0a in the raw request is a real
-// CRLF by the time it reaches any sink here. The fast-path probe includes
-// DEL (0x7f): without it, a path carrying only DEL bypassed the encoder and
-// was logged raw.
+// CRLF by the time it reaches any sink here. The fast-path probe (c0AndDelSet)
+// covers the whole C0 range plus DEL: without the full set, a path carrying
+// only an uncovered byte (e.g. a lone SOH) bypassed the encoder.
 func scrubControlBytes(s string) string {
-	if !strings.ContainsAny(s, "\x00\r\n\t\v\f\b\x1b\x7f") {
+	if !strings.ContainsAny(s, c0AndDelSet) {
 		return s
 	}
 	var b strings.Builder

--- a/core/middleware/logging_security_test.go
+++ b/core/middleware/logging_security_test.go
@@ -239,6 +239,7 @@ func TestScrubControlBytes_FullC0Range(t *testing.T) {
 	// DEL.
 	out := scrubControlBytes("x" + string(byte(0x7f)) + "y")
 	if strings.ContainsRune(out, rune(byte(0x7f))) {
+		t.Errorf("byte 0x7f (DEL) reached output raw: %q", out)
 	}
 }
 
@@ -287,8 +288,8 @@ func TestLogSinks_BoundMethod(t *testing.T) {
 			if got == "" {
 				t.Fatalf("no method attribute captured")
 			}
-			if len(got) >= huge {
-				t.Errorf("10KB method logged unbounded: %d bytes", len(got))
+			if len(got) > maxRecoveryMethodLen {
+				t.Errorf("method not bounded to maxRecoveryMethodLen (%d): got %d bytes", maxRecoveryMethodLen, len(got))
 			}
 		})
 	}
@@ -319,5 +320,41 @@ func TestRecovery_EncodeBeforeTruncate(t *testing.T) {
 	}
 	if len(got) > maxRecoveryPanicLen {
 		t.Errorf("encoded error exceeded cap: got %d bytes, max %d (encode-then-truncate violated)", len(got), maxRecoveryPanicLen)
+	}
+}
+
+// TestTimeout_EncodeBeforeTruncate is the timeout-sink twin of
+// TestRecovery_EncodeBeforeTruncate. PR #199 fixed recovery.go to
+// control-byte-encode FIRST and only then length-bound, but the sibling
+// slog.Error in timeout.go's late-panic watcher kept the reverse order
+// (truncate-then-encode): N bytes of \r truncate to N bytes, then each
+// encodes to %0d (3 bytes), yielding 3N bytes in the log — blowing past
+// maxRecoveryPanicLen. The property: the logged "error" attribute never
+// exceeds maxRecoveryPanicLen, even when every byte expands on encoding.
+func TestTimeout_EncodeBeforeTruncate(t *testing.T) {
+	prev := slog.Default()
+	cap := &captureHandler{}
+	slog.SetDefault(slog.New(cap))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	h := Timeout(50 * time.Millisecond)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // wait for the deadline, then panic late
+		panic(strings.Repeat("\r", maxRecoveryPanicLen))
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	// The late-panic log fires from a watcher goroutine after the 504.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && cap.get("error") == "" {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	got := cap.get("error")
+	if got == "" {
+		t.Fatalf("no error attribute captured (late-panic watcher did not fire)")
+	}
+	if len(got) > maxRecoveryPanicLen {
+		t.Errorf("encoded error exceeded cap: got %d bytes, max %d (timeout encodes AFTER truncating)", len(got), maxRecoveryPanicLen)
 	}
 }

--- a/core/middleware/logging_security_test.go
+++ b/core/middleware/logging_security_test.go
@@ -221,3 +221,103 @@ func TestLogSinksScrubAndBound(t *testing.T) {
 		})
 	}
 }
+
+// TestScrubControlBytes_FullC0Range pins that EVERY C0 control byte
+// (0x00–0x1F) and DEL (0x7F) is percent-encoded by scrubControlBytes.
+// The fast-path probe is a ContainsAny allow-list over a byte set; if it
+// omits any byte the encoder loop would catch, a string carrying ONLY that
+// byte bypasses the encoder and is returned raw — so a lone SOH (0x01) or
+// FS (0x1c) reached the log attribute verbatim. Property: no raw C0/DEL
+// byte survives scrubbing, for every byte in the range.
+func TestScrubControlBytes_FullC0Range(t *testing.T) {
+	for b := byte(0); b < 0x20; b++ {
+		out := scrubControlBytes("x" + string(b) + "y")
+		if strings.ContainsRune(out, rune(b)) {
+			t.Errorf("byte %#02x reached output raw: %q", b, out)
+		}
+	}
+	// DEL.
+	out := scrubControlBytes("x" + string(byte(0x7f)) + "y")
+	if strings.ContainsRune(out, rune(byte(0x7f))) {
+	}
+}
+
+// TestLogSinks_BoundMethod pins the third log-injection axis the path
+// already had: the HTTP method (attacker-controlled — net/http accepts any
+// RFC 7230 token) must be length-bounded in every request-log sink, or a
+// forged 10 KB method string lands in the log whole. Recovery/Logging both
+// logged it unbounded after the path got its cap.
+func TestLogSinks_BoundMethod(t *testing.T) {
+	prev := slog.Default()
+	cap := &captureHandler{}
+	slog.SetDefault(slog.New(cap))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	sinks := []struct {
+		name    string
+		handler http.Handler
+		async   bool
+	}{
+		{"logging", Logging()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})), false},
+		{"recovery", Recovery()(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			panic("boom")
+		})), false},
+		{"timeout", Timeout(50 * time.Millisecond)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+			panic("late")
+		})), true},
+	}
+
+	const huge = 10000
+	for _, sk := range sinks {
+		t.Run(sk.name, func(t *testing.T) {
+			cap.reset()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Method = strings.Repeat("X", huge)
+			sk.handler.ServeHTTP(httptest.NewRecorder(), req)
+			if sk.async {
+				deadline := time.Now().Add(2 * time.Second)
+				for time.Now().Before(deadline) && cap.get("method") == "" {
+					time.Sleep(5 * time.Millisecond)
+				}
+			}
+			got := cap.get("method")
+			if got == "" {
+				t.Fatalf("no method attribute captured")
+			}
+			if len(got) >= huge {
+				t.Errorf("10KB method logged unbounded: %d bytes", len(got))
+			}
+		})
+	}
+}
+
+// TestRecovery_EncodeBeforeTruncate pins the order: the panic value is
+// control-byte-encoded FIRST and only then length-bounded. The reverse
+// (truncate-then-encode) lets the encoded form blow past the cap — N bytes
+// of \r truncate to N bytes, then each encodes to %0d (3 bytes), yielding
+// 3N bytes in the log — and can also split a %xx encoding at the cut. The
+// property: the logged "error" attribute never exceeds maxRecoveryPanicLen,
+// even when every byte expands on encoding.
+func TestRecovery_EncodeBeforeTruncate(t *testing.T) {
+	prev := slog.Default()
+	cap := &captureHandler{}
+	slog.SetDefault(slog.New(cap))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	h := Recovery()(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic(strings.Repeat("\r", maxRecoveryPanicLen))
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	got := cap.get("error")
+	if got == "" {
+		t.Fatalf("no error attribute captured")
+	}
+	if len(got) > maxRecoveryPanicLen {
+		t.Errorf("encoded error exceeded cap: got %d bytes, max %d (encode-then-truncate violated)", len(got), maxRecoveryPanicLen)
+	}
+}

--- a/core/middleware/metrics.go
+++ b/core/middleware/metrics.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"log/slog"
@@ -225,28 +226,38 @@ func MetricsHandler(m *Metrics) http.Handler {
 		m.mu.Unlock()
 		sort.Slice(snapshot, func(i, j int) bool { return snapshot[i].name < snapshot[j].name })
 		for _, c := range snapshot {
-			runCollectorSafely(&sb, c.name, c.fn)
+			if out := runCollectorSafely(c.name, c.fn); out != nil {
+				sb.Write(out)
+			}
 		}
 
 		w.Write([]byte(sb.String()))
 	})
 }
 
-// runCollectorSafely runs one metrics collector with a per-call recover,
-// mirroring hook.runHookSafely. A third-party CollectorFunc that panics is
-// isolated (logged once) instead of aborting the whole /metrics scrape: the
-// exposition buffer is shared across the loop, so without this guard one bad
-// collector would drop every family's metrics for that scrape.
-func runCollectorSafely(w io.Writer, name string, fn CollectorFunc) {
+// runCollectorSafely runs one metrics collector into an ISOLATED buffer with
+// a per-call recover, mirroring hook.runHookSafely. A third-party
+// CollectorFunc that panics is isolated (logged once) instead of aborting
+// the whole /metrics scrape. The collector writes into its OWN buffer, so a
+// half-written line from a collector that panics mid-write is discarded:
+// only a collector that returns normally contributes its bytes to the
+// scrape. Without the private buffer the partial bytes a panicking collector
+// had already flushed into the shared exposition buffer would survive the
+// recover and corrupt the output (a truncated metric line a parser rejects).
+// Returns nil on panic so the caller appends nothing.
+func runCollectorSafely(name string, fn CollectorFunc) (out []byte) {
 	defer func() {
 		if r := recover(); r != nil {
+			out = nil
 			slog.Error("metrics collector panic isolated",
 				"collector", name,
 				"error", truncate(fmt.Sprint(r), maxRecoveryPanicLen),
 			)
 		}
 	}()
-	fn(w)
+	var buf bytes.Buffer
+	fn(&buf)
+	return buf.Bytes()
 }
 
 // metricsResponseWriter captures the response status code so the recording

--- a/core/middleware/metrics_security_test.go
+++ b/core/middleware/metrics_security_test.go
@@ -111,3 +111,42 @@ func TestMetricsCollectorPanicIsolated(t *testing.T) {
 		t.Errorf("SECURITY: [availability] collector AFTER the panicking one was lost:\n%s", body)
 	}
 }
+
+// TestMetricsCollectorPanicDiscardsPartialOutput pins the second half of
+// panic isolation: a collector that has already written a PARTIAL metric
+// line into the shared exposition buffer before it panics must contribute
+// NOTHING to the scrape. Without a per-collector buffer, the half-written
+// line ("partial_metric{...} " with no value or newline) survived the
+// recover and corrupted the output — a truncated line a Prometheus parser
+// rejects, dropping families after it too. The good families still appear.
+func TestMetricsCollectorPanicDiscardsPartialOutput(t *testing.T) {
+	m := NewMetrics()
+	m.RegisterCollector("good", func(w io.Writer) {
+		fmt.Fprintln(w, "good_metric 42")
+	})
+	m.RegisterCollector("partial", func(w io.Writer) {
+		// Write a half-line (no value, no newline) then blow up.
+		fmt.Fprint(w, "partial_metric{label=\"x\"} ")
+		panic("mid-write explosion")
+	})
+	m.RegisterCollector("also_good", func(w io.Writer) {
+		fmt.Fprintln(w, "also_good_metric 7")
+	})
+
+	rec := httptest.NewRecorder()
+	MetricsHandler(m).ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("scrape status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "good_metric 42") {
+		t.Errorf("good collector lost:\n%s", body)
+	}
+	if !strings.Contains(body, "also_good_metric 7") {
+		t.Errorf("collector after the panicking one lost:\n%s", body)
+	}
+	if strings.Contains(body, "partial_metric") {
+		t.Errorf("SECURITY: partial output from a panicking collector leaked into the scrape:\n%s", body)
+	}
+}

--- a/core/middleware/metrics_security_test.go
+++ b/core/middleware/metrics_security_test.go
@@ -119,9 +119,15 @@ func TestMetricsCollectorPanicIsolated(t *testing.T) {
 // line ("partial_metric{...} " with no value or newline) survived the
 // recover and corrupted the output — a truncated line a Prometheus parser
 // rejects, dropping families after it too. The good families still appear.
+//
+// Collectors run in SORTED name order, so the names are chosen to put
+// "partial" in the MIDDLE (aaa_good < partial < zzz_also_good): a collector
+// runs both before AND after the panicking one. With the old names
+// (good/partial/also_good) "partial" sorted last, so the test proved nothing
+// about a collector running after the panic.
 func TestMetricsCollectorPanicDiscardsPartialOutput(t *testing.T) {
 	m := NewMetrics()
-	m.RegisterCollector("good", func(w io.Writer) {
+	m.RegisterCollector("aaa_good", func(w io.Writer) {
 		fmt.Fprintln(w, "good_metric 42")
 	})
 	m.RegisterCollector("partial", func(w io.Writer) {
@@ -129,7 +135,7 @@ func TestMetricsCollectorPanicDiscardsPartialOutput(t *testing.T) {
 		fmt.Fprint(w, "partial_metric{label=\"x\"} ")
 		panic("mid-write explosion")
 	})
-	m.RegisterCollector("also_good", func(w io.Writer) {
+	m.RegisterCollector("zzz_also_good", func(w io.Writer) {
 		fmt.Fprintln(w, "also_good_metric 7")
 	})
 

--- a/core/middleware/recovery.go
+++ b/core/middleware/recovery.go
@@ -11,9 +11,10 @@ import (
 // string doesn't write a 100 MB log line through slog.Default for
 // apps that don't load a structured-logging plugin.
 const (
-	maxRecoveryPanicLen = 4 << 10  // 4 KiB
-	maxRecoveryStackLen = 64 << 10 // 64 KiB
-	maxRecoveryPathLen  = 2 << 10  // 2 KiB
+	maxRecoveryPanicLen  = 4 << 10  // 4 KiB
+	maxRecoveryStackLen  = 64 << 10 // 64 KiB
+	maxRecoveryPathLen   = 2 << 10  // 2 KiB
+	maxRecoveryMethodLen = 1 << 5   // 32 B — real HTTP methods are ≤ ~10 chars
 )
 
 func truncate(s string, max int) string {
@@ -49,9 +50,9 @@ func RecoveryFn(getLogger func() *slog.Logger) Middleware {
 						}
 					}
 					logger.Error("panic recovered",
-						"error", scrubControlBytes(truncate(fmt.Sprint(err), maxRecoveryPanicLen)),
-						"path", safeLogPath(truncate(r.URL.Path, maxRecoveryPathLen)),
-						"method", safeLogMethod(r.Method),
+						"error", truncate(scrubControlBytes(fmt.Sprint(err)), maxRecoveryPanicLen),
+						"path", truncate(safeLogPath(r.URL.Path), maxRecoveryPathLen),
+						"method", truncate(safeLogMethod(r.Method), maxRecoveryMethodLen),
 						"stack", truncate(string(debug.Stack()), maxRecoveryStackLen),
 					)
 					http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/core/middleware/timeout.go
+++ b/core/middleware/timeout.go
@@ -311,7 +311,7 @@ func Timeout(d time.Duration) Middleware {
 						slog.Error("panic in timed-out handler",
 							"error", scrubControlBytes(truncate(fmt.Sprint(childPanic), maxRecoveryPanicLen)),
 							"path", safeLogPath(truncate(r.URL.Path, maxRecoveryPathLen)),
-							"method", safeLogMethod(r.Method),
+							"method", truncate(safeLogMethod(r.Method), maxRecoveryMethodLen),
 						)
 					}
 				}()

--- a/core/middleware/timeout.go
+++ b/core/middleware/timeout.go
@@ -309,8 +309,8 @@ func Timeout(d time.Duration) Middleware {
 					<-done
 					if childPanic != nil {
 						slog.Error("panic in timed-out handler",
-							"error", scrubControlBytes(truncate(fmt.Sprint(childPanic), maxRecoveryPanicLen)),
-							"path", safeLogPath(truncate(r.URL.Path, maxRecoveryPathLen)),
+							"error", truncate(scrubControlBytes(fmt.Sprint(childPanic)), maxRecoveryPanicLen),
+							"path", truncate(safeLogPath(r.URL.Path), maxRecoveryPathLen),
 							"method", truncate(safeLogMethod(r.Method), maxRecoveryMethodLen),
 						)
 					}

--- a/examples/backoffice/e2e_test.go
+++ b/examples/backoffice/e2e_test.go
@@ -46,15 +46,19 @@ func backofficeBrowser(t *testing.T) context.Context {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the returned context then only has to cover
-	// the assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)

--- a/examples/meridian/e2e_ui_test.go
+++ b/examples/meridian/e2e_ui_test.go
@@ -76,15 +76,19 @@ func e2eBrowser(t *testing.T) context.Context {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the returned context then only has to cover
-	// the assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)

--- a/framework/docs/content/data-export.md
+++ b/framework/docs/content/data-export.md
@@ -253,12 +253,16 @@ type EraseReport struct {
     DryRun    bool
     Entities  []EraseTableResult // owner-scoped entity tables (always delete)
     Batteries []EraseTableResult // registered erasers (delete or anonymize)
-    Audit     *EraseTableResult  // built-in audit anonymization
-}
+    Audit     *EraseTableResult  // built-in audit anonymization; nil if the audit table is absent
+    Skipped   []string           // erasers skipped because their identity could not be resolved (idempotent re-run)
 ```
 
 Each `EraseTableResult` carries the table name, the mode (`delete` or
 `anonymize`), and the row count. `report.TotalErased()` sums every plane.
+`Skipped` names identity-resolved erasers that were skipped because the
+resolved identity row was already gone — the idempotent-re-run case (see
+"Identity-keyed tables" above): skipping is not an error, and the erasure
+reports zero for those tables rather than failing.
 
 ### Dry-run
 

--- a/framework/docs/content/idempotency.md
+++ b/framework/docs/content/idempotency.md
@@ -72,9 +72,11 @@ Principal: func(r *http.Request) string {
 the user value is whatever your middleware stored, so the assertion is
 yours to write.
 
-When `Principal` is unset, the middleware still runs — but the cache
-is shared globally across callers and you accept the cross-request
-leak. Set it.
+When `Principal` is unset, the middleware disables replay caching
+entirely: it degrades to a pass-through that logs a warning and never
+caches, so there is no shared namespace and no cross-request leak. The
+cost is that you lose duplicate-suppression until you wire one. Set it
+to enable caching.
 
 ### Headers stripped from replays
 
@@ -186,8 +188,10 @@ next reap cycle.
 
 ## Common mistakes
 
-- **Don't forget `Principal`.** Without it the cache is global and a
-  client-chosen `Idempotency-Key` collides across users.
+- **Don't forget `Principal`.** Without it the middleware disables
+  replay caching entirely (a pass-through that logs a warning) rather
+  than cache into a namespace shared across callers — so you silently
+  lose duplicate-suppression, you don't leak cross-request.
 - **Don't ignore the fingerprint in a custom `Finish`.** `Finish` is
   fingerprint-bound for a reason: a claim can expire mid-handler and be
   re-claimed by another principal, and a `Finish` that writes by key alone

--- a/framework/static/pwa_static_chrome_e2e_test.go
+++ b/framework/static/pwa_static_chrome_e2e_test.go
@@ -58,15 +58,19 @@ func TestPWAStaticChromeE2E(t *testing.T) {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	defer browserCancel()
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the work context then only has to cover the
-	// assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	defer startCancel()
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 120*time.Second)

--- a/framework/typed_hooks_after_error_test.go
+++ b/framework/typed_hooks_after_error_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -28,6 +29,12 @@ func TestTypedHook_AfterCreateErrorPropagates(t *testing.T) {
 		}
 		if err == nil {
 			t.Fatal("AfterCreate hook error did not propagate to CreateOne")
+		}
+		// Assert the SPECIFIC hook error, not merely that some error occurred:
+		// a generic failure (e.g. a SQL error from a broken hook) would satisfy
+		// a nil-check and mask the propagation contract this test pins.
+		if !strings.Contains(err.Error(), "typed after-create reject") {
+			t.Fatalf("AfterCreate returned the wrong error, want the hook's typed after-create reject: %v", err)
 		}
 	})
 }
@@ -55,6 +62,10 @@ func TestTypedHook_AfterUpdateErrorPropagates(t *testing.T) {
 		}
 		if err == nil {
 			t.Fatal("AfterUpdate hook error did not propagate to UpdateOne")
+		}
+		// Same as the AfterCreate case: pin the SPECIFIC error, not just non-nil.
+		if !strings.Contains(err.Error(), "typed after-update reject") {
+			t.Fatalf("UpdateOne returned the wrong error, want the hook's typed after-update reject: %v", err)
 		}
 	})
 }

--- a/framework/ui/filtertoolbar.go
+++ b/framework/ui/filtertoolbar.go
@@ -247,6 +247,11 @@ func FilterToolbar(cfg FilterToolbarConfig) render.HTML {
 	for k, v := range cfg.ExtraAttrs {
 		formAttrs[k] = v
 	}
+	// The sanitized action must win: ExtraAttrs is a developer escape hatch,
+	// but letting it rewrite "action" would silently undo the
+	// urlsafe.CleanAnchor pass above (a "javascript:" action would come back
+	// live). Re-assert after the merge so the sanitizer is not reversible.
+	formAttrs["action"] = action
 
 	return filterToolbarStyle.WrapHTML(render.Tag("form", flattenAttrs(formAttrs), controls...))
 }

--- a/framework/ui/filtertoolbar.go
+++ b/framework/ui/filtertoolbar.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"strings"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
@@ -245,6 +246,14 @@ func FilterToolbar(cfg FilterToolbarConfig) render.HTML {
 		formAttrs["id"] = cfg.ID
 	}
 	for k, v := range cfg.ExtraAttrs {
+		// HTML attribute names are case-insensitive, so a case-variant key
+		// ("Action"/"ACTION"/"AcTiOn") would survive a lowercase-only drop,
+		// render as a second attribute, and fold back onto "action" in the
+		// parser (first occurrence wins) — silently reversing the
+		// urlsafe.CleanAnchor pass below. Drop every case-variant here.
+		if strings.EqualFold(k, "action") {
+			continue
+		}
 		formAttrs[k] = v
 	}
 	// The sanitized action must win: ExtraAttrs is a developer escape hatch,

--- a/framework/ui/image_placeholder_chromium_test.go
+++ b/framework/ui/image_placeholder_chromium_test.go
@@ -60,13 +60,19 @@ func TestPlaceholderPaintsWhileSourceIsPending(t *testing.T) {
 	ctx, cancel := chromedp.NewContext(allocCtx)
 	defer cancel()
 
-	// chromedp starts Chrome lazily on the first Run: give the cold
-	// start its own budget so the work budget below is not also a
-	// launch budget (and so it does not cap WSURLReadTimeout).
-	startCtx, startCancel := context.WithTimeout(ctx, 90*time.Second)
-	defer startCancel()
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(ctx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancelTimeout := context.WithTimeout(ctx, 60*time.Second)

--- a/framework/ui/searchinput.go
+++ b/framework/ui/searchinput.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"strings"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
@@ -79,6 +80,15 @@ func SearchInput(cfg SearchInputConfig) render.HTML {
 		"aria-label":  i18nui.T(ctx, i18nui.KeySearchLabel),
 	}
 	for k, v := range cfg.ExtraAttrs {
+		// HTML attribute names are case-insensitive: a case-variant key
+		// ("Type"/"Name"/"ID") survives a lowercase-only re-assert as a
+		// distinct entry, renders as a second attribute, and folds back onto
+		// the protected one in the parser (e.g. "Type" can flip the search
+		// box to a hidden/submit input, "Name" can clobber the submitted
+		// field). Drop every case-variant of the re-asserted keys here.
+		if strings.EqualFold(k, "type") || strings.EqualFold(k, "name") || strings.EqualFold(k, "id") {
+			continue
+		}
 		inputAttrs[k] = v
 	}
 	// Protect critical attrs from Attrs override.

--- a/framework/ui/srcset_datauri_chromium_test.go
+++ b/framework/ui/srcset_datauri_chromium_test.go
@@ -43,13 +43,19 @@ func TestSrcsetDataURICommaInBrowser(t *testing.T) {
 	ctx, cancel := chromedp.NewContext(allocCtx)
 	defer cancel()
 
-	// chromedp starts Chrome lazily on the first Run: give the cold
-	// start its own budget so the work budget below is not also a
-	// launch budget (and so it does not cap WSURLReadTimeout).
-	startCtx, startCancel := context.WithTimeout(ctx, 90*time.Second)
-	defer startCancel()
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(ctx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancelTimeout := context.WithTimeout(ctx, 60*time.Second)
@@ -99,13 +105,19 @@ func TestSrcsetDataURIPayloadIsNotASecondCandidate(t *testing.T) {
 	ctx, cancel := chromedp.NewContext(allocCtx)
 	defer cancel()
 
-	// chromedp starts Chrome lazily on the first Run: give the cold
-	// start its own budget so the work budget below is not also a
-	// launch budget (and so it does not cap WSURLReadTimeout).
-	startCtx, startCancel := context.WithTimeout(ctx, 90*time.Second)
-	defer startCancel()
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(ctx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancelTimeout := context.WithTimeout(ctx, 60*time.Second)

--- a/framework/ui/ui_link_form_security_test.go
+++ b/framework/ui/ui_link_form_security_test.go
@@ -845,3 +845,26 @@ func schemeOf(u string) string {
 	}
 	return strings.ToLower(u[:i])
 }
+
+// TestFilterToolbarExtraAttrsCannotOverrideAction pins that the sanitized
+// form action is NOT silently reversible via ExtraAttrs. #198 ran cfg.Action
+// through urlsafe.CleanAnchor, but the ExtraAttrs merge that followed wrote
+// cfg.ExtraAttrs["action"] straight over the sanitized value — so a
+// developer-supplied "javascript:" action undid the sanitizer our own code
+// just applied. The sanitized action must win. (SearchInput merges
+// ExtraAttrs into the <input>, never the <form>, so it does not share this
+// shape — covered by TestFormActionSinksRejectUnsafeURL instead.)
+func TestFilterToolbarExtraAttrsCannotOverrideAction(t *testing.T) {
+	out := string(ui.FilterToolbar(ui.FilterToolbarConfig{
+		Action:     "/search",
+		HideReset:  true,
+		Sort:       []ui.SortOption{{Value: "x", Label: "X"}},
+		ExtraAttrs: html.Attrs{"action": "javascript:alert(1)"},
+	}))
+	if strings.Contains(out, "javascript:") {
+		t.Errorf("SECURITY: ExtraAttrs overrode the sanitized form action:\n%s", out)
+	}
+	if !strings.Contains(out, `action="/search"`) {
+		t.Errorf("sanitized action lost from output:\n%s", out)
+	}
+}

--- a/framework/ui/ui_link_form_security_test.go
+++ b/framework/ui/ui_link_form_security_test.go
@@ -847,24 +847,58 @@ func schemeOf(u string) string {
 }
 
 // TestFilterToolbarExtraAttrsCannotOverrideAction pins that the sanitized
-// form action is NOT silently reversible via ExtraAttrs. #198 ran cfg.Action
-// through urlsafe.CleanAnchor, but the ExtraAttrs merge that followed wrote
-// cfg.ExtraAttrs["action"] straight over the sanitized value — so a
-// developer-supplied "javascript:" action undid the sanitizer our own code
-// just applied. The sanitized action must win. (SearchInput merges
-// ExtraAttrs into the <input>, never the <form>, so it does not share this
-// shape — covered by TestFormActionSinksRejectUnsafeURL instead.)
+// form action is NOT silently reversible via ExtraAttrs — including via a
+// case-VARIANT key, because HTML attribute names are case-insensitive.
+// #198 ran cfg.Action through urlsafe.CleanAnchor but let the ExtraAttrs
+// merge write cfg.ExtraAttrs["action"] straight over it; #199 dropped the
+// lowercase "action" key from ExtraAttrs. A mixed-case key ("Action" /
+// "ACTION" / "AcTiOn") still survived as a distinct map entry, rendered as a
+// SECOND attribute, and the HTML parser folds duplicate attributes back onto
+// "action" (first occurrence wins) — so whichever rendered first became the
+// live form action, silently reversing the sanitizer. Property × key-case:
+// the sanitized action must be the ONLY attribute that folds to "action".
 func TestFilterToolbarExtraAttrsCannotOverrideAction(t *testing.T) {
-	out := string(ui.FilterToolbar(ui.FilterToolbarConfig{
-		Action:     "/search",
-		HideReset:  true,
-		Sort:       []ui.SortOption{{Value: "x", Label: "X"}},
-		ExtraAttrs: html.Attrs{"action": "javascript:alert(1)"},
-	}))
-	if strings.Contains(out, "javascript:") {
-		t.Errorf("SECURITY: ExtraAttrs overrode the sanitized form action:\n%s", out)
+	for _, key := range []string{"action", "Action", "ACTION", "AcTiOn"} {
+		t.Run(key, func(t *testing.T) {
+			out := string(ui.FilterToolbar(ui.FilterToolbarConfig{
+				Action:     "/search",
+				HideReset:  true,
+				Sort:       []ui.SortOption{{Value: "x", Label: "X"}},
+				ExtraAttrs: html.Attrs{key: "javascript:alert(1)"},
+			}))
+			if strings.Contains(out, "javascript:") {
+				t.Errorf("SECURITY: ExtraAttrs[%q] (case-variant of action) leaked a javascript: action:\n%s", key, out)
+			}
+			if !strings.Contains(out, `action="/search"`) {
+				t.Errorf("sanitized action lost from output:\n%s", out)
+			}
+		})
 	}
-	if !strings.Contains(out, `action="/search"`) {
-		t.Errorf("sanitized action lost from output:\n%s", out)
+}
+
+// TestSearchInputExtraAttrsCaseInsensitiveProtected pins the same property on
+// SearchInput's <input>: the re-asserted attributes (type/name/id) must win
+// over ExtraAttrs even when the caller uses a case-variant key. HTML attribute
+// names are case-insensitive, so an ExtraAttrs "Type"/"Name"/"ID" survives the
+// lowercase re-assert as a distinct map key, renders as a second attribute,
+// and folds back onto the protected one in the parser (e.g. "Type" can flip a
+// search box to a hidden/submit input, "Name" can clobber the submitted field).
+func TestSearchInputExtraAttrsCaseInsensitiveProtected(t *testing.T) {
+	// Every case-variant of each re-asserted key; "PWNED" must never render.
+	cases := []string{
+		"type", "Type", "TYPE", "tYpE",
+		"name", "Name", "NAME", "nAmE",
+		"id", "ID", "Id", "iD",
+	}
+	for _, key := range cases {
+		t.Run(key, func(t *testing.T) {
+			out := string(ui.SearchInput(ui.SearchInputConfig{
+				Name: "q", ID: "q",
+				ExtraAttrs: html.Attrs{key: "PWNED"},
+			}))
+			if strings.Contains(out, "PWNED") {
+				t.Errorf("SECURITY: ExtraAttrs[%q] (case-variant of a protected attr) leaked into <input>:\n%s", key, out)
+			}
+		})
 	}
 }

--- a/framework/ui_e2e_test.go
+++ b/framework/ui_e2e_test.go
@@ -261,13 +261,19 @@ func newE2EChrome(t *testing.T) context.Context {
 	browser, browserCancel := chromedp.NewContext(alloc)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run: give the cold start its
-	// own budget so the work budget below is not also a launch budget (and so
-	// it does not cap WSURLReadTimeout).
-	startCtx, startCancel := context.WithTimeout(browser, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browser) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browser, 60*time.Second)

--- a/framework/uihost/embed_e2e_test.go
+++ b/framework/uihost/embed_e2e_test.go
@@ -249,15 +249,19 @@ func newEmbedBrowserCtx(t *testing.T) context.Context {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the returned context then only has to cover
-	// the assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)

--- a/framework/uihost/partial_redirect_e2e_test.go
+++ b/framework/uihost/partial_redirect_e2e_test.go
@@ -116,13 +116,19 @@ func newE2EChromeForUIHost(t *testing.T) context.Context {
 	browser, browserCancel := chromedp.NewContext(alloc)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run: give the cold start its
-	// own budget so the work budget below is not also a launch budget (and so
-	// it does not cap WSURLReadTimeout).
-	startCtx, startCancel := context.WithTimeout(browser, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browser) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browser, 60*time.Second)

--- a/framework/uihost/pwa_chrome_e2e_test.go
+++ b/framework/uihost/pwa_chrome_e2e_test.go
@@ -69,15 +69,19 @@ func TestPWAChromeE2E(t *testing.T) {
 	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
 	defer browserCancel()
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that 90s ineffective. Start the browser
-	// under its own budget first; the work context then only has to cover the
-	// assertions.
-	startCtx, startCancel := context.WithTimeout(browserCtx, 90*time.Second)
-	defer startCancel()
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browserCtx) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, cancel := context.WithTimeout(browserCtx, 120*time.Second)

--- a/kiln/integration/browser_test.go
+++ b/kiln/integration/browser_test.go
@@ -143,14 +143,19 @@ func newChrome(t *testing.T) (context.Context, context.CancelFunc) {
 	browser, browserCancel := chromedp.NewContext(alloc)
 	t.Cleanup(browserCancel)
 
-	// chromedp starts Chrome lazily on the first Run, so one timeout would
-	// have to cover BOTH the cold start and the page work — and it caps the
-	// WSURLReadTimeout above, making that ineffective. Start the browser
-	// under its own budget first; the returned context covers only the work.
-	startCtx, startCancel := context.WithTimeout(browser, 90*time.Second)
-	t.Cleanup(startCancel)
-	if err := chromedp.Run(startCtx); err != nil {
-		t.Fatalf("chrome did not start within 90s: %v", err)
+	// chromedp starts Chrome lazily on the first Run: allocate against the
+	// browser context so the browser's lifetime is the browser context's —
+	// passing a timeout context here would make the browser die when that
+	// deadline passed. The watchdog bounds only the startup wait.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(browser) }()
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("chrome did not start: %v", err)
+		}
+	case <-time.After(90 * time.Second):
+		t.Fatal("chrome did not start within 90s")
 	}
 
 	ctx, timeoutCancel := context.WithTimeout(browser, 60*time.Second)


### PR DESCRIPTION
Addresses all 12 line-level review comments CodeRabbit posted on #198 — which I merged without reading them. Six were Major, and the most serious was a bug in my own fix from that PR.

## The cold-start fix from #198 was wrong

chromedp allocates the browser against the context passed to the **first** `Run`, so the 90-second cold-start budget #198 introduced became the browser's *lifetime*. Any test still using that browser after 90 seconds lost it mid-run. It passed CI only because cancellation happened at test end.

Proven, not assumed — a standalone probe with the old pattern:

```
BROWSER DIED with startCtx: context canceled
```

and the same probe against the corrected pattern:

```
browser alive after startup watchdog — fix holds
```

All 24 harnesses now allocate against the browser context, with a watchdog bounding only the startup wait. Work budgets are unchanged.

## Other Major findings

- **A panicking metrics collector still corrupted the scrape.** #198 added a recover per collector, but whatever it had already written into the shared buffer stayed. Each collector now writes to its own buffer, appended only on success.
- **`ExtraAttrs` could override the form action #198 had just sanitized**, silently reversing the guard. The sanitized action now wins, in both `FilterToolbar` and `SearchInput`. (This is distinct from treating `ExtraAttrs` as attacker input, which would be wrong-layer — the issue is that our own sanitizer was reversible.)
- **`logging.go`** did not cover the full C0 range and did not bound the logged method.
- **`recovery.go`** truncated before encoding, so encoding could push the result past the bound.

## Minor

- **My F4 race test could pass vacuously** — it only failed when more than one claimant won, so if contention meant *nobody* won, it asserted nothing. It now requires exactly one fresh claimant per iteration and fails on any unexpected `Begin` error.
- `typed_hooks_after_error_test.go` asserts the specific hook error instead of any error.
- `data-export.md` documents the new `Skipped` field.
- `idempotency.md` corrected: it claimed an unset `Principal` shares a global cache; the code disables replay caching entirely.

## Also in here

`CLAUDE.md` gains hard rule 10: read the PR's line-level review comments before merging. `gh pr view --json comments` returns only issue-level comments, and a review bot showing `pass` in `gh pr checks` means it ran, not that it found nothing — #198 showed `CodeRabbit pass` while holding 12 unread comments.

## Noted, not fixed

Three of the touched files carry `//go:build chromium`, and `ci.yml:195-197` documents that no CI step passes `-tags chromium` — so those tests never run in the pipeline. They were run locally with the tag for this change. Pre-existing and apparently deliberate, but it means a class of SSRF and image tests is unexercised by CI.

## Verification

`./scripts/test-all.sh` → exit 0, 192 packages. `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved request, recovery, and timeout logging by sanitizing control characters and limiting logged values.
  * Prevented unsafe action URLs and protected form attributes from being overridden.
  * Prevented partial metrics from failed collectors appearing in responses.

* **Behavior Changes**
  * Requests without a principal now bypass replay caching with a warning, avoiding shared-cache leakage.

* **Documentation**
  * Clarified data-erasure audit results and skipped, idempotent erasers.
  * Updated idempotency guidance to reflect pass-through behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->