### PR TITLE
test(framework): de-flake the seed-wiring poll deadline

### DIFF
--- a/framework/seed_test.go
+++ b/framework/seed_test.go
@@ -515,7 +515,11 @@ func TestAppStart_WiresRunSeeds(t *testing.T) {
 	startErr := make(chan error, 1)
 	go func() { startErr <- app.Start(":0") }()
 
-	deadline := time.Now().Add(3 * time.Second)
+	// Generous deadline: the poll breaks the moment the row lands, so
+	// the budget is only ever spent on failure — 3s was a real 1-in-N
+	// CI flake when Start→migrate→seed ran on a box under full
+	// parallel-job load (v0.65.0's release gate caught exactly that).
+	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
 		var rows int
 		if err := db.QueryRow("SELECT COUNT(*) FROM startup_seeded").Scan(&rows); err == nil && rows == 1 {


### PR DESCRIPTION
The v0.65.0 release gate went red on `TestAppStart_WiresRunSeeds` — "seeded row not present after App.Start; got 0 rows" at exactly 3.00s — on the merge commit, while the identical tree was green on the PR head and green again on rerun. The test polls a 3-second wall-clock deadline for Start → migrate → seed under a CI box running the full parallel job matrix; that budget is the flake.

The poll breaks the moment the row lands, so raising the deadline to 30s costs nothing when healthy and only extends the report time on a genuine failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved startup seeding test reliability by allowing more time for initialization to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->