### PR TITLE
Low-hanging fixes from the 2026-08-16 clean-room assessment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,18 @@ jobs:
       - name: Build
         run: go build ./...
 
+      - name: Cross-compile smoke (windows, darwin)
+        # The runner is ubuntu-only, so windows-tagged files never compile
+        # in any gate without this. Compile-only — no tests run. CGO_ENABLED
+        # is forced off: the job-level "1" would make the cross-build
+        # compile runtime/cgo with the host gcc, which cannot target the
+        # other OSes.
+        env:
+          CGO_ENABLED: "0"
+        run: |
+          GOOS=windows go build ./...
+          GOOS=darwin go build ./...
+
       - name: gofmt (tracked files must be clean)
         run: |
           drift=$(git ls-files '*.go' | xargs gofmt -l)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+
+- **The release gate now checks SECURITY.md.** `scripts/release-gate.sh`
+  refuses to publish a tag unless SECURITY.md names the released minor as
+  the supported line (v0.64.0 shipped while the policy still said
+  `0.63.x`; that class of drift now aborts the release instead).
+- **CI cross-compiles for Windows and macOS.** The blocking job now runs
+  `GOOS=windows` / `GOOS=darwin` compile smokes, so the windows-tagged
+  runtime files can no longer rot uncompiled on the ubuntu-only matrix.
+- **The layering rules are now a test.** `framework/layering_test.go`
+  mechanically enforces the ARCHITECTURE.md invariants: no framework
+  subpackage depends on the root facade (with the one sanctioned
+  `pluginhost` → `battery/auth` carve-out pinned), `uihost` never links
+  `framework/ui`, and `core-ui` never imports `framework`.
+- Direct tests and a 98.0 coverage floor for `framework/datexport`, the
+  registry behind `ExportData` / `ImportData` / `EraseUserData` —
+  previously covered only from the consumer side.
+
+### Fixed
+
+- **Docs told the truth about `.env` loading.** `deploy.md` claimed
+  dotfiles load "in development"; `NewApp` loads them in every
+  environment unless `GOFASTR_DOTENV=off`, and `.env.<APP_ENV>` joins the
+  load order whenever `APP_ENV` is set. The corrected wording is pinned
+  by the docs truth sweep.
+- `query-dsl.md` pointed composite cursors at `EntityConfig.CursorFields`;
+  the real path is `EntityConfig.Pagination.CursorFields`. Also pinned.
+- **The docs site stopped calling Meridian regenerable.** The homepage and
+  `/examples` cards said Meridian "is generated from one gofastr.yml"
+  (the `/examples` card added "zero hand-written app code" and a
+  `gofastr generate` run command its own doc.go forbids). Both now say
+  what `examples/meridian/doc.go` says: seeded from one blueprint,
+  hand-evolved since.
+- `framework/ARCHITECTURE.md` caught up with the tree: the real
+  subpackage count, map entries for the eight packages that had none
+  (contracts, datexport, embed, fanout, gallery, outbox, ratelimit,
+  semcov), the current intra-layer import edges, and why-it-stays rows
+  for the root files added since the last refresh.
+- README's documentation list now links the auth reference, access
+  control, the runtime contract, and the browsable docs index — the
+  most-asked topics were previously unreachable from the front door.
+
 ## [0.64.0] - 2026-08-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ connected to a running app.
 - [UI composition recipes](framework/docs/content/ui-composition-recipes.md) — product-shaped page structures built entirely from `framework/ui` primitives
 - [UI components index](framework/docs/content/ui-new-components.md) — **the catalog**: every component the framework ships, with its `go doc` path and live demo at `/components/<slug>` in `examples/site`
 - [core-ui architecture](core-ui/ARCHITECTURE.md) — **deeper UI/runtime reference** (SSR, hydration, islands, component CSS, data-fui-* primitives)
+- [Runtime contract](framework/docs/content/runtime-contract.md) — the SSR/hydration/island/SSE model and the full `data-fui-*` attribute reference as an embedded page (extract of `core-ui/ARCHITECTURE.md`, kept in sync by test)
 - [Interactive patterns](framework/docs/content/interactive-patterns.md) — every `data-fui-*` behavior, plus **"Writing a hand-written island, end to end"** (no-reload updates on your own screens) and themed confirms
 - [framework architecture](framework/ARCHITECTURE.md) — package layout, layering rules, cycle-breaking interfaces
 - [Entity declarations](framework/docs/content/entity-declarations.md) — JSON schema reference
@@ -379,6 +380,8 @@ connected to a running app.
 - [Search](framework/docs/content/search.md) — the `battery/search` interface
 - [Semantic search](framework/docs/content/semantic-search.md) — local semantic search via `battery/semantic`
 - [Embeddable surfaces](framework/docs/content/embed.md) — hand a screen to a website you don't control: single-use handshake nonce, exact origin allowlist, a frame runtime with no SPA navigation
+- [Authentication](framework/docs/content/auth.md) — the `battery/auth` reference: password login, magic links, OAuth (Google + GitHub built in, any OIDC IdP), 2FA, password reset, sessions, scoped API tokens — each method an opt-in plugin
+- [Access control](framework/docs/content/access-control.md) — permission-based RBAC: `RequirePermission` on your own routes, `AccessMiddleware`, gating auto-CRUD per entity, and where owner scoping fits alongside it
 - [Security](framework/docs/content/security.md) — defaults, headers, and limits
 - [Deployment](framework/docs/content/deploy.md) — single-binary build, graceful shutdown, production checklist
 - [Horizontal scaling](framework/docs/content/scaling.md) — what's process-local by default and the replica-safe alternative for each
@@ -387,7 +390,7 @@ connected to a running app.
 - [Agent-ready](framework/docs/content/agent-ready.md) — the discovery endpoints for AI agents (llms.txt, agent card, MCP)
 - [Strict mode](framework/docs/content/strict-mode.md) — `uihost.WithStrict` turns missing SEO and missing per-screen axe tests into boot failures
 
-The full, per-topic index lives in the docs site catalogue (`gofastr docs --list`, or `examples/site/docs_catalog.go`), which a parity test keeps in sync with every embedded page. The list above is a curated subset.
+The list above is a curated subset. The [docs index](framework/docs/content/README.md) is the browsable entry point to the rest; the full, per-topic catalogue lives in the docs site (`gofastr docs --list`, or `examples/site/docs_catalog.go`), which a parity test keeps in sync with every embedded page.
 
 ## Project status
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ Honest expectations:
 
 ## Supported versions
 
-GoFastr is pre-1.0. Only the **latest minor release** (currently `0.63.x`)
+GoFastr is pre-1.0. Only the **latest minor release** (currently `0.64.x`)
 receives security fixes. Older `0.x` lines are not patched — upgrade to
 the latest release to stay supported.
 

--- a/cmd/gofastr/release_gate_test.go
+++ b/cmd/gofastr/release_gate_test.go
@@ -440,11 +440,16 @@ func runGate(t *testing.T, sha, mainHead string, tc gateCase) (bool, string) {
 		"STUB_MAIN_HEAD="+mainHead,
 		"STUB_ON_MAIN="+onMain,
 	)
+	// Always set SECURITY_MD so an ambient value in the runner's
+	// environment cannot leak into non-fixture cases. Empty falls through
+	// to the script's default, which does not exist at this cwd, so the
+	// policy check stays out of cases that do not opt in.
+	securityPath := ""
 	if tc.securityMD != "" {
-		sec := filepath.Join(dir, "SECURITY.md")
-		writeFixture(t, sec, tc.securityMD)
-		cmd.Env = append(cmd.Env, "SECURITY_MD="+sec)
+		securityPath = filepath.Join(dir, "SECURITY.md")
+		writeFixture(t, securityPath, tc.securityMD)
 	}
+	cmd.Env = append(cmd.Env, "SECURITY_MD="+securityPath)
 	out, err := cmd.CombinedOutput()
 	if err != nil && cmd.ProcessState.ExitCode() != 1 {
 		t.Fatalf("unexpected exit (not 0/1): %v\n--- output ---\n%s", err, out)

--- a/cmd/gofastr/release_gate_test.go
+++ b/cmd/gofastr/release_gate_test.go
@@ -188,6 +188,36 @@ func TestReleaseGate(t *testing.T) {
 			wantSubs: []string{"all 3 required checks green"},
 		},
 		{
+			// The policy check fires when SECURITY_MD is supplied: the
+			// declared supported line must name the minor being released.
+			name:       "current SECURITY.md passes",
+			manifest:   []string{A},
+			runs:       mk(A),
+			onMain:     true,
+			securityMD: "## Supported versions\n\nOnly `0.99.x` receives security fixes.\n",
+			wantPass:   true,
+			wantSubs:   []string{"all 1 required checks green"},
+		},
+		{
+			name:       "stale SECURITY.md fails",
+			manifest:   []string{A},
+			runs:       mk(A),
+			onMain:     true,
+			securityMD: "## Supported versions\n\nOnly `0.63.x` receives security fixes.\n",
+			wantSubs:   []string{"does not name 0.99.x"},
+		},
+		{
+			// A mention of the minor OUTSIDE the Supported versions section
+			// must not satisfy the gate while the declaration stays stale.
+			name:     "minor named outside the section fails",
+			manifest: []string{A},
+			runs:     mk(A),
+			onMain:   true,
+			securityMD: "## Audit trail\n\n0.99.x fixed a header bug.\n\n" +
+				"## Supported versions\n\nOnly `0.63.x` receives security fixes.\n",
+			wantSubs: []string{"does not name 0.99.x"},
+		},
+		{
 			// Newest run wins: a red re-run of an already-green check
 			// must block, or a release ships on a stale success.
 			name:     "red rerun of a green check fails",
@@ -315,6 +345,7 @@ type gateCase struct {
 	releaseExists bool
 	onMain        bool
 	mainHead      string
+	securityMD    string // written to a fixture and passed as SECURITY_MD when non-empty
 	wantPass      bool
 	wantSubs      []string
 }
@@ -409,6 +440,11 @@ func runGate(t *testing.T, sha, mainHead string, tc gateCase) (bool, string) {
 		"STUB_MAIN_HEAD="+mainHead,
 		"STUB_ON_MAIN="+onMain,
 	)
+	if tc.securityMD != "" {
+		sec := filepath.Join(dir, "SECURITY.md")
+		writeFixture(t, sec, tc.securityMD)
+		cmd.Env = append(cmd.Env, "SECURITY_MD="+sec)
+	}
 	out, err := cmd.CombinedOutput()
 	if err != nil && cmd.ProcessState.ExitCode() != 1 {
 		t.Fatalf("unexpected exit (not 0/1): %v\n--- output ---\n%s", err, out)

--- a/examples/site/screen_home.go
+++ b/examples/site/screen_home.go
@@ -515,7 +515,7 @@ func builtWithSection() render.HTML {
 		card("https://barcode.donaldmurillo.com/", "in production", "Barcode & QR Code Maker",
 			render.Text("A live tool, no signup required, to generate and read barcodes and QR codes as PNG, SVG, or PDF, with CSV/Excel batch export, a REST API, and an MCP server."), true),
 		card("/examples#meridian", "examples/meridian", "Meridian: SaaS console",
-			render.Text("The flagship is a billing console with customers, subscriptions, invoices, MRR, and charts, plus its marketing site, auth, and admin. It is generated from one gofastr.yml."), false),
+			render.Text("The flagship is a billing console with customers, subscriptions, invoices, MRR, and charts, plus its marketing site, auth, and admin. It was seeded from one gofastr.yml and has been hand-evolved since."), false),
 	)
 
 	head := sectionHead(

--- a/examples/site/screens_pages.go
+++ b/examples/site/screens_pages.go
@@ -403,10 +403,10 @@ func exHero() render.HTML {
 // the content again.
 func exRowItems() []render.HTML {
 	return []render.HTML{
-		exRow("01", "examples/meridian", "Meridian — SaaS console", "flagship", "100% generated",
-			"A billing & revenue console (customers, subscriptions, invoices, MRR + charts) plus its marketing site, auth, RBAC, and an admin back-office — generated from one gofastr.yml, with writable screens (add/edit/delete) and zero hand-written app code.",
-			[]string{"One blueprint → marketing + app + auth + admin", "Server-rendered DataTable / charts / forms, island RPCs", "Writable CRUD + RBAC, with a generated end-to-end test suite"},
-			"cd examples/meridian && gofastr generate --from=gofastr.yml && go run .",
+		exRow("01", "examples/meridian", "Meridian — SaaS console", "flagship", "seeded + hand-evolved",
+			"A billing & revenue console (customers, subscriptions, invoices, MRR + charts) plus its marketing site, auth, RBAC, and an admin back-office — seeded from one gofastr.yml and hand-evolved since, with writable screens (add/edit/delete).",
+			[]string{"One blueprint seeded marketing + app + auth + admin", "Server-rendered DataTable / charts / forms, island RPCs", "Writable CRUD + RBAC, with a generated end-to-end test suite"},
+			"cd examples/meridian && go run .",
 			// The exact, full blueprint that generates the app — embedded at
 			// build time, shown verbatim in a scrolling block. Drift-guarded by
 			// TestEmbeddedBlueprintsMatchSource.

--- a/framework/ARCHITECTURE.md
+++ b/framework/ARCHITECTURE.md
@@ -12,7 +12,7 @@
 
 `framework/` used to be a single 22k-LOC package. It now exposes the same
 public API through a thin **facade** at `framework/`, with the actual
-implementations split across ~25 runtime subpackages (plus a handful of
+implementations split across ~44 runtime subpackages (plus a handful of
 test-infra and `experimental/` packages that are out-of-contract — see
 the map). The facade re-exports
 types/funcs via type aliases and `var` bindings so external callers
@@ -193,23 +193,41 @@ framework/
 │                    written by testkit/axetest scans, read by uihost strict
 │                    mode. Deliberately chromedp-free so production code can
 │                    read it without linking a browser.
+├── contracts/       Semantic analysis: the rule catalog (stable GOFASTR
+│                    ids, each with Why/Fix + a bad/good example pair) and
+│                    the analyzer runner behind `gofastr verify`. The
+│                    analyzers self-register from `contracts/analyzers`.
 ├── cron/            CronJob / Scheduler — minimal in-process tick loop
 ├── crud/            HTTP CRUD layer, eager loading, includes, nested
 │                    filters, typed query, MCP tool generator,
 │                    JSONCase config, owner/tenant scoping, in-tx helper.
 │                    The biggest pkg.
+├── datexport/       Process-wide registry of data-bearing tables that live
+│                    outside the entity registry (battery raw DDL), so
+│                    App.ExportData / ImportData / EraseUserData reach them.
 ├── db/              Executor + tx context primitives shared across
 │                    crud, slowquery, and the framework root tx wrapper
 ├── dev/             Dev-mode-only helpers (livereload, debug surfaces)
 ├── docs/            Embedded doc content (framework/docs/content/*.md) + `gofastr docs`
 ├── dsl/             ?dsl=… query string parser/builder
+├── embed/           Embeddable screens/islands — a customer pastes one
+│                    <script> tag and gets a live, themed, authenticated
+│                    iframe of the app, gated by a per-surface origin list.
 ├── entity/          Entity + EntityConfig + Define, all column types
 │                    and operators (And/Or/Not/Condition/Order),
 │                    relations, validators, EntityDeclaration JSON
 │                    loader, and the shared Registry interface
 ├── event/           EventBus / Event / EventHandler
+├── fanout/          Postgres LISTEN/NOTIFY implementation of the
+│                    core/fanout.Fanout interface — one channel, fallback
+│                    table for oversize payloads. Lossy best-effort by
+│                    design; durable delivery is outbox's job.
 ├── file/            FileField + Process/Delete/GeneratePath
 ├── filter/          Query-string filter & sort parsing
+├── gallery/         Importable component catalog behind the /components
+│                    showcase — renders every design-system component
+│                    against an arbitrary theme. Composes framework/ui, so
+│                    like sdkdocs it is deliberately NOT a uihost option.
 ├── hook/            HookRegistry / HookType + lifecycle constants
 │                    (BeforeCreate, AfterCreate, etc.)
 ├── i18nui/          Translated default strings for framework UI surfaces
@@ -229,6 +247,10 @@ framework/
 ├── migrate/         AutoMigrate / DiffSchema / Dialect / Bulk queries
 ├── openapi/         EntityOpenAPI spec generator + the entity-endpoint
 │                    URL builders (EntityEndpointPath etc.)
+├── outbox/          Transactional outbox — Append writes the event row in
+│                    the caller's tx; a background Relay delivers each
+│                    committed row to declared durable consumers with
+│                    at-least-once semantics.
 ├── owner/           "Who owns this row" seam — OwnerField scoping for CRUD
 ├── pagination/      Cursor + offset pagination
 ├── pluginhost/      Heavy-JS plugin platform: sandboxed-iframe isolation host
@@ -238,6 +260,10 @@ framework/
 │                    relaxation, data-fui-plugin* mount markers, capability
 │                    gate over battery/auth scopes. Extracted from the
 │                    gofastr-plugins wysiwyg build (#37 client mirror).
+├── ratelimit/       Sliding-window + lockout HTTP rate limiter ("N per
+│                    period, then block") — battery/auth's login/register/
+│                    reset limiters build on it. The token-bucket sibling
+│                    is core/middleware.RateLimit.
 ├── routegroup/      Route groups — prefix, middleware, access, OpenAPI tags
 ├── sdk/             Shared contract between `gofastr generate sdk` and the
 │                    serving side (sdkdocs): artifact manifest schema, the
@@ -250,6 +276,10 @@ framework/
 │                    is NOT a uihost option: uihost must never import
 │                    framework/ui (always-on styles would leak into every
 │                    host's CSS bundle).
+├── semcov/          Semantic-coverage manifest — records which routes,
+│                    permissions, and entity endpoints a test run actually
+│                    exercised through the real router, as opposed to line
+│                    coverage's "did this statement run".
 ├── slowquery/       SlowQueryLogger — wraps any db.Executor
 ├── softdelete/      SoftDelete / Restore / ForceDelete + filter
 ├── tenant/          TenantConfig / Middleware / GetTenantID / etc.
@@ -276,12 +306,22 @@ Out-of-contract (NOT part of the layering rules below):
 
 The root package `framework/` itself contains:
 
-- **App spine**: `app.go`, `plugin.go`, `battery.go`, `module.go`, `registry.go`, `typed_hooks.go`
+- **App spine**: `app.go`, `plugin.go`, `battery.go`, `module.go`, `registry.go`, `typed_hooks.go`, `role.go`, `setup.go`
 - **App-method-tied helpers**: `audit.go` (App.WithAuditLog),
   `tx.go` (App.InTx), `flags.go` (App feature-flag store),
   `health.go` (App health/readiness probes), `i18n.go` (App.WithI18n / T),
-  `mcp_introspection.go` (App.WithMCPIntrospection), `agents.go`
+  `seed.go` (App.WithSeed), `metrics.go` (App.Metrics accessor),
+  `export.go` (App.ExportStatic), `export_data.go` / `erase_data.go`
+  (App.ExportData / ImportData / EraseUserData), `dbctx.go`
+  (WithDBContext / DBFromContext), `agents.go`
   (App agents-inventory wiring)
+- **MCP surfaces**: `mcp_introspection.go` (App.WithMCPIntrospection),
+  `mcp_control.go` (WithMCPControl / WithMCPGate), `mcp_app.go`
+  (WithMCPApp), `mcp_contracts.go` + `mcp_contracts_dev.go` (contract
+  tools), `devmcp_bind.go` (loopback guard for the dev MCP listener)
+- **Agent-readiness endpoints**: `wellknown.go`, `agent_extras.go`,
+  `authmd.go`, `oauth_resource.go`
+- **Semantic coverage**: `semanticcoverage.go` (RecordSemanticCoverage)
 - **Test harness**: `testharness.go` (TestApp wraps `*App`)
 - **Facade re-exports**: `reexports_*.go` — one file per subpackage
   whose symbols are referenced as `framework.X` by external code
@@ -293,31 +333,44 @@ The root package `framework/` itself contains:
 
 ```
 L1  internal/casing                         (no internal deps)
-L2  entity                                   (imports core/ only — no
-                                              framework-internal deps)
+L2  entity                                   (imports core/ +
+                                              internal/casing only)
 L3  hook, event, file, cron, access, db,    (leaf packages — no framework-
-    pagination, filter, owner                internal imports at all)
-    dsl, tenant, softdelete, migrate         (each imports entity)
-    slowquery, outbox                        (intra-L3 edges: slowquery
-                                             → db; outbox → event + db)
+    pagination, filter, owner, agentsinv,    internal imports at all)
+    axecov, datexport, fanout, i18nui,
+    image, lifecycle, ratelimit, semcov,
+    docs, dev, routegroup
+    dsl, tenant, softdelete, migrate, sdk    (each imports entity)
+    slowquery, outbox, embed, imagefield,    (intra-L3 edges — listed
+    contracts                                 below)
 L4  crud                                     (uses entity, hook, event, db,
                                               file, filter, pagination,
-                                              tenant, owner, access,
+                                              tenant, owner, access, embed,
                                               internal/casing; softdelete
                                               is inlined, not imported)
     openapi                                  (uses crud, entity,
                                               internal/casing — sits above
                                               crud within L4)
+L4+ ui, uihost, and the packages             (the UI stack — same direction
+    composing them: ui/resource, static,      rule; uihost never imports
+    gallery, sdkdocs, pluginhost              ui — edges listed below)
 L5  framework/  (facade)                     (re-exports everything for
                                               the public API surface)
 ```
 
-(The map above is the real import graph as of v0.5.0 — verify with
+(The map above is the real import graph as of v0.64.0 — verify with
 `go list -f '{{join .Imports "\n"}}' ./framework/<pkg>` when in doubt.
 The rule is direction: a package may import packages in lower layers,
-never higher, and intra-layer edges should stay rare and deliberate —
-today only `slowquery → db`, `outbox → event`, `outbox → db`, and
-`openapi → crud` exist.)
+never higher, and intra-layer edges should stay rare and deliberate.
+Today's intra-L3 edges: `slowquery → db`, `outbox → event + db`,
+`embed → db + migrate + tenant`, `imagefield → file + image`,
+`contracts → agentsinv`. Within L4: `openapi → crud`. In the UI stack:
+`ui → i18nui + agentsinv`, `uihost → axecov + dev + embed + image +
+tenant`, `ui/resource → crud + filter + ui`, `static → ui + uihost`,
+`gallery → ui + image + agentsinv`, `sdkdocs → ui + sdk + entity +
+internal/casing`, and `pluginhost → uihost`. `uihost/uinoderender → ui` is a separate
+package on purpose: the host itself never links `framework/ui` — the
+node renderer that needs the component catalog sits above it.)
 
 One cross-tree edge is deliberate: **`battery/auth` → `framework/access`.**
 The token-scope matcher (`scopeMatches`, backing `auth.HasScope` and the
@@ -328,9 +381,23 @@ the framework tree, so the edge points downward and introduces no cycle;
 `core/handler` + `core/query`). `access.Can` — the exact-match RBAC hot
 path — is a different matcher on purpose and never learns wildcards.
 
+One edge runs the other way and is tracked, not hidden:
+**`framework/pluginhost` → `battery/auth`.** The capability gate
+(`pluginhost.Allow`) needs both halves of the scope check —
+`access.ScopeMatch` (reachable downward) and `auth.HasScope`, which reads
+the caller's token out of the request context and is genuinely
+battery/auth's. The import carries a `//gofastr:allow(GOFASTR1301)`
+annotation in `pluginhost/gate.go` and is the only upward edge in the
+tree.
+
 **No subpackage may import `framework/`.** If a subpackage needs a type
 defined in framework root (App, Registry, CrudHandler), one of three
-patterns applies — see "Cycle-breaking interfaces" below.
+patterns applies — see "Cycle-breaking interfaces" below. This invariant
+is enforced mechanically by `framework/layering_test.go`, which also
+asserts that `uihost`'s dependency closure excludes `framework/ui` and
+that no `core-ui` package imports `framework`. The test pins one
+sanctioned carve-out: `pluginhost` carries the root in its closure
+transitively, through the `battery/auth` edge above — and only there.
 
 ---
 
@@ -353,6 +420,13 @@ either require an API redesign or create an unbreakable import cycle.
 | `tx.go` | `(a *App) InTx(...)` is the public entry. The lower-level context helpers already moved to `framework/db`; this file is just App's wrapper. |
 | `testharness.go` | `TestApp.App *App` field is used by tests. Sixteen test files use `TestApp` / `TestHarness` unqualified inside `package framework`. Extracting requires either an interface refactor or qualifying every test. |
 | `processmodule*.go` | Process-isolated third-party modules (#37). The supervisor, store, runner, sandbox, broker, and proxy are bound to `*App` (spawn under the app's lifecycle drainer, re-dispatch reverse calls through the app router, enforce the app's `RolePolicy`). `RegisterProcessModule` is the single `(a *App)` entry. See the process-module section below. |
+| `role.go` | `Role` (all / serve / worker) + `WithRole` + `resolveRole`. The role decides at boot which responsibilities the binary assumes; `App.Start` consults it to skip worker-scoped consumers (cron, queues, the outbox relay) or the HTTP surface, so it is read directly by the spine. An unknown role fails loudly in `NewApp`. |
+| `setup.go` | `SetupRunner` interface + `WithSetup` first-run setup. framework defines the interface rather than importing `battery/setup` to avoid a layering cycle; `App.Start` owns the lifecycle (incomplete → wizard or headless run → atomic swap to the real handler). |
+| `export_data.go`, `erase_data.go` | `(a *App) ExportData` / `ImportData` / `EraseUserData` — data portability and right-to-be-forgotten. Both walk the App's entity registry plus the `datexport` registry, and all raw table access funnels through the SafeIdent-guarded path here, so they need the App's DB handle and migrate dialect. |
+| `wellknown.go`, `agent_extras.go`, `authmd.go`, `oauth_resource.go` | The agent-readiness discovery endpoints (`/.well-known/api-catalog`, the MCP server card, Web Bot Auth JWKS, UCP/ACP docs, `/auth.md`, RFC 9728 protected-resource metadata). Each auto-serves when its precondition holds — entities registered, WithMCP mounted, or a host opt-in config — all of which is App state. |
+| `mcp_contracts.go` (+ `mcp_contracts_dev.go`) | Contract-catalog MCP tools (`contracts_list` / `_explain` / `_capabilities`) registered alongside `WithMCPIntrospection`; the dev file adds the verify/fix tools that read the source tree and exist only in the dev loop. Registration hangs off the App's `/mcp` server. |
+| `mcp_control.go` | `WithMCPControl` — the mutating tool set (`app_module_enable` / `app_module_disable`), deliberately separate from read-only introspection, plus `WithMCPGate` for caller gating. Outside the dev loop the tools require an authenticated caller and refuse embed-grant credentials; dev-implied tools are ungated but loopback-bound. Same App-bound registration shape as introspection. |
+| `semanticcoverage.go` | `RecordSemanticCoverage(t, app)` wires the app's router serve hook and the access/hook/event observers into the `semcov` recorder; `TestHarness` calls it automatically, and `GOFASTR_SEMANTIC_COVERAGE=1` enables it in a serving process. Needs `app.router`, so it stays with App. |
 
 ---
 

--- a/framework/datexport/registry_test.go
+++ b/framework/datexport/registry_test.go
@@ -1,0 +1,253 @@
+package datexport_test
+
+import (
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/framework/datexport"
+)
+
+// The registry stores entries verbatim — identifier validation (SafeIdent /
+// MustIdent) is deliberately NOT here; it happens at the SQL-building sites
+// in framework/export_data.go and framework/erase_data.go. These tests cover
+// the guarantees the registry itself makes: last-writer-wins dedup by Name,
+// Name-sorted copies out, defensive slice/map copies in both directions, and
+// the resolver lookup that drives EraseUserData's fail-loud path.
+
+func TestRegisterAndAll(t *testing.T) {
+	datexport.Reset(t)
+
+	datexport.Register(datexport.DataExporter{
+		Name: "auth_sessions", Source: "auth", Table: "auth_sessions",
+		PrimaryKey: "id", Columns: []string{"id", "user_id"},
+	})
+
+	got := datexport.All()
+	if len(got) != 1 {
+		t.Fatalf("len(All())=%d, want 1", len(got))
+	}
+	e := got[0]
+	if e.Name != "auth_sessions" || e.Source != "auth" || e.Table != "auth_sessions" ||
+		e.PrimaryKey != "id" || len(e.Columns) != 2 {
+		t.Fatalf("entry mismatch: %+v", e)
+	}
+}
+
+func TestAllSortedByName(t *testing.T) {
+	datexport.Reset(t)
+
+	datexport.Register(datexport.DataExporter{Name: "zeta", Table: "z"})
+	datexport.Register(datexport.DataExporter{Name: "alpha", Table: "a"})
+	datexport.Register(datexport.DataExporter{Name: "mid", Table: "m"})
+
+	got := datexport.All()
+	if len(got) != 3 || got[0].Name != "alpha" || got[1].Name != "mid" || got[2].Name != "zeta" {
+		t.Fatalf("All() not sorted by Name: %+v", got)
+	}
+}
+
+func TestRegisterDupNameReplaces(t *testing.T) {
+	datexport.Reset(t)
+
+	datexport.Register(datexport.DataExporter{
+		Name: "jobs", Table: "jobs_old", Columns: []string{"id"},
+	})
+	datexport.Register(datexport.DataExporter{
+		Name: "jobs", Table: "jobs_new", Columns: []string{"id", "state"},
+	})
+
+	got := datexport.All()
+	if len(got) != 1 {
+		t.Fatalf("duplicate Name grew the registry: %d entries", len(got))
+	}
+	if got[0].Table != "jobs_new" || len(got[0].Columns) != 2 {
+		t.Fatalf("last-writer-wins violated: %+v", got[0])
+	}
+}
+
+func TestRegisterCopiesColumns(t *testing.T) {
+	datexport.Reset(t)
+
+	cols := []string{"id", "email"}
+	datexport.Register(datexport.DataExporter{Name: "users", Table: "users", Columns: cols})
+	cols[0] = "mutated"
+
+	if got := datexport.All()[0].Columns[0]; got != "id" {
+		t.Fatalf("caller slice aliased into registry: Columns[0]=%q", got)
+	}
+}
+
+func TestAllReturnsCopies(t *testing.T) {
+	datexport.Reset(t)
+
+	datexport.Register(datexport.DataExporter{Name: "users", Table: "users", Columns: []string{"id"}})
+	out := datexport.All()
+	out[0].Columns[0] = "mutated"
+	out[0].Table = "mutated"
+
+	fresh := datexport.All()[0]
+	if fresh.Columns[0] != "id" || fresh.Table != "users" {
+		t.Fatalf("All() result aliased into registry: %+v", fresh)
+	}
+}
+
+func TestUnregister(t *testing.T) {
+	datexport.Reset(t)
+
+	datexport.Register(datexport.DataExporter{Name: "users", Table: "users"})
+	if !datexport.Unregister("users") {
+		t.Fatal("Unregister of a present entry returned false")
+	}
+	if datexport.Unregister("users") {
+		t.Fatal("Unregister of an absent entry returned true")
+	}
+	if got := datexport.All(); len(got) != 0 {
+		t.Fatalf("entry survived Unregister: %+v", got)
+	}
+}
+
+func TestEraserDupNameReplaces(t *testing.T) {
+	datexport.Reset(t)
+
+	datexport.RegisterEraser(datexport.DataEraser{
+		Name: "sessions", Table: "sessions", Column: "user_id",
+		Mode: datexport.EraseDelete,
+	})
+	datexport.RegisterEraser(datexport.DataEraser{
+		Name: "sessions", Table: "sessions_v2", Column: "owner_id",
+		Mode: datexport.EraseAnonymize, ScrubColumns: []string{"owner_id"},
+	})
+
+	got := datexport.AllErasers()
+	if len(got) != 1 {
+		t.Fatalf("duplicate Name grew the eraser registry: %d entries", len(got))
+	}
+	if got[0].Table != "sessions_v2" || got[0].Mode != datexport.EraseAnonymize {
+		t.Fatalf("last-writer-wins violated: %+v", got[0])
+	}
+}
+
+func TestEraserCopiesScrubColumns(t *testing.T) {
+	datexport.Reset(t)
+
+	scrub := []string{"email"}
+	datexport.RegisterEraser(datexport.DataEraser{
+		Name: "audit", Table: "audit", Column: "actor_id",
+		Mode: datexport.EraseAnonymize, ScrubColumns: scrub,
+	})
+	scrub[0] = "mutated"
+
+	out := datexport.AllErasers()
+	if out[0].ScrubColumns[0] != "email" {
+		t.Fatalf("caller slice aliased into registry: %q", out[0].ScrubColumns[0])
+	}
+	out[0].ScrubColumns[0] = "mutated"
+	if got := datexport.AllErasers()[0].ScrubColumns[0]; got != "email" {
+		t.Fatalf("AllErasers() result aliased into registry: %q", got)
+	}
+}
+
+func TestAllErasersSortedByName(t *testing.T) {
+	datexport.Reset(t)
+
+	datexport.RegisterEraser(datexport.DataEraser{Name: "b", Table: "b", Column: "user_id"})
+	datexport.RegisterEraser(datexport.DataEraser{Name: "a", Table: "a", Column: "user_id"})
+
+	got := datexport.AllErasers()
+	if len(got) != 2 || got[0].Name != "a" || got[1].Name != "b" {
+		t.Fatalf("AllErasers() not sorted by Name: %+v", got)
+	}
+}
+
+func TestUnregisterEraser(t *testing.T) {
+	datexport.Reset(t)
+
+	datexport.RegisterEraser(datexport.DataEraser{Name: "sessions", Table: "sessions", Column: "user_id"})
+	if !datexport.UnregisterEraser("sessions") {
+		t.Fatal("UnregisterEraser of a present entry returned false")
+	}
+	if datexport.UnregisterEraser("sessions") {
+		t.Fatal("UnregisterEraser of an absent entry returned true")
+	}
+}
+
+func TestResolverReplaceAndLookup(t *testing.T) {
+	datexport.Reset(t)
+
+	datexport.RegisterIdentityResolver(datexport.IdentityEmail, datexport.DataIdentityResolver{
+		Table: "users_old", IDColumn: "id", ValueColumn: "email",
+	})
+	datexport.RegisterIdentityResolver(datexport.IdentityEmail, datexport.DataIdentityResolver{
+		Table: "auth_users", IDColumn: "id", ValueColumn: "email",
+	})
+
+	r, ok := datexport.ResolveIdentity(datexport.IdentityEmail)
+	if !ok {
+		t.Fatal("registered resolver not found")
+	}
+	if r.Table != "auth_users" {
+		t.Fatalf("last-writer-wins violated: %+v", r)
+	}
+}
+
+func TestResolveIdentityMissing(t *testing.T) {
+	datexport.Reset(t)
+
+	// EraseUserData treats an eraser declaring an unresolvable identity as a
+	// fail-loud misconfiguration; ok=false is what triggers it.
+	if _, ok := datexport.ResolveIdentity(datexport.IdentityEmail); ok {
+		t.Fatal("ResolveIdentity reported a resolver that was never registered")
+	}
+}
+
+func TestUnregisterIdentityResolver(t *testing.T) {
+	datexport.Reset(t)
+
+	datexport.RegisterIdentityResolver(datexport.IdentityEmail, datexport.DataIdentityResolver{
+		Table: "auth_users", IDColumn: "id", ValueColumn: "email",
+	})
+	if !datexport.UnregisterIdentityResolver(datexport.IdentityEmail) {
+		t.Fatal("UnregisterIdentityResolver of a present kind returned false")
+	}
+	if datexport.UnregisterIdentityResolver(datexport.IdentityEmail) {
+		t.Fatal("UnregisterIdentityResolver of an absent kind returned true")
+	}
+}
+
+func TestAllIdentityResolversIsCopy(t *testing.T) {
+	datexport.Reset(t)
+
+	datexport.RegisterIdentityResolver(datexport.IdentityEmail, datexport.DataIdentityResolver{
+		Table: "auth_users", IDColumn: "id", ValueColumn: "email",
+	})
+	out := datexport.AllIdentityResolvers()
+	if len(out) != 1 {
+		t.Fatalf("len(AllIdentityResolvers())=%d, want 1", len(out))
+	}
+	delete(out, datexport.IdentityEmail)
+
+	if _, ok := datexport.ResolveIdentity(datexport.IdentityEmail); !ok {
+		t.Fatal("mutating the returned map reached the registry")
+	}
+}
+
+func TestResetClearsAllPlanes(t *testing.T) {
+	datexport.Reset(t)
+
+	datexport.Register(datexport.DataExporter{Name: "users", Table: "users"})
+	datexport.RegisterEraser(datexport.DataEraser{Name: "users", Table: "users", Column: "id"})
+	datexport.RegisterIdentityResolver(datexport.IdentityEmail, datexport.DataIdentityResolver{
+		Table: "auth_users", IDColumn: "id", ValueColumn: "email",
+	})
+
+	datexport.Reset(t)
+
+	if n := len(datexport.All()); n != 0 {
+		t.Fatalf("%d exporters survived Reset", n)
+	}
+	if n := len(datexport.AllErasers()); n != 0 {
+		t.Fatalf("%d erasers survived Reset", n)
+	}
+	if n := len(datexport.AllIdentityResolvers()); n != 0 {
+		t.Fatalf("%d resolvers survived Reset", n)
+	}
+}

--- a/framework/docs/content/deploy.md
+++ b/framework/docs/content/deploy.md
@@ -68,14 +68,16 @@ ENTRYPOINT ["/app"]
 
 ## Configuration (env)
 
-GoFastr reads config from the environment (with `.env` auto-loaded in
-development — see [dotenv](dotenv.md); real env always wins). Common vars:
+GoFastr reads config from the environment. `NewApp` also loads `.env`
+files at boot in every environment, not just development; set
+`GOFASTR_DOTENV=off` to suppress it — see [dotenv](dotenv.md); real env
+always wins. Common vars:
 
 | Var | Purpose |
 |-----|---------|
 | `PORT` | Listen port. A bare value like `8080` is normalized to `:8080`, so PaaS-injected `$PORT` works. |
 | `DATABASE_URL` | Your app reads this and passes the connection to `WithDB`. |
-| `APP_ENV` | Selects `.env.<APP_ENV>` in development. |
+| `APP_ENV` | Adds `.env.<APP_ENV>` to the dotenv load order whenever it is set. |
 | auth secrets | If you use `battery/auth`, set its JWT/session secret explicitly in production — do not rely on the dev auto-generated secret (it rotates per process and silently invalidates sessions). See [auth](auth.md). |
 | `GOFASTR_SECRET` | HMAC signing key for the uihost session token. Set it (or use `framework.WithSecret` in code) so a session token issued by one replica verifies on every other replica. With one replica and no secret, an ephemeral boot secret is minted (sessions roll over on restart). With `WithFanout` and no secret, the app refuses to boot. See [Reactivity model](reactivity.md) and [Horizontal scaling](scaling.md). |
 

--- a/framework/docs/content/query-dsl.md
+++ b/framework/docs/content/query-dsl.md
@@ -95,8 +95,8 @@ pagination via `after(cursor)` instead.
 ### `after(cursor)`
 
 Forward keyset pagination. `BuildDSLQuery` wires `after(value)` into a
-`field > value` predicate on the entity's cursor column — `CursorField`
-when set, otherwise the primary key. Unlike the HTTP cursor API (which
+`field > value` predicate on the entity's cursor column —
+`Pagination.CursorField` when set, otherwise the primary key. Unlike the HTTP cursor API (which
 round-trips an opaque base64 token), the DSL takes the **bare keyset
 value**: `posts.after(1024)` means "rows after id 1024".
 
@@ -105,7 +105,7 @@ posts.where(status="published").order(id).after(1024).limit(20)
 → … WHERE (status = $1) AND (id > $2) ORDER BY id LIMIT $3
 ```
 
-Composite cursors (`EntityConfig.CursorFields`) have no single-value
+Composite cursors (`EntityConfig.Pagination.CursorFields`) have no single-value
 DSL form, so `after()` on such an entity returns an error rather than
 silently paging from the start — use the HTTP cursor API for those.
 

--- a/framework/docs/truth_sweep_test.go
+++ b/framework/docs/truth_sweep_test.go
@@ -188,6 +188,40 @@ func TestIsolationDocNamesTheRealConfigFile(t *testing.T) {
 	}
 }
 
+// ── 2026-08-16 truth audit ──
+
+// query-dsl.md pointed composite cursors at EntityConfig.CursorFields.
+// Cursor config lives in the Pagination group: the real path is
+// EntityConfig.Pagination.CursorFields (framework/entity/entity.go).
+func TestQueryDSLDocUsesGroupedCursorPath(t *testing.T) {
+	doc := readDoc(t, "query-dsl.md")
+	if strings.Contains(doc, "EntityConfig.CursorFields") {
+		t.Error("query-dsl.md references EntityConfig.CursorFields; the field is EntityConfig.Pagination.CursorFields (framework/entity/entity.go)")
+	}
+	if !strings.Contains(readRepo(t, "framework/entity/entity.go"), "CursorFields []string") {
+		t.Error("PaginationConfig lost CursorFields — recheck query-dsl.md's composite-cursor paragraph")
+	}
+}
+
+// deploy.md qualified the .env auto-load with "in development". NewApp
+// loads dotfiles in EVERY environment; only GOFASTR_DOTENV=off suppresses
+// the load, and .env.<APP_ENV> is probed whenever APP_ENV is set.
+func TestDeployDocDotenvLoadIsUnconditional(t *testing.T) {
+	// Collapse whitespace so the assertion survives line-wrapping.
+	doc := strings.Join(strings.Fields(readDoc(t, "deploy.md")), " ")
+	for _, stale := range []string{
+		"auto-loaded in development",
+		"`.env.<APP_ENV>` in development",
+	} {
+		if strings.Contains(doc, stale) {
+			t.Errorf("deploy.md says %q; the load is unconditional, gated only by GOFASTR_DOTENV=off (framework/app.go NewApp)", stale)
+		}
+	}
+	if !strings.Contains(readRepo(t, "framework/app.go"), `os.Getenv("GOFASTR_DOTENV") != "off"`) {
+		t.Error("the NewApp dotenv gate changed — recheck deploy.md's Configuration section")
+	}
+}
+
 // access-control.md used framework.Wildcard. Wildcard lives in
 // framework/access and is not among the framework facade's re-exports.
 func TestAccessControlDocUsesTheRealWildcardPath(t *testing.T) {

--- a/framework/docs/truth_sweep_test.go
+++ b/framework/docs/truth_sweep_test.go
@@ -198,6 +198,9 @@ func TestQueryDSLDocUsesGroupedCursorPath(t *testing.T) {
 	if strings.Contains(doc, "EntityConfig.CursorFields") {
 		t.Error("query-dsl.md references EntityConfig.CursorFields; the field is EntityConfig.Pagination.CursorFields (framework/entity/entity.go)")
 	}
+	if !strings.Contains(doc, "EntityConfig.Pagination.CursorFields") {
+		t.Error("query-dsl.md no longer documents EntityConfig.Pagination.CursorFields — the composite-cursor paragraph must name the real path")
+	}
 	if !strings.Contains(readRepo(t, "framework/entity/entity.go"), "CursorFields []string") {
 		t.Error("PaginationConfig lost CursorFields — recheck query-dsl.md's composite-cursor paragraph")
 	}
@@ -215,6 +218,11 @@ func TestDeployDocDotenvLoadIsUnconditional(t *testing.T) {
 	} {
 		if strings.Contains(doc, stale) {
 			t.Errorf("deploy.md says %q; the load is unconditional, gated only by GOFASTR_DOTENV=off (framework/app.go NewApp)", stale)
+		}
+	}
+	for _, want := range []string{"every environment", "GOFASTR_DOTENV=off"} {
+		if !strings.Contains(doc, want) {
+			t.Errorf("deploy.md no longer says %q — the Configuration section must state the unconditional load and its kill switch", want)
 		}
 	}
 	if !strings.Contains(readRepo(t, "framework/app.go"), `os.Getenv("GOFASTR_DOTENV") != "off"`) {

--- a/framework/layering_test.go
+++ b/framework/layering_test.go
@@ -1,6 +1,7 @@
 package framework_test
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -15,6 +16,23 @@ import (
 // and framework/crud/layering_test.go: go list, then fail on the edge.
 
 const modRoot = "github.com/DonaldMurillo/gofastr"
+
+// ARCHITECTURE.md's "Out-of-contract" list: these trees are exempt from
+// the layering rules (test helpers, fixtures, dev tooling, experimental).
+func outOfContract(pkg string) bool {
+	root := modRoot + "/framework"
+	for _, prefix := range []string{
+		root + "/experimental",
+		root + "/testkit",
+		root + "/factory",
+		root + "/isolation",
+	} {
+		if pkg == prefix || strings.HasPrefix(pkg, prefix+"/") {
+			return true
+		}
+	}
+	return false
+}
 
 // The framework root package is the facade: it imports the subpackages,
 // never the reverse. A subpackage that pulls the root into its dependency
@@ -35,7 +53,7 @@ func TestFrameworkPkgsDontImportRoot(t *testing.T) {
 	}
 	for _, line := range strings.Split(string(out), "\n") {
 		pkg, deps, ok := strings.Cut(line, ": ")
-		if !ok || pkg == root {
+		if !ok || pkg == root || outOfContract(pkg) {
 			continue
 		}
 		hasRoot := false
@@ -52,6 +70,30 @@ func TestFrameworkPkgsDontImportRoot(t *testing.T) {
 			t.Errorf("%s no longer depends on the root — delete its exemption "+
 				"from this test so the allowlist cannot rot", pkg)
 		}
+	}
+
+	// The exemption is valid only via the documented route: pluginhost's
+	// direct battery/auth import, annotated //gofastr:allow(GOFASTR1301) in
+	// gate.go. If the route or its annotation is gone, the root dependency
+	// arrived some other way and must not ride the old carve-out.
+	imp, err := exec.Command("go", "list", "-f", "{{join .Imports \" \"}}",
+		root+"/pluginhost").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list pluginhost imports: %v\n%s", err, imp)
+	}
+	if !strings.Contains(" "+string(imp)+" ", " "+modRoot+"/battery/auth ") {
+		t.Error("pluginhost no longer imports battery/auth — its root exemption " +
+			"above no longer describes reality; re-derive how the root enters " +
+			"its closure and cut or re-sanction that edge")
+	}
+	gate, err := os.ReadFile("pluginhost/gate.go")
+	if err != nil {
+		t.Fatalf("read pluginhost/gate.go: %v", err)
+	}
+	if !strings.Contains(string(gate), "gofastr:allow(GOFASTR1301)") {
+		t.Error("pluginhost/gate.go lost its gofastr:allow(GOFASTR1301) " +
+			"annotation — the sanctioned edge this test exempts is no longer " +
+			"marked in code")
 	}
 }
 

--- a/framework/layering_test.go
+++ b/framework/layering_test.go
@@ -1,0 +1,99 @@
+package framework_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// framework/ARCHITECTURE.md fixes the layering: core-ui sits below every
+// framework package, framework subpackages sit below the framework root
+// facade, and framework/uihost stays below the framework/ui component
+// layer. The gofastr verify gate enforces layer order but permits
+// intra-layer edges, so until now these three invariants held by
+// convention only. Same enforcement style as framework/ui/layering_test.go
+// and framework/crud/layering_test.go: go list, then fail on the edge.
+
+const modRoot = "github.com/DonaldMurillo/gofastr"
+
+// The framework root package is the facade: it imports the subpackages,
+// never the reverse. A subpackage that pulls the root into its dependency
+// closure closes a cycle the facade pattern exists to prevent. One edge is
+// sanctioned: pluginhost imports battery/auth (the //gofastr:allow(GOFASTR1301)
+// exception in pluginhost/gate.go), and battery/auth links the root — so
+// pluginhost is pinned here as the only package allowed to carry the root
+// transitively. If that edge ever goes away, this test fails too, so the
+// exemption cannot outlive its reason.
+func TestFrameworkPkgsDontImportRoot(t *testing.T) {
+	root := modRoot + "/framework"
+	sanctioned := map[string]bool{root + "/pluginhost": true}
+	out, err := exec.Command("go", "list",
+		"-f", "{{.ImportPath}}: {{join .Deps \" \"}}",
+		root+"/...").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list %s/...: %v\n%s", root, err, out)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		pkg, deps, ok := strings.Cut(line, ": ")
+		if !ok || pkg == root {
+			continue
+		}
+		hasRoot := false
+		for _, dep := range strings.Fields(deps) {
+			if dep == root {
+				hasRoot = true
+			}
+		}
+		switch {
+		case hasRoot && !sanctioned[pkg]:
+			t.Errorf("%s depends on the framework root facade — move the "+
+				"shared code into a subpackage both sides can import", pkg)
+		case !hasRoot && sanctioned[pkg]:
+			t.Errorf("%s no longer depends on the root — delete its exemption "+
+				"from this test so the allowlist cannot rot", pkg)
+		}
+	}
+}
+
+// framework/uihost is the SSR host below the component layer. It serves
+// whatever screens the app hands it; pulling framework/ui in would bake
+// the component catalog into every host binary and invert the layering.
+func TestUIHostDoesNotLinkFrameworkUI(t *testing.T) {
+	const banned = modRoot + "/framework/ui"
+	out, err := exec.Command("go", "list", "-deps",
+		modRoot+"/framework/uihost").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list -deps framework/uihost: %v\n%s", err, out)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(line) == banned {
+			t.Errorf("framework/uihost depends on %s — the host renders screens "+
+				"it is handed; components stay above it", banned)
+		}
+	}
+}
+
+// core-ui is the bottom layer: framework builds on it, never the other
+// way around. Any framework/... dep from a core-ui package is an
+// inverted edge.
+func TestCoreUIDoesNotImportFramework(t *testing.T) {
+	const banned = modRoot + "/framework"
+	out, err := exec.Command("go", "list",
+		"-f", "{{.ImportPath}}: {{join .Deps \" \"}}",
+		modRoot+"/core-ui/...").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list core-ui/...: %v\n%s", err, out)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		pkg, deps, ok := strings.Cut(line, ": ")
+		if !ok {
+			continue
+		}
+		for _, dep := range strings.Fields(deps) {
+			if dep == banned || strings.HasPrefix(dep, banned+"/") {
+				t.Errorf("%s depends on %s — core-ui sits below framework; "+
+					"invert the edge or move the code up", pkg, dep)
+			}
+		}
+	}
+}

--- a/scripts/coverage-floors.sh
+++ b/scripts/coverage-floors.sh
@@ -63,6 +63,7 @@ FLOORS="
 ./framework/contracts/ 72.0
 ./framework/contracts/analyzers/ 70.5
 ./framework/crud/ 96.9
+./framework/datexport/ 98.0
 ./framework/entity/ 86.5
 ./framework/migrate/ 73.5
 ./framework/semcov/ 87.0

--- a/scripts/release-gate.sh
+++ b/scripts/release-gate.sh
@@ -10,17 +10,20 @@
 # creates the release — the workflow step after a passing gate does) and
 # refuses to publish unless:
 #
-#   1. no release for the tag already exists (a manual `gh release create`
+#   1. SECURITY.md names the minor being released as the supported line
+#      (vX.Y.Z tag -> `X.Y.x` in the "Supported versions" section),
+#   2. no release for the tag already exists (a manual `gh release create`
 #      bypassed the gate, or a prior run already shipped),
-#   2. the tag commit IS the current head of main (not a stale re-tag, not an
+#   3. the tag commit IS the current head of main (not a stale re-tag, not an
 #      unmerged-PR commit), and
-#   3. EVERY required blocking check named in the manifest ran green on that
+#   4. EVERY required blocking check named in the manifest ran green on that
 #      commit's main-push CI run (ci.yml has no v* trigger; check runs attach
 #      to the commit, so the main-push run carries them).
 #
 # Fail-closed by construction: a red / cancelled / skipped / neutral /
-# timed-out check, a missing check, a stale or unmerged SHA, or a
-# pre-existing release all abort before anything is published.
+# timed-out check, a missing check, a stale or unmerged SHA, a stale
+# SECURITY.md, or a pre-existing release all abort before anything is
+# published.
 #
 # Why a script (not inline YAML): the gate is behavioral and must be testable
 # locally — GitHub Actions cannot run as a PR check. The logic lives here and
@@ -34,6 +37,7 @@
 #   MAIN_REF       ref to validate on    (default: origin/main)
 #   GATE_TIMEOUT   seconds to wait       (default: 3600)
 #   POLL_INTERVAL  seconds between polls (default: 30)
+#   SECURITY_MD    security policy file  (default: SECURITY.md)
 set -euo pipefail
 
 TAG="${1:?usage: release-gate.sh <tag> <repo> <sha> <manifest>}"
@@ -45,6 +49,7 @@ GIT_BIN="${GIT_BIN:-git}"
 MAIN_REF="${MAIN_REF:-origin/main}"
 GATE_TIMEOUT="${GATE_TIMEOUT:-3600}"
 POLL_INTERVAL="${POLL_INTERVAL:-30}"
+SECURITY_MD="${SECURITY_MD:-SECURITY.md}"
 
 fail() { echo "::error::release gate: $*" >&2; exit 1; }
 
@@ -64,7 +69,28 @@ if [ "${#REQUIRED[@]}" -eq 0 ]; then
 	fail "manifest $MANIFEST lists no required checks"
 fi
 
-# --- 1. A release must not pre-exist -----------------------------------------
+# --- 1. SECURITY.md must name the minor being released -----------------------
+# The "Supported versions" section promises fixes for the latest minor only,
+# and it drifts silently on release (it still named 0.63.x after v0.64.0
+# shipped). Derive the supported line from the tag (vX.Y.Z -> X.Y.x) and
+# require SECURITY.md to contain it. The workflow always invokes this script
+# from the checkout root (the scripts/ path could not resolve otherwise), so
+# there a missing SECURITY.md fails rather than skips; the one caller NOT at
+# the root is cmd/gofastr/release_gate_test.go, which drives the script from
+# its own package dir against stub tags — neither path below exists there, so
+# the policy check stays out of that harness.
+if [ -f "$SECURITY_MD" ] || [ -f scripts/release-gate.sh ]; then
+	supported="${TAG#v}"
+	supported="${supported%.*}.x"
+	if [ ! -f "$SECURITY_MD" ]; then
+		fail "$SECURITY_MD not found — the supported-versions policy must exist and name $supported before $TAG ships."
+	fi
+	if ! grep -qF "$supported" "$SECURITY_MD"; then
+		fail "$SECURITY_MD does not name $supported as the supported minor for $TAG — update its 'Supported versions' section, merge that to main, and re-tag."
+	fi
+fi
+
+# --- 2. A release must not pre-exist -----------------------------------------
 # The workflow is the publisher. An existing release means someone ran
 # `gh release create` by hand (bypassing this gate entirely — the old flow
 # documented exactly that, and the old "already exists" check ran only AFTER
@@ -73,7 +99,7 @@ if "$GH_BIN" release view "$TAG" --json tagName >/dev/null 2>&1; then
 	fail "a release for $TAG already exists. The workflow must be the only publisher — delete the release (gh release delete $TAG --yes) and let the gate create it; do not run 'gh release create' by hand."
 fi
 
-# --- 2. The tag commit must BE the current head of main ----------------------
+# --- 3. The tag commit must BE the current head of main ----------------------
 # Equality is the rule. The ancestor check runs first only to give a sharper
 # error for a tag pointing at a commit that never landed on main at all
 # (unmerged PR / wrong branch); the equality check then catches a stale re-tag
@@ -86,7 +112,7 @@ if [ "$main_head" != "$SHA" ]; then
 	fail "$SHA ($TAG) is behind $MAIN_REF (head is $main_head). Re-tag on the current main head."
 fi
 
-# --- 3. Every required blocking check must be present + green ----------------
+# --- 4. Every required blocking check must be present + green ----------------
 # Fetch the tag commit's check runs and reduce them to one (status, conclusion)
 # per name — NEWEST wins, by descending id, so a red re-run of an
 # already-green check blocks the release (and a green re-run unblocks a

--- a/scripts/release-gate.sh
+++ b/scripts/release-gate.sh
@@ -85,8 +85,15 @@ if [ -f "$SECURITY_MD" ] || [ -f scripts/release-gate.sh ]; then
 	if [ ! -f "$SECURITY_MD" ]; then
 		fail "$SECURITY_MD not found — the supported-versions policy must exist and name $supported before $TAG ships."
 	fi
-	if ! grep -qF "$supported" "$SECURITY_MD"; then
-		fail "$SECURITY_MD does not name $supported as the supported minor for $TAG — update its 'Supported versions' section, merge that to main, and re-tag."
+	# Scope the match to the "Supported versions" section: a mention of the
+	# minor elsewhere (audit-trail prose, a "not supported" sentence) must
+	# not satisfy the gate while the declaration itself stays stale.
+	section=$(awk '/^## Supported versions/{f=1; next} /^## /{f=0} f' "$SECURITY_MD")
+	if [ -z "$section" ]; then
+		fail "$SECURITY_MD has no '## Supported versions' section — the gate cannot verify $supported is the declared line for $TAG."
+	fi
+	if ! printf '%s\n' "$section" | grep -qF "$supported"; then
+		fail "$SECURITY_MD's 'Supported versions' section does not name $supported as the supported minor for $TAG — update it, merge that to main, and re-tag."
 	fi
 fi
 


### PR DESCRIPTION
A clean-room holistic assessment (7 analysts, 4 adversarial verifiers, findings independently re-verified) surfaced a batch of small, verified defects. This PR fixes the ones that fit in an afternoon; the structural items (adoption motion, blueprint.go split, -race CI) are out of scope here.

## What changed

- **b5111660 fix(docs)** — the only two drifted claims the truth audit found in ~35 sampled. `deploy.md` said `.env` loads "in development"; `NewApp` loads it in every environment unless `GOFASTR_DOTENV=off` (framework/app.go:1441), and `.env.<APP_ENV>` joins the load order whenever `APP_ENV` is set. `query-dsl.md` pointed composite cursors at `EntityConfig.CursorFields`; the field is `EntityConfig.Pagination.CursorFields`. Both pinned in `truth_sweep_test.go`, observed red against the old text first.
- **1790889c fix(site)** — the homepage and `/examples` cards called Meridian "generated from one gofastr.yml" (the `/examples` card added "zero hand-written app code" and a `gofastr generate` run command that `examples/meridian/doc.go` forbids). Both cards now match doc.go: seeded, then hand-evolved. The generated-pipeline claims stay on ShopFront, where they are true.
- **db5f6270 test(framework)** — `framework/ARCHITECTURE.md` refresh (real subpackage count, map entries for 8 missing packages, current intra-layer edges, why-it-stays rows for the root files added since the last update; facts only, no rule changes) plus `framework/layering_test.go`, which enforces the three invariants `gofastr verify` cannot (it checks layer order, not intra-layer edges). The test caught a real fact during development: `pluginhost` carries the root facade transitively through its sanctioned GOFASTR1301 `battery/auth` edge — that carve-out is pinned explicitly, and the test also fails if the edge ever disappears, so the allowlist cannot rot.
- **31a6b406 ci** — SECURITY.md said `0.63.x` on the released v0.64.0 tag; now current, and `release-gate.sh` refuses to publish a tag unless SECURITY.md names the released minor. Plus a `GOOS=windows` / `GOOS=darwin` compile smoke in the blocking job (`CGO_ENABLED=0` — the job-level cgo toggle cannot target other OSes), since 13 windows-tagged files were never compiled by any gate.
- **ca36b1a6 test(datexport)** — the registry behind `ExportData` / `ImportData` / `EraseUserData` had zero direct tests. 15 tests now cover it at 100.0%, floored at 98.0.
- **0755b227 docs(readme)** — the Documentation list now links `auth.md`, `access-control.md`, `runtime-contract.md`, and the browsable docs index; changelog for the batch.

## Verification

- Full pre-commit sweep (build, gofmt, vet, secrets, deterministic tests, coverage floors with `TEST_POSTGRES_DSN` set, contracts) ran green on every commit, and the pre-push gate ran green on push.
- `go test ./examples/site -short`, `./framework/docs`, `./framework/datexport`, `./cmd/gofastr -run 'Readme|ReleaseGate'`, and the three new layering tests all pass.
- The release-gate check was exercised against a stub harness in both directions: passes with the updated SECURITY.md, fails with the old `0.63.x` text and on a missing file.

## Known limits

- The release-gate grep matches the `X.Y.x` string anywhere in SECURITY.md, not only the supported-versions line. Good enough to catch the observed failure; a stricter line-anchored check would need a fixture case in `release_gate_test.go`.
- `framework/docs/content/README.md` (the index the README now links) itself omits 26 docs, deploy.md and scaling.md among them. Separate gap, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Quality & Reliability**
  * Added Windows and macOS cross-compilation checks.
  * Added architecture and documentation consistency validation.
  * Raised date export coverage enforcement to 98%.
  * Added release validation for supported security versions.

* **Documentation**
  * Clarified `.env` loading and cursor-based pagination configuration.
  * Updated architecture, security, and example documentation.
  * Expanded the documentation index with runtime, authentication, and access-control guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->