### PR TITLE
v0.66.0: queue lease fencing, blueprint boot gate, and the assessment backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,109 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.66.0] - 2026-08-17
+
+### Fixed
+
+- **BREAKING: a stale queue worker could delete another worker's job.**
+  `Queue.Ack` and `Queue.Nack` now take a `Job` instead of a job ID
+  string, and `RedisQueue` verifies `Job.ClaimToken` before acting. The
+  old signature carried no claim identity, so this sequence lost a job
+  outright: worker A claims job J, A stalls past its lease, worker B
+  re-claims J, A wakes and Acks. A's Ack deleted the processing entry
+  that belonged to B, and when B then crashed the job was on no list, in
+  no hash, and had never been dead-lettered. A mismatched token is now a
+  no-op counted by `StaleClaimCount()`. Update call sites to pass the
+  `Job` returned by `Dequeue`.
+- **A worker crash on a job's final attempt stranded it forever.**
+  `DBQueue` reclaimed expired leases only while `attempts <
+  max_attempts`, but `Dequeue` had already incremented `attempts` — so a
+  crash on the last permitted attempt left the row `claimed` with
+  nothing able to see it, including `Replay`. An expired lease on the
+  final attempt is now dead-lettered and logged.
+- **Multipart uploads over 1 MiB always failed.** The CRUD write
+  handlers wrapped every request body in a 1 MiB `MaxBytesReader` before
+  deciding whether it was multipart, so `ParseMultipartForm` read
+  through a cap 32× smaller than the 32 MiB it was asked for. JSON
+  bodies still cap at `MaxJSONBodyBytes`; multipart bodies now cap at
+  the new `crud.MaxMultipartBodyBytes` (64 MiB) and a request over it
+  gets a 413 instead of a 400.
+- **Cursor pagination re-served rows whose sort key held invisible
+  characters.** `EncodeCursor` kept the raw keyset value while
+  `DecodeCursor` stripped zero-width and bidi codepoints, so paging
+  resumed before the row it had just emitted. Values now decode
+  verbatim; field names, which reach SQL as identifiers, are still
+  scrubbed.
+- **Repeating a `?field_in=` key dropped every occurrence but the
+  first.** `?tag_in=a,b&tag_in=c` filtered on `a,b` alone and said
+  nothing. All occurrences now union, and the 1000-entry cap counts the
+  union. The same cap now applies to relation-scoped lists
+  (`?author.name_in=`), which had no cap at all.
+- **`?page=` near `MaxInt64` wrapped to a negative offset.** The guard
+  in `framework/pagination` existed but nothing called it. It is now
+  wired into the buffered list, the streaming list, and the admin table.
+- **Two users uploading the same filename overwrote each other.** The
+  standalone `upload.Handler` keyed objects on the sanitized client
+  filename with no unique component, and `LocalStorage.Save` opens
+  `O_TRUNC`. Keys now come from `upload.UniqueFilename`, matching what
+  the auto-CRUD path already did. Read `key` from the response rather
+  than rebuilding it from `originalName`.
+- **The blog blueprint generated an app that would not boot.**
+  `examples/blog/gofastr.yml` seeded `post_id: 1` against UUID string
+  primary keys; the generated app compiled and then died at startup with
+  `seed comments: validation failed`. `gofastr generate` now rejects a
+  seed value whose type cannot satisfy its target field and names the
+  `@entity.field=value` form to use instead. The blueprint uses that
+  form.
+- **A failing seed said only "validation failed".** The generated seed
+  hook discarded `crud.ValidationError.Fields()`, where the per-field
+  messages live. It now reports the entity, the row, and each field's
+  message.
+- **Auth-gated blueprint screens panicked under strict mode.** The
+  generator chained `WithTitle` but not `WithDescription` when mounting
+  a screen behind a policy, so every screen with a declared description
+  tripped `uihost strict mode: screen "…": no description`. Meridian's
+  generated app could not start.
+- **The stability tier gate checked one package instead of 219.**
+  `TestEveryPackageIsClassified` ran `go list ./...` from its own
+  package directory, so it saw only `stability` itself and an entire
+  unclassified top-level tree would have shipped green. The enumeration
+  runs from the module root, and `TestGateSeesWholeModule` fails if it
+  ever narrows again.
+- **Every contract diagnostic linked to a domain that does not resolve.**
+  `contracts.docBaseURL` pointed at `gofastr.dev`, which has no A
+  record, so each `HelpURI` was dead. It points at the published docs
+  site.
+- **Eight documentation claims contradicted the code.** `multi-tenant.md`
+  taught reading the tenant from a request header — `TenantMiddleware`
+  ignores any client header precisely because trusting one lets a caller
+  impersonate a tenant, so the page described a vulnerability the code
+  refuses to have. Also corrected: the webhook secret codec default,
+  the idempotency middleware's position, `EnableMCP`'s tool count,
+  anonymous subjects at partial rollout, batch rollback's `data`
+  scrubbing, the `TrustTrusted` tier name, and the PWA cache-name
+  format.
+- **Documented Go examples that could not compile.** Enabling the
+  compile gate on 83 more blocks surfaced ten of them, including
+  `new(0)` for a `*time.Duration`, `Post` given an `http.HandlerFunc`,
+  and `q.Nack(ctx, job.ID)`.
+
+### Added
+
+- **Every shipped blueprint is now booted, not just compiled.**
+  `TestExampleBlueprintsBoot` generates each `examples/*/gofastr.yml`,
+  compiles it, starts the binary, and fails if it exits or never
+  serves. The ladder stopped at compilation before, which is why a seed
+  that only fails at runtime survived. It caught the meridian strict-mode
+  panic above on its first run.
+- **`gofastr generate` reports every schema error at once.** Fixing a
+  blueprint was a serial guess-and-recompile loop because validation
+  stopped at the first bad key. Unknown top-level keys also get a
+  location hint — `auth:` at the root suggests `app.auth:`.
+- **The doc-example compile gate covers 85 blocks, up from 2.** Blocks
+  opt in with a `gofastr:compile` directive, using the same mechanism as
+  before.
+
 ## [0.65.0] - 2026-08-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Fixed
 
+- **Mixed-case `Content-Type` defeated the multipart body cap.**
+  `isMultipart` matched the `multipart/form-data` prefix case-sensitively
+  while the content-type gate parsed per RFC 9110, so
+  `Multipart/Form-Data` requests passed the gate but took the JSON path —
+  and its 1 MiB cap. Both checks now parse the media type the same way.
+- **`pagination.OffsetForPage` panicked on a zero page size.** The
+  overflow guard divided by `limit`; `limit == 0` is now clamped to
+  offset 0 alongside `page < 2`. No in-repo HTTP path could reach it, but
+  the function is exported.
+- **A comma bomb in `?field_in=` allocated the full list before the cap
+  check.** `filter.SplitINValuesBounded` counts entries first and never
+  materializes more than cap+1, while the over-cap 400 still reports the
+  exact entry count; both the top-level and nested (`?rel.f_in=`) paths
+  use it.
 - **BREAKING: a stale queue worker could delete another worker's job.**
   `Queue.Ack` and `Queue.Nack` now take a `Job` instead of a job ID
   string, and `RedisQueue` verifies `Job.ClaimToken` before acting. The
@@ -27,6 +41,14 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   crash on the last permitted attempt left the row `claimed` with
   nothing able to see it, including `Replay`. An expired lease on the
   final attempt is now dead-lettered and logged.
+- **`DBQueue.Ack` retires only a live claim.** The delete had no status
+  predicate, so the stale worker whose crash caused a dead-lettering
+  could wake, `Ack`, and erase the very row that made the failure visible
+  to `Stats`, `ListJobs("failed")`, and `Replay`. It now matches
+  `status='claimed'`. The route from `failed` to gone is `Replay`, claim,
+  `Ack` — the same path an operator already used. This also aligns the
+  three backends: `MemoryQueue` and `RedisQueue` already no-op an `Ack`
+  for a job they do not have claimed.
 - **Multipart uploads over 1 MiB always failed.** The CRUD write
   handlers wrapped every request body in a 1 MiB `MaxBytesReader` before
   deciding whether it was multipart, so `ParseMultipartForm` read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ MCP tools `framework_docs_list` / `framework_docs_get` /
 5. Never add new `data-fui-*` attributes without updating
    `core-ui/ARCHITECTURE.md` and the runtime test suite.
 6. Never expose an entity holding per-user data via auto-CRUD without
-   setting `EntityConfig.OwnerField`. See
+   setting `EntityConfig.Scope.OwnerField`. See
    `framework/docs/content/entity-declarations.md` → "Per-user scoping".
 7. **One styling surface.** Generators and apps ship ZERO bespoke CSS and
    ZERO hand-rolled structural markup. ALL styling + layout lives in the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ Honest expectations:
 
 ## Supported versions
 
-GoFastr is pre-1.0. Only the **latest minor release** (currently `0.65.x`)
+GoFastr is pre-1.0. Only the **latest minor release** (currently `0.66.x`)
 receives security fixes. Older `0.x` lines are not patched — upgrade to
 the latest release to stay supported.
 

--- a/battery/queue/agents.md
+++ b/battery/queue/agents.md
@@ -64,6 +64,10 @@ and stamping `claimed_at`. If the worker dies before Ack/Nack the row would
 otherwise be stranded; instead, a claimed row whose `claimed_at` is older than
 the lease timeout (default 5m, set via `WithLeaseTimeout` / `SetLeaseTimeout`)
 becomes eligible for re-dequeue again — as long as it still has attempts left.
+An expired lease on the FINAL permitted attempt is not re-delivered; it is
+swept to `status='failed'` inside Dequeue (the crash equivalent of a terminal
+Nack) and logged at ERROR, so it shows up in `Stats`/`ListJobs("failed")` and
+is rescuable via `Replay` instead of being stranded in `claimed` forever.
 A handler that **panics** is recovered and routed through Nack (retry /
 dead-letter); the worker goroutine is respawned, so a poison message can never
 permanently drain the pool or crash the process. `MemoryQueue` recovers handler
@@ -73,9 +77,13 @@ panics the same way.
 `queue.WithBackoff(base, max)` to delay each retry by `base*2^(attempts-1)`,
 capped at `max`, so a flapping handler can't burn through every attempt in a
 tight loop. `RegisterHandler` and `SetLeaseTimeout` are safe to call while the
-worker loop is running. `MemoryQueue.Nack(jobID)` re-enqueues a manually
+worker loop is running. `MemoryQueue.Nack(job)` re-enqueues a manually
 dequeued job (incrementing `Attempts`) when retries remain, rather than
-silently dropping it.
+silently dropping it. Note Ack/Nack take the claimed `Job`, not an ID:
+RedisQueue verifies `Job.ClaimToken` against the current processing entry and
+treats a stale claimant's completion as a counted no-op
+(`StaleClaimCount()`), so a worker that outlived its visibility timeout can
+no longer delete or re-enqueue the newer claimant's in-flight job.
 
 `RedisQueue` records a visibility timeout per in-flight job; call
 `RedisQueue.Reclaim(ctx)` periodically (e.g. from a ticker) to re-deliver jobs

--- a/battery/queue/db.go
+++ b/battery/queue/db.go
@@ -584,17 +584,32 @@ func (q *DBQueue) eligibleWhere(types []string, startIdx int, lane string) (stri
 }
 
 // Ack permanently removes the job — work is done, no replay needed. The
-// claim is deleted by identity; DBQueue has no per-claim fencing because a
-// stale worker's DELETE cannot strand the row (the work completed, and a
-// concurrent re-claimant's duplicate execution is within the at-least-once
-// contract).
+// DELETE is qualified with status='claimed' so it retires only a live claim:
+// a row the dead-letter sweep has already adjudicated ('failed' — lease
+// expired on the final attempt) survives a late Ack from the crashed worker.
+// The work may well have completed, but the sweep already logged the
+// dead-letter at ERROR and Stats counted a failure — deleting the record
+// afterwards would strand that signal with no way to reconcile it. The
+// operator reconciles explicitly via Replay, which makes the row claimable
+// again so a live claim's Ack deletes it through this same path. This
+// mirrors RedisQueue, where a stale claim's Ack is a fenced no-op.
+//
+// DBQueue has no per-claim fencing (no ClaimToken column), so a stale Ack
+// that lands while a re-claimant holds the row still deletes that claim —
+// within the at-least-once contract, as before.
 func (q *DBQueue) Ack(ctx context.Context, job Job) error {
 	_, err := q.db.ExecContext(ctx,
-		fmt.Sprintf(`DELETE FROM %s WHERE id = $1`, q.qt()), job.ID)
+		fmt.Sprintf(`DELETE FROM %s WHERE id = $1 AND status='claimed'`, q.qt()), job.ID)
 	return err
 }
 
 // Nack returns a claimed job to the queue (status=pending) when it still
+// has attempts left; on the final permitted attempt (attempts >=
+// max_attempts) it dead-letters the row to status='failed' instead, where
+// it stays visible to Stats, ListJobs("failed"), and Replay until replayed.
+// When backoff is enabled (see WithBackoff), a requeued job's scheduled_at
+// is pushed into the future so a flapping handler can't burn through every
+// attempt in a tight loop.
 func (q *DBQueue) Nack(ctx context.Context, job Job) error {
 	if q.backoffBase <= 0 {
 		// No backoff: one round-trip. A CASE expression decides between

--- a/battery/queue/db.go
+++ b/battery/queue/db.go
@@ -409,6 +409,15 @@ func (q *DBQueue) Dequeue(ctx context.Context, types ...string) (Job, error) {
 // any lane) and the dedicated lane workers (lane != "", restricted to that
 // lane). Sharing one code path keeps the two dialects' claim logic in sync.
 func (q *DBQueue) dequeue(ctx context.Context, lane string, types []string) (Job, error) {
+	// A lease that expired on the job's FINAL attempt is not reclaimable
+	// (eligibleWhere requires attempts < max_attempts for re-delivery) and
+	// never reaches Nack — without this sweep the row would sit in 'claimed'
+	// forever: invisible to Stats-as-failed, ListJobs("failed"), and Replay.
+	// Lease expiry on the final attempt is the crash equivalent of a terminal
+	// Nack, so route it to the same dead-letter state.
+	if err := q.deadLetterExpiredFinalClaims(ctx); err != nil {
+		return Job{}, err
+	}
 	switch q.dialect {
 	case dialectPostgres:
 		return q.dequeuePostgres(ctx, lane, types)
@@ -416,6 +425,63 @@ func (q *DBQueue) dequeue(ctx context.Context, lane string, types []string) (Job
 		return q.dequeueSQLite(ctx, lane, types)
 	}
 }
+
+// deadLetterExpiredFinalClaims moves rows whose lease expired on their final
+// permitted attempt from 'claimed' to 'failed'. It runs before every claim
+// (the same "reclaim happens inside Dequeue" model as the eligibleWhere
+// lease-expiry clause), so a running worker loop sweeps stranded rows on its
+// next poll. Each swept job is logged at ERROR — a job that vanished because
+// its worker crashed must not disappear silently.
+func (q *DBQueue) deadLetterExpiredFinalClaims(ctx context.Context) error {
+	cutoff := q.now().UTC().Add(-q.leaseTimeout())
+	rows, err := q.db.QueryContext(ctx, fmt.Sprintf(
+		`SELECT id, type, attempts, max_attempts FROM %s
+		WHERE status='claimed' AND claimed_at IS NOT NULL AND claimed_at <= $1
+		AND attempts >= max_attempts`, q.qt()), cutoff)
+	if err != nil {
+		return err
+	}
+	type stranded struct {
+		id, jobType         string
+		attempts, maxAttspt int
+	}
+	var found []stranded
+	for rows.Next() {
+		var s stranded
+		if err := rows.Scan(&s.id, &s.jobType, &s.attempts, &s.maxAttspt); err != nil {
+			rows.Close()
+			return err
+		}
+		found = append(found, s)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+	for _, s := range found {
+		// Re-check the full predicate inside the UPDATE: between the SELECT
+		// and now another path (Ack, Nack, release) may have transitioned the
+		// row — the sweep must never dead-letter a claim that is no longer
+		// expired-and-final.
+		res, err := q.db.ExecContext(ctx, fmt.Sprintf(
+			`UPDATE %s SET status='failed'
+			WHERE id=$1 AND status='claimed' AND claimed_at IS NOT NULL AND claimed_at <= $2
+			AND attempts >= max_attempts`, q.qt()), s.id, cutoff)
+		if err != nil {
+			return err
+		}
+		if n, _ := res.RowsAffected(); n > 0 {
+			q.logger.Error("queue: lease expired on final attempt; job dead-lettered",
+				"job_id", s.id,
+				"job_type", s.jobType,
+				"attempt", s.attempts,
+				"max_attempts", s.maxAttspt)
+		}
+	}
+	return nil
+}
+
 func (q *DBQueue) dequeuePostgres(ctx context.Context, lane string, types []string) (Job, error) {
 	where, args := q.eligibleWhere(types, 2, lane)
 	// $1 is the claim timestamp (claimed_at = now); eligibleWhere starts its
@@ -517,26 +583,26 @@ func (q *DBQueue) eligibleWhere(types []string, startIdx int, lane string) (stri
 	return strings.Join(parts, " AND "), args
 }
 
-// Ack permanently removes the job — work is done, no replay needed.
-func (q *DBQueue) Ack(ctx context.Context, jobID string) error {
+// Ack permanently removes the job — work is done, no replay needed. The
+// claim is deleted by identity; DBQueue has no per-claim fencing because a
+// stale worker's DELETE cannot strand the row (the work completed, and a
+// concurrent re-claimant's duplicate execution is within the at-least-once
+// contract).
+func (q *DBQueue) Ack(ctx context.Context, job Job) error {
 	_, err := q.db.ExecContext(ctx,
-		fmt.Sprintf(`DELETE FROM %s WHERE id = $1`, q.qt()), jobID)
+		fmt.Sprintf(`DELETE FROM %s WHERE id = $1`, q.qt()), job.ID)
 	return err
 }
 
 // Nack returns a claimed job to the queue (status=pending) when it still
-// has retry attempts left; otherwise marks it 'failed' for later inspection.
-// When backoff is enabled (see WithBackoff), a requeued job's scheduled_at is
-// pushed into the future so a flapping handler can't burn through every
-// attempt in a tight loop.
-func (q *DBQueue) Nack(ctx context.Context, jobID string) error {
+func (q *DBQueue) Nack(ctx context.Context, job Job) error {
 	if q.backoffBase <= 0 {
 		// No backoff: one round-trip. A CASE expression decides between
 		// requeue and dead-letter based on attempts vs max_attempts.
 		stmt := fmt.Sprintf(`UPDATE %s
 			SET status = CASE WHEN attempts >= max_attempts THEN 'failed' ELSE 'pending' END
 			WHERE id = $1`, q.qt())
-		_, err := q.db.ExecContext(ctx, stmt, jobID)
+		_, err := q.db.ExecContext(ctx, stmt, job.ID)
 		return err
 	}
 
@@ -544,7 +610,7 @@ func (q *DBQueue) Nack(ctx context.Context, jobID string) error {
 	// dead-letter and to compute the next scheduled_at.
 	var attempts, maxAttempts int
 	row := q.db.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT attempts, max_attempts FROM %s WHERE id = $1", q.qt()), jobID)
+		fmt.Sprintf("SELECT attempts, max_attempts FROM %s WHERE id = $1", q.qt()), job.ID)
 	if err := row.Scan(&attempts, &maxAttempts); err != nil {
 		if err == sql.ErrNoRows {
 			return nil // already acked/removed; nothing to do
@@ -553,12 +619,12 @@ func (q *DBQueue) Nack(ctx context.Context, jobID string) error {
 	}
 	if attempts >= maxAttempts {
 		stmt := fmt.Sprintf("UPDATE %s SET status='failed' WHERE id = $1", q.qt())
-		_, err := q.db.ExecContext(ctx, stmt, jobID)
+		_, err := q.db.ExecContext(ctx, stmt, job.ID)
 		return err
 	}
 	next := q.now().UTC().Add(backoff.Exponential(q.backoffBase, q.backoffMax, attempts))
 	stmt := fmt.Sprintf("UPDATE %s SET status='pending', scheduled_at=$1 WHERE id = $2", q.qt())
-	_, err := q.db.ExecContext(ctx, stmt, next, jobID)
+	_, err := q.db.ExecContext(ctx, stmt, next, job.ID)
 	return err
 }
 
@@ -818,7 +884,7 @@ func (q *DBQueue) workerLoop(ctx context.Context, lane string) {
 		h, ok := q.handlerFor(job.Type)
 		if !ok {
 			// No handler — drop the row so it doesn't loop forever.
-			_ = q.Ack(ctx, job.ID)
+			_ = q.Ack(ctx, job)
 			continue
 		}
 		// Gate race window: the gate may flip from allow to deny between
@@ -853,12 +919,12 @@ func (q *DBQueue) workerLoop(ctx context.Context, lane string) {
 					"max_attempts", job.MaxAttempts,
 					"err", err)
 			}
-			if err := q.Nack(ctx, job.ID); err != nil {
+			if err := q.Nack(ctx, job); err != nil {
 				q.logger.Warn("queue: nack failed", "job_id", job.ID, "err", err)
 			}
 			continue
 		}
-		if err := q.Ack(ctx, job.ID); err != nil {
+		if err := q.Ack(ctx, job); err != nil {
 			q.logger.Warn("queue: ack failed", "job_id", job.ID, "err", err)
 		}
 	}

--- a/battery/queue/db_test.go
+++ b/battery/queue/db_test.go
@@ -158,7 +158,7 @@ func TestDBQueue_AckRemovesRow(t *testing.T) {
 
 	q.Enqueue(ctx, Job{Type: "x"})
 	job, _ := q.Dequeue(ctx)
-	if err := q.Ack(ctx, job.ID); err != nil {
+	if err := q.Ack(ctx, job); err != nil {
 		t.Fatalf("ack: %v", err)
 	}
 	var count int
@@ -178,7 +178,7 @@ func TestDBQueue_NackRequeuesWhenRetriesLeft(t *testing.T) {
 
 	q.Enqueue(ctx, Job{Type: "x", MaxAttempts: 3})
 	job1, _ := q.Dequeue(ctx)
-	if err := q.Nack(ctx, job1.ID); err != nil {
+	if err := q.Nack(ctx, job1); err != nil {
 		t.Fatalf("nack: %v", err)
 	}
 	job2, err := q.Dequeue(ctx)
@@ -203,7 +203,7 @@ func TestDBQueue_NackMovesToFailedAtMaxAttempts(t *testing.T) {
 
 	q.Enqueue(ctx, Job{Type: "x", MaxAttempts: 1})
 	job, _ := q.Dequeue(ctx) // attempts now = 1 = max
-	if err := q.Nack(ctx, job.ID); err != nil {
+	if err := q.Nack(ctx, job); err != nil {
 		t.Fatalf("nack: %v", err)
 	}
 	var status string

--- a/battery/queue/durable_scheduler_dst_test.go
+++ b/battery/queue/durable_scheduler_dst_test.go
@@ -101,7 +101,7 @@ func drainPending(t *testing.T, q *DBQueue) {
 		if err != nil {
 			return
 		}
-		if err := q.Ack(context.Background(), job.ID); err != nil {
+		if err := q.Ack(context.Background(), job); err != nil {
 			t.Fatalf("ack drained job: %v", err)
 		}
 	}

--- a/battery/queue/durable_scheduler_hardening_test.go
+++ b/battery/queue/durable_scheduler_hardening_test.go
@@ -95,15 +95,26 @@ func TestDurableSchedulerRetentionPrunesOnlySafeOldOccurrences(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, job := range []Job{
-		{ID: "live-job", Type: "test"},
-		{ID: "done-job", Type: "test"},
-	} {
-		if err := q.Enqueue(context.Background(), job); err != nil {
-			t.Fatal(err)
-		}
+	// done-job is completed by a worker the way production does it —
+	// claimed (Dequeue) then Acked — so its row is gone and retention may
+	// prune its occurrence. Ack alone must not remove a never-claimed
+	// pending row (parity with Redis/Memory, where Ack of nothing claimed
+	// is a no-op).
+	if err := q.Enqueue(context.Background(), Job{ID: "done-job", Type: "test"}); err != nil {
+		t.Fatal(err)
 	}
-	if err := q.Ack(context.Background(), Job{ID: "done-job"}); err != nil {
+	claimed, err := q.Dequeue(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claimed.ID != "done-job" {
+		t.Fatalf("claimed %q, want done-job", claimed.ID)
+	}
+	if err := q.Ack(context.Background(), claimed); err != nil {
+		t.Fatal(err)
+	}
+	// live-job stays enqueued and unclaimed.
+	if err := q.Enqueue(context.Background(), Job{ID: "live-job", Type: "test"}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/battery/queue/durable_scheduler_hardening_test.go
+++ b/battery/queue/durable_scheduler_hardening_test.go
@@ -103,7 +103,7 @@ func TestDurableSchedulerRetentionPrunesOnlySafeOldOccurrences(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err := q.Ack(context.Background(), "done-job"); err != nil {
+	if err := q.Ack(context.Background(), Job{ID: "done-job"}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/battery/queue/durable_scheduler_overlap_test.go
+++ b/battery/queue/durable_scheduler_overlap_test.go
@@ -43,7 +43,7 @@ func TestDurableSchedulerSkipsTickWhilePriorOccurrenceIsActive(t *testing.T) {
 		t.Fatalf("skip reason = %q, want overlap", reason)
 	}
 
-	if err := q.Ack(context.Background(), first[0].ID); err != nil {
+	if err := q.Ack(context.Background(), first[0]); err != nil {
 		t.Fatal(err)
 	}
 	if err := sched.RunOnce(context.Background(), base.Add(3*time.Minute)); err != nil {

--- a/battery/queue/durable_scheduler_overlap_test.go
+++ b/battery/queue/durable_scheduler_overlap_test.go
@@ -43,7 +43,17 @@ func TestDurableSchedulerSkipsTickWhilePriorOccurrenceIsActive(t *testing.T) {
 		t.Fatalf("skip reason = %q, want overlap", reason)
 	}
 
-	if err := q.Ack(context.Background(), first[0]); err != nil {
+	// A worker claims and completes the first occurrence's job, so the 3m
+	// tick enqueues fresh work instead of skipping as overlap. Claim first —
+	// Ack alone must not remove a never-claimed pending row.
+	claimed, err := q.Dequeue(context.Background())
+	if err != nil {
+		t.Fatalf("claim first tick's job: %v", err)
+	}
+	if claimed.OccurrenceID != first[0].OccurrenceID {
+		t.Fatalf("claimed occurrence %q, want the first tick's %q", claimed.OccurrenceID, first[0].OccurrenceID)
+	}
+	if err := q.Ack(context.Background(), claimed); err != nil {
 		t.Fatal(err)
 	}
 	if err := sched.RunOnce(context.Background(), base.Add(3*time.Minute)); err != nil {

--- a/battery/queue/durable_scheduler_test.go
+++ b/battery/queue/durable_scheduler_test.go
@@ -237,8 +237,17 @@ func TestDurableSchedulerRestartResumesPersistedWatermark(t *testing.T) {
 		t.Fatalf("first process enqueued %d jobs, want 1", len(firstJobs))
 	}
 	firstOccurrenceID := firstJobs[0].OccurrenceID
-	// Complete the first occurrence so the next tick is not an overlap skip.
-	if err := q.Ack(context.Background(), firstJobs[0]); err != nil {
+	// Complete the first occurrence so the next tick is not an overlap skip:
+	// claim it (a worker's Dequeue) then Ack — Ack alone must not remove a
+	// never-claimed pending row.
+	claimed, err := q.Dequeue(context.Background())
+	if err != nil {
+		t.Fatalf("claim first occurrence's job: %v", err)
+	}
+	if claimed.OccurrenceID != firstOccurrenceID {
+		t.Fatalf("claimed occurrence %q, want %q", claimed.OccurrenceID, firstOccurrenceID)
+	}
+	if err := q.Ack(context.Background(), claimed); err != nil {
 		t.Fatal(err)
 	}
 

--- a/battery/queue/durable_scheduler_test.go
+++ b/battery/queue/durable_scheduler_test.go
@@ -238,7 +238,7 @@ func TestDurableSchedulerRestartResumesPersistedWatermark(t *testing.T) {
 	}
 	firstOccurrenceID := firstJobs[0].OccurrenceID
 	// Complete the first occurrence so the next tick is not an overlap skip.
-	if err := q.Ack(context.Background(), firstJobs[0].ID); err != nil {
+	if err := q.Ack(context.Background(), firstJobs[0]); err != nil {
 		t.Fatal(err)
 	}
 

--- a/battery/queue/f9_f17_f18_test.go
+++ b/battery/queue/f9_f17_f18_test.go
@@ -38,7 +38,7 @@ func TestRedisBrowsable_ListJobsAndStats(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Dequeue: %v", err)
 	}
-	if err := q.Nack(ctx, job.ID); err != nil {
+	if err := q.Nack(ctx, job); err != nil {
 		t.Fatalf("Nack: %v", err)
 	}
 
@@ -73,7 +73,7 @@ func TestRedisBrowsable_ListJobsLimit(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		_ = q.Enqueue(ctx, Job{ID: "dead-lim-" + string(rune('a'+i)), Type: "x", MaxAttempts: 1})
 		job, _ := q.Dequeue(ctx)
-		_ = q.Nack(ctx, job.ID)
+		_ = q.Nack(ctx, job)
 	}
 
 	// Limit to 3.
@@ -94,7 +94,7 @@ func TestRedisBrowsable_ListJobsAllStatus(t *testing.T) {
 	// Drive a job to DLQ.
 	_ = q.Enqueue(ctx, Job{ID: "dead-all", Type: "x", MaxAttempts: 1})
 	job, _ := q.Dequeue(ctx)
-	_ = q.Nack(ctx, job.ID)
+	_ = q.Nack(ctx, job)
 
 	// Passing empty status should return same as "failed" for Redis (dead list).
 	jobs, err := q.ListJobs(ctx, "", 10)
@@ -115,8 +115,8 @@ func (f *failQueue) Enqueue(_ context.Context, _ Job) error {
 	return ErrQueueClosed
 }
 func (f *failQueue) Dequeue(_ context.Context, _ ...string) (Job, error) { return Job{}, ErrNoJob }
-func (f *failQueue) Ack(_ context.Context, _ string) error               { return nil }
-func (f *failQueue) Nack(_ context.Context, _ string) error              { return nil }
+func (f *failQueue) Ack(_ context.Context, _ Job) error                  { return nil }
+func (f *failQueue) Nack(_ context.Context, _ Job) error                 { return nil }
 func (f *failQueue) Close() error                                        { return nil }
 
 // slogCapture captures slog records for assertions.

--- a/battery/queue/lease_blackhole_test.go
+++ b/battery/queue/lease_blackhole_test.go
@@ -1,0 +1,145 @@
+package queue
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	_ "github.com/DonaldMurillo/gofastr/sqlite/stdlib"
+)
+
+// openDBQueueWithLeaseLogging is openDBQueueWithLogger plus a short lease, so
+// lease-expiry dead-lettering can be driven by a fake clock and its ERROR log
+// asserted in one place.
+func openDBQueueWithLeaseLogging(t *testing.T) (*sql.DB, *DBQueue, *bytes.Buffer) {
+	t.Helper()
+	db, q, buf := openDBQueueWithLogger(t, 0)
+	q.SetLeaseTimeout(time.Minute)
+	return db, q, buf
+}
+
+// ============================================================================
+// Property: a worker crash on the FINAL permitted attempt must dead-letter
+// the job, never strand it in 'claimed'.
+// Surface: DBQueue dequeue / eligibleWhere lease reclaim + dead-letter sweep.
+//
+// Dequeue increments attempts at claim, and the reclaim clause requires
+// attempts < max_attempts — so an expired lease on the final attempt matches
+// no path: not re-delivered, never Nacked (so never 'failed'), invisible to
+// Replay. A lease expiry on the final attempt is the crash equivalent of a
+// terminal Nack and must land in the same dead-letter state.
+// ============================================================================
+
+// TestDBFinalAttemptLeaseExpiryDeadLetters simulates a worker that claimed a
+// MaxAttempts=1 job and crashed: after the lease expires the job must be
+// status='failed' (observable in Stats/ListJobs, rescuable via Replay), not
+// stranded in 'claimed'.
+func TestDBFinalAttemptLeaseExpiryDeadLetters(t *testing.T) {
+	db, q, buf := openDBQueueWithLeaseLogging(t)
+	// Fake clock: no workers are running, so the single test goroutine is the
+	// only reader of q.now — lease expiry is asserted by advancing the clock,
+	// not by sleeping.
+	now := time.Now()
+	q.now = func() time.Time { return now }
+	ctx := context.Background()
+
+	if err := q.Enqueue(ctx, Job{ID: "critical", Type: "x", MaxAttempts: 1}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	job, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("first dequeue: %v", err)
+	}
+	if job.Attempts != 1 {
+		t.Fatalf("attempts after claim = %d, want 1 (the final attempt)", job.Attempts)
+	}
+	// Worker "crashes" — never Ack/Nack.
+
+	// Before the lease expires nothing may change (clock is frozen; no race).
+	if _, err := q.Dequeue(ctx); !errors.Is(err, ErrNoJob) {
+		t.Fatalf("pre-expiry dequeue: %v", err)
+	}
+	var status string
+	db.QueryRow("SELECT status FROM queue_jobs WHERE id='critical'").Scan(&status)
+	if status != "claimed" {
+		t.Fatalf("pre-expiry status = %q, want claimed", status)
+	}
+
+	// Advance the clock past the lease. The final-attempt crash must NOT
+	// re-deliver (fail closed, like a terminal Nack)…
+	now = now.Add(time.Minute + time.Second)
+	if _, err := q.Dequeue(ctx); !errors.Is(err, ErrNoJob) {
+		t.Fatalf("expired final-attempt job was re-delivered: %v", err)
+	}
+	// …and must be dead-lettered, not stranded.
+	db.QueryRow("SELECT status FROM queue_jobs WHERE id='critical'").Scan(&status)
+	if status != "failed" {
+		t.Fatalf("post-expiry status = %q, want failed — job stranded in claimed (black hole)", status)
+	}
+
+	// The dead-letter is observable through the Browsable surface.
+	failed, err := q.ListJobs(ctx, "failed", 10)
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if len(failed) != 1 || failed[0].ID != "critical" {
+		t.Fatalf("ListJobs(failed) = %+v, want the critical job", failed)
+	}
+	stats, err := q.Stats(ctx)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats["failed"] != 1 || stats["claimed"] != 0 {
+		t.Fatalf("stats = %v, want failed=1 claimed=0", stats)
+	}
+
+	// Replay can rescue it — attempts reset, immediately claimable again.
+	if err := q.Replay(ctx, "critical"); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	replayed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("dequeue after replay: %v", err)
+	}
+	if replayed.ID != "critical" || replayed.Attempts != 1 {
+		t.Fatalf("replayed job = %+v, want critical with a fresh attempt", replayed)
+	}
+
+	// The silent loss is also logged at ERROR, matching the worker loop's
+	// dead-letter records.
+	if err := q.Ack(ctx, replayed); err != nil {
+		t.Fatalf("ack replayed: %v", err)
+	}
+	assertLogLine(t, buf, "ERROR", "queue: lease expired on final attempt")
+}
+
+// ============================================================================
+// Companion: a crash with attempts REMAINING still re-delivers (the reclaim
+// path itself is unchanged by the dead-letter sweep).
+// ============================================================================
+
+func TestDBNonFinalLeaseExpiryStillReclaims(t *testing.T) {
+	_, q, _ := openDBQueueWithLeaseLogging(t)
+	now := time.Now()
+	q.now = func() time.Time { return now }
+	ctx := context.Background()
+
+	if err := q.Enqueue(ctx, Job{ID: "retryable", Type: "x", MaxAttempts: 3}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if _, err := q.Dequeue(ctx); err != nil {
+		t.Fatalf("first dequeue: %v", err)
+	}
+	// Crash on attempt 1 of 3 — must be re-delivered, not dead-lettered.
+	now = now.Add(time.Minute + time.Second)
+	reclaimed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("expired non-final job was not reclaimed: %v", err)
+	}
+	if reclaimed.ID != "retryable" || reclaimed.Attempts != 2 {
+		t.Fatalf("reclaimed = %+v, want retryable attempts=2", reclaimed)
+	}
+}

--- a/battery/queue/lease_blackhole_test.go
+++ b/battery/queue/lease_blackhole_test.go
@@ -117,6 +117,86 @@ func TestDBFinalAttemptLeaseExpiryDeadLetters(t *testing.T) {
 }
 
 // ============================================================================
+// Property: a late Ack from a crashed worker must not erase the dead-letter
+// record the sweep just wrote.
+// Surface: DBQueue Ack × deadLetterExpiredFinalClaims interaction.
+// ============================================================================
+
+// TestLateAckKeepsDeadLetterRow pins Ack's contract against the sweep: Ack
+// retires a job only while its claim is live (status='claimed'). A worker
+// whose lease expired on the final attempt may wake long after the sweep
+// dead-lettered its job and report success — that Ack must be a no-op, not a
+// DELETE.
+//
+// Why no-op rather than delete, even though the work did finish: the sweep
+// already logged the dead-letter at ERROR and Stats counted a failure;
+// deleting the row afterwards leaves that signal unreconcilable. The
+// operator's sanctioned cleanup is Replay, which makes the row claimable so
+// a live worker Ack deletes it through the normal route. This also matches
+// RedisQueue, where a stale claim's Ack is a fenced no-op and the
+// dead-letter entry survives — the unfenced DB backend is the one that most
+// needs the conservative delete.
+func TestLateAckKeepsDeadLetterRow(t *testing.T) {
+	db, q, _ := openDBQueueWithLeaseLogging(t)
+	now := time.Now()
+	q.now = func() time.Time { return now }
+	ctx := context.Background()
+
+	if err := q.Enqueue(ctx, Job{ID: "lateacker", Type: "x", MaxAttempts: 1}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	job, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+
+	// Lease expires on the final attempt; the sweep dead-letters the row.
+	now = now.Add(time.Minute + time.Second)
+	if _, err := q.Dequeue(ctx); !errors.Is(err, ErrNoJob) {
+		t.Fatalf("post-expiry dequeue: %v", err)
+	}
+
+	// The crashed worker finally wakes and reports success. This must not
+	// erase the failure record.
+	if err := q.Ack(ctx, job); err != nil {
+		t.Fatalf("late ack: %v", err)
+	}
+	failed, err := q.ListJobs(ctx, "failed", 10)
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	if len(failed) != 1 || failed[0].ID != "lateacker" {
+		t.Fatalf("ListJobs(failed) = %+v, want the dead-lettered job to survive the late Ack", failed)
+	}
+	var status string
+	db.QueryRow("SELECT status FROM queue_jobs WHERE id='lateacker'").Scan(&status)
+	if status != "failed" {
+		t.Fatalf("status after late ack = %q, want failed", status)
+	}
+
+	// The operator reconciles explicitly: Replay makes the row claimable, and
+	// the OWNING claim's Ack still retires it — the predicate fences stale
+	// completions only, not live ones.
+	if err := q.Replay(ctx, "lateacker"); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	replayed, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("dequeue after replay: %v", err)
+	}
+	if err := q.Ack(ctx, replayed); err != nil {
+		t.Fatalf("ack after replay: %v", err)
+	}
+	left, err := q.ListJobs(ctx, "", 10)
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if len(left) != 0 {
+		t.Fatalf("jobs after owning ack = %+v, want none", left)
+	}
+}
+
+// ============================================================================
 // Companion: a crash with attempts REMAINING still re-delivers (the reclaim
 // path itself is unchanged by the dead-letter sweep).
 // ============================================================================

--- a/battery/queue/memory.go
+++ b/battery/queue/memory.go
@@ -473,8 +473,8 @@ func randomID() string {
 // Ack confirms a manually-dequeued job is done, discarding any tracked
 // in-flight copy. For jobs processed by the automatic worker pool it is a
 // no-op (those are auto-acknowledged after successful handler execution).
-func (q *MemoryQueue) Ack(_ context.Context, jobID string) error {
-	q.takeInflight(jobID)
+func (q *MemoryQueue) Ack(_ context.Context, job Job) error {
+	q.takeInflight(job.ID)
 	return nil
 }
 
@@ -483,20 +483,20 @@ func (q *MemoryQueue) Ack(_ context.Context, jobID string) error {
 // The job must have been handed out by Dequeue (the in-flight set is consulted
 // by ID). Jobs processed by the automatic worker pool retry internally and are
 // never in the in-flight set; calling Nack for one is a harmless no-op.
-func (q *MemoryQueue) Nack(ctx context.Context, jobID string) error {
-	job, ok := q.takeInflight(jobID)
+func (q *MemoryQueue) Nack(ctx context.Context, job Job) error {
+	stored, ok := q.takeInflight(job.ID)
 	if !ok {
 		// Unknown job (auto-pool retry, or already acked) — nothing to requeue.
 		return nil
 	}
-	job.Attempts++
-	if job.MaxAttempts > 0 && job.Attempts >= job.MaxAttempts {
+	stored.Attempts++
+	if stored.MaxAttempts > 0 && stored.Attempts >= stored.MaxAttempts {
 		// Retries exhausted — retain as terminally-failed (inspectable via
 		// ListJobs/Stats and re-queuable via Replay) rather than dropping it.
-		q.retainDead(job)
+		q.retainDead(stored)
 		return nil
 	}
-	return q.Enqueue(ctx, job)
+	return q.Enqueue(ctx, stored)
 }
 
 // retainDead stores a terminally-failed job in the bounded dead-letter set.

--- a/battery/queue/memory_replay_test.go
+++ b/battery/queue/memory_replay_test.go
@@ -20,7 +20,7 @@ func driveToFailure(t *testing.T, q *MemoryQueue) string {
 	if err != nil {
 		t.Fatalf("dequeue: %v", err)
 	}
-	if err := q.Nack(ctx, job.ID); err != nil { // attempts -> 1 >= max -> terminal
+	if err := q.Nack(ctx, job); err != nil { // attempts -> 1 >= max -> terminal
 		t.Fatalf("nack: %v", err)
 	}
 	return job.ID

--- a/battery/queue/queue.go
+++ b/battery/queue/queue.go
@@ -21,6 +21,15 @@ type Job struct {
 	MaxAttempts  int             `json:"max_attempts"`
 	CreatedAt    time.Time       `json:"created_at"`
 	ScheduledAt  time.Time       `json:"scheduled_at"`
+
+	// ClaimToken is minted by Dequeue per claim and identifies THAT claim,
+	// not just the job. Backends that lease work to possibly-stale workers
+	// (RedisQueue) verify it on Ack/Nack: a completion presented for a claim
+	// that is no longer current — e.g. a worker whose visibility timeout
+	// expired and whose job was re-claimed by another worker — is a fenced
+	// no-op instead of mutating the current claimant's lease. Empty for jobs
+	// that have never been claimed (and on backends without lease fencing).
+	ClaimToken string `json:"claim_token,omitempty"`
 }
 
 // Handler processes a job. Return a non-nil error to trigger a retry.
@@ -32,10 +41,14 @@ type Queue interface {
 	Enqueue(ctx context.Context, job Job) error
 	// Dequeue retrieves and removes the next available job, optionally filtered by type.
 	Dequeue(ctx context.Context, types ...string) (Job, error)
-	// Ack confirms successful processing of a job.
-	Ack(ctx context.Context, jobID string) error
-	// Nack marks a job as failed and triggers retry logic.
-	Nack(ctx context.Context, jobID string) error
+	// Ack confirms successful processing of the claimed job. Backends with
+	// lease fencing (RedisQueue) verify Job.ClaimToken and treat a stale
+	// claim's Ack as a no-op.
+	Ack(ctx context.Context, job Job) error
+	// Nack marks a claimed job as failed and triggers retry logic. Backends
+	// with lease fencing (RedisQueue) verify Job.ClaimToken and treat a
+	// stale claim's Nack as a no-op.
+	Nack(ctx context.Context, job Job) error
 	// Close gracefully shuts down the queue, draining in-progress work.
 	Close() error
 }

--- a/battery/queue/queue_test.go
+++ b/battery/queue/queue_test.go
@@ -355,17 +355,16 @@ func (m *mockRedis) HSet(_ context.Context, key string, values ...interface{}) e
 	}
 	return nil
 }
-
 func (m *mockRedis) HGet(_ context.Context, key, field string) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	h, ok := m.hashes[key]
 	if !ok {
-		return "", fmt.Errorf("hash not found")
+		return "", ErrRedisEmpty
 	}
 	v, ok := h[field]
 	if !ok {
-		return "", fmt.Errorf("field not found")
+		return "", ErrRedisEmpty
 	}
 	return v, nil
 }
@@ -458,7 +457,7 @@ func TestRedisAckRemovesOneJob(t *testing.T) {
 	}
 
 	// Ack only job1.
-	if err := q.Ack(ctx, job1.ID); err != nil {
+	if err := q.Ack(ctx, job1); err != nil {
 		t.Fatalf("Ack job1: %v", err)
 	}
 
@@ -495,7 +494,7 @@ func TestRedisNackRetries(t *testing.T) {
 	}
 
 	// Nack — should re-enqueue with incremented attempts.
-	if err := q.Nack(ctx, job.ID); err != nil {
+	if err := q.Nack(ctx, job); err != nil {
 		t.Fatalf("Nack: %v", err)
 	}
 
@@ -532,7 +531,7 @@ func TestRedisNackMovesToDLQ(t *testing.T) {
 	}
 
 	// Nack — MaxAttempts=1 so it should go to DLQ.
-	if err := q.Nack(ctx, job.ID); err != nil {
+	if err := q.Nack(ctx, job); err != nil {
 		t.Fatalf("Nack: %v", err)
 	}
 

--- a/battery/queue/redis.go
+++ b/battery/queue/redis.go
@@ -21,11 +21,20 @@ type RedisClient interface {
 	// a missing hash or field MUST be reported as ErrRedisEmpty (map the
 	// driver's nil-sentinel, e.g. redis.Nil) — the queue relies on it to
 	// make Ack/Nack of a non-claimed job an idempotent no-op instead of a
+	// hard error: a missing claim is normal (already completed, or the
+	// lease expired and another worker took it) and must not be mistaken
+	// for a backend outage.
 	HGet(ctx context.Context, key, field string) (string, error)
 	HSet(ctx context.Context, key string, values ...interface{}) error
 	// HGetAll returns every field→value pair in the hash. Used by Reclaim to
+	// scan the processing hash for expired in-flight jobs.
 	HGetAll(ctx context.Context, key string) (map[string]string, error)
 	HDel(ctx context.Context, key string, fields ...string) error
+	// Del removes one or more keys entirely. RedisQueue's own lease
+	// protocol never calls it — per-job bookkeeping uses HDel — but it
+	// stays in the adapter contract for callers that hold a RedisClient
+	// and need whole-key cleanup.
+	Del(ctx context.Context, keys ...string) error
 	// LRange returns the elements of the list at key in the inclusive range
 	// [start, stop]; negative indices count from the tail (-1 is the last
 	// element). Used by Replay to read the dead-letter list.

--- a/battery/queue/redis.go
+++ b/battery/queue/redis.go
@@ -17,13 +17,15 @@ import (
 type RedisClient interface {
 	LPush(ctx context.Context, key string, values ...interface{}) error
 	RPop(ctx context.Context, key string) (string, error)
-	HSet(ctx context.Context, key string, values ...interface{}) error
+	// HGet returns the value stored at field in the hash at key. Like RPop,
+	// a missing hash or field MUST be reported as ErrRedisEmpty (map the
+	// driver's nil-sentinel, e.g. redis.Nil) — the queue relies on it to
+	// make Ack/Nack of a non-claimed job an idempotent no-op instead of a
 	HGet(ctx context.Context, key, field string) (string, error)
+	HSet(ctx context.Context, key string, values ...interface{}) error
 	// HGetAll returns every field→value pair in the hash. Used by Reclaim to
-	// scan the processing set for expired in-flight jobs.
 	HGetAll(ctx context.Context, key string) (map[string]string, error)
 	HDel(ctx context.Context, key string, fields ...string) error
-	Del(ctx context.Context, keys ...string) error
 	// LRange returns the elements of the list at key in the inclusive range
 	// [start, stop]; negative indices count from the tail (-1 is the last
 	// element). Used by Replay to read the dead-letter list.
@@ -34,11 +36,13 @@ type RedisClient interface {
 	LRem(ctx context.Context, key string, count int64, value interface{}) (int64, error)
 }
 
-// ErrRedisEmpty is the sentinel a RedisClient.RPop implementation returns (or
-// wraps) when the source list is empty. It is how RedisQueue distinguishes a
-// genuinely empty queue from a real backend failure: an empty list is a normal
-// "no work" signal (→ ErrNoJob), while any other error means the backend is
-// unreachable and MUST be surfaced so an outage is not masked as idle.
+// ErrRedisEmpty is the sentinel a RedisClient implementation returns (or
+// wraps) when a read finds nothing: RPop on an empty list, HGet on a missing
+// hash or field. It is how RedisQueue distinguishes a genuinely missing
+// value from a real backend failure: "nothing there" is a normal signal (an
+// empty poll → ErrNoJob; an Ack/Nack with nothing claimed → idempotent
+// no-op), while any other error means the backend is unreachable and MUST be
+// surfaced so an outage is not masked as idle.
 //
 // Adapter authors translating a real driver MUST map its own nil-sentinel
 // (e.g. go-redis's redis.Nil, redigo's redis.ErrNil) onto this via errors.Is.
@@ -63,6 +67,22 @@ type RedisQueue struct {
 	// Defaults to time.Now; tests substitute a fake clock so reclaim
 	// behaviour can be asserted without wall-clock sleeps.
 	now func() time.Time
+
+	// staleClaims counts completions (Ack/Nack) rejected because the claim
+	// token they presented no longer matches the processing entry — i.e. the
+	// job was re-claimed by another worker after this claimant's visibility
+	// timeout expired. Atomic: workers on different goroutines complete
+	// independently. Read via StaleClaimCount; a rising value means worker
+	// handlers are outliving their visibility timeout.
+	staleClaims atomic.Int64
+}
+
+// StaleClaimCount returns how many Ack/Nack calls were rejected as coming
+// from a stale claim (fenced out by Job.ClaimToken mismatch). Monitoring it
+// distinguishes "handlers routinely exceed the visibility timeout" from
+// silent double-delivery confusion.
+func (q *RedisQueue) StaleClaimCount() int64 {
+	return q.staleClaims.Load()
 }
 
 // NewRedisQueue creates a new Redis-backed queue.
@@ -218,6 +238,10 @@ func (q *RedisQueue) Dequeue(ctx context.Context, types ...string) (Job, error) 
 			}
 			continue
 		}
+		// Mint a fresh claim token: it identifies THIS claim, so a stale
+		// worker whose visibility timeout expired (and whose job was
+		// re-claimed by someone else) cannot Ack/Nack the newer claim.
+		job.ClaimToken = redisRandomID()
 		bumped, _ := json.Marshal(job)
 
 		// Track in processing queue for visibility timeout. The job was
@@ -258,33 +282,82 @@ func (q *RedisQueue) Dequeue(ctx context.Context, types ...string) (Job, error) 
 // whole queue into process memory.
 const maxSkipDrain = 1024
 
-// Ack removes a single job from the processing queue after successful handling.
-func (q *RedisQueue) Ack(ctx context.Context, jobID string) error {
-	return q.client.HDel(ctx, q.processingQueue, jobID)
+// processingEntry is the per-claim record stored in the processing hash:
+// the claimed job (with its ClaimToken) plus the lease's expiry stamp.
+type processingEntry struct {
+	Job       string `json:"job"`
+	ExpiresAt int64  `json:"expiresAt"`
+}
+
+// currentClaim reads the processing entry for jobID and returns the job of
+// the CURRENT claim. found is false when nothing is claimed under that ID.
+func (q *RedisQueue) currentClaim(ctx context.Context, jobID string) (current Job, found bool, err error) {
+	data, err := q.client.HGet(ctx, q.processingQueue, jobID)
+	if err != nil {
+		if errors.Is(err, ErrRedisEmpty) {
+			return Job{}, false, nil
+		}
+		return Job{}, false, fmt.Errorf("read processing entry: %w", err)
+	}
+	var entry processingEntry
+	if err := json.Unmarshal([]byte(data), &entry); err != nil {
+		return Job{}, false, fmt.Errorf("unmarshal processing entry: %w", err)
+	}
+	var job Job
+	if err := json.Unmarshal([]byte(entry.Job), &job); err != nil {
+		return Job{}, false, fmt.Errorf("unmarshal job: %w", err)
+	}
+	return job, true, nil
+}
+
+// ownsClaim reports whether the completion being presented (job) matches the
+// current processing entry for that ID. A mismatch means the presenter's
+// visibility timeout expired and another worker re-claimed the job — their
+// completion must not touch the newer claim. Counts a rejected completion in
+// q.staleClaims so the fencing is observable, and returns false. A missing
+// entry surfaces as found=false for the caller to treat as an idempotent
+// no-op.
+func (q *RedisQueue) ownsClaim(job, current Job, found bool) bool {
+	if !found {
+		return false
+	}
+	if current.ClaimToken == job.ClaimToken {
+		return true
+	}
+	q.staleClaims.Add(1)
+	return false
+}
+
+// Ack removes the job's processing entry after successful handling. The
+// claim is fenced by Job.ClaimToken: an Ack from a worker whose visibility
+// timeout already expired (the job was re-claimed elsewhere) is a no-op —
+// deleting the newer claimant's entry would make the job unreclaimable
+// if that claimant then crashed. Acking an ID nothing is claimed
+// under (already acked) is an idempotent no-op.
+func (q *RedisQueue) Ack(ctx context.Context, job Job) error {
+	current, found, err := q.currentClaim(ctx, job.ID)
+	if err != nil {
+		return fmt.Errorf("ack: %w", err)
+	}
+	if !q.ownsClaim(job, current, found) {
+		return nil // stale claim (counted) or nothing claimed — no-op
+	}
+	return q.client.HDel(ctx, q.processingQueue, job.ID)
 }
 
 // Nack handles a failed job. If retries remain, it re-enqueues the job;
-// otherwise it moves it to the dead letter queue.
-func (q *RedisQueue) Nack(ctx context.Context, jobID string) error {
-	// Get the job from processing queue.
-	data, err := q.client.HGet(ctx, q.processingQueue, jobID)
+// otherwise it moves it to the dead letter queue. Like Ack it is fenced by
+// Job.ClaimToken: a stale claimant's Nack must neither re-enqueue the newer
+// claimant's in-flight job (concurrent double-run) nor delete its entry
+// (unreclaimable loss). Nacking an ID nothing is claimed under is an
+// idempotent no-op.
+func (q *RedisQueue) Nack(ctx context.Context, claimed Job) error {
+	job, found, err := q.currentClaim(ctx, claimed.ID)
 	if err != nil {
-		return fmt.Errorf("nack: job not found in processing: %w", err)
+		return fmt.Errorf("nack: %w", err)
 	}
-
-	var entry map[string]interface{}
-	if err := json.Unmarshal([]byte(data), &entry); err != nil {
-		return fmt.Errorf("nack: unmarshal: %w", err)
-	}
-
-	// Extract original job — entry["job"] is a string containing the job JSON.
-	jobStr, ok := entry["job"].(string)
-	if !ok {
-		return fmt.Errorf("nack: job field has unexpected type")
-	}
-	var job Job
-	if err := json.Unmarshal([]byte(jobStr), &job); err != nil {
-		return fmt.Errorf("nack: unmarshal job: %w", err)
+	if !q.ownsClaim(claimed, job, found) {
+		return nil // stale claim (counted) or nothing claimed — no-op
 	}
 
 	// Attempts were bumped at claim (Dequeue), so the processing entry
@@ -310,7 +383,7 @@ func (q *RedisQueue) Nack(ctx context.Context, jobID string) error {
 		return fmt.Errorf("nack: push to %s: %w", dest, err)
 	}
 
-	return q.client.HDel(ctx, q.processingQueue, jobID)
+	return q.client.HDel(ctx, q.processingQueue, claimed.ID)
 }
 
 // Reclaim scans the processing set for in-flight jobs whose visibility
@@ -326,10 +399,7 @@ func (q *RedisQueue) Reclaim(ctx context.Context) (int, error) {
 	now := q.now().UnixNano()
 	reclaimed := 0
 	for jobID, raw := range entries {
-		var entry struct {
-			Job       string `json:"job"`
-			ExpiresAt int64  `json:"expiresAt"`
-		}
+		var entry processingEntry
 		if err := json.Unmarshal([]byte(raw), &entry); err != nil {
 			// Corrupt processing entry: drop it so it can't wedge the sweep.
 			_ = q.client.HDel(ctx, q.processingQueue, jobID)
@@ -376,8 +446,11 @@ func (q *RedisQueue) Replay(ctx context.Context, jobID string) error {
 			continue
 		}
 
-		// Reset for a fresh set of retries, then re-marshal.
+		// Reset for a fresh set of retries, then re-marshal. ClaimToken is
+		// cleared too — it identified a claim that is now terminal; the next
+		// Dequeue mints a fresh one.
 		job.Attempts = 0
+		job.ClaimToken = ""
 		requeued, err := json.Marshal(job)
 		if err != nil {
 			return fmt.Errorf("replay: marshal job: %w", err)

--- a/battery/queue/redis_dlq_safety_test.go
+++ b/battery/queue/redis_dlq_safety_test.go
@@ -109,7 +109,7 @@ func TestRedisNackKeepsJobWhenPushFails(t *testing.T) {
 
 			fail := &pushFailingRedis{RedisClient: r, err: errors.New("redis down")}
 			failing := NewRedisQueue(fail, "test")
-			if err := failing.Nack(ctx, claimed.ID); err == nil {
+			if err := failing.Nack(ctx, claimed); err == nil {
 				t.Fatal("Nack must surface the failed push")
 			}
 

--- a/battery/queue/redis_replay_test.go
+++ b/battery/queue/redis_replay_test.go
@@ -79,7 +79,7 @@ func TestRedisReplayMovesDLQJobToQueue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Dequeue: %v", err)
 	}
-	if err := q.Nack(ctx, job.ID); err != nil {
+	if err := q.Nack(ctx, job); err != nil {
 		t.Fatalf("Nack: %v", err)
 	}
 

--- a/battery/queue/redis_stale_claim_test.go
+++ b/battery/queue/redis_stale_claim_test.go
@@ -1,0 +1,179 @@
+package queue
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// ============================================================================
+// Property: a completion (Ack/Nack) presented by a claim that is no longer
+// current must not mutate the current claimant's state.
+// Surface: RedisQueue Ack/Nack claim fencing (Job.ClaimToken).
+//
+// W1 claims J and stalls past the visibility timeout; Reclaim re-enqueues J;
+// W2 re-claims it. The processing entry now belongs to W2. If W1 then wakes
+// and Acks/Nacks by bare job ID, it deletes or re-enqueues W2's entry — and
+// when W2 later crashes there is nothing left to reclaim: the job is on no
+// list, in no hash, never dead-lettered. The claim token mints a fresh
+// identity per claim so a stale holder's completion is a fenced no-op.
+// ============================================================================
+
+// claimByTwoWorkers drives the shared scenario: enqueue, W1 claims, lease
+// expires, Reclaim re-enqueues, W2 re-claims. Returns both claims (W1's is
+// the now-stale one). The fake clock (*now) is left just after W2's claim.
+func claimByTwoWorkers(t *testing.T, q *RedisQueue, now *time.Time) (w1, w2 Job) {
+	t.Helper()
+	ctx := context.Background()
+	q.SetVisibilityTimeout(time.Minute)
+
+	if err := q.Enqueue(ctx, Job{ID: "pay", Type: "x", MaxAttempts: 3}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	w1, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("W1 dequeue: %v", err)
+	}
+	if w1.ClaimToken == "" {
+		t.Fatalf("claim minted no ClaimToken — fencing impossible")
+	}
+	// W1 stalls past the visibility timeout; the entry is reclaimed and
+	// re-claimed by W2.
+	*now = now.Add(2 * time.Minute)
+	if _, err := q.Reclaim(ctx); err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+	w2, err = q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("W2 dequeue: %v", err)
+	}
+	if w2.ID != w1.ID {
+		t.Fatalf("W2 claimed %q, want the same job %q", w2.ID, w1.ID)
+	}
+	if w2.ClaimToken == "" || w2.ClaimToken == w1.ClaimToken {
+		t.Fatalf("re-claim reused W1's token %q — fencing broken", w2.ClaimToken)
+	}
+	return w1, w2
+}
+
+// TestRedisStaleAckCannotDeleteReclaimant: W1's late Ack must NOT delete
+// W2's processing entry. After W2 crashes (visibility expiry + Reclaim), the
+// job must still exist — re-delivered on the main list, not lost.
+func TestRedisStaleAckCannotDeleteReclaimant(t *testing.T) {
+	r := newMockRedis()
+	q := NewRedisQueue(r, "jobs")
+	now := time.Now()
+	q.now = func() time.Time { return now }
+	ctx := context.Background()
+
+	w1, _ := claimByTwoWorkers(t, q, &now)
+
+	// W1's handler finishes late and Acks the claim it no longer holds.
+	if err := q.Ack(ctx, w1); err != nil {
+		t.Fatalf("stale ack must be a no-op, not an error: %v", err)
+	}
+
+	// W2's entry must survive the stale Ack — it is the current claim.
+	if _, err := r.HGet(ctx, "jobs:processing", w1.ID); err != nil {
+		t.Fatalf("stale Ack deleted the re-claimant's processing entry: %v", err)
+	}
+	if got := q.StaleClaimCount(); got != 1 {
+		t.Fatalf("StaleClaimCount = %d, want 1 (stale completion must be observable)", got)
+	}
+
+	// W2 crashes. After its visibility window the job must be resurrected —
+	// not vanished from every list and hash.
+	now = now.Add(2 * time.Minute)
+	n, err := q.Reclaim(ctx)
+	if err != nil {
+		t.Fatalf("reclaim after W2 crash: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("reclaim after W2 crash moved %d jobs, want 1 — job was lost", n)
+	}
+	revived, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("revived job was not re-deliverable: %v", err)
+	}
+	if revived.ID != "pay" {
+		t.Fatalf("revived job = %q, want pay", revived.ID)
+	}
+}
+
+// TestRedisStaleNackCannotTouchReclaimant: W1's late Nack must NOT re-enqueue
+// W2's in-flight job nor delete W2's entry — otherwise the job runs twice
+// concurrently and W2's crash finds nothing to reclaim.
+func TestRedisStaleNackCannotTouchReclaimant(t *testing.T) {
+	r := newMockRedis()
+	q := NewRedisQueue(r, "jobs")
+	now := time.Now()
+	q.now = func() time.Time { return now }
+	ctx := context.Background()
+
+	w1, w2 := claimByTwoWorkers(t, q, &now)
+
+	// W1's handler fails late and Nacks the claim it no longer holds.
+	if err := q.Nack(ctx, w1); err != nil {
+		t.Fatalf("stale nack must be a no-op, not an error: %v", err)
+	}
+
+	// The main list must stay empty (no premature re-enqueue) and W2's
+	// processing entry must survive.
+	if got, err := r.LRange(ctx, "jobs", 0, -1); err != nil || len(got) != 0 {
+		t.Fatalf("stale Nack re-enqueued the re-claimant's job: %v (%v)", got, err)
+	}
+	if _, err := r.HGet(ctx, "jobs:processing", w1.ID); err != nil {
+		t.Fatalf("stale Nack deleted the re-claimant's processing entry: %v", err)
+	}
+	if got := q.StaleClaimCount(); got != 1 {
+		t.Fatalf("StaleClaimCount = %d, want 1 (stale completion must be observable)", got)
+	}
+
+	// Sanity: the CURRENT claimant (W2) can still complete normally — the
+	// fenced nack re-enqueues its job for the next attempt.
+	if err := q.Nack(ctx, w2); err != nil {
+		t.Fatalf("current claimant's nack failed: %v", err)
+	}
+	if _, err := r.HGet(ctx, "jobs:processing", w2.ID); !errors.Is(err, ErrRedisEmpty) {
+		t.Fatalf("current claimant's nack did not clear its entry (err=%v)", err)
+	}
+	retry, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("nacked job was not re-delivered: %v", err)
+	}
+	if retry.ID != "pay" || retry.Attempts != 3 {
+		t.Fatalf("re-delivered = %+v, want pay attempts=3", retry)
+	}
+}
+
+// TestRedisCurrentClaimAckStillWorks is the positive control: the CURRENT
+// claimant's Ack removes the entry (fencing must not break the happy path),
+// and double-acking stays an idempotent no-op.
+func TestRedisCurrentClaimAckStillWorks(t *testing.T) {
+	r := newMockRedis()
+	q := NewRedisQueue(r, "jobs")
+	now := time.Now()
+	q.now = func() time.Time { return now }
+	ctx := context.Background()
+	q.SetVisibilityTimeout(time.Minute)
+
+	_ = q.Enqueue(ctx, Job{ID: "happy", Type: "x"})
+	job, err := q.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if err := q.Ack(ctx, job); err != nil {
+		t.Fatalf("current claimant's ack: %v", err)
+	}
+	if _, err := r.HGet(ctx, "jobs:processing", "happy"); !errors.Is(err, ErrRedisEmpty) {
+		t.Fatalf("ack did not remove the processing entry (err=%v)", err)
+	}
+	// Double-ack is an idempotent no-op, and it is NOT a stale claim.
+	if err := q.Ack(ctx, job); err != nil {
+		t.Fatalf("double ack: %v", err)
+	}
+	if got := q.StaleClaimCount(); got != 0 {
+		t.Fatalf("StaleClaimCount = %d after double ack, want 0", got)
+	}
+}

--- a/battery/queue/replay_test.go
+++ b/battery/queue/replay_test.go
@@ -20,7 +20,7 @@ func TestDBQueue_ReplayFailedJob(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := q.Nack(ctx, job.ID); err != nil { // attempts >= max -> failed
+	if err := q.Nack(ctx, job); err != nil { // attempts >= max -> failed
 		t.Fatal(err)
 	}
 	// Failed jobs are not dequeuable.

--- a/battery/queue/retry_backoff_test.go
+++ b/battery/queue/retry_backoff_test.go
@@ -37,7 +37,7 @@ func TestDBQueue_NackBackoffDelaysRetry(t *testing.T) {
 	q.Enqueue(ctx, Job{Type: "x", MaxAttempts: 3})
 	job, _ := q.Dequeue(ctx) // attempts now = 1
 	before := time.Now().UTC()
-	if err := q.Nack(ctx, job.ID); err != nil {
+	if err := q.Nack(ctx, job); err != nil {
 		t.Fatalf("nack: %v", err)
 	}
 
@@ -65,7 +65,7 @@ func TestDBQueue_NackBackoffCapped(t *testing.T) {
 	q.Enqueue(ctx, Job{Type: "x", Attempts: 20, MaxAttempts: 100})
 	job, _ := q.Dequeue(ctx) // attempts now = 21
 	before := time.Now().UTC()
-	if err := q.Nack(ctx, job.ID); err != nil {
+	if err := q.Nack(ctx, job); err != nil {
 		t.Fatalf("nack: %v", err)
 	}
 	var sched time.Time
@@ -85,7 +85,7 @@ func TestDBQueue_NackNoBackoffByDefault(t *testing.T) {
 
 	q.Enqueue(ctx, Job{Type: "x", MaxAttempts: 3})
 	job1, _ := q.Dequeue(ctx)
-	if err := q.Nack(ctx, job1.ID); err != nil {
+	if err := q.Nack(ctx, job1); err != nil {
 		t.Fatalf("nack: %v", err)
 	}
 	job2, err := q.Dequeue(ctx)
@@ -111,7 +111,7 @@ func TestMemoryQueue_NackReEnqueues(t *testing.T) {
 		t.Fatalf("dequeue: %v", err)
 	}
 
-	if err := q.Nack(ctx, job.ID); err != nil {
+	if err := q.Nack(ctx, job); err != nil {
 		t.Fatalf("nack: %v", err)
 	}
 
@@ -141,7 +141,7 @@ func TestMemoryQueue_NackExhaustedDropsJob(t *testing.T) {
 		t.Fatalf("dequeue: %v", err)
 	}
 	// attempts will become 3 == max on nack → not re-enqueued.
-	if err := q.Nack(ctx, job.ID); err != nil {
+	if err := q.Nack(ctx, job); err != nil {
 		t.Fatalf("nack: %v", err)
 	}
 	if _, err := q.Dequeue(ctx); !errors.Is(err, ErrNoJob) {

--- a/battery/queue/scheduler_cron_test.go
+++ b/battery/queue/scheduler_cron_test.go
@@ -20,8 +20,8 @@ func (r *recordQueue) Enqueue(_ context.Context, j Job) error {
 	return nil
 }
 func (r *recordQueue) Dequeue(_ context.Context, _ ...string) (Job, error) { return Job{}, ErrNoJob }
-func (r *recordQueue) Ack(_ context.Context, _ string) error               { return nil }
-func (r *recordQueue) Nack(_ context.Context, _ string) error              { return nil }
+func (r *recordQueue) Ack(_ context.Context, _ Job) error                  { return nil }
+func (r *recordQueue) Nack(_ context.Context, _ Job) error                 { return nil }
 func (r *recordQueue) Close() error                                        { return nil }
 
 func (r *recordQueue) count() int {

--- a/battery/webhook/inbound_test.go
+++ b/battery/webhook/inbound_test.go
@@ -38,9 +38,9 @@ func (q *stubQueue) Enqueue(_ context.Context, job queue.Job) error {
 func (q *stubQueue) Dequeue(context.Context, ...string) (queue.Job, error) {
 	return queue.Job{}, queue.ErrNoJob
 }
-func (q *stubQueue) Ack(context.Context, string) error  { return nil }
-func (q *stubQueue) Nack(context.Context, string) error { return nil }
-func (q *stubQueue) Close() error                       { return nil }
+func (q *stubQueue) Ack(context.Context, queue.Job) error  { return nil }
+func (q *stubQueue) Nack(context.Context, queue.Job) error { return nil }
+func (q *stubQueue) Close() error                          { return nil }
 
 func (q *stubQueue) count() int {
 	q.mu.Lock()

--- a/cmd/gofastr/blueprint.go
+++ b/cmd/gofastr/blueprint.go
@@ -2236,15 +2236,21 @@ func sortedMapKeys[V any](m map[string]V) []string {
 // "42" on an int column is fine, a fractional float is not) so it never
 // rejects a seed that would have booted.
 func validateBlueprintSeedTypes(bp Blueprint, entitiesByName map[string]framework.EntityDeclaration) error {
+	var errs schemaErrors
 	for _, seed := range bp.Seed {
 		decl, known := entitiesByName[seed.Entity]
 		if !known {
 			// A seed for an undeclared entity fails at boot with
 			// "no handler" — same fail-late shape, catch it here too.
-			return fmt.Errorf("blueprint: seed targets unknown entity %q — declare an entity named %q under entities: (or fix the seed's entity: value)", seed.Entity, seed.Entity)
+			errs.add(fmt.Errorf("blueprint: seed targets unknown entity %q — declare an entity named %q under entities: (or fix the seed's entity: value)", seed.Entity, seed.Entity))
+			continue
 		}
 		for i, row := range seed.Rows {
-			for name, value := range row {
+			// Rows are maps: iterate their keys sorted so a row with two
+			// bad values reports both, in a stable order, instead of one
+			// picked by map-iteration luck.
+			for _, name := range sortedMapKeys(row) {
+				value := row[name]
 				field, fieldKind := blueprintSeedFieldKind(decl, name)
 				if !fieldKind {
 					continue // not a declared column: not this check's business
@@ -2255,14 +2261,15 @@ func validateBlueprintSeedTypes(bp Blueprint, entitiesByName map[string]framewor
 				}
 				if strings.EqualFold(strings.TrimSpace(field.Type), "relation") && strings.TrimSpace(field.To) != "" {
 					if target, ok := entitiesByName[strings.TrimSpace(field.To)]; ok {
-						return fmt.Errorf("blueprint: seed row %d for entity %q sets %q to %v — a relation column holds the target row's id, and every generated entity's id is a UUID string, so a number can never satisfy it; reference a row seeded earlier in the same pass instead: %q", i, seed.Entity, name, value, "@"+strings.TrimSpace(field.To)+"."+blueprintDisplayField(target)+"=<value>")
+						errs.add(fmt.Errorf("blueprint: seed row %d for entity %q sets %q to %v — a relation column holds the target row's id, and every generated entity's id is a UUID string, so a number can never satisfy it; reference a row seeded earlier in the same pass instead: %q", i+1, seed.Entity, name, value, "@"+strings.TrimSpace(field.To)+"."+blueprintDisplayField(target)+"=<value>"))
+						continue
 					}
 				}
-				return fmt.Errorf("blueprint: seed row %d for entity %q sets %q (type %s) to %v — the generated app would reject it at boot: %s", i, seed.Entity, name, field.Type, value, reason)
+				errs.add(fmt.Errorf("blueprint: seed row %d for entity %q sets %q (type %s) to %v — the generated app would reject it at boot: %s", i+1, seed.Entity, name, field.Type, value, reason))
 			}
 		}
 	}
-	return nil
+	return errs.err()
 }
 
 // blueprintSeedFieldKind resolves a seed row key to the field declaration
@@ -4147,10 +4154,10 @@ func renderBlueprintMain(bp Blueprint) string {
 		sb.WriteString("\t\t\tn, err := ch.CountAll(ctx, framework.ListOptions{})\n")
 		sb.WriteString("\t\t\tif err != nil {\n\t\t\t\treturn fmt.Errorf(\"seed %s: count: %w\", s.Entity, err)\n\t\t\t}\n")
 		sb.WriteString("\t\t\tif n > 0 {\n\t\t\t\tcontinue\n\t\t\t}\n")
-		sb.WriteString("\t\t\tfor _, row := range s.Rows {\n")
+		sb.WriteString("\t\t\tfor i, row := range s.Rows {\n")
 		sb.WriteString("\t\t\t\tresolveSeedRefs(ctx, fwApp, row)\n")
 		sb.WriteString("\t\t\t\tif _, err := ch.CreateOne(ctx, row); err != nil {\n")
-		sb.WriteString("\t\t\t\t\treturn seedCreateError(s.Entity, row, err)\n")
+		sb.WriteString("\t\t\t\t\treturn seedCreateError(s.Entity, i+1, err)\n")
 		sb.WriteString("\t\t\t\t}\n")
 		sb.WriteString("\t\t\t}\n")
 		sb.WriteString("\t\t}\n")
@@ -4322,8 +4329,11 @@ func renderBlueprintMain(bp Blueprint) string {
 		sb.WriteString("// bare string \"validation failed\" — the messages worth reading live in\n")
 		sb.WriteString("// Fields() — so a plain %w would abort the boot with zero actionable\n")
 		sb.WriteString("// information. Unwrap, print every field message (sorted, so the output\n")
-		sb.WriteString("// is stable), and name the row so it can be found in gofastr.yml.\n")
-		sb.WriteString("func seedCreateError(entity string, row map[string]any, err error) error {\n")
+		sb.WriteString("// is stable), and name the row by its one-based position in the\n")
+		sb.WriteString("// blueprint's seed: block. The position — never a row value — is the\n")
+		sb.WriteString("// label: this error aborts boot through log.Fatal, so its text lands\n")
+		sb.WriteString("// in application logs, and seed rows carry admin emails and passwords.\n")
+		sb.WriteString("func seedCreateError(entity string, index int, err error) error {\n")
 		sb.WriteString("\tvar ve *crud.ValidationError\n")
 		sb.WriteString("\tif !errors.As(err, &ve) || len(ve.Fields()) == 0 {\n")
 		sb.WriteString("\t\treturn fmt.Errorf(\"seed %s: %w\", entity, err)\n")
@@ -4334,24 +4344,13 @@ func renderBlueprintMain(bp Blueprint) string {
 		sb.WriteString("\t}\n")
 		sb.WriteString("\tsort.Strings(names)\n")
 		sb.WriteString("\tvar b strings.Builder\n")
-		sb.WriteString("\tfmt.Fprintf(&b, \"seed %s row %s failed validation:\", entity, seedRowLabel(row))\n")
+		sb.WriteString("\tfmt.Fprintf(&b, \"seed %s row %d failed validation:\", entity, index)\n")
 		sb.WriteString("\tfor _, name := range names {\n")
 		sb.WriteString("\t\tfor _, msg := range ve.Fields()[name] {\n")
 		sb.WriteString("\t\t\tfmt.Fprintf(&b, \"\\n  - %s: %s\", name, msg)\n")
 		sb.WriteString("\t\t}\n")
 		sb.WriteString("\t}\n")
 		sb.WriteString("\treturn fmt.Errorf(\"%s\\ncause: %w\", b.String(), err)\n")
-		sb.WriteString("}\n")
-		sb.WriteString("\n// seedRowLabel picks the scalar that identifies a seed row against the\n")
-		sb.WriteString("// blueprint's seed: block (the title/name/email it was authored under),\n")
-		sb.WriteString("// falling back to the whole row.\n")
-		sb.WriteString("func seedRowLabel(row map[string]any) string {\n")
-		sb.WriteString("\tfor _, k := range []string{\"title\", \"name\", \"email\", \"label\", \"slug\", \"body\", \"key\"} {\n")
-		sb.WriteString("\t\tif s, ok := row[k].(string); ok && s != \"\" {\n")
-		sb.WriteString("\t\t\treturn fmt.Sprintf(\"%q\", s)\n")
-		sb.WriteString("\t\t}\n")
-		sb.WriteString("\t}\n")
-		sb.WriteString("\treturn fmt.Sprintf(\"%v\", row)\n")
 		sb.WriteString("}\n")
 	}
 	return sb.String()

--- a/cmd/gofastr/blueprint.go
+++ b/cmd/gofastr/blueprint.go
@@ -1832,13 +1832,42 @@ func validateIslandPathsAreDistinct(bp Blueprint) error {
 	return nil
 }
 
+// schemaErrors accumulates validation findings so one pass reports every
+// fixable problem, not just the first. The alternative is a serial
+// guess-and-recompile loop: fix one error, rerun, meet the next. A single
+// finding returns unchanged (existing exact-shape callers keep their
+// message); multiple findings join under a count.
+type schemaErrors struct{ errs []error }
+
+func (s *schemaErrors) add(err error) {
+	if err != nil {
+		s.errs = append(s.errs, err)
+	}
+}
+
+func (s *schemaErrors) err() error {
+	switch len(s.errs) {
+	case 0:
+		return nil
+	case 1:
+		return s.errs[0]
+	default:
+		msgs := make([]string, len(s.errs))
+		for i, err := range s.errs {
+			msgs[i] = err.Error()
+		}
+		return fmt.Errorf("blueprint has %d validation errors:\n  - %s", len(s.errs), strings.Join(msgs, "\n  - "))
+	}
+}
+
 func validateBlueprint(bp Blueprint) error {
+	var errs schemaErrors
 	// Production auth without a signing key: the generated app's auth
 	// battery fails closed at boot (battery/auth Init refuses an empty
 	// JWTSecret with DevMode=false). Fail at generate/validate time
 	// instead, with the same remedy.
 	if bp.App.Auth.Enabled && !bp.App.Auth.DevMode && bp.App.Auth.JWTSecret == "" {
-		return fmt.Errorf("blueprint: app.auth has dev_mode: false but no jwt_secret — the generated app would refuse to boot (production auth requires a signing key); set jwt_secret from your secret store, or set dev_mode: true for local development")
+		errs.add(fmt.Errorf("blueprint: app.auth has dev_mode: false but no jwt_secret — the generated app would refuse to boot (production auth requires a signing key); set jwt_secret from your secret store, or set dev_mode: true for local development"))
 	}
 	// A multi-tenant entity needs a request-time tenant resolver, and the
 	// right one is host-specific (subdomain, JWT claim, user's org). The
@@ -1848,7 +1877,7 @@ func validateBlueprint(bp Blueprint) error {
 	// to generate rather than ship that.
 	for _, decl := range bp.Entities {
 		if entityDeclarationScope(decl).MultiTenant {
-			return fmt.Errorf("blueprint: entity %q sets multi_tenant: true, but the generator cannot emit a tenant resolver (the strategy — subdomain, JWT claim, user's org — is app-specific). A generated app with none reads empty and stamps an empty tenant on every write. Wire tenant.TenantMiddleware + SetTenantID in your own main (see `gofastr docs multi-tenant`) and drop multi_tenant from the blueprint, or use owner_field for per-user scoping", decl.Name)
+			errs.add(fmt.Errorf("blueprint: entity %q sets multi_tenant: true, but the generator cannot emit a tenant resolver (the strategy — subdomain, JWT claim, user's org — is app-specific). A generated app with none reads empty and stamps an empty tenant on every write. Wire tenant.TenantMiddleware + SetTenantID in your own main (see `gofastr docs multi-tenant`) and drop multi_tenant from the blueprint, or use owner_field for per-user scoping", decl.Name))
 		}
 	}
 	// Island endpoints are keyed by toSnakeCase(screen name) + entity, so
@@ -1861,20 +1890,18 @@ func validateBlueprint(bp Blueprint) error {
 	// The same collapse happens when one screen lists the same entity twice:
 	// both blocks derive one endpoint and one signal, so sorting either table
 	// rewrites both from the first block's columns.
-	if err := validateIslandPathsAreDistinct(bp); err != nil {
-		return err
-	}
+	errs.add(validateIslandPathsAreDistinct(bp))
 	if bp.App.PWA.Enabled {
 		switch bp.App.PWA.Display {
 		case "", "standalone", "fullscreen", "minimal-ui", "browser":
 		default:
-			return fmt.Errorf("blueprint: app.pwa.display %q is not a web-app-manifest display mode; use standalone, fullscreen, minimal-ui, or browser (or omit it for standalone)", bp.App.PWA.Display)
+			errs.add(fmt.Errorf("blueprint: app.pwa.display %q is not a web-app-manifest display mode; use standalone, fullscreen, minimal-ui, or browser (or omit it for standalone)", bp.App.PWA.Display))
 		}
 		if u := bp.App.PWA.StartURL; u != "" && !strings.HasPrefix(u, "/") {
-			return fmt.Errorf("blueprint: app.pwa.start_url %q must be a root-relative path (start with /)", u)
+			errs.add(fmt.Errorf("blueprint: app.pwa.start_url %q must be a root-relative path (start with /)", u))
 		}
 		if s := bp.App.PWA.Scope; s != "" && !strings.HasPrefix(s, "/") {
-			return fmt.Errorf("blueprint: app.pwa.scope %q must be a root-relative path (start with /)", s)
+			errs.add(fmt.Errorf("blueprint: app.pwa.scope %q must be a root-relative path (start with /)", s))
 		}
 	}
 	// Theme VALUES need the same boundary as theme keys. The emitter writes
@@ -1885,11 +1912,13 @@ func validateBlueprint(bp Blueprint) error {
 	// host (/app.css) and the admin battery serve. A `;` or `}` there closes
 	// :root and appends rules of the author's choosing; `url(` is an outbound
 	// fetch on every page load. style.ValidateColorValue is that one grammar,
-	// called here rather than copied.
-	for key, value := range bp.App.Theme {
+	// called here rather than copied. Keys are sorted so the multi-error
+	// report is deterministic (map iteration order is not).
+	for _, key := range sortedMapKeys(bp.App.Theme) {
+		value := bp.App.Theme[key]
 		if _, ok := blueprintThemeColorPath(key); ok {
 			if err := style.ValidateColorValue(value); err != nil {
-				return fmt.Errorf("blueprint: app.theme %s %q: %w", key, value, err)
+				errs.add(fmt.Errorf("blueprint: app.theme %s %q: %w", key, value, err))
 			}
 			continue
 		}
@@ -1900,24 +1929,28 @@ func validateBlueprint(bp Blueprint) error {
 		if key == "font_body" || key == "font_heading" || key == "font_display" {
 			continue
 		}
-		return fmt.Errorf("blueprint: app.theme has unsupported token %q", key)
+		errs.add(fmt.Errorf("blueprint: app.theme has unsupported token %q", key))
 	}
-	for key, value := range bp.App.ThemeDark {
+	for _, key := range sortedMapKeys(bp.App.ThemeDark) {
+		value := bp.App.ThemeDark[key]
 		if _, ok := blueprintThemeColorPath(key); !ok {
-			return fmt.Errorf("blueprint: app.theme.dark has unsupported color token %q", key)
+			errs.add(fmt.Errorf("blueprint: app.theme.dark has unsupported color token %q", key))
+			continue
 		}
 		if err := style.ValidateColorValue(value); err != nil {
-			return fmt.Errorf("blueprint: app.theme.dark %s %q: %w", key, value, err)
+			errs.add(fmt.Errorf("blueprint: app.theme.dark %s %q: %w", key, value, err))
 		}
 	}
 	entityNames := map[string]bool{}
 	entitiesByName := map[string]framework.EntityDeclaration{}
 	for _, decl := range bp.Entities {
 		if decl.Name == "" {
-			return fmt.Errorf("blueprint: entity name is required")
+			errs.add(fmt.Errorf("blueprint: entity name is required"))
+			continue
 		}
 		if !isGoIdentifier(toCamelCase(decl.Name)) {
-			return fmt.Errorf("blueprint: entity %q does not produce a valid Go identifier — the generated code would not compile; rename it to start with a letter (e.g. \"two_fa_tokens\" instead of \"2fa_tokens\")", decl.Name)
+			errs.add(fmt.Errorf("blueprint: entity %q does not produce a valid Go identifier — the generated code would not compile; rename it to start with a letter (e.g. \"two_fa_tokens\" instead of \"2fa_tokens\")", decl.Name))
+			continue
 		}
 		// The table name reaches two sinks that neither re-escape nor
 		// re-validate it: the generated typed client emits it into Go string
@@ -1926,11 +1959,12 @@ func validateBlueprint(bp Blueprint) error {
 		// identifier above; `table:` was the way around that.
 		if decl.Table != "" {
 			if _, err := query.SafeIdent(decl.Table); err != nil {
-				return fmt.Errorf("blueprint: entity %q table %q must be letters, digits and underscores (it becomes a SQL identifier and is emitted into generated Go)", decl.Name, decl.Table)
+				errs.add(fmt.Errorf("blueprint: entity %q table %q must be letters, digits and underscores (it becomes a SQL identifier and is emitted into generated Go)", decl.Name, decl.Table))
 			}
 		}
 		if entityNames[decl.Name] {
-			return fmt.Errorf("blueprint: duplicate entity %q", decl.Name)
+			errs.add(fmt.Errorf("blueprint: duplicate entity %q", decl.Name))
+			continue
 		}
 		entityNames[decl.Name] = true
 		entitiesByName[decl.Name] = decl
@@ -1940,20 +1974,20 @@ func validateBlueprint(bp Blueprint) error {
 		// where the error can name the offending field.
 		for _, f := range decl.Fields {
 			if !isGoIdentifier(toCamelCase(f.Name)) {
-				return fmt.Errorf("blueprint: entity %q field %q does not produce a valid Go identifier — rename it to letters, digits and underscores starting with a letter", decl.Name, f.Name)
+				errs.add(fmt.Errorf("blueprint: entity %q field %q does not produce a valid Go identifier — rename it to letters, digits and underscores starting with a letter", decl.Name, f.Name))
 			}
 			for _, v := range f.Values {
 				if strings.ContainsAny(v, "`\"\\\n\r") {
-					return fmt.Errorf("blueprint: entity %q field %q enum value %q contains a quote, backtick, backslash or newline — these break the generated Go source", decl.Name, f.Name, v)
+					errs.add(fmt.Errorf("blueprint: entity %q field %q enum value %q contains a quote, backtick, backslash or newline — these break the generated Go source", decl.Name, f.Name, v))
 				}
 			}
 		}
 		if _, err := decl.Config(); err != nil {
-			return fmt.Errorf("blueprint: entity %q: %w", decl.Name, err)
+			errs.add(fmt.Errorf("blueprint: entity %q: %w", decl.Name, err))
 		}
 		for _, endpoint := range decl.Endpoints {
 			if endpoint.MCP {
-				return fmt.Errorf("blueprint: entity %q endpoint %q cannot set mcp=true without Go MCP handler", decl.Name, endpoint.Path)
+				errs.add(fmt.Errorf("blueprint: entity %q endpoint %q cannot set mcp=true without Go MCP handler", decl.Name, endpoint.Path))
 			}
 		}
 	}
@@ -1967,10 +2001,11 @@ func validateBlueprint(bp Blueprint) error {
 				continue
 			}
 			if strings.TrimSpace(field.To) == "" {
-				return fmt.Errorf("blueprint: entity %q field %q has type \"relation\" but no target — add `to: <entity>` naming a declared entity", decl.Name, field.Name)
+				errs.add(fmt.Errorf("blueprint: entity %q field %q has type \"relation\" but no target — add `to: <entity>` naming a declared entity", decl.Name, field.Name))
+				continue
 			}
 			if !entityNames[field.To] {
-				return fmt.Errorf("blueprint: entity %q field %q is a relation to unknown entity %q — declare an entity named %q under entities: (or fix the field's to: value)", decl.Name, field.Name, field.To, field.To)
+				errs.add(fmt.Errorf("blueprint: entity %q field %q is a relation to unknown entity %q — declare an entity named %q under entities: (or fix the field's to: value)", decl.Name, field.Name, field.To, field.To))
 			}
 		}
 		// Both sides of a rename become column names in emitted
@@ -1985,19 +2020,19 @@ func validateBlueprint(bp Blueprint) error {
 		}
 		for old, next := range decl.Renames {
 			if _, err := query.SafeIdent(old); err != nil {
-				return fmt.Errorf("blueprint: entity %q rename key %q is not a safe column name: %w", decl.Name, old, err)
+				errs.add(fmt.Errorf("blueprint: entity %q rename key %q is not a safe column name: %w", decl.Name, old, err))
 			}
 			if _, err := query.SafeIdent(next); err != nil {
-				return fmt.Errorf("blueprint: entity %q rename target %q is not a safe column name: %w", decl.Name, next, err)
+				errs.add(fmt.Errorf("blueprint: entity %q rename target %q is not a safe column name: %w", decl.Name, next, err))
 			}
 			if old == next {
-				return fmt.Errorf("blueprint: entity %q renames %q to itself — drop the entry", decl.Name, old)
+				errs.add(fmt.Errorf("blueprint: entity %q renames %q to itself — drop the entry", decl.Name, old))
 			}
 			if !declaredFields[next] {
-				return fmt.Errorf("blueprint: entity %q renames %q to %q, but %q is not a declared field — a rename only fires when the new name is declared on the entity", decl.Name, old, next, next)
+				errs.add(fmt.Errorf("blueprint: entity %q renames %q to %q, but %q is not a declared field — a rename only fires when the new name is declared on the entity", decl.Name, old, next, next))
 			}
 			if declaredFields[old] {
-				return fmt.Errorf("blueprint: entity %q renames %q to %q while still declaring %q as a field — the diff would see both columns; remove the old field", decl.Name, old, next, old)
+				errs.add(fmt.Errorf("blueprint: entity %q renames %q to %q while still declaring %q as a field — the diff would see both columns; remove the old field", decl.Name, old, next, old))
 			}
 		}
 		// A relation name is an identifier, not a label: the entity emitter
@@ -2013,41 +2048,52 @@ func validateBlueprint(bp Blueprint) error {
 		}
 		for _, rel := range decl.Relations {
 			if rel.Name == "" {
-				return fmt.Errorf("blueprint: entity %q has a relation with no name — add `name: <name>`; it becomes a struct field and an include name in the generated Go", decl.Name)
+				errs.add(fmt.Errorf("blueprint: entity %q has a relation with no name — add `name: <name>`; it becomes a struct field and an include name in the generated Go", decl.Name))
+				continue
 			}
 			camel := toCamelCase(rel.Name)
 			if !isGoIdentifier(camel) {
-				return fmt.Errorf("blueprint: entity %q relation %q does not produce a valid Go identifier — it is emitted as a struct field name and an include constant, so the generated code would not compile; use letters, digits and underscores (e.g. \"author\" or \"line_items\")", decl.Name, rel.Name)
+				errs.add(fmt.Errorf("blueprint: entity %q relation %q does not produce a valid Go identifier — it is emitted as a struct field name and an include constant, so the generated code would not compile; use letters, digits and underscores (e.g. \"author\" or \"line_items\")", decl.Name, rel.Name))
+				continue
 			}
 			if owner, dup := relNames[camel]; dup {
-				return fmt.Errorf("blueprint: entity %q relation %q collides with %s — both become the Go struct field %s, which would not compile; rename one", decl.Name, rel.Name, owner, camel)
+				errs.add(fmt.Errorf("blueprint: entity %q relation %q collides with %s — both become the Go struct field %s, which would not compile; rename one", decl.Name, rel.Name, owner, camel))
+				continue
 			}
 			relNames[camel] = "relation " + rel.Name
 			if rel.Entity == "" {
-				return fmt.Errorf("blueprint: entity %q relation %q target entity is required — add `entity: <name>` referencing a declared entity", decl.Name, rel.Name)
+				errs.add(fmt.Errorf("blueprint: entity %q relation %q target entity is required — add `entity: <name>` referencing a declared entity", decl.Name, rel.Name))
+				continue
 			}
 			if !entityNames[rel.Entity] {
-				return fmt.Errorf("blueprint: entity %q relation %q targets unknown entity %q — declare an entity named %q under entities: (or fix the relation's entity: value)", decl.Name, rel.Name, rel.Entity, rel.Entity)
+				errs.add(fmt.Errorf("blueprint: entity %q relation %q targets unknown entity %q — declare an entity named %q under entities: (or fix the relation's entity: value)", decl.Name, rel.Name, rel.Entity, rel.Entity))
 			}
 		}
 	}
+	// Seed values are typed inserts the generated app runs through the
+	// CRUD validators at boot. Check them here — see validateBlueprintSeedTypes.
+	errs.add(validateBlueprintSeedTypes(bp, entitiesByName))
 	routes := map[string]bool{}
 	for _, screen := range bp.Screens {
 		if screen.Name == "" {
-			return fmt.Errorf("blueprint: screen name is required")
+			errs.add(fmt.Errorf("blueprint: screen name is required"))
+			continue
 		}
 		if !isGoIdentifier(toCamelCase(screen.Name)) {
-			return fmt.Errorf("blueprint: screen %q does not produce a valid Go identifier", screen.Name)
+			errs.add(fmt.Errorf("blueprint: screen %q does not produce a valid Go identifier", screen.Name))
+			continue
 		}
 		if screen.Route == "" {
-			return fmt.Errorf("blueprint: screen %q route is required", screen.Name)
+			errs.add(fmt.Errorf("blueprint: screen %q route is required", screen.Name))
+			continue
 		}
 		if routes[screen.Route] {
-			return fmt.Errorf("blueprint: duplicate screen route %q", screen.Route)
+			errs.add(fmt.Errorf("blueprint: duplicate screen route %q", screen.Route))
+			continue
 		}
 		routes[screen.Route] = true
 		if _, err := screenTypeConst(screen.Type); err != nil {
-			return err
+			errs.add(err)
 		}
 		// blueprintScreenLayoutExpr maps ANYTHING that is not "marketing" to
 		// appLayout, so a typo ("markting") silently renders a public marketing
@@ -2059,12 +2105,10 @@ func validateBlueprint(bp Blueprint) error {
 		case "", "app", "marketing":
 			// recognized
 		default:
-			return fmt.Errorf("blueprint: screen %q layout %q is not a layout; use \"app\", \"marketing\", or omit it", screen.Name, screen.Layout)
+			errs.add(fmt.Errorf("blueprint: screen %q layout %q is not a layout; use \"app\", \"marketing\", or omit it", screen.Name, screen.Layout))
 		}
 		for _, block := range screen.Body {
-			if err := validateBlueprintBlock(screen.Name, entitiesByName, block); err != nil {
-				return err
-			}
+			errs.add(validateBlueprintBlock(screen.Name, entitiesByName, block))
 		}
 		// entity_detail renders .Detail(ctx, s.id) and the list's "View" link is
 		// BasePath+"/"+id; entity_form mode:edit posts to {entity}/{id}. Both
@@ -2076,12 +2120,10 @@ func validateBlueprint(bp Blueprint) error {
 				if !detail {
 					what = "entity_form (mode: edit)"
 				}
-				return fmt.Errorf("blueprint: screen %q has an %s block but its route %q has no {id} parameter — add {id} (e.g. %s/{id}) so the record id is in the URL", screen.Name, what, screen.Route, strings.TrimRight(screen.Route, "/"))
+				errs.add(fmt.Errorf("blueprint: screen %q has an %s block but its route %q has no {id} parameter — add {id} (e.g. %s/{id}) so the record id is in the URL", screen.Name, what, screen.Route, strings.TrimRight(screen.Route, "/")))
 			}
 		}
-		if err := validateBlueprintActions(screen.Name, screen.Body); err != nil {
-			return err
-		}
+		errs.add(validateBlueprintActions(screen.Name, screen.Body))
 	}
 	endpointNames := map[string]bool{}
 	endpointHandlers := map[string]bool{}
@@ -2089,46 +2131,55 @@ func validateBlueprint(bp Blueprint) error {
 	crudRoutes := blueprintCRUDRoutes(bp.Entities)
 	for _, endpoint := range bp.Endpoints {
 		if endpoint.Name == "" {
-			return fmt.Errorf("blueprint: endpoint name is required")
+			errs.add(fmt.Errorf("blueprint: endpoint name is required"))
+			continue
 		}
 		if endpointNames[endpoint.Name] {
-			return fmt.Errorf("blueprint: duplicate endpoint %q", endpoint.Name)
+			errs.add(fmt.Errorf("blueprint: duplicate endpoint %q", endpoint.Name))
+			continue
 		}
 		endpointNames[endpoint.Name] = true
 		if endpoint.Handler == "" {
-			return fmt.Errorf("blueprint: endpoint %q handler is required", endpoint.Name)
+			errs.add(fmt.Errorf("blueprint: endpoint %q handler is required", endpoint.Name))
+			continue
 		}
 		handlerName := toCamelCase(endpoint.Handler)
 		if !isGoIdentifier(handlerName) {
-			return fmt.Errorf("blueprint: endpoint %q handler %q does not produce a valid Go identifier", endpoint.Name, endpoint.Handler)
+			errs.add(fmt.Errorf("blueprint: endpoint %q handler %q does not produce a valid Go identifier", endpoint.Name, endpoint.Handler))
+			continue
 		}
 		if endpointHandlers[handlerName] {
-			return fmt.Errorf("blueprint: duplicate endpoint handler %q", endpoint.Handler)
+			errs.add(fmt.Errorf("blueprint: duplicate endpoint handler %q", endpoint.Handler))
+			continue
 		}
 		endpointHandlers[handlerName] = true
 		if endpoint.Path == "" {
-			return fmt.Errorf("blueprint: endpoint %q path is required", endpoint.Name)
+			errs.add(fmt.Errorf("blueprint: endpoint %q path is required", endpoint.Name))
+			continue
 		}
 		method := strings.ToUpper(endpoint.Method)
 		if method == "" {
-			return fmt.Errorf("blueprint: endpoint %q method is required", endpoint.Name)
+			errs.add(fmt.Errorf("blueprint: endpoint %q method is required", endpoint.Name))
+			continue
 		}
 		if _, ok := validHTTPMethods[method]; !ok {
-			return fmt.Errorf("blueprint: endpoint %q method %q is not supported", endpoint.Name, endpoint.Method)
+			errs.add(fmt.Errorf("blueprint: endpoint %q method %q is not supported", endpoint.Name, endpoint.Method))
+			continue
 		}
 		if endpoint.Entity != "" && !entityNames[endpoint.Entity] {
-			return fmt.Errorf("blueprint: endpoint %q targets unknown entity %q", endpoint.Name, endpoint.Entity)
+			errs.add(fmt.Errorf("blueprint: endpoint %q targets unknown entity %q", endpoint.Name, endpoint.Entity))
 		}
 		routeKey := method + " " + blueprintEndpointPath(endpoint)
 		if endpointRoutes[routeKey] {
-			return fmt.Errorf("blueprint: duplicate endpoint route %q", routeKey)
+			errs.add(fmt.Errorf("blueprint: duplicate endpoint route %q", routeKey))
+			continue
 		}
 		endpointRoutes[routeKey] = true
 		if crudRoutes[routeKey] {
-			return fmt.Errorf("blueprint: endpoint %q collides with generated CRUD route %q", endpoint.Name, routeKey)
+			errs.add(fmt.Errorf("blueprint: endpoint %q collides with generated CRUD route %q", endpoint.Name, routeKey))
 		}
 		if endpoint.MCP {
-			return fmt.Errorf("blueprint: endpoint %q cannot set mcp=true without Go MCP handler", endpoint.Name)
+			errs.add(fmt.Errorf("blueprint: endpoint %q cannot set mcp=true without Go MCP handler", endpoint.Name))
 		}
 	}
 	for _, group := range []struct {
@@ -2142,18 +2193,177 @@ func validateBlueprint(bp Blueprint) error {
 		names := map[string]bool{}
 		for _, item := range group.items {
 			if item.Name == "" {
-				return fmt.Errorf("blueprint: %s name is required", group.label)
+				errs.add(fmt.Errorf("blueprint: %s name is required", group.label))
+				continue
 			}
 			if !isGoIdentifier(toCamelCase(item.Name)) {
-				return fmt.Errorf("blueprint: %s %q does not produce a valid Go identifier", group.label, item.Name)
+				errs.add(fmt.Errorf("blueprint: %s %q does not produce a valid Go identifier", group.label, item.Name))
+				continue
 			}
 			if names[item.Name] {
-				return fmt.Errorf("blueprint: duplicate %s %q", group.label, item.Name)
+				errs.add(fmt.Errorf("blueprint: duplicate %s %q", group.label, item.Name))
+				continue
 			}
 			names[item.Name] = true
 		}
 	}
+	return errs.err()
+}
+
+// sortedMapKeys returns m's keys in sorted order, so multi-error reports
+// built from map iteration are deterministic.
+func sortedMapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// validateBlueprintSeedTypes rejects seed values whose YAML type can never
+// satisfy the target field's runtime validator (core/schema/validate.go).
+//
+// Without this check, a blueprint like the blog's — comments.post_id is a
+// relation (a UUID string column) seeded with `post_id: 1` — sails through
+// generate, compiles, and then the app DIES at boot with
+// "seed comments: validation failed": the least discoverable point in the
+// pipeline, after the author has done everything the tool told them to.
+// Every generated entity has a UUID string primary key, so a numeric
+// literal on a relation column can never work; the fix the author needs is
+// the "@entity.field=value" reference form resolveSeedRefs resolves at
+// boot. The check mirrors the runtime's coercion rules exactly (a string
+// "42" on an int column is fine, a fractional float is not) so it never
+// rejects a seed that would have booted.
+func validateBlueprintSeedTypes(bp Blueprint, entitiesByName map[string]framework.EntityDeclaration) error {
+	for _, seed := range bp.Seed {
+		decl, known := entitiesByName[seed.Entity]
+		if !known {
+			// A seed for an undeclared entity fails at boot with
+			// "no handler" — same fail-late shape, catch it here too.
+			return fmt.Errorf("blueprint: seed targets unknown entity %q — declare an entity named %q under entities: (or fix the seed's entity: value)", seed.Entity, seed.Entity)
+		}
+		for i, row := range seed.Rows {
+			for name, value := range row {
+				field, fieldKind := blueprintSeedFieldKind(decl, name)
+				if !fieldKind {
+					continue // not a declared column: not this check's business
+				}
+				reason := seedValueRejection(field, value)
+				if reason == "" {
+					continue
+				}
+				if strings.EqualFold(strings.TrimSpace(field.Type), "relation") && strings.TrimSpace(field.To) != "" {
+					if target, ok := entitiesByName[strings.TrimSpace(field.To)]; ok {
+						return fmt.Errorf("blueprint: seed row %d for entity %q sets %q to %v — a relation column holds the target row's id, and every generated entity's id is a UUID string, so a number can never satisfy it; reference a row seeded earlier in the same pass instead: %q", i, seed.Entity, name, value, "@"+strings.TrimSpace(field.To)+"."+blueprintDisplayField(target)+"=<value>")
+					}
+				}
+				return fmt.Errorf("blueprint: seed row %d for entity %q sets %q (type %s) to %v — the generated app would reject it at boot: %s", i, seed.Entity, name, field.Type, value, reason)
+			}
+		}
+	}
 	return nil
+}
+
+// blueprintSeedFieldKind resolves a seed row key to the field declaration
+// it targets. Synthesized system columns (the UUID id) get a synthesized
+// declaration. The second return is false for keys that match no column.
+func blueprintSeedFieldKind(decl framework.EntityDeclaration, name string) (framework.FieldDeclaration, bool) {
+	for _, f := range decl.Fields {
+		if f.Name == name {
+			return f, true
+		}
+	}
+	if name == "id" {
+		// Every generated model carries `ID string` (renderEntityModel);
+		// seeding it directly is legal but takes a UUID string.
+		return framework.FieldDeclaration{Name: "id", Type: "uuid"}, true
+	}
+	return framework.FieldDeclaration{}, false
+}
+
+// seedValueRejection returns "" when value can satisfy the field's runtime
+// validator, else the message that validator would produce. Mirrors the
+// per-type validators in core/schema/validate.go — including their
+// coercions (toString accepts only strings; toInt64 accepts integral
+// floats and integer-parsable strings; toFloat64 accepts no strings) —
+// so the generate-time verdict never disagrees with boot.
+func seedValueRejection(field framework.FieldDeclaration, value any) string {
+	if value == nil {
+		return "" // absent value; required-ness fails at boot with field detail
+	}
+	switch strings.ToLower(strings.TrimSpace(field.Type)) {
+	case "relation", "uuid":
+		if _, ok := value.(string); !ok {
+			return "must be a string reference"
+		}
+	case "string", "text", "enum", "timestamp", "date", "image", "file":
+		s, ok := value.(string)
+		if !ok {
+			return "must be a string"
+		}
+		// An enum's Values list is closed; a string outside it can never
+		// satisfy the validator either.
+		if strings.EqualFold(strings.TrimSpace(field.Type), "enum") && len(field.Values) > 0 {
+			for _, allowed := range field.Values {
+				if s == allowed {
+					return ""
+				}
+			}
+			return fmt.Sprintf("must be one of %v", field.Values)
+		}
+	case "int", "integer":
+		switch v := value.(type) {
+		case int64:
+		case float64:
+			if v != math.Trunc(v) {
+				return "must be an integer"
+			}
+		case string:
+			if _, err := strconv.ParseInt(v, 10, 64); err != nil {
+				return "must be an integer"
+			}
+		default:
+			return "must be an integer"
+		}
+	case "float", "number":
+		switch value.(type) {
+		case int64, float64:
+		default:
+			return "must be a number"
+		}
+	case "decimal":
+		// Numbers are fine: the stub emitter re-quotes them as the decimal
+		// string the validator expects (blueprintSeedFieldIsDecimal).
+		switch value.(type) {
+		case string, int64, float64:
+		default:
+			return "must be a decimal string"
+		}
+	case "bool", "boolean":
+		switch v := value.(type) {
+		case bool:
+		case int64:
+			if v != 0 && v != 1 {
+				return "must be true or false"
+			}
+		case float64:
+			if v != 0 && v != 1 {
+				return "must be true or false"
+			}
+		case string:
+			switch strings.ToLower(v) {
+			case "true", "false", "1", "0":
+			default:
+				return "must be true or false"
+			}
+		default:
+			return "must be true or false"
+		}
+	case "json":
+		// Any value marshals — the validator accepts strings, maps, lists.
+	}
+	return ""
 }
 
 func blueprintCRUDRoutes(entities []framework.EntityDeclaration) map[string]bool {
@@ -3812,6 +4022,7 @@ func renderBlueprintMain(bp Blueprint) string {
 	sb.WriteString("import (\n")
 	if hasSeed {
 		sb.WriteString("\t\"context\"\n")
+		sb.WriteString("\t\"errors\"\n")
 	}
 	sb.WriteString("\t\"database/sql\"\n")
 	sb.WriteString("\t\"fmt\"\n")
@@ -3819,6 +4030,7 @@ func renderBlueprintMain(bp Blueprint) string {
 	sb.WriteString("\t\"net/http\"\n")
 	sb.WriteString("\t\"os\"\n")
 	if hasSeed {
+		sb.WriteString("\t\"sort\"\n")
 		sb.WriteString("\t\"strings\"\n")
 	}
 	sb.WriteString("\n")
@@ -3836,6 +4048,7 @@ func renderBlueprintMain(bp Blueprint) string {
 	}
 	sb.WriteString("\t\"github.com/DonaldMurillo/gofastr/framework\"\n")
 	if hasSeed {
+		sb.WriteString("\t\"github.com/DonaldMurillo/gofastr/framework/crud\"\n")
 		sb.WriteString("\t\"github.com/DonaldMurillo/gofastr/framework/filter\"\n")
 	}
 	sb.WriteString("\tfwimage \"github.com/DonaldMurillo/gofastr/framework/image\"\n")
@@ -3937,7 +4150,7 @@ func renderBlueprintMain(bp Blueprint) string {
 		sb.WriteString("\t\t\tfor _, row := range s.Rows {\n")
 		sb.WriteString("\t\t\t\tresolveSeedRefs(ctx, fwApp, row)\n")
 		sb.WriteString("\t\t\t\tif _, err := ch.CreateOne(ctx, row); err != nil {\n")
-		sb.WriteString("\t\t\t\t\treturn fmt.Errorf(\"seed %s: %w\", s.Entity, err)\n")
+		sb.WriteString("\t\t\t\t\treturn seedCreateError(s.Entity, row, err)\n")
 		sb.WriteString("\t\t\t\t}\n")
 		sb.WriteString("\t\t\t}\n")
 		sb.WriteString("\t\t}\n")
@@ -4103,6 +4316,42 @@ func renderBlueprintMain(bp Blueprint) string {
 		sb.WriteString("\t\tif err != nil || len(rows) == 0 {\n\t\t\tcontinue\n\t\t}\n")
 		sb.WriteString("\t\tif id, ok := rows[0][\"id\"]; ok {\n\t\t\trow[k] = id\n\t\t}\n")
 		sb.WriteString("\t}\n")
+		sb.WriteString("}\n")
+		sb.WriteString("\n// seedCreateError renders a failed seed insert with the per-field detail\n")
+		sb.WriteString("// the CRUD validator already computed. ValidationError.Error() is the\n")
+		sb.WriteString("// bare string \"validation failed\" — the messages worth reading live in\n")
+		sb.WriteString("// Fields() — so a plain %w would abort the boot with zero actionable\n")
+		sb.WriteString("// information. Unwrap, print every field message (sorted, so the output\n")
+		sb.WriteString("// is stable), and name the row so it can be found in gofastr.yml.\n")
+		sb.WriteString("func seedCreateError(entity string, row map[string]any, err error) error {\n")
+		sb.WriteString("\tvar ve *crud.ValidationError\n")
+		sb.WriteString("\tif !errors.As(err, &ve) || len(ve.Fields()) == 0 {\n")
+		sb.WriteString("\t\treturn fmt.Errorf(\"seed %s: %w\", entity, err)\n")
+		sb.WriteString("\t}\n")
+		sb.WriteString("\tnames := make([]string, 0, len(ve.Fields()))\n")
+		sb.WriteString("\tfor name := range ve.Fields() {\n")
+		sb.WriteString("\t\tnames = append(names, name)\n")
+		sb.WriteString("\t}\n")
+		sb.WriteString("\tsort.Strings(names)\n")
+		sb.WriteString("\tvar b strings.Builder\n")
+		sb.WriteString("\tfmt.Fprintf(&b, \"seed %s row %s failed validation:\", entity, seedRowLabel(row))\n")
+		sb.WriteString("\tfor _, name := range names {\n")
+		sb.WriteString("\t\tfor _, msg := range ve.Fields()[name] {\n")
+		sb.WriteString("\t\t\tfmt.Fprintf(&b, \"\\n  - %s: %s\", name, msg)\n")
+		sb.WriteString("\t\t}\n")
+		sb.WriteString("\t}\n")
+		sb.WriteString("\treturn fmt.Errorf(\"%s\\ncause: %w\", b.String(), err)\n")
+		sb.WriteString("}\n")
+		sb.WriteString("\n// seedRowLabel picks the scalar that identifies a seed row against the\n")
+		sb.WriteString("// blueprint's seed: block (the title/name/email it was authored under),\n")
+		sb.WriteString("// falling back to the whole row.\n")
+		sb.WriteString("func seedRowLabel(row map[string]any) string {\n")
+		sb.WriteString("\tfor _, k := range []string{\"title\", \"name\", \"email\", \"label\", \"slug\", \"body\", \"key\"} {\n")
+		sb.WriteString("\t\tif s, ok := row[k].(string); ok && s != \"\" {\n")
+		sb.WriteString("\t\t\treturn fmt.Sprintf(\"%q\", s)\n")
+		sb.WriteString("\t\t}\n")
+		sb.WriteString("\t}\n")
+		sb.WriteString("\treturn fmt.Sprintf(\"%v\", row)\n")
 		sb.WriteString("}\n")
 	}
 	return sb.String()
@@ -4486,11 +4735,19 @@ func blueprintScreenMountStmt(screen BlueprintScreen, bp Blueprint) string {
 	typeName := toCamelCase(screen.Name) + "Screen"
 	layoutExpr := blueprintScreenLayoutExpr(screen, bp)
 	guestRedirect := bp.App.Auth.Enabled && blueprintHasAuthFormScreen(bp)
+	// NewScreen does not probe the component the way site.Register does
+	// (no ScreenDescriber discovery), so a declared description must be
+	// chained explicitly or uihost strict mode fails the boot with
+	// `screen %q: no description`.
+	withDescription := ""
+	if screen.Description != "" {
+		withDescription = fmt.Sprintf(".WithDescription(%q)", screen.Description)
+	}
 	switch {
 	case screen.Access.Auth:
-		return fmt.Sprintf("\tsite.RegisterScreen(app.NewScreen(%q, &%s{}).WithTitle(%q).WithPolicy(authPolicy(%q, %q)), %s)", route, typeName, screen.TitleOrName(), "/login", screen.Access.Role, layoutExpr)
+		return fmt.Sprintf("\tsite.RegisterScreen(app.NewScreen(%q, &%s{}).WithTitle(%q)%s.WithPolicy(authPolicy(%q, %q)), %s)", route, typeName, screen.TitleOrName(), withDescription, "/login", screen.Access.Role, layoutExpr)
 	case guestRedirect && screenHasAuthForm(screen):
-		return fmt.Sprintf("\tsite.RegisterScreen(app.NewScreen(%q, &%s{}).WithTitle(%q).WithPolicy(guestPolicy(%q)), %s)", route, typeName, screen.TitleOrName(), blueprintAppHome(bp), layoutExpr)
+		return fmt.Sprintf("\tsite.RegisterScreen(app.NewScreen(%q, &%s{}).WithTitle(%q)%s.WithPolicy(guestPolicy(%q)), %s)", route, typeName, screen.TitleOrName(), withDescription, blueprintAppHome(bp), layoutExpr)
 	default:
 		return fmt.Sprintf("\tsite.Register(%q, &%s{}, %s)", route, typeName, layoutExpr)
 	}
@@ -7523,13 +7780,72 @@ func expectList(node *coreyaml.Node, label string) ([]*coreyaml.Node, error) {
 	return node.List, nil
 }
 
-func rejectUnknownKeys(m map[string]*coreyaml.Node, allowed map[string]bool, label string) error {
-	for key, node := range m {
-		if !allowed[key] && !strings.HasPrefix(key, "x_") && !strings.HasPrefix(key, "x-") {
-			return fmt.Errorf("blueprint: unknown key %q in %s at line %d", key, label, node.Line)
+// appLevelKeys are settings that live under `app:` — the most common
+// misplacement is writing them at the blueprint root, where they silently
+// do nothing (an agent or a YAML-merge tool has no way to know).
+var appLevelKeys = map[string]bool{
+	"name": true, "description": true, "base_url": true, "module": true,
+	"db": true, "static_dir": true, "output_dir": true, "api_prefix": true,
+	"public_openapi": true, "theme": true, "auth": true, "admin": true,
+	"pwa": true, "llm_md": true,
+}
+
+// topLevelKeys are the blueprint's root sections — written under `app:`
+// they are equally dead.
+var topLevelKeys = map[string]bool{
+	"entities": true, "screens": true, "nav": true, "seed": true,
+	"endpoints": true, "middleware": true, "plugins": true, "helpers": true,
+	"isolation": true,
+}
+
+// unknownKeyLocationHint names the correct nesting for a known key found
+// at the wrong level, so the fix is one edit instead of a schema hunt.
+func unknownKeyLocationHint(key, label string) string {
+	switch label {
+	case "blueprint":
+		if appLevelKeys[key] {
+			return fmt.Sprintf("did you mean \"app.%s:\"? %s is an app-level setting and has no effect at the blueprint root", key, key)
+		}
+	case "app":
+		if topLevelKeys[key] {
+			return fmt.Sprintf("did you mean \"%s:\" at the top level? %s is a blueprint section, not an app setting", key, key)
 		}
 	}
-	return nil
+	return ""
+}
+
+// rejectUnknownKeys reports EVERY unknown key at the level in one pass,
+// sorted for determinism, each with a location hint when the key is a
+// known setting nested at the wrong level. Reporting one per run turned
+// fixing a blueprint into a serial guess-and-recompile loop.
+func rejectUnknownKeys(m map[string]*coreyaml.Node, allowed map[string]bool, label string) error {
+	var unknown []string
+	for key, node := range m {
+		if !allowed[key] && !strings.HasPrefix(key, "x_") && !strings.HasPrefix(key, "x-") {
+			unknown = append(unknown, fmt.Sprintf("unknown key %q in %s at line %d", key, label, node.Line))
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	msgs := make([]string, len(unknown))
+	for i, msg := range unknown {
+		if idx := strings.IndexByte(msg, '"'); idx >= 0 {
+			key := msg[idx+1:]
+			if end := strings.IndexByte(key, '"'); end >= 0 {
+				key = key[:end]
+				if hint := unknownKeyLocationHint(key, label); hint != "" {
+					msg += " — " + hint
+				}
+			}
+		}
+		msgs[i] = msg
+	}
+	if len(msgs) == 1 {
+		return fmt.Errorf("blueprint: %s", msgs[0])
+	}
+	return fmt.Errorf("blueprint: %d unknown keys in %s:\n  - %s", len(msgs), label, strings.Join(msgs, "\n  - "))
 }
 
 func stringValue(node *coreyaml.Node) string {

--- a/cmd/gofastr/blueprint_multierror_test.go
+++ b/cmd/gofastr/blueprint_multierror_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// multiErrorBlueprint carries three independent schema errors: a
+// duplicate entity, a screen with no route, and an endpoint with no
+// handler. One validation pass must report all three — the alternative
+// is a serial guess-and-recompile loop where each fix reveals the next
+// error.
+func TestValidateReportsAllSchemaErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gofastr.yml")
+	writeTestFile(t, path, `app:
+  name: Multi
+  module: example.com/multi
+entities:
+  - name: posts
+    fields:
+      - name: title
+        type: string
+  - name: posts
+    fields:
+      - name: body
+        type: text
+screens:
+  - name: home
+    route: /
+  - name: about
+endpoints:
+  - name: broken
+    method: GET
+    path: /broken
+`)
+	_, err := loadBlueprint(path)
+	if err == nil {
+		t.Fatal("blueprint with three schema errors validated")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		`duplicate entity "posts"`,              // entities section
+		`screen "about" route is required`,      // screens section
+		`endpoint "broken" handler is required`, // endpoints section
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("one-pass validation missed %q:\n%s", want, msg)
+		}
+	}
+	if !strings.Contains(msg, "3 validation errors") {
+		t.Errorf("error does not say how many findings there are:\n%s", msg)
+	}
+}
+
+// An unknown top-level key that is a known app-level setting must point
+// at the right nesting level — `auth:` at the root silently does nothing
+// (the real key is app.auth), which is exactly the misplacement an agent
+// or a YAML-merging tool produces.
+func TestUnknownKeySuggestsCorrectLocation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		yml  string
+		want string
+	}{
+		{"auth at root", "app:\n  name: A\nauth:\n  enabled: true\n", "app.auth"},
+		{"theme at root", "app:\n  name: A\ntheme:\n  primary: \"#111111\"\n", "app.theme"},
+		{"db at root", "app:\n  name: A\ndb:\n  driver: sqlite\n", "app.db"},
+		{"screens under app", "app:\n  name: A\n  screens: []\n", "top level"},
+		{"entities under app", "app:\n  name: A\n  entities: []\n", "top level"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "gofastr.yml")
+			writeTestFile(t, path, tc.yml)
+			_, err := loadBlueprint(path)
+			if err == nil {
+				t.Fatalf("misplaced known key %s was accepted", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error does not suggest the correct location %q:\n%s", tc.want, err.Error())
+			}
+		})
+	}
+}
+
+// Every unknown key at one level must be reported in the same pass, not
+// one per run (they are all in the same map — the fix is the same edit).
+func TestUnknownKeysAllReportedAtOnce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gofastr.yml")
+	writeTestFile(t, path, "app:\n  name: A\n  bogus_one: 1\n  bogus_two: 2\n")
+	_, err := loadBlueprint(path)
+	if err == nil {
+		t.Fatal("two unknown app keys were accepted")
+	}
+	for _, want := range []string{`bogus_one`, `bogus_two`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("unknown key %q not reported in the same pass:\n%s", want, err.Error())
+		}
+	}
+}

--- a/cmd/gofastr/blueprint_screen_mount_test.go
+++ b/cmd/gofastr/blueprint_screen_mount_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Screens mounted through app.NewScreen (the auth-gated and guest-policy
+// paths in blueprintScreenMountStmt) do NOT get the component probed for
+// ScreenDescriber the way site.Register does — uihost strict mode reads
+// the Screen struct's Description field. A blueprint screen that declares
+// a description must therefore chain WithDescription at the mount, or the
+// generated app panics at boot: `screen "/app": no description`. This is
+// exactly how the meridian blueprint rotted: it generated, it compiled,
+// it died.
+func TestAuthScreensMountWithDescription(t *testing.T) {
+	login := BlueprintScreen{Name: "login", Route: "/login", Title: "Sign in",
+		Description: "Sign in to your account.",
+		Body:        []BlueprintBlock{{Kind: "login_form"}}}
+	bp := Blueprint{App: BlueprintApp{Auth: BlueprintAuth{Enabled: true}}, Screens: []BlueprintScreen{login}}
+	for _, tc := range []struct {
+		name   string
+		screen BlueprintScreen
+	}{
+		{"auth-gated", BlueprintScreen{
+			Name: "dashboard", Route: "/app", Title: "Overview",
+			Description: "Your revenue at a glance.",
+			Access:      BlueprintAccess{Auth: true},
+		}},
+		{"guest login form", login},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mount := blueprintScreenMountStmt(tc.screen, bp)
+			if !strings.Contains(mount, `.WithDescription("`+tc.screen.Description+`")`) {
+				t.Errorf("mount statement drops the declared description (strict-mode boot panic):\n%s", mount)
+			}
+			if !strings.Contains(mount, `.WithTitle("`) {
+				t.Errorf("mount statement lost its title:\n%s", mount)
+			}
+		})
+	}
+}

--- a/cmd/gofastr/blueprint_seed_errdetail_test.go
+++ b/cmd/gofastr/blueprint_seed_errdetail_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The emitted seed hook's CreateOne failure path must surface the
+// per-field detail the CRUD validator already computed. A bare
+// fmt.Errorf("seed %s: %w", ...) wraps ValidationError, whose Error() is
+// the literal string "validation failed" — the generated app dies with a
+// message containing zero actionable information. The hook must
+// errors.As the *crud.ValidationError, print each field's messages, and
+// identify the offending row.
+func TestSeedCreateErrorCarriesFieldDetail(t *testing.T) {
+	main := renderBlueprintMain(seedDetailBlueprint())
+	for _, want := range []string{
+		"crud.ValidationError",
+		"errors.As(",
+		".Fields()",
+		"seedCreateError(",
+	} {
+		if !strings.Contains(main, want) {
+			t.Errorf("emitted main.go missing %q:\n%s", want, main)
+		}
+	}
+	// The failure path must route through the detail helper, not wrap bare.
+	if !strings.Contains(main, "return seedCreateError(s.Entity, row, err)") {
+		t.Errorf("CreateOne error path does not route through seedCreateError:\n%s", main)
+	}
+	// Field messages must be ordered deterministically (sorted), so the
+	// boot message is stable across runs and grep-able in tests.
+	if !strings.Contains(main, "sort.Strings(") {
+		t.Errorf("field detail is not sorted — nondeterministic boot messages:\n%s", main)
+	}
+	// The row identity must come from the row's own fields, not its map
+	// repr alone.
+	if !strings.Contains(main, "seedRowLabel") {
+		t.Errorf("emitted helper does not identify the failing row:\n%s", main)
+	}
+}
+
+// The non-validation error path keeps the %w wrap: WithSeed errors abort
+// App.Start and callers up the stack may errors.As the cause.
+func TestSeedCreateErrorWrapsNonValidationCauses(t *testing.T) {
+	main := renderBlueprintMain(seedDetailBlueprint())
+	if !strings.Contains(main, `return fmt.Errorf("seed %s: %w", entity, err)`) {
+		t.Errorf("non-validation seed errors must keep the wrapping form:\n%s", main)
+	}
+}
+
+func seedDetailBlueprint() Blueprint {
+	return Blueprint{
+		App: BlueprintApp{Name: "SeedDetail", Module: "example.com/seeddetail"},
+		Seed: []BlueprintSeedEntity{{
+			Entity: "posts",
+			Rows:   []map[string]any{{"title": "Hello"}},
+		}},
+	}
+}

--- a/cmd/gofastr/blueprint_seed_errdetail_test.go
+++ b/cmd/gofastr/blueprint_seed_errdetail_test.go
@@ -25,7 +25,9 @@ func TestSeedCreateErrorCarriesFieldDetail(t *testing.T) {
 		}
 	}
 	// The failure path must route through the detail helper, not wrap bare.
-	if !strings.Contains(main, "return seedCreateError(s.Entity, row, err)") {
+	// The row is identified by its one-based position in the blueprint's
+	// seed: block — i+1, matching how a human counts YAML list entries.
+	if !strings.Contains(main, "return seedCreateError(s.Entity, i+1, err)") {
 		t.Errorf("CreateOne error path does not route through seedCreateError:\n%s", main)
 	}
 	// Field messages must be ordered deterministically (sorted), so the
@@ -33,10 +35,25 @@ func TestSeedCreateErrorCarriesFieldDetail(t *testing.T) {
 	if !strings.Contains(main, "sort.Strings(") {
 		t.Errorf("field detail is not sorted — nondeterministic boot messages:\n%s", main)
 	}
-	// The row identity must come from the row's own fields, not its map
-	// repr alone.
-	if !strings.Contains(main, "seedRowLabel") {
-		t.Errorf("emitted helper does not identify the failing row:\n%s", main)
+	// The row identity must be its one-based index, not any row value.
+	if !strings.Contains(main, "func seedCreateError(entity string, index int, err error) error") {
+		t.Errorf("emitted helper does not take a row index:\n%s", main)
+	}
+}
+
+// A failed seed aborts boot through log.Fatal, so anything in the message
+// lands in application logs. Seed rows carry admin emails and seed
+// passwords — the row's VALUES must never appear; only its position.
+func TestSeedErrorOmitsRowValues(t *testing.T) {
+	main := renderBlueprintMain(seedDetailBlueprint())
+	if strings.Contains(main, "seedRowLabel") {
+		t.Errorf("emitted main.go labels failing rows by value (seedRowLabel):\n%s", main)
+	}
+	if strings.Contains(main, `fmt.Sprintf("%v", row)`) {
+		t.Errorf("emitted main.go formats the row map — values would reach the logs:\n%s", main)
+	}
+	if !strings.Contains(main, `"seed %s row %d failed validation:"`) {
+		t.Errorf("emitted main.go does not label the failing row by index:\n%s", main)
 	}
 }
 

--- a/cmd/gofastr/blueprint_seed_failfast_test.go
+++ b/cmd/gofastr/blueprint_seed_failfast_test.go
@@ -15,7 +15,7 @@ func TestSeedHookReturnsRowErrors(t *testing.T) {
 	if strings.Contains(main, "skipping row") {
 		t.Fatalf("seed hook logs-and-skips failed rows — fail-open boot:\n%s", main)
 	}
-	if !strings.Contains(main, `return fmt.Errorf("seed %s: %w", s.Entity, err)`) {
+	if !strings.Contains(main, "return seedCreateError(s.Entity, row, err)") {
 		t.Fatalf("seed hook does not return CreateOne errors:\n%s", main)
 	}
 }

--- a/cmd/gofastr/blueprint_seed_failfast_test.go
+++ b/cmd/gofastr/blueprint_seed_failfast_test.go
@@ -15,7 +15,7 @@ func TestSeedHookReturnsRowErrors(t *testing.T) {
 	if strings.Contains(main, "skipping row") {
 		t.Fatalf("seed hook logs-and-skips failed rows — fail-open boot:\n%s", main)
 	}
-	if !strings.Contains(main, "return seedCreateError(s.Entity, row, err)") {
+	if !strings.Contains(main, "return seedCreateError(s.Entity, i+1, err)") {
 		t.Fatalf("seed hook does not return CreateOne errors:\n%s", main)
 	}
 }

--- a/cmd/gofastr/blueprint_seed_types_test.go
+++ b/cmd/gofastr/blueprint_seed_types_test.go
@@ -129,3 +129,26 @@ func TestSeedAcceptsSatisfiableValueTypes(t *testing.T) {
 		t.Fatalf("valid seed rows rejected:\n%v", err)
 	}
 }
+
+// One pass must report every unsatisfiable seed value, not just the first
+// — and in a stable order: the rows are maps, so iterating them raw makes
+// the reported field change between runs when a row has two bad values.
+// Both findings in one row, and bad values across two rows, must all
+// appear, sorted by field name within each row.
+func TestSeedErrorsReportEveryField(t *testing.T) {
+	rows := "      - body: hi\n        author: 42\n        rating: true\n" +
+		"      - body: also hi\n        published: maybe\n"
+	err := loadSeedTypesBlueprint(t, rows)
+	if err == nil {
+		t.Fatal("blueprint with three unsatisfiable seed values must be rejected")
+	}
+	got := err.Error()
+	for _, want := range []string{"author", "rating", "published"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("error does not name %q — first-rejection reporting:\n%s", want, got)
+		}
+	}
+	if i, j := strings.Index(got, "author"), strings.Index(got, "rating"); i > j || j < 0 || i < 0 {
+		t.Errorf("findings are not in sorted field order (author before rating):\n%s", got)
+	}
+}

--- a/cmd/gofastr/blueprint_seed_types_test.go
+++ b/cmd/gofastr/blueprint_seed_types_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedTypesYAML builds a minimal blueprint whose comments.post_id is a
+// relation to posts (a UUID string column at runtime) and whose seed rows
+// are provided per test.
+func seedTypesYAML(seedRows string) string {
+	return `app:
+  name: SeedTypes
+  module: example.com/seedtypes
+entities:
+  - name: posts
+    fields:
+      - name: title
+        type: string
+        required: true
+  - name: comments
+    fields:
+      - name: body
+        type: text
+        required: true
+      - name: post_id
+        type: relation
+        to: posts
+        required: true
+      - name: author
+        type: string
+      - name: views
+        type: int
+      - name: rating
+        type: float
+      - name: price
+        type: decimal
+      - name: published
+        type: bool
+seed:
+  - entity: posts
+    rows:
+      - title: First post
+      - title: Second post
+  - entity: comments
+    rows:
+` + seedRows
+}
+
+func loadSeedTypesBlueprint(t *testing.T, seedRows string) error {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gofastr.yml")
+	writeTestFile(t, path, seedTypesYAML(seedRows))
+	_, err := loadBlueprint(path)
+	return err
+}
+
+// The blog-blueprint defect: a numeric literal seeded into a relation
+// field. Relation columns are UUID strings at runtime, so the generated
+// app dies at boot with "seed comments: validation failed" — zero
+// actionable detail, after generate said everything was fine. The check
+// must fire at generate/validate time and teach the @ref form.
+func TestSeedRejectsNumericRelationValue(t *testing.T) {
+	err := loadSeedTypesBlueprint(t, "      - body: hi\n        post_id: 1\n")
+	if err == nil {
+		t.Fatal("numeric seed into a relation field must fail at generate time, got nil")
+	}
+	for _, want := range []string{"comments", "post_id", "1", "@posts.title=", "relation"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing %q:\n%s", want, err.Error())
+		}
+	}
+}
+
+// The general invariant: a seed value whose Go type can never satisfy the
+// target field's runtime validator. Each row seeds one column with a
+// value the runtime would reject ("must be a string", "must be a
+// number", ...). All of them must be caught before any code is emitted.
+func TestSeedRejectsUnsatisfiableValueTypes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rows string
+		want string
+	}{
+		{"int into string field", "      - body: hi\n        author: 42\n", "author"},
+		{"bool into string field", "      - body: hi\n        author: true\n", "author"},
+		{"string into float field", "      - body: hi\n        rating: \"4.5\"\n", "rating"},
+		{"bool into float field", "      - body: hi\n        rating: true\n", "rating"},
+		{"int into relation field", "      - body: hi\n        post_id: 2\n", "post_id"},
+		{"bool into int field", "      - body: hi\n        views: true\n", "views"},
+		{"non-numeric string into int field", "      - body: hi\n        views: many\n", "views"},
+		{"fractional float into int field", "      - body: hi\n        views: 1.5\n", "views"},
+		{"bool into decimal field", "      - body: hi\n        price: true\n", "price"},
+		{"non-boolean string into bool field", "      - body: hi\n        published: yes\n", "published"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := loadSeedTypesBlueprint(t, tc.rows)
+			if err == nil {
+				t.Fatalf("seed row must be rejected at generate time:\n%s", tc.rows)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error must name the offending field %q:\n%s", tc.want, err.Error())
+			}
+		})
+	}
+}
+
+// Everything the runtime validators DO accept must keep flowing through:
+// @refs on relations, ints on int columns, numbers on decimals (the
+// emitter re-quotes them), true/false and 1/0 on bools, integral floats
+// on ints, integer-parsable strings on ints.
+func TestSeedAcceptsSatisfiableValueTypes(t *testing.T) {
+	rows := `      - body: ref row
+        post_id: "@posts.title=First post"
+        views: 10
+        rating: 4.5
+        price: 19.99
+        published: true
+      - body: coercions row
+        post_id: "@posts.title=Second post"
+        author: "42"
+        views: 7.0
+        price: "3.50"
+        published: 1
+`
+	if err := loadSeedTypesBlueprint(t, rows); err != nil {
+		t.Fatalf("valid seed rows rejected:\n%v", err)
+	}
+}

--- a/cmd/gofastr/examples_blueprint_test.go
+++ b/cmd/gofastr/examples_blueprint_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -115,6 +116,13 @@ func TestExampleBlueprintsBoot(t *testing.T) {
 	}
 }
 
+// bootProbeClient bounds every readiness probe in bootGeneratedApp. A raw
+// http.Get has no timeout: an app that accepts the connection but never
+// responds would block the probe forever and the 90s deadline below would
+// never fire. Five seconds is generous for a first response and well under
+// the deadline, so each hung attempt costs one bounded retry, not the gate.
+var bootProbeClient = &http.Client{Timeout: 5 * time.Second}
+
 // bootGeneratedApp starts a generated app binary on a free port and waits
 // for it to serve. A process that exits first (seed validation, failed
 // migration, refused bind) fails immediately with its captured output —
@@ -153,7 +161,7 @@ func bootGeneratedApp(t *testing.T, name, bin, appDir string) {
 			t.Fatalf("generated %s app exited before serving (err=%v):\n%s", name, err, output.String())
 		default:
 		}
-		resp, err := http.Get(baseURL + "/")
+		resp, err := bootProbeClient.Get(baseURL + "/")
 		if err == nil {
 			resp.Body.Close()
 			// Any non-server-error answer proves the app is up and routing —
@@ -165,6 +173,30 @@ func bootGeneratedApp(t *testing.T, name, bin, appDir string) {
 		time.Sleep(100 * time.Millisecond)
 	}
 	t.Fatalf("generated %s app did not serve at %s within 90s:\n%s", name, baseURL, output.String())
+}
+
+// TestBootProbeClientTimesOut pins the readiness probe's timeout: a
+// generated app that accepts the connection but never responds must fail
+// the probe (and let the 90s deadline fire) rather than hanging the test
+// forever on an unbounded http.Get.
+func TestBootProbeClientTimesOut(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // accepts, never responds
+	}))
+	defer srv.Close()
+	defer close(release)
+	start := time.Now()
+	resp, err := bootProbeClient.Get(srv.URL)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("probe returned no error against a hung server — timeout is not bounded")
+	}
+	if elapsed := time.Since(start); elapsed >= 10*time.Second {
+		t.Fatalf("probe took %s against a hung server — the boot gate would never reach its deadline", elapsed)
+	}
 }
 
 // generateAndCompileBlueprint generates one blueprint into a scratch package

--- a/cmd/gofastr/examples_blueprint_test.go
+++ b/cmd/gofastr/examples_blueprint_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestExampleBlueprintsLoad validates every examples/<name>/gofastr.yml parses
@@ -84,9 +87,90 @@ func TestExampleBlueprintsGenerateAndCompile(t *testing.T) {
 	}
 }
 
+// TestExampleBlueprintsBoot is the top rung of the blueprint ladder:
+// load → generate → compile → START the binary and serve. Compile-only
+// was not enough: the blog blueprint rotted for a whole release while
+// passing all three lower rungs — its seed seeded `post_id: 1` into a
+// UUID relation column, an app that builds cleanly and dies at boot
+// ("seed hooks: seed comments: validation failed"). Nothing below the
+// boot rung can see a runtime failure, so this test is the gate that
+// would have caught it.
+//
+// Failure modes asserted: non-zero exit before serving (the seed-death
+// class), failure to bind/serve within the deadline, and error output on
+// the way down. The child runs in its own process group and is killed by
+// tree even when the test fails mid-flight, so no app leaks past the run
+// (CI-safe on Linux and macOS via configureTestProcessGroup).
+func TestExampleBlueprintsBoot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("generates, compiles, and boots every example blueprint; skipped under -short")
+	}
+	for _, path := range exampleBlueprints(t) {
+		path := path
+		name := filepath.Base(filepath.Dir(path))
+		t.Run(name, func(t *testing.T) {
+			bin, appDir := generateAndCompileBlueprint(t, path, name)
+			bootGeneratedApp(t, name, bin, appDir)
+		})
+	}
+}
+
+// bootGeneratedApp starts a generated app binary on a free port and waits
+// for it to serve. A process that exits first (seed validation, failed
+// migration, refused bind) fails immediately with its captured output —
+// faster than burning the whole HTTP deadline, and the output is the
+// diagnostic that matters.
+func bootGeneratedApp(t *testing.T, name, bin, appDir string) {
+	t.Helper()
+	addr := freeAddr(t)
+	cmd := exec.Command(testExecutablePath(bin))
+	cmd.Dir = appDir
+	cmd.Env = append(os.Environ(),
+		"PORT="+addr,
+		// Scratch-scoped DB file: the scratch dir's cleanup removes it, so
+		// repeated runs never inherit a stale, already-seeded database.
+		"DATABASE_URL=file:"+filepath.Join(appDir, "boot-gate.db"),
+	)
+	configureTestProcessGroup(cmd)
+	output := &bytes.Buffer{}
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start generated %s app: %v", name, err)
+	}
+	t.Cleanup(func() {
+		_ = killTestProcessTree(cmd)
+		_, _ = cmd.Process.Wait()
+	})
+	exited := make(chan error, 1)
+	go func() { exited <- cmd.Wait() }()
+
+	baseURL := "http://" + addr
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-exited:
+			t.Fatalf("generated %s app exited before serving (err=%v):\n%s", name, err, output.String())
+		default:
+		}
+		resp, err := http.Get(baseURL + "/")
+		if err == nil {
+			resp.Body.Close()
+			// Any non-server-error answer proves the app is up and routing —
+			// auth-gated apps answer 302/401 on /, a screen-less one 404.
+			if resp.StatusCode < 500 {
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("generated %s app did not serve at %s within 90s:\n%s", name, baseURL, output.String())
+}
+
 // generateAndCompileBlueprint generates one blueprint into a scratch package
-// beside it and compiles every package it emitted.
-func generateAndCompileBlueprint(t *testing.T, blueprintPath, name string) {
+// beside it, compiles every package it emitted, and returns the built app
+// binary plus the directory it should run from (output_dir aware).
+func generateAndCompileBlueprint(t *testing.T, blueprintPath, name string) (string, string) {
 	t.Helper()
 
 	exampleDir := filepath.Dir(blueprintPath)
@@ -161,6 +245,7 @@ func generateAndCompileBlueprint(t *testing.T, blueprintPath, name string) {
 	if out, err := vet.CombinedOutput(); err != nil {
 		t.Fatalf("generated code fails go vet for %s:\n%s", blueprintPath, out)
 	}
+	return bin, appDir
 }
 
 // blueprintOutputDir extracts an uncommented `output_dir:` from a blueprint.

--- a/cmd/gofastr/init.go
+++ b/cmd/gofastr/init.go
@@ -601,7 +601,11 @@ func (h *HomeScreen) Render() render.HTML {
 	)
 }
 
-func (h *HomeScreen) ScreenTitle() string        { return "%[1]s" }
+// No ScreenTitle here on purpose: the page renderer composes
+// "<title>SCREEN — APP NAME</title>", so a home screen titled after the
+// app itself ships "myapp — myapp". Untitled, the tab reads exactly the
+// app name. Add ScreenTitle() (and ScreenDescription()) on inner pages,
+// where the screen name differs from the site's.
 func (h *HomeScreen) ScreenDescription() string  { return "" }
 func (h *HomeScreen) ScreenType() app.ScreenType { return app.ScreenPage }
 `, name, entityHint)

--- a/cmd/gofastr/scaffold_gate_test.go
+++ b/cmd/gofastr/scaffold_gate_test.go
@@ -101,6 +101,18 @@ func TestInitScaffoldBootsSecureByDefault(t *testing.T) {
 	if homeResp.StatusCode != http.StatusOK || !strings.Contains(string(homeBody), "blog") {
 		t.Fatalf("GET / = %d — want 200 with the scaffolded home screen\n%s", homeResp.StatusCode, output.String())
 	}
+	// The browser tab must not parrot the app name twice: the scaffold's
+	// home screen used to carry ScreenTitle() == app name, which the page
+	// renderer composes as "<title>NAME — NAME</title>". With no screen
+	// title the tab reads exactly the app name.
+	titleStart := strings.Index(string(homeBody), "<title>")
+	titleEnd := strings.Index(string(homeBody), "</title>")
+	if titleStart < 0 || titleEnd < titleStart {
+		t.Fatalf("GET / has no <title> element:\n%s", string(homeBody))
+	}
+	if got := string(homeBody)[titleStart : titleEnd+len("</title>")]; got != "<title>blog</title>" {
+		t.Fatalf("GET / title = %s, want <title>blog</title> — the scaffold duplicated the app name into the screen title:\n%s", got, string(homeBody))
+	}
 
 	// Secure by default: the sample entity has no Public/Access/OwnerField,
 	// so anonymous CRUD refuses — the 401 /get-started demonstrates.

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.65.0
+through: v0.66.0
 
 releases:
   - version: v0.3.0
@@ -720,3 +720,24 @@ releases:
       - change: The CLI snake-cases leading acronyms correctly
         breaking: false
         guidance: "gofastr generate and gofastr pack now agree: HTTPServer becomes http_server (generate previously produced httpserver, pack h_t_t_p_server). Shipped goldens are unchanged; only identifiers with leading acronym runs are affected on the next generate/pack run."
+  - version: v0.66.0
+    title: Queue lease fencing, multipart wire cap, blueprint boot gate
+    notes:
+      - change: "BREAKING: Queue.Ack and Queue.Nack take a Job, not a job ID"
+        breaking: true
+        guidance: "Pass the Job returned by Dequeue instead of job.ID. The string form carried no claim identity, so a worker that stalled past its lease could Ack a job another worker had already re-claimed — deleting the new holder's lease and losing the job with no dead-letter trace. RedisQueue now checks Job.ClaimToken and counts rejected calls in StaleClaimCount(). Custom Queue implementations must update both method signatures."
+        detect: "\\.Ack\\(|\\.Nack\\("
+      - change: Multipart request bodies are capped on the wire and rejected 413
+        breaking: false
+        guidance: "CRUD write handlers previously wrapped every body in a 1 MiB reader before checking the content type, so any multipart upload over 1 MiB failed with a 400. Multipart bodies now cap at crud.MaxMultipartBodyBytes (64 MiB) and over-limit requests get a 413. If you relied on the 400, expect 413; if you need a different ceiling, the constant is exported."
+      - change: Standalone upload keys are unique, not the client filename
+        breaking: false
+        guidance: "upload.Handler now keys objects with upload.UniqueFilename (sanitized name plus a timestamp and 8 random bytes), matching the auto-CRUD path. Two users uploading report.txt no longer overwrite each other. Read `key` from the response; code that rebuilt the storage key from `originalName` will no longer find the object. Objects stored before this release keep their old keys."
+        detect: "upload.Handler"
+      - change: Repeated ?field_in= keys union instead of dropping
+        breaking: false
+        guidance: "?tag_in=a,b&tag_in=c previously filtered on a,b alone and reported nothing. Every occurrence now contributes and the 1000-entry cap counts the union, so a client that sent repeated keys will get more rows than before — the rows it was already asking for. Relation-scoped lists (?author.name_in=) now enforce the same cap and 400 above it."
+      - change: gofastr generate rejects seed values that cannot satisfy their field
+        breaking: false
+        guidance: "A seed row assigning a number to a relation column now fails at generate time naming the @entity.field=value form to use, instead of emitting an app that compiles and then dies at boot. Regenerate any blueprint carrying a numeric foreign key in its seed block."
+        detect: "seed:"

--- a/core/featureflag/flag.go
+++ b/core/featureflag/flag.go
@@ -218,10 +218,13 @@ func (e *Evaluator) BoolDefault(ctx context.Context, key string, fallback bool) 
 }
 
 // subjectID picks the stable identifier to hash for rollout.
-// Preference order: user → tenant → empty (yields a uniform 0 bucket).
-// "Empty" subjects always fall in bucket 0 so the rollout still gates
-// them — that matches the principle of "anonymous traffic sees the new
-// thing only at high rollout percentages."
+// Preference order: user → tenant → empty.
+//
+// An empty subject is NOT bucketed: the caller forces the flag OFF at
+// partial rollout rather than hashing every anonymous request into one
+// shared bucket, which would flip all of them together at the same
+// percentage. Callers who want anonymous traffic in a rollout derive a
+// stable pseudo-subject and put it in EvalContext.UserID themselves.
 func subjectID(ec EvalContext) string {
 	if ec.UserID != "" {
 		return ec.UserID

--- a/core/upload/upload.go
+++ b/core/upload/upload.go
@@ -38,6 +38,11 @@ const multipartFramingSlack = 4 << 10 // 4 KiB
 // single unique-key generator the framework's upload surfaces share —
 // framework/file.GenerateFilePath builds its entity/field-scoped paths
 // on top of it; do not grow a second scheme.
+//
+// The only error is a failed crypto/rand read. RNG failure means the
+// host's entropy source is broken; the caller must reject the upload
+// rather than store under a timestamp-only key, which would silently
+// re-enable the O_TRUNC clobber this scheme exists to prevent.
 func UniqueFilename(filename string) string {
 	safe := SanitizeFilename(filename)
 	ext := filepath.Ext(safe)
@@ -48,15 +53,15 @@ func UniqueFilename(filename string) string {
 	return fmt.Sprintf("%s_%d_%s%s", name, time.Now().UnixNano(), randomSuffix(), ext)
 }
 
-// randomSuffix returns a hex-encoded 8-byte crypto-random token. If the
-// platform RNG fails it returns an empty string; the caller still has
-// the timestamp, so a failure degrades uniqueness rather than aborting
-// the upload.
+// randomSuffix returns a hex-encoded 8-byte crypto-random token. It has no
+// error path because crypto/rand.Read has none: it "never returns an
+// error, and always fills b entirely", crashing the program irrecoverably
+// if the OS source fails. So there is no reachable state where the suffix
+// is missing and two requests on the same clock tick could collide into an
+// O_TRUNC clobber — which is the whole reason the suffix exists.
 func randomSuffix() string {
 	var b [8]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return ""
-	}
+	rand.Read(b[:])
 	return hex.EncodeToString(b[:])
 }
 

--- a/core/upload/upload.go
+++ b/core/upload/upload.go
@@ -39,10 +39,8 @@ const multipartFramingSlack = 4 << 10 // 4 KiB
 // framework/file.GenerateFilePath builds its entity/field-scoped paths
 // on top of it; do not grow a second scheme.
 //
-// The only error is a failed crypto/rand read. RNG failure means the
-// host's entropy source is broken; the caller must reject the upload
-// rather than store under a timestamp-only key, which would silently
-// re-enable the O_TRUNC clobber this scheme exists to prevent.
+// There is no error return: crypto/rand.Read cannot fail (see
+// randomSuffix), so the random component is always present.
 func UniqueFilename(filename string) string {
 	safe := SanitizeFilename(filename)
 	ext := filepath.Ext(safe)

--- a/core/upload/upload.go
+++ b/core/upload/upload.go
@@ -2,12 +2,15 @@ package upload
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -24,6 +27,38 @@ const maxMultipartMemory = 1 << 20 // 1 MiB
 // other framing bytes don't push a legitimately-sized file part over
 // the body cap and trigger a spurious 413.
 const multipartFramingSlack = 4 << 10 // 4 KiB
+
+// UniqueFilename derives a collision-proof storage name from a client
+// filename: the sanitized base name, a UnixNano timestamp, and 16 hex
+// chars of crypto/rand. The random component is the real uniqueness
+// guarantee — the timestamp is retained only for human-readable
+// ordering, because two requests landing on the same clock tick must
+// still map to different objects (Storage.Save implementations open
+// with O_TRUNC, so a colliding key silently overwrites). This is the
+// single unique-key generator the framework's upload surfaces share —
+// framework/file.GenerateFilePath builds its entity/field-scoped paths
+// on top of it; do not grow a second scheme.
+func UniqueFilename(filename string) string {
+	safe := SanitizeFilename(filename)
+	ext := filepath.Ext(safe)
+	name := strings.TrimSuffix(safe, ext)
+	if name == "" {
+		name = "upload"
+	}
+	return fmt.Sprintf("%s_%d_%s%s", name, time.Now().UnixNano(), randomSuffix(), ext)
+}
+
+// randomSuffix returns a hex-encoded 8-byte crypto-random token. If the
+// platform RNG fails it returns an empty string; the caller still has
+// the timestamp, so a failure degrades uniqueness rather than aborting
+// the upload.
+func randomSuffix() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b[:])
+}
 
 // Storage defines the interface for file storage backends.
 type Storage interface {
@@ -127,12 +162,13 @@ func Handler(cfg Config) http.HandlerFunc {
 			return
 		}
 
-		// Sanitize filename for storage key
-		safeName := SanitizeFilename(header.Filename)
-		key := safeName
-		if key == "" {
-			key = fmt.Sprintf("upload_%d", time.Now().UnixNano())
-		}
+		// Storage key: the sanitized filename PLUS a unique timestamp/rand
+		// component. The bare sanitized filename keyed objects per-client-
+		// name, and Storage.Save implementations open O_TRUNC — two users
+		// uploading report.txt silently overwrote each other. UniqueFilename
+		// is the same generator the auto-CRUD path builds on
+		// (framework/file.GenerateFilePath).
+		key := UniqueFilename(header.Filename)
 
 		// Save via storage backend
 		if err := cfg.Storage.Save(r.Context(), key, file); err != nil {

--- a/core/upload/upload_test.go
+++ b/core/upload/upload_test.go
@@ -3,6 +3,7 @@ package upload
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"mime/multipart"
 	"net/http"
@@ -60,13 +61,21 @@ func TestUploadValidFileSucceeds(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
 
-	// Verify file was saved
-	exists, err := storage.Exists(context.Background(), "hello.txt")
+	// Verify the file was saved under the key the response reports.
+	// The key is no longer the bare client filename: two uploads of the
+	// same name must not overwrite each other, so the handler appends a
+	// unique timestamp/rand component (see UniqueFilename). Clients read
+	// the key from this response — they never derive it themselves.
+	var meta Metadata
+	if err := json.Unmarshal(rr.Body.Bytes(), &meta); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	exists, err := storage.Exists(context.Background(), meta.Key)
 	if err != nil {
 		t.Fatalf("checking existence: %v", err)
 	}
 	if !exists {
-		t.Fatal("file should exist in storage after upload")
+		t.Fatalf("file should exist in storage after upload (key %q)", meta.Key)
 	}
 }
 

--- a/core/upload/upload_unique_key_test.go
+++ b/core/upload/upload_unique_key_test.go
@@ -1,0 +1,74 @@
+package upload
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func postNamedFile(t *testing.T, h http.HandlerFunc, name, content string) Metadata {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, _ := mw.CreateFormFile("file", name)
+	_, _ = fw.Write([]byte(content))
+	_ = mw.Close()
+	req := httptest.NewRequest(http.MethodPost, "/upload", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("upload %q = %d: %s", name, rec.Code, rec.Body.String())
+	}
+	var meta Metadata
+	if err := json.Unmarshal(rec.Body.Bytes(), &meta); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	return meta
+}
+
+// TestSameFilenameDoesNotClobber pins the storage-key contract: two
+// uploads of the same client filename must land at DIFFERENT keys, and
+// the first upload's bytes must survive the second. Keying objects on
+// the sanitized client filename (with LocalStorage.Save opening
+// O_TRUNC) meant user B's report.txt silently overwrote user A's —
+// cross-user data loss with no error anywhere. The auto-CRUD path
+// already solves this with a timestamp + crypto/rand suffix
+// (file.GenerateFilePath); the standalone handler must use the same
+// unique-name generation, not a second scheme.
+func TestSameFilenameDoesNotClobber(t *testing.T) {
+	dir := tmpDir(t)
+	store := NewLocalStorage(dir)
+	h := Handler(Config{Storage: store})
+
+	m1 := postNamedFile(t, h, "report.txt", "USER-A-SECRET-CONTENT")
+	m2 := postNamedFile(t, h, "report.txt", "USER-B-CONTENT")
+
+	if m1.Key == m2.Key {
+		t.Fatalf("two uploads of %q produced the same key %q — second silently overwrites first (O_TRUNC clobber)", "report.txt", m1.Key)
+	}
+
+	got, err := store.Get(t.Context(), m1.Key)
+	if err != nil {
+		t.Fatalf("get first upload: %v", err)
+	}
+	data, err := io.ReadAll(got)
+	if err != nil {
+		t.Fatalf("read first upload: %v", err)
+	}
+	_ = got.Close()
+	if string(data) != "USER-A-SECRET-CONTENT" {
+		t.Fatalf("first upload's bytes were clobbered: got %q", string(data))
+	}
+
+	// The key keeps the sanitized base name (minus extension) so storage
+	// listings stay readable, and carries the extension through.
+	if !strings.HasPrefix(m1.Key, "report_") || !strings.HasSuffix(m1.Key, ".txt") {
+		t.Errorf("key %q lost the sanitized name/extension", m1.Key)
+	}
+}

--- a/docs/agent-notes.md
+++ b/docs/agent-notes.md
@@ -105,3 +105,11 @@
 - Evidence: `evals/backend-adoption/results/2026-08-16-codex.md` — cold-start 313,579 → 233,716 tokens against a control that rose 34%, ratio 4.35× → 2.42×; `framework/withconfig_order_test.go` and `TestInitScaffoldsWithConfigFirst` pin the fix.
 - Next time: When a run fails a probe, read the candidate's code before blaming the framework — run 1's isolation miss was a hand-rolled handler validating before the owner-scoped lookup, with the framework's contract warning suppressed.
 - Status: active
+
+## 2026-08-17 - Seed error hygiene: values never reach logs; refuted bigint alias claim
+- Scope: `cmd/gofastr` blueprint emitter/validator, `examples/ecommerce/app` regeneration
+- Trigger: CodeRabbit round — generated apps labeled failed seed rows by VALUE (title/email/body, falling back to the whole row map) in a log.Fatal path; boot-gate probe used unbounded http.Get; seed type validation returned on first map-iteration-ordered rejection.
+- Approach: `seedCreateError(entity, index, err)` now labels rows by one-based position only (seeds carry admin emails/passwords); `bootProbeClient = &http.Client{Timeout: 5s}` bounds the readiness probe; `validateBlueprintSeedTypes` accumulates every finding via schemaErrors over sortedMapKeys, rows reported one-based to match boot.
+- Evidence: `TestSeedErrorOmitsRowValues`, `TestBootProbeClientTimesOut` (fires at 5.00s against a hung server), `TestSeedErrorsReportEveryField`; `TestExampleBlueprintsBoot` and ecommerce byte-parity pass after regeneration.
+- Next time: The canonical field-type alias table is `parseFieldType` (framework/entity/declaration.go) — int is `int|integer`, float is `float|number`, nothing else. A claim that `bigint`/`money`/`double`/`numeric` "fall through seed validation and die at boot" is wrong: `decl.Config()` rejects those types at validate time (blueprint.go entity loop), so no generated app can carry them. `blueprintGenerateSeedRows`' extra case labels are dead aliases — align the VALIDATOR to parseFieldType, never to the generator's list.
+- Status: active

--- a/examples/blog/gofastr.yml
+++ b/examples/blog/gofastr.yml
@@ -145,7 +145,7 @@ nav:
 screens:
   - name: home
     route: /
-    title: Blog — Home
+    title: Home
     description: Blog homepage
     body:
       - type: heading
@@ -275,8 +275,8 @@ seed:
   - entity: comments
     rows:
       - body: Great introduction! Really helpful for getting started.
-        post_id: 1
+        post_id: "@posts.title=Getting Started with GoFastr"
       - body: The YAML entity system is so clean. Love it!
-        post_id: 1
+        post_id: "@posts.title=Getting Started with GoFastr"
       - body: Can you add a tutorial on authentication next?
-        post_id: 2
+        post_id: "@posts.title=Building Your First Entity"

--- a/examples/ecommerce/app/main.go
+++ b/examples/ecommerce/app/main.go
@@ -85,10 +85,10 @@ func main() {
 			if n > 0 {
 				continue
 			}
-			for _, row := range s.Rows {
+			for i, row := range s.Rows {
 				resolveSeedRefs(ctx, fwApp, row)
 				if _, err := ch.CreateOne(ctx, row); err != nil {
-					return seedCreateError(s.Entity, row, err)
+					return seedCreateError(s.Entity, i+1, err)
 				}
 			}
 		}
@@ -200,8 +200,11 @@ func resolveSeedRefs(ctx context.Context, fwApp *framework.App, row map[string]a
 // bare string "validation failed" — the messages worth reading live in
 // Fields() — so a plain %w would abort the boot with zero actionable
 // information. Unwrap, print every field message (sorted, so the output
-// is stable), and name the row so it can be found in gofastr.yml.
-func seedCreateError(entity string, row map[string]any, err error) error {
+// is stable), and name the row by its one-based position in the
+// blueprint's seed: block. The position — never a row value — is the
+// label: this error aborts boot through log.Fatal, so its text lands
+// in application logs, and seed rows carry admin emails and passwords.
+func seedCreateError(entity string, index int, err error) error {
 	var ve *crud.ValidationError
 	if !errors.As(err, &ve) || len(ve.Fields()) == 0 {
 		return fmt.Errorf("seed %s: %w", entity, err)
@@ -212,23 +215,11 @@ func seedCreateError(entity string, row map[string]any, err error) error {
 	}
 	sort.Strings(names)
 	var b strings.Builder
-	fmt.Fprintf(&b, "seed %s row %s failed validation:", entity, seedRowLabel(row))
+	fmt.Fprintf(&b, "seed %s row %d failed validation:", entity, index)
 	for _, name := range names {
 		for _, msg := range ve.Fields()[name] {
 			fmt.Fprintf(&b, "\n  - %s: %s", name, msg)
 		}
 	}
 	return fmt.Errorf("%s\ncause: %w", b.String(), err)
-}
-
-// seedRowLabel picks the scalar that identifies a seed row against the
-// blueprint's seed: block (the title/name/email it was authored under),
-// falling back to the whole row.
-func seedRowLabel(row map[string]any) string {
-	for _, k := range []string{"title", "name", "email", "label", "slug", "body", "key"} {
-		if s, ok := row[k].(string); ok && s != "" {
-			return fmt.Sprintf("%q", s)
-		}
-	}
-	return fmt.Sprintf("%v", row)
 }

--- a/examples/ecommerce/app/main.go
+++ b/examples/ecommerce/app/main.go
@@ -3,16 +3,19 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 
 	gflog "github.com/DonaldMurillo/gofastr/battery/log"
 	uiapp "github.com/DonaldMurillo/gofastr/core-ui/app"
 	"github.com/DonaldMurillo/gofastr/core/dotenv"
 	"github.com/DonaldMurillo/gofastr/framework"
+	"github.com/DonaldMurillo/gofastr/framework/crud"
 	"github.com/DonaldMurillo/gofastr/framework/filter"
 	fwimage "github.com/DonaldMurillo/gofastr/framework/image"
 	"github.com/DonaldMurillo/gofastr/framework/isolation"
@@ -85,7 +88,7 @@ func main() {
 			for _, row := range s.Rows {
 				resolveSeedRefs(ctx, fwApp, row)
 				if _, err := ch.CreateOne(ctx, row); err != nil {
-					return fmt.Errorf("seed %s: %w", s.Entity, err)
+					return seedCreateError(s.Entity, row, err)
 				}
 			}
 		}
@@ -190,4 +193,42 @@ func resolveSeedRefs(ctx context.Context, fwApp *framework.App, row map[string]a
 			row[k] = id
 		}
 	}
+}
+
+// seedCreateError renders a failed seed insert with the per-field detail
+// the CRUD validator already computed. ValidationError.Error() is the
+// bare string "validation failed" — the messages worth reading live in
+// Fields() — so a plain %w would abort the boot with zero actionable
+// information. Unwrap, print every field message (sorted, so the output
+// is stable), and name the row so it can be found in gofastr.yml.
+func seedCreateError(entity string, row map[string]any, err error) error {
+	var ve *crud.ValidationError
+	if !errors.As(err, &ve) || len(ve.Fields()) == 0 {
+		return fmt.Errorf("seed %s: %w", entity, err)
+	}
+	names := make([]string, 0, len(ve.Fields()))
+	for name := range ve.Fields() {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	fmt.Fprintf(&b, "seed %s row %s failed validation:", entity, seedRowLabel(row))
+	for _, name := range names {
+		for _, msg := range ve.Fields()[name] {
+			fmt.Fprintf(&b, "\n  - %s: %s", name, msg)
+		}
+	}
+	return fmt.Errorf("%s\ncause: %w", b.String(), err)
+}
+
+// seedRowLabel picks the scalar that identifies a seed row against the
+// blueprint's seed: block (the title/name/email it was authored under),
+// falling back to the whole row.
+func seedRowLabel(row map[string]any) string {
+	for _, k := range []string{"title", "name", "email", "label", "slug", "body", "key"} {
+		if s, ok := row[k].(string); ok && s != "" {
+			return fmt.Sprintf("%q", s)
+		}
+	}
+	return fmt.Sprintf("%v", row)
 }

--- a/framework/app.go
+++ b/framework/app.go
@@ -168,7 +168,7 @@ const defaultShutdownTimeout = 15 * time.Second
 //
 //	app := framework.NewApp(framework.WithHTTPServerTimeouts(framework.HTTPServerTimeoutsConfig{
 //	    WriteTimeout: new(2 * time.Minute), // raise for slow handlers
-//	    ReadTimeout:  new(0),               // disable (e.g. huge uploads)
+//	    ReadTimeout:  new(time.Duration(0)), // disable (e.g. huge uploads)
 //	}))
 //
 // ReadHeaderTimeout bounds reading the request headers (slowloris defence)

--- a/framework/contracts/format_json.go
+++ b/framework/contracts/format_json.go
@@ -276,7 +276,7 @@ func FormatSARIF(r *Report, version string) ([]byte, error) {
 			Tool: sarifTool{Driver: sarifDriver{
 				Name:           "gofastr verify",
 				Version:        version,
-				InformationURI: "https://gofastr.dev/docs/contracts",
+				InformationURI: docBaseURL + "contracts",
 				Rules:          rules,
 			}},
 			OriginalUriBaseIds: map[string]sarifUriBase{

--- a/framework/contracts/rule.go
+++ b/framework/contracts/rule.go
@@ -65,9 +65,11 @@ type Rule struct {
 	Autofix bool `json:"autofix"`
 }
 
-// docBaseURL is where the embedded docs are published. Diagnostics carry
-// a resolvable link even when the reader is nowhere near a checkout.
-const docBaseURL = "https://gofastr.dev/docs/"
+// docBaseURL is where the embedded docs are published (the GitHub Pages
+// deployment of examples/site; see .github/workflows/pages.yml).
+// Diagnostics carry a resolvable link even when the reader is nowhere
+// near a checkout.
+const docBaseURL = "https://donaldmurillo.github.io/gofastr/docs/"
 
 // DocURL is the published location of the rule's doc topic.
 func (r Rule) DocURL() string {

--- a/framework/crud/crud.go
+++ b/framework/crud/crud.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/framework/filter"
 	"github.com/DonaldMurillo/gofastr/framework/hook"
 	"github.com/DonaldMurillo/gofastr/framework/internal/casing"
+	"github.com/DonaldMurillo/gofastr/framework/pagination"
 	"github.com/DonaldMurillo/gofastr/framework/tenant"
 )
 
@@ -655,7 +656,7 @@ func (ch *CrudHandler) List() http.HandlerFunc {
 		}
 		filter.ApplySortToQuery(qb, sorts)
 
-		offset := (page - 1) * perPage
+		offset := pagination.OffsetForPage(page, perPage)
 		// An explicit ?offset= overrides the page-derived offset. The
 		// process-module broker paginates by raw offset (it sets ?offset=
 		// without ?page=), and it is a documented control param — honoring it
@@ -915,7 +916,7 @@ func (ch *CrudHandler) Create() http.HandlerFunc {
 		if !ch.requireScope(w, r, opCreate) {
 			return
 		}
-		limitJSONBody(w, r)
+		limitRequestBody(w, r)
 		body, err := ch.readRequestBody(r)
 		if err != nil {
 			if errors.Is(err, errBodyTooLarge) {
@@ -981,7 +982,7 @@ func (ch *CrudHandler) Update() http.HandlerFunc {
 			return
 		}
 
-		limitJSONBody(w, r)
+		limitRequestBody(w, r)
 		body, err := ch.readRequestBody(r)
 		if err != nil {
 			if errors.Is(err, errBodyTooLarge) {

--- a/framework/crud/crud_stream.go
+++ b/framework/crud/crud_stream.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/core/query"
 	"github.com/DonaldMurillo/gofastr/framework/filter"
 	"github.com/DonaldMurillo/gofastr/framework/hook"
+	"github.com/DonaldMurillo/gofastr/framework/pagination"
 )
 
 // streamListThreshold is the limit beyond which the List handler
@@ -94,8 +95,8 @@ func (ch *CrudHandler) ServeStreamingList(ctx context.Context, w http.ResponseWr
 		if o > 0 {
 			qb.Offset(o)
 		}
-	} else if page > 1 {
-		qb.Offset((page - 1) * limit)
+	} else if offset := pagination.OffsetForPage(page, limit); offset > 0 {
+		qb.Offset(offset)
 	}
 
 	dataSQL, dataArgs := qb.Build()

--- a/framework/crud/crud_upload.go
+++ b/framework/crud/crud_upload.go
@@ -22,6 +22,15 @@ import (
 // through a temp file.
 const MaxMultipartMemory = 32 << 20 // 32 MiB
 
+// MaxMultipartBodyBytes caps the total wire size of a multipart request
+// accepted by the CRUD write handlers. MaxMultipartMemory above is the
+// in-RAM spill threshold, not a body cap — without a wire cap a hostile
+// client can stream an unbounded body into parser temp files (and, via
+// non-file form values, straight into memory). 64 MiB leaves headroom
+// over the 32 MiB per-file ProcessFileField cap for framing and form
+// fields. Requests over the cap are rejected 413.
+const MaxMultipartBodyBytes int64 = 64 << 20 // 64 MiB
+
 // MaxJSONBodyBytes caps the size of a JSON request body the CRUD handlers
 // will read. 1 MiB is large enough for any realistic single record or
 // batch envelope, while bounding the memory an unauthenticated caller can
@@ -68,6 +77,22 @@ func enforceJSONContentType(r *http.Request) error {
 	return errUnsupportedMediaType
 }
 
+// limitRequestBody wraps r.Body with the http.MaxBytesReader matching the
+// request's Content-Type: JSON bodies cap at MaxJSONBodyBytes, multipart
+// bodies at MaxMultipartBodyBytes. One cap for both would break whichever
+// side it doesn't fit — a JSON-sized cap rejects every multipart upload
+// above 1 MiB (multipart framing plus file parts dwarf a JSON record), and
+// a multipart-sized cap would let unauthenticated callers pin ~64 MiB of
+// parser memory with a JSON body. Callers map the resulting
+// errBodyTooLarge to 413.
+func limitRequestBody(w http.ResponseWriter, r *http.Request) {
+	if isMultipart(r) {
+		r.Body = http.MaxBytesReader(w, r.Body, MaxMultipartBodyBytes)
+		return
+	}
+	limitJSONBody(w, r)
+}
+
 // limitJSONBody wraps r.Body with http.MaxBytesReader so JSON decoding
 // caps at MaxJSONBodyBytes. The wrapped body is installed back onto the
 // request so other readers see the same limit.
@@ -103,7 +128,7 @@ func decodeJSONBody(r *http.Request, v any) error {
 // schema's field names regardless of the wire casing.
 //
 // Pre-condition: the caller has already validated Content-Type via
-// enforceJSONContentType and (for JSON) wrapped r.Body with limitJSONBody.
+// enforceJSONContentType and wrapped r.Body with limitRequestBody.
 func (ch *CrudHandler) readRequestBody(r *http.Request) (map[string]any, error) {
 	if isMultipart(r) {
 		return ch.parseMultipartBody(r)
@@ -122,9 +147,17 @@ func (ch *CrudHandler) readRequestBody(r *http.Request) (map[string]any, error) 
 // by name with type coercion driven by the schema (Int/Float/Bool).
 //
 // The handler must have Storage set; otherwise the function errors. Callers
-// should validate Content-Type with isMultipart first.
+// should validate Content-Type with isMultipart first and wrap r.Body with
+// limitRequestBody so the multipart wire cap applies.
 func (ch *CrudHandler) parseMultipartBody(r *http.Request) (map[string]any, error) {
 	if err := r.ParseMultipartForm(MaxMultipartMemory); err != nil {
+		// An over-cap body is a size problem, not a malformed request:
+		// map it to errBodyTooLarge so callers answer 413 (matching the
+		// JSON path) instead of a 400 the client would retry verbatim.
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) || strings.Contains(err.Error(), "request body too large") {
+			return nil, errBodyTooLarge
+		}
 		return nil, fmt.Errorf("parse multipart: %w", err)
 	}
 

--- a/framework/crud/crud_upload.go
+++ b/framework/crud/crud_upload.go
@@ -50,9 +50,15 @@ var errUnsupportedMediaType = errors.New("unsupported media type")
 var errBodyTooLarge = errors.New("request body too large")
 
 // isMultipart reports whether the request carries a multipart/form-data body.
+// Parsed with mime.ParseMediaType — media types are case-insensitive
+// (RFC 9110 §8.3.1) and lowercased by the parser — so this agrees with
+// enforceJSONContentType for a header like `Multipart/Form-Data; …`. A
+// case-sensitive prefix check here let such a request through the gate
+// but not the multipart branch, so the JSON 1 MiB body cap applied and
+// >1 MiB uploads failed with a bogus 400.
 func isMultipart(r *http.Request) bool {
-	ct := r.Header.Get("Content-Type")
-	return strings.HasPrefix(ct, "multipart/form-data")
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	return err == nil && mediaType == "multipart/form-data"
 }
 
 // enforceJSONContentType refuses requests whose Content-Type isn't either

--- a/framework/crud/cursor_fidelity_test.go
+++ b/framework/crud/cursor_fidelity_test.go
@@ -1,0 +1,109 @@
+package crud
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+	"github.com/DonaldMurillo/gofastr/framework/pagination"
+)
+
+// cursorFidelityHandler: entity cursored on a TEXT column (title), the
+// shape that loses rows when the cursor decode mutates the keyset value.
+func cursorFidelityHandler(t *testing.T) *CrudHandler {
+	t.Helper()
+	db := setupDB(t, `CREATE TABLE docs (id TEXT PRIMARY KEY, title TEXT)`)
+	ent := entity.Define("docs", entity.EntityConfig{
+		Name: "docs", Table: "docs",
+		Pagination: &entity.PaginationConfig{CursorField: "title"},
+		Fields:     []schema.Field{{Name: "title", Type: schema.String, Required: true}},
+	}.WithTimestamps(false))
+	ent.SetDB(db)
+	return NewCrudHandler(ent, db).WithJSONCase(CaseSnake)
+}
+
+// TestCursorPagingServesEveryRowOnce: page through rows whose sort keys
+// include zero-width / bidi codepoints and assert the union of pages is
+// exactly the seeded set — no duplicates, no missing rows. DecodeCursor
+// used to strip those codepoints, so the keyset resumed BEFORE the
+// stripped row and re-served it (and its predecessors' tail) twice.
+func TestCursorPagingServesEveryRowOnce(t *testing.T) {
+	ch := cursorFidelityHandler(t)
+	titles := []string{"aa", "a\u200bb", "a\ufeffb", "mm", "zz"}
+	for _, ti := range titles {
+		req := withTestUser(httptest.NewRequest("POST", "/docs",
+			strings.NewReader(fmt.Sprintf(`{"title":%s}`, mustJSONString(ti)))), "u1")
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		ch.Create()(rec, req)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("seed %q: %d %s", ti, rec.Code, rec.Body.String())
+		}
+	}
+
+	seen := map[string]int{}
+	cursor := ""
+	pages := 0
+	for {
+		path := "/docs?cursor=" + pagination.EncodeCursor("title", cursor) + "&limit=2"
+		if cursor == "" {
+			path = "/docs?cursor=&limit=2"
+		}
+		req := withTestUser(httptest.NewRequest("GET", path, nil), "u1")
+		rec := httptest.NewRecorder()
+		ch.List()(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("page %d: %d %s", pages, rec.Code, rec.Body.String())
+		}
+		var page pagination.CursorPage
+		if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+			t.Fatalf("decode page: %v", err)
+		}
+		pages++
+		for _, row := range page.Data {
+			title, _ := row["title"].(string)
+			seen[title]++
+		}
+		if !page.HasMore || page.Cursor == "" {
+			break
+		}
+		cursor = decodeCursorValue(t, page.Cursor)
+		if pages > 10 {
+			t.Fatal("paging did not terminate")
+		}
+	}
+
+	var dupes, missing []string
+	for _, want := range titles {
+		n := seen[want]
+		if n == 0 {
+			missing = append(missing, want)
+		} else if n > 1 {
+			dupes = append(dupes, want)
+		}
+	}
+	if len(dupes) > 0 || len(missing) > 0 {
+		t.Fatalf("cursor paging corrupted: dupes=%v missing=%v seen=%v", dupes, missing, seen)
+	}
+}
+
+// decodeCursorValue extracts the value half of an emitted cursor so the
+// test can follow the paging chain without depending on the token shape.
+func decodeCursorValue(t *testing.T, cur string) string {
+	t.Helper()
+	_, v, err := pagination.DecodeCursor(cur)
+	if err != nil {
+		t.Fatalf("decode cursor: %v", err)
+	}
+	return v
+}
+
+func mustJSONString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/framework/crud/include.go
+++ b/framework/crud/include.go
@@ -363,10 +363,13 @@ func parseScopedFilters(raw string, fields []schema.Field, pathForErrors string)
 			field = col
 		}
 		if op == filter.OpIn {
-			vals := strings.Split(value, "|")
-			if len(vals) > maxScopedINEntries {
-				return nil, fmt.Errorf("include %q: scoped IN list on %q has %d entries (max %d)", pathForErrors, field, len(vals), maxScopedINEntries)
+			// Count separators before splitting, so an oversized list is
+			// rejected without materializing it. Same shape as the top-level
+			// ?field_in= path (filter.SplitINValuesBounded).
+			if n := strings.Count(value, "|") + 1; n > maxScopedINEntries {
+				return nil, fmt.Errorf("include %q: scoped IN list on %q has %d entries (max %d)", pathForErrors, field, n, maxScopedINEntries)
 			}
+			vals := strings.Split(value, "|")
 			for _, v := range vals {
 				out = append(out, filter.ParsedFilter{Field: field, Op: filter.OpIn, Value: v}.Coerced(colType[field]))
 			}

--- a/framework/crud/multipart_body_limit_test.go
+++ b/framework/crud/multipart_body_limit_test.go
@@ -97,3 +97,22 @@ func TestMultipartCreateOverWireCapIs413(t *testing.T) {
 		t.Fatalf("over-cap multipart create = %d, want 413. body=%s", rec.Code, rec.Body.String())
 	}
 }
+
+// TestMultipartMixedCaseTypeLargeFile: media types are case-insensitive
+// (RFC 9110 §8.3.1). enforceJSONContentType parses the header with
+// mime.ParseMediaType — which lowercases — so `Multipart/Form-Data`
+// passes the content-type gate, but isMultipart used a case-sensitive
+// prefix check and routed the request down the JSON path: the 1 MiB
+// MaxJSONBodyBytes cap applied and every >1 MiB upload died. The two
+// checks must agree, whatever the case.
+func TestMultipartMixedCaseTypeLargeFile(t *testing.T) {
+	ch := multipartLimitHandler(t)
+	req := withTestUser(multipartRequest("POST", "/uploads", 2<<20), "u1")
+	ct := req.Header.Get("Content-Type")
+	req.Header.Set("Content-Type", "Multipart/Form-Data"+strings.TrimPrefix(ct, "multipart/form-data"))
+	rec := httptest.NewRecorder()
+	ch.Create()(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("2 MiB mixed-case multipart create = %d, want 201. body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/framework/crud/multipart_body_limit_test.go
+++ b/framework/crud/multipart_body_limit_test.go
@@ -1,0 +1,99 @@
+package crud
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/core/upload"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// multipartLimitHandler builds a handler over an entity with a schema.File
+// field plus storage, for exercising the multipart wire-cap paths.
+func multipartLimitHandler(t *testing.T) *CrudHandler {
+	t.Helper()
+	db := setupDB(t, `CREATE TABLE uploads (id TEXT PRIMARY KEY, title TEXT, doc TEXT)`)
+	ent := entity.Define("uploads", entity.EntityConfig{
+		Name: "uploads", Table: "uploads",
+		Fields: []schema.Field{
+			{Name: "title", Type: schema.String},
+			{Name: "doc", Type: schema.File},
+		},
+	}.WithTimestamps(false))
+	ent.SetDB(db)
+	ch := NewCrudHandler(ent, db).WithJSONCase(CaseSnake)
+	ch.Storage = upload.NewLocalStorage(t.TempDir())
+	return ch
+}
+
+// multipartRequest builds a POST/PATCH request whose "doc" file part is
+// size bytes of inert data (no markup tokens, so the content sniffer
+// accepts it).
+func multipartRequest(method, path string, size int) *http.Request {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("title", "has-file")
+	fw, _ := mw.CreateFormFile("doc", "blob.bin")
+	_, _ = fw.Write(bytes.Repeat([]byte{0x42}, size))
+	_ = mw.Close()
+	req := httptest.NewRequest(method, path, &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	return req
+}
+
+// TestMultipartCreateAcceptsLargeFile: a 2 MiB multipart upload must
+// succeed. Create wraps r.Body in a 1 MiB MaxBytesReader sized for JSON
+// bodies; multipart requests must be capped at the multipart limit
+// instead, or every upload above 1 MiB dies with a bogus 400 and the
+// 32 MiB MaxMultipartMemory constant is a dead letter.
+func TestMultipartCreateAcceptsLargeFile(t *testing.T) {
+	ch := multipartLimitHandler(t)
+	req := withTestUser(multipartRequest("POST", "/uploads", 2<<20), "u1")
+	rec := httptest.NewRecorder()
+	ch.Create()(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("2 MiB multipart create = %d, want 201. body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestMultipartUpdateAcceptsLargeFile: the Update sibling of the above —
+// PATCH with a >1 MiB multipart body must succeed, not 400.
+func TestMultipartUpdateAcceptsLargeFile(t *testing.T) {
+	ch := multipartLimitHandler(t)
+	req := withTestUser(httptest.NewRequest("POST", "/uploads",
+		strings.NewReader(`{"title":"x"}`)), "u1")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	ch.Create()(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("seed create = %d body=%s", rec.Code, rec.Body.String())
+	}
+	id, _ := decodeSingleResponse(t, rec.Body.Bytes())["id"].(string)
+
+	preq := withTestUser(multipartRequest("PATCH", "/uploads/"+id, 2560<<10), "u1")
+	preq.SetPathValue("id", id)
+	prec := httptest.NewRecorder()
+	ch.Update()(prec, preq)
+	if prec.Code != http.StatusOK {
+		t.Fatalf("2.5 MiB multipart update = %d, want 200. body=%s", prec.Code, prec.Body.String())
+	}
+}
+
+// TestMultipartCreateOverWireCapIs413: a multipart body over the
+// multipart wire cap must be rejected 413 (too large), not 400 (parse
+// error). Over-limit is a size problem; reporting it as a malformed
+// request misleads clients into retrying the same bytes.
+func TestMultipartCreateOverWireCapIs413(t *testing.T) {
+	ch := multipartLimitHandler(t)
+	req := withTestUser(multipartRequest("POST", "/uploads", int(MaxMultipartBodyBytes)+(64<<10)), "u1")
+	rec := httptest.NewRecorder()
+	ch.Create()(rec, req)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("over-cap multipart create = %d, want 413. body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/framework/crud/nested_filter.go
+++ b/framework/crud/nested_filter.go
@@ -161,8 +161,16 @@ func parseNestedFiltersValues(q url.Values, ent *entity.Entity, registry entity.
 			// separate AND-ed EXISTS made a to-one relation (BelongsTo/HasOne)
 			// unmatchable — a single related row can't equal every value — so
 			// `?author.name_in=a,b` silently returned nothing. One IN matches
-			// the top-level _in semantics.
-			out = append(out, nestedFilter{Relation: rel, Field: fieldName, Op: op, Values: strings.Split(values[0], ","), isBool: isBool})
+			// the top-level _in semantics, including the union across
+			// repeated keys (filter.SplitINValues) and the entry cap the
+			// flat path enforces — same cap, same error shape, so the
+			// nested surface can't drive uncapped placeholders per request.
+			vals := filter.SplitINValues(values)
+			if len(vals) > filter.MaxINListEntries {
+				return nil, fmt.Errorf("nested filter %q: in-list on %q has %d entries (max %d)",
+					key, fieldName, len(vals), filter.MaxINListEntries)
+			}
+			out = append(out, nestedFilter{Relation: rel, Field: fieldName, Op: op, Values: vals, isBool: isBool})
 		} else {
 			out = append(out, nestedFilter{Relation: rel, Field: fieldName, Op: op, Value: values[0], isBool: isBool})
 		}

--- a/framework/crud/nested_filter.go
+++ b/framework/crud/nested_filter.go
@@ -162,13 +162,13 @@ func parseNestedFiltersValues(q url.Values, ent *entity.Entity, registry entity.
 			// unmatchable — a single related row can't equal every value — so
 			// `?author.name_in=a,b` silently returned nothing. One IN matches
 			// the top-level _in semantics, including the union across
-			// repeated keys (filter.SplitINValues) and the entry cap the
-			// flat path enforces — same cap, same error shape, so the
+			// repeated keys (filter.SplitINValuesBounded) and the entry cap
+			// the flat path enforces — same cap, same error shape, so the
 			// nested surface can't drive uncapped placeholders per request.
-			vals := filter.SplitINValues(values)
-			if len(vals) > filter.MaxINListEntries {
+			vals, total := filter.SplitINValuesBounded(values, filter.MaxINListEntries)
+			if total > filter.MaxINListEntries {
 				return nil, fmt.Errorf("nested filter %q: in-list on %q has %d entries (max %d)",
-					key, fieldName, len(vals), filter.MaxINListEntries)
+					key, fieldName, total, filter.MaxINListEntries)
 			}
 			out = append(out, nestedFilter{Relation: rel, Field: fieldName, Op: op, Values: vals, isBool: isBool})
 		} else {

--- a/framework/crud/page_overflow_test.go
+++ b/framework/crud/page_overflow_test.go
@@ -1,0 +1,98 @@
+package crud
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// pageOverflowHandler: plain offset-paginated entity.
+func pageOverflowHandler(t *testing.T) *CrudHandler {
+	t.Helper()
+	db := setupDB(t, `CREATE TABLE items (id TEXT PRIMARY KEY, n INTEGER)`)
+	ent := entity.Define("items", entity.EntityConfig{
+		Name: "items", Table: "items",
+		Fields: []schema.Field{{Name: "n", Type: schema.Int}},
+	}.WithTimestamps(false))
+	ent.SetDB(db)
+	rows := make([]map[string]any, 8)
+	for i := range rows {
+		rows[i] = map[string]any{"id": fmt.Sprintf("i-%d", i+1), "n": i + 1}
+	}
+	seedRows(t, db, "items", rows)
+	return NewCrudHandler(ent, db).WithJSONCase(CaseSnake)
+}
+
+// hugePageWrapPositive is a page number parsePaginationValues accepts
+// (>0, fits int) whose (page-1)*limit product wraps int arithmetic to a
+// POSITIVE wrong value: (2^62+1)*4 = 2^64+4 → 4. The request then
+// silently serves the page-2 window while labelling it page 2^62+2.
+// (The MaxInt64 flavor wraps NEGATIVE: SQLite treats a negative OFFSET
+// as 0 — masking the bug — while Postgres rejects it, turning the
+// request into a 500.)
+const hugePageWrapPositive = 4611686018427387906 // 2^62 + 2, wraps ×4
+
+// TestListHugePageNotWrappedWindow: an overflowing page number must be
+// clamped by the same guard pagination.ParsePagination applies, not
+// wrapped to an arbitrary window by int overflow.
+func TestListHugePageNotWrappedWindow(t *testing.T) {
+	ch := pageOverflowHandler(t)
+
+	req := withTestUser(httptest.NewRequest("GET",
+		fmt.Sprintf("/items?page=%d&limit=4&sort=n", hugePageWrapPositive), nil), "u1")
+	rec := httptest.NewRecorder()
+	ch.List()(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("huge page = %d: %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeListResponse(t, rec.Body.String())
+	if len(resp.Data) == 0 {
+		t.Fatal("expected the first window of rows, got none")
+	}
+	first, _ := resp.Data[0]["n"].(float64)
+	if first != 1 {
+		t.Fatalf("overflowing page wrapped to window starting at n=%v — int overflow in (page-1)*limit; want the guarded first window", first)
+	}
+}
+
+// TestStreamingListHugePageNotWrappedWindow: the streaming list path
+// computes its own (page-1)*limit offset and must apply the same
+// overflow guard.
+func TestStreamingListHugePageNotWrappedWindow(t *testing.T) {
+	ch := pageOverflowHandler(t)
+
+	req := withTestUser(httptest.NewRequest("GET",
+		fmt.Sprintf("/items?stream=true&page=%d&limit=4&sort=n", hugePageWrapPositive), nil), "u1")
+	rec := httptest.NewRecorder()
+	ch.List()(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("streaming huge page = %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	// Buggy offset 4 streams rows 5..8; the guarded path streams 1..4.
+	want := `"n":1`
+	for i := 1; i <= 4; i++ {
+		if !contains(body, fmt.Sprintf(`"n":%d`, i)) {
+			t.Fatalf("streaming huge page missed row n=%d (wrapped window): %s", i, body)
+		}
+	}
+	_ = want
+	if contains(body, `"n":5`) {
+		t.Fatalf("streaming huge page served the wrapped window (n=5 present): %s", body)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (func() bool {
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				return true
+			}
+		}
+		return false
+	})()
+}

--- a/framework/crud/repeat_in_test.go
+++ b/framework/crud/repeat_in_test.go
@@ -1,0 +1,110 @@
+package crud
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// nestedInHandler: posts BelongsTo author (people), the shape the nested
+// _in path filters through an EXISTS subquery.
+func nestedInHandler(t *testing.T) *CrudHandler {
+	t.Helper()
+	db := setupDB(t,
+		`CREATE TABLE people (id TEXT PRIMARY KEY, name TEXT)`,
+		`CREATE TABLE posts (id TEXT PRIMARY KEY, title TEXT, author_id TEXT)`)
+	people := entity.Define("people", entity.EntityConfig{
+		Name: "people", Table: "people",
+		Fields: []schema.Field{{Name: "name", Type: schema.String}},
+	}.WithTimestamps(false))
+	posts := entity.Define("posts", entity.EntityConfig{
+		Name: "posts", Table: "posts",
+		Fields: []schema.Field{
+			{Name: "title", Type: schema.String},
+			{Name: "author_id", Type: schema.String},
+		},
+		Relations: []entity.Relation{entity.BelongsTo("author", "people", "author_id")},
+	}.WithTimestamps(false))
+	people.SetDB(db)
+	posts.SetDB(db)
+	ch := NewCrudHandler(posts, db).WithJSONCase(CaseSnake)
+	ch.Registry = stubRegistry{byName: map[string]*entity.Entity{"people": people, "posts": posts}}
+	seedRows(t, db, "people", []map[string]any{
+		{"id": "p-alice", "name": "alice"},
+		{"id": "p-bob", "name": "bob"},
+		{"id": "p-carol", "name": "carol"},
+	})
+	seedRows(t, db, "posts", []map[string]any{
+		{"id": "po-1", "title": "by alice", "author_id": "p-alice"},
+		{"id": "po-2", "title": "by bob", "author_id": "p-bob"},
+		{"id": "po-3", "title": "by carol", "author_id": "p-carol"},
+	})
+	return ch
+}
+
+func nestedInList(t *testing.T, ch *CrudHandler, query string) ListResponse {
+	t.Helper()
+	req := withTestUser(httptest.NewRequest("GET", "/posts"+query, nil), "u1")
+	rec := httptest.NewRecorder()
+	ch.List()(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s = %d: %s", query, rec.Code, rec.Body.String())
+	}
+	return decodeListResponse(t, rec.Body.String())
+}
+
+// TestNestedRepeatedInKeysUnion: every occurrence of a repeated
+// ?rel.field_in= key must contribute values — the same union contract the
+// flat path has. Reading only values[0] narrowed ?author.name_in=alice&
+// ?author.name_in=bob to alice alone, silently dropping bob's posts.
+func TestNestedRepeatedInKeysUnion(t *testing.T) {
+	ch := nestedInHandler(t)
+
+	single := nestedInList(t, ch, "?author.name_in=alice")
+	if len(single.Data) != 1 {
+		t.Fatalf("sanity: ?author.name_in=alice returned %d rows, want 1", len(single.Data))
+	}
+
+	double := nestedInList(t, ch, "?author.name_in=alice&author.name_in=bob")
+	if len(double.Data) != 2 {
+		t.Fatalf("?author.name_in=alice&author.name_in=bob returned %d rows, want 2 (union)", len(double.Data))
+	}
+
+	// Comma form and repeated form must agree.
+	comma := nestedInList(t, ch, "?author.name_in=alice,bob")
+	if len(comma.Data) != len(double.Data) {
+		t.Fatalf("repeated keys (%d rows) disagree with comma form (%d rows)", len(double.Data), len(comma.Data))
+	}
+}
+
+// TestNestedInListOverCapErrors: a nested ?rel.field_in= list must obey
+// the same 1000-entry cap (and error shape) as the flat ?field_in= path.
+// Without it, one request drives 1100+ bind parameters through the EXISTS
+// subquery — uncapped memory/CPU per request, exactly what the flat cap
+// exists to prevent.
+func TestNestedInListOverCapErrors(t *testing.T) {
+	ch := nestedInHandler(t)
+
+	flatVals := strings.Repeat("x,", 1100) + "x"
+	req := withTestUser(httptest.NewRequest("GET", "/posts?title_in="+flatVals, nil), "u1")
+	rec := httptest.NewRecorder()
+	ch.List()(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("sanity: flat 1101-entry list = %d, want 400", rec.Code)
+	}
+
+	req2 := withTestUser(httptest.NewRequest("GET", "/posts?author.name_in="+flatVals, nil), "u1")
+	rec2 := httptest.NewRecorder()
+	ch.List()(rec2, req2)
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("nested 1101-entry list = %d, want 400 (same cap as flat path). body=%s", rec2.Code, rec2.Body.String())
+	}
+	if !strings.Contains(rec2.Body.String(), fmt.Sprint("max")) && !strings.Contains(rec2.Body.String(), "1000") {
+		t.Errorf("nested cap error does not report the max: %s", rec2.Body.String())
+	}
+}

--- a/framework/docs/content/access-control.md
+++ b/framework/docs/content/access-control.md
@@ -203,6 +203,12 @@ perms := framework.GetPermissions(ctx)
 To branch UI (or any logic) on the caller's roles rather than their
 resolved permissions, read the roles back with `GetRoles`:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+import "context"
+var ctx = context.Background()
+import "slices"
+-->
 ```go
 roles := framework.GetRoles(ctx)
 // [editor reader] — the same slice installed by WithRoles
@@ -333,6 +339,14 @@ For apps that need **runtime-editable** RBAC (an admin UI that grants and
 revokes without a redeploy), `access.GrantStore` persists grants to a
 database table and keeps the live `*RolePolicy` in sync.
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+import "github.com/DonaldMurillo/gofastr/framework/access"
+import "database/sql"
+var db *sql.DB
+import "context"
+var ctx = context.Background()
+-->
 ```go
 policy := framework.NewRolePolicy()
 policy.Grant("admin", access.Wildcard) // code-defined baseline
@@ -367,10 +381,14 @@ Attaching a fanout closes that window. Register the store with the app
 fanout as `WithFanout`:
 
 ```go
+pg, err := fanout.NewPostgres(dsn, db)
+if err != nil {
+    log.Fatal(err)
+}
 app := framework.NewApp(
     framework.WithDB(db),
     framework.WithGrantStore(store),
-    framework.WithFanout(fanout.NewPostgres(dsn, db)),
+    framework.WithFanout(pg),
 )
 ```
 
@@ -607,6 +625,9 @@ RBAC for every caller, so it is untouched.
 separate, pure matcher for the richer `resource:verb` wildcard grammar used
 by **token scopes** and **module capability grants**:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework/access"
+-->
 ```go
 // exact | resource wildcard | verb wildcard | grant-all
 access.ScopeMatch([]access.Permission{"posts:*"}, "posts:read")  // true

--- a/framework/docs/content/admin.md
+++ b/framework/docs/content/admin.md
@@ -42,6 +42,9 @@ Exposure is **opt-in**. An empty `Entities` exposes nothing — a
 zero-value config must not silently turn every table into an editable
 back-office. Either name the entities:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/battery/admin"
+-->
 ```go
 admin.New(admin.Config{Entities: []string{"products", "orders"}})
 ```
@@ -109,6 +112,14 @@ admin and JSON API writes. The proxy also forwards the parent request's
 
 ## Ops dashboards (queue + audit)
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/battery/queue"
+import "database/sql"
+var db *sql.DB
+import "github.com/DonaldMurillo/gofastr/framework"
+var app = framework.NewApp()
+import "github.com/DonaldMurillo/gofastr/battery/admin"
+-->
 ```go
 q, _ := queue.NewDBQueue(db)
 app.RegisterBattery(admin.New(admin.Config{

--- a/framework/docs/content/agent-ready.md
+++ b/framework/docs/content/agent-ready.md
@@ -56,6 +56,9 @@ enables markdown content negotiation when `WithMarkdownNegotiation` is added.
 
 ### `/llms.txt` — curated markdown index  (llmstxt.org)
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework/uihost"
+-->
 ```go
 uihost.WithLLMsTxt("Acme", "A billing console.",
 	[]uihost.LLMsTxtSection{
@@ -95,9 +98,10 @@ uihost.WithAgentReady(uihost.AgentReadyConfig{
 
 The content is served verbatim as `text/plain`. Nothing links it
 automatically — add a `Sections` entry pointing at `/llms-full.txt` so
-agents reading the index can find it. gofastr.dev does exactly this:
-its `/llms.txt` indexes every embedded framework doc as a raw markdown
-URL, and its `/llms-full.txt` is the whole corpus concatenated.
+agents reading the index can find it. The docs site in `examples/site`
+does exactly this: its `/llms.txt` indexes every embedded framework
+doc as a raw markdown URL, and its `/llms-full.txt` is the whole
+corpus concatenated.
 
 ### A2A agent card  (Agent2Agent v1.0)
 
@@ -234,6 +238,9 @@ app.MCP.RegisterTool("orders_refund", "…", schema, refundHandler,
 
 When the whole endpoint is private, close it in one place instead:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+-->
 ```go
 framework.NewApp(
     framework.WithMCP(),
@@ -382,6 +389,9 @@ bearer API), `framework.WithOAuthProtectedResource` serves
 authorization servers mint accepted tokens, the supported scopes, and how to
 present a bearer token:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+-->
 ```go
 framework.WithOAuthProtectedResource(framework.OAuthProtectedResourceConfig{
 	Resource:             "https://api.example.com",

--- a/framework/docs/content/api-versioning.md
+++ b/framework/docs/content/api-versioning.md
@@ -31,6 +31,9 @@ app.Entity("posts", entity.EntityConfig{ /* … */ })
 `/api/v1/posts/_batch`, and so on. The bare `/posts` path is **not**
 mounted. The prefix is also settable via config:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+-->
 ```go
 framework.NewApp(framework.WithConfig(framework.AppConfig{APIPrefix: "/api/v1"}))
 ```

--- a/framework/docs/content/auth.md
+++ b/framework/docs/content/auth.md
@@ -368,7 +368,7 @@ if !auth.HasScope(ctx, "posts:read") { /* 403 */ }
 
 // As route middleware: 403s token-authenticated requests lacking the scope;
 // non-token (session/JWT) requests pass unscoped.
-r.With(auth.RequireScope("posts:write")).Post("/posts", handler)
+r.Group("/posts", auth.RequireScope("posts:write")).Post("", handler)
 ```
 
 For the auto-CRUD tree there is a blanket gate: `RequireAPIScopes(prefix)`
@@ -501,6 +501,9 @@ Defaults applied when no failure option is passed:
 To suppress the auto-`?next=` on a redirect (e.g. anon "/" →
 "/marketing"), pass `auth.NoNext()`:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/battery/auth"
+-->
 ```go
 auth.SessionPolicy(auth.WithRedirect("/marketing", auth.NoNext()))
 ```
@@ -1167,6 +1170,12 @@ the auth audit gate before merge.
 `OAuth2Provider` interface as the built-in Google/GitHub providers — one
 config block, discovered endpoints, JWKS-verified id_tokens.
 
+<!-- gofastr:compile
+stmt: _ = err
+import "github.com/DonaldMurillo/gofastr/battery/auth"
+import "os"
+stmt: _ = oauth
+-->
 ```go
 provider, err := auth.NewOIDCProvider(auth.OIDCConfig{
     Issuer:       "https://keycloak.example/realms/myrealm",

--- a/framework/docs/content/backend-capability-map.md
+++ b/framework/docs/content/backend-capability-map.md
@@ -12,6 +12,13 @@ The UI equivalent is [ui-capability-map.md](ui-capability-map.md).
 
 Everything below assumes this shape. It is the whole spine.
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+import "database/sql"
+var db *sql.DB
+import "github.com/DonaldMurillo/gofastr/framework/entity"
+import "github.com/DonaldMurillo/gofastr/core/schema"
+-->
 ```go
 app := framework.NewApp(
     framework.WithDB(db),              // any *sql.DB — sqlite3 or postgres
@@ -19,7 +26,7 @@ app := framework.NewApp(
 )
 app.Entity("tickets", entity.EntityConfig{
     Table:      "tickets",
-    OwnerField: "user_id",             // per-user scoping — see the table
+    Scope:      &framework.ScopeConfig{OwnerField: "user_id"}, // per-user scoping — see the table
     Fields: []schema.Field{
         {Name: "title", Type: schema.String, Required: true},
     },
@@ -62,7 +69,7 @@ route, marks which need auth, and names the option that ungates them.
 | Job to be done | Compose | Prove it | Docs |
 |---|---|---|---|
 | CRUD over a table | `framework.App.Entity` with `entity.EntityConfig` | `curl localhost:8080/api/tickets` | [Entity declarations](entity-declarations.md) |
-| Scope rows to the signed-in user | `EntityConfig.OwnerField` — **not** a hand-written filter | `gofastr verify data` fails when an entity with user data lacks it | [Entity declarations](entity-declarations.md), [Access control](access-control.md) |
+| Scope rows to the signed-in user | `EntityConfig.Scope.OwnerField` — **not** a hand-written filter | `gofastr verify data` fails when an entity with user data lacks it | [Entity declarations](entity-declarations.md), [Access control](access-control.md) |
 | Login, signup, sessions, password reset | `battery/auth`: `auth.New`, `auth.SessionMiddleware` | `curl -i -X POST localhost:8080/auth/login -d '{...}'` → `Set-Cookie` | [Auth](auth.md) |
 | Roles and permissions | `access.NewRolePolicy`, `access.Middleware`, `access.Wildcard` | `gofastr verify permissions` | [Access control](access-control.md) |
 | Signed sessions across replicas | `framework.WithSecret` / `GOFASTR_SECRET`, `framework.WithSecretRotation` | restart the process; an existing cookie still authenticates | [Scaling](scaling.md), [Auth](auth.md) |

--- a/framework/docs/content/backend-capability-map.md
+++ b/framework/docs/content/backend-capability-map.md
@@ -97,7 +97,7 @@ route, marks which need auth, and names the option that ungates them.
 Each of these is a declaration, and writing it by hand is the most common way
 an app ends up with a bug the framework would have prevented:
 
-- a `WHERE user_id = ?` filter → `OwnerField`
+- a `WHERE user_id = ?` filter → `Scope.OwnerField`
 - a pagination/sort/filter query string parser → `framework/filter`,
   `framework/pagination`, `framework/dsl`
 - a password hash and session cookie → `battery/auth`
@@ -108,7 +108,7 @@ an app ends up with a bug the framework would have prevented:
 
 - **Reading topic docs before this page.** They are references, not
   orientation. Land on the row first, then open the one link it points at.
-- **Hand-writing a filter for per-user data.** `OwnerField` is enforced on
+- **Hand-writing a filter for per-user data.** `Scope.OwnerField` is enforced on
   every generated surface — REST, batch, MCP, includes. A hand-written `WHERE`
   covers the one handler you remembered. `gofastr verify data` flags the gap.
 - **Trusting `paths` in a stale mental model of the spec.** Under

--- a/framework/docs/content/batch-endpoints.md
+++ b/framework/docs/content/batch-endpoints.md
@@ -31,9 +31,8 @@ the whole transaction.
 - The first per-item failure populates `error` (and optionally
   `fields` for validation failures) on that index. Later indices are
   marked `"skipped": true`.
-- Earlier successes still show their `data` so you can see what
-  would have happened, but `committed: false` means none of it was
-  saved.
+- On `committed: false` no result carries `data` — errors and
+  `fields` remain.
 
 ## Limits
 

--- a/framework/docs/content/cache.md
+++ b/framework/docs/content/cache.md
@@ -25,6 +25,10 @@ _ = c.Get(ctx, "42", &u)
 
 ## The `Cache` interface
 
+<!-- gofastr:compile
+import "context"
+import "time"
+-->
 ```go
 type Cache interface {
     Get(ctx context.Context, key string, dest any) error

--- a/framework/docs/content/compute.md
+++ b/framework/docs/content/compute.md
@@ -73,6 +73,9 @@ complete host `main.go`.
 Add the load marker to the server-rendered screen. It declares no work and
 needs no worker-name companion attribute:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/core-ui/html"
+-->
 ```go
 html.Div(html.DivConfig{
 	ExtraAttrs: html.Attrs{"data-fui-compute": ""},
@@ -205,6 +208,8 @@ operations through `syscall/js` or add a worker adapter around its Go runtime.
 
 Go 1.24 and newer also support `//go:wasmexport` with a WASI reactor build:
 
+<!-- gofastr:compile
+-->
 ```go
 //go:wasmexport sum
 func sum(a, b int32) int32 { return a + b }

--- a/framework/docs/content/cron.md
+++ b/framework/docs/content/cron.md
@@ -52,6 +52,14 @@ tick after a restart is acceptable. See
 
 ## Quickstart
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+import "log"
+import "context"
+import "database/sql"
+var db *sql.DB
+var ctx = context.Background()
+-->
 ```go
 sched := framework.NewScheduler()
 sched.OnError = func(name string, err error) {

--- a/framework/docs/content/data-export.md
+++ b/framework/docs/content/data-export.md
@@ -47,6 +47,8 @@ Batteries own physical tables the entity registry doesn't know about
 (`auth_sessions`, `queue_jobs`, …). A registry walk alone misses them, so a
 battery registers its tables into the `datexport` registry from `init()`:
 
+<!-- gofastr:compile
+-->
 ```go
 package mybattery
 
@@ -153,6 +155,9 @@ is commonly `users` or `auth_users`). The registered entries cover the
 canonical names. If you renamed a table, register the actual name from your
 app's `main.go` (or a `main`-owned `init`) so it is included:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework/datexport"
+-->
 ```go
 datexport.Register(datexport.DataExporter{
     Name: "my_users", Source: "app", Table: "users",
@@ -289,6 +294,9 @@ the tombstone, a re-run's `WHERE` matches nothing.
 A battery or app registers a table for erasure the same way it registers one
 for export. Two modes:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework/datexport"
+-->
 ```go
 // Hard-delete every row owned by the user.
 datexport.RegisterEraser(datexport.DataEraser{
@@ -324,6 +332,9 @@ at erase time (before the write transaction opens) through a registered
 `DataIdentityResolver` and binds the resolved value for `Column` instead of the
 user id:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework/datexport"
+-->
 ```go
 // Resolve email from the user table: SELECT email FROM auth_users WHERE id = $1
 datexport.RegisterIdentityResolver(datexport.IdentityEmail, datexport.DataIdentityResolver{

--- a/framework/docs/content/deploy.md
+++ b/framework/docs/content/deploy.md
@@ -173,10 +173,15 @@ or point at a value — including `0`, which **disables** that one deadline
 (matching `net/http`, where a zero duration means "no timeout"). Build the
 pointers with the Go 1.26 `new(expr)` builtin:
 
+<!-- gofastr:compile
+stmt: _ = app
+import "github.com/DonaldMurillo/gofastr/framework"
+import "time"
+-->
 ```go
 app := framework.NewApp(framework.WithHTTPServerTimeouts(framework.HTTPServerTimeoutsConfig{
     WriteTimeout: new(2 * time.Minute), // slow report handler
-    ReadTimeout:  new(0),               // disable — accept arbitrarily large uploads
+    ReadTimeout:  new(time.Duration(0)), // disable — accept arbitrarily large uploads
 }))
 ```
 
@@ -192,6 +197,11 @@ A request that legitimately outlives the default `WriteTimeout` — a slow
 report, a large export, an AI completion — needs the deadline raised or
 removed for that path:
 
+<!-- gofastr:compile
+stmt: _ = app
+import "github.com/DonaldMurillo/gofastr/framework"
+import "time"
+-->
 ```go
 // Raise the server write deadline app-wide for a report-heavy service.
 app := framework.NewApp(framework.WithHTTPServerTimeouts(framework.HTTPServerTimeoutsConfig{

--- a/framework/docs/content/email.md
+++ b/framework/docs/content/email.md
@@ -76,6 +76,10 @@ a MIME part.
 
 ## Log sender (development)
 
+<!-- gofastr:compile
+stmt: _ = sender
+import "github.com/DonaldMurillo/gofastr/battery/email"
+-->
 ```go
 sender := email.NewLogSender() // writes to stdout
 ```

--- a/framework/docs/content/embed.md
+++ b/framework/docs/content/embed.md
@@ -276,6 +276,9 @@ request names. That is the ordinary product shape this was built for: a SaaS
 customer's allowed domain lives in your own table, and each frame response
 carries only theirs.
 
+<!-- gofastr:compile
+import "context"
+-->
 ```go
 type OriginSource interface {
     // Origins returns the exact origins allowed to frame the named surface for
@@ -603,10 +606,23 @@ identity on the request.
 So tell it how to find the tenant, and multi-tenant entities work behind an
 embed:
 
+<!-- gofastr:compile
+import embed "github.com/DonaldMurillo/gofastr/framework/embed"
+import "context"
+import "database/sql"
+import "log"
+var db *sql.DB
+var reportsSurface embed.Surface
+type w4User struct{ TenantID string }
+var users = struct{ FindByID func(ctx context.Context, subject string) (*w4User, error) }{}
+stmt: _ = embeds
+-->
 ```go
+burn, err := embed.NewSQLBurnStore(db)
+if err != nil { log.Fatal(err) }
 embeds, _ := embed.New(embed.Config{
     Surfaces:  []embed.Surface{reportsSurface},
-    BurnStore: embed.NewSQLBurnStore(db),
+    BurnStore: burn,
     Resolve: func(ctx context.Context, subject string) (any, error) {
         return users.FindByID(ctx, subject)
     },

--- a/framework/docs/content/entity-declarations.md
+++ b/framework/docs/content/entity-declarations.md
@@ -182,6 +182,13 @@ record the entity as seeded with empty data on first run.
 
 Attach a `*slog.Logger` so each seed emits structured lifecycle events:
 
+<!-- gofastr:compile
+stmt: _ = ctx
+import migrate "github.com/DonaldMurillo/gofastr/framework/migrate"
+import "context"
+import "log/slog"
+var logger = slog.Default()
+-->
 ```go
 ctx := migrate.WithSeedLogger(context.Background(), logger)
 // (the framework calls migrate.RunSeeds with the App's lifecycle ctx
@@ -549,6 +556,12 @@ declarative knob for that: name an RBAC permission, and when the request
 context holds it, owner scoping is lifted for List/Get/Count (HTTP and
 in-process) on that entity. Writes stay owner-scoped, always.
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+var app = framework.NewApp()
+import "github.com/DonaldMurillo/gofastr/framework/entity"
+import "github.com/DonaldMurillo/gofastr/core/schema"
+-->
 ```go
 app.Entity("tickets", entity.EntityConfig{
     Fields: []schema.Field{{Name: "user_id", Type: schema.String}, {Name: "subject", Type: schema.String}},
@@ -571,6 +584,12 @@ entities:
 
 Grant the permission to the role that should see across owners:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework/access"
+import "github.com/DonaldMurillo/gofastr/framework"
+var app = framework.NewApp()
+import "context"
+-->
 ```go
 policy := access.NewRolePolicy()
 policy.Grant("staff", "tickets:read:all")
@@ -652,6 +671,11 @@ you want for anything a user sees about *their own* data. Two hard rules:
 When you register the `users` / `sessions` entities for `battery/auth`,
 use the pre-built configs so they don't get exposed via REST or MCP:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+var app = framework.NewApp()
+import "github.com/DonaldMurillo/gofastr/battery/auth"
+-->
 ```go
 app.Entity("users",    auth.UserEntityConfig())    // CRUD=false, MCP=false
 app.Entity("sessions", auth.SessionEntityConfig()) // CRUD=false, MCP=false
@@ -667,6 +691,12 @@ Set `SearchFields` to a slice of DB column names and List requests
 carrying `?q=<term>` perform a multi-field, case-insensitive free-text
 search across them:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+var app = framework.NewApp()
+import "github.com/DonaldMurillo/gofastr/framework/entity"
+import "github.com/DonaldMurillo/gofastr/core/schema"
+-->
 ```go
 app.Entity("articles", entity.EntityConfig{
     Fields:       []schema.Field{{Name: "title", Type: schema.String}, {Name: "body", Type: schema.Text}},
@@ -738,6 +768,13 @@ GET /api/tickets?status=open&priority_gte=2&assignee_in=me,you&sort=-created_at
 | `_like`  | literal `contains` (`LIKE '%value%'`)      |
 | `_in`    | `IN (…)` — comma-separated, capped at 1000 |
 
+**Repeating `_in` unions.** `?tag_in=a,b&tag_in=c` matches all three.
+Every occurrence of the key contributes; the 1000-entry cap
+(`filter.MaxINListEntries`) counts the union, and the same cap applies to
+relation-scoped lists like `?author.name_in=`. A list over the cap is a
+**400** naming the field and both counts — never a silent truncation,
+for the same reason unknown filters fail closed below.
+
 **Unknown filters fail closed (strict).** A misspelled or unrecognized
 top-level filter — `?stauts=open`, or a suffixed op on a non-field like
 `?scor_gt=5` — returns a **400** naming the bad key (with a "did you
@@ -763,6 +800,11 @@ never silently swallowed.
 (e.g. a `BeforeList` hook scoping on `?region=eu`) declares them so strict
 parsing skips them without disabling typo protection for real fields:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+var app = framework.NewApp()
+import "github.com/DonaldMurillo/gofastr/framework/entity"
+-->
 ```go
 app.Entity("things", entity.EntityConfig{
     AllowedFilterParams: []string{"region"}, // consumed by a BeforeList hook

--- a/framework/docs/content/factories.md
+++ b/framework/docs/content/factories.md
@@ -77,6 +77,11 @@ caller, so a typo should fail loudly.
 `Sequence` is an atomic counter for unique base values inside
 `BaseFunc`. Concurrent-test safe — `Next()` never repeats.
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework/factory"
+stmt: _ = base
+import "fmt"
+-->
 ```go
 seq := &factory.Sequence{}
 

--- a/framework/docs/content/feature-flags.md
+++ b/framework/docs/content/feature-flags.md
@@ -59,6 +59,8 @@ Both consult the same evaluator.
 
 ## Flag rules
 
+<!-- gofastr:compile
+-->
 ```go
 type Flag struct {
     Key     string
@@ -79,10 +81,14 @@ Evaluation order:
 5. `Rollout` percentage of the stable hash → on or off.
 
 The hash is FNV-1a over `key + 0x00 + subjectID`. Subject id is the
-user id when present, otherwise the tenant id, otherwise empty (which
-hashes to a single deterministic bucket per flag key — anonymous traffic
-is therefore binary on-or-off per key at any rollout < 100%; choose
-allow-list gating for anonymous-sensitive flags).
+user id when present, otherwise the tenant id, otherwise empty. An
+empty subject is forced off at any partial rollout (1–99): anonymous
+traffic hashes to a single constant bucket per flag key, so a "50%
+rollout" would be 100% or 0% of anonymous traffic depending on the
+key. Apps that want anonymous traffic in a rollout derive a stable
+pseudo-subject (session, request signature) and put it in
+`EvalContext.UserID`; for anonymous-sensitive flags, use allow-list
+gating.
 
 The `Envs` filter is the **outermost** rule: even a user that appears
 in the `Users` allow list does not see the flag if their request's

--- a/framework/docs/content/harness-architecture.md
+++ b/framework/docs/content/harness-architecture.md
@@ -2080,6 +2080,9 @@ call fails. Supervisor contract:
 
 ### MCP server supervision
 
+<!-- gofastr:compile
+import "time"
+-->
 ```go
 type MCPServerSupervisor struct {
     MaxRestarts          int           // default 3

--- a/framework/docs/content/health-checks.md
+++ b/framework/docs/content/health-checks.md
@@ -90,6 +90,10 @@ infrastructure detail useful only to an attacker doing recon.
 To turn on verbose reporting (e.g. behind an internal listener or with
 auth in front of `/readyz`), pass the option at app construction:
 
+<!-- gofastr:compile
+stmt: _ = app
+import "github.com/DonaldMurillo/gofastr/framework"
+-->
 ```go
 app := framework.NewApp(framework.WithVerboseReadiness())
 ```
@@ -108,6 +112,11 @@ under `recover()`, so a panicking check marks that row as
 `"timeout"` immediately — the response does not wait for the
 straggler.
 
+<!-- gofastr:compile
+stmt: _ = app
+import "github.com/DonaldMurillo/gofastr/framework"
+import "time"
+-->
 ```go
 app := framework.NewApp(
     framework.WithReadinessTimeout(2*time.Second),

--- a/framework/docs/content/hooks-and-transactions.md
+++ b/framework/docs/content/hooks-and-transactions.md
@@ -98,7 +98,7 @@ app.HookRegistry("users").RegisterHook(framework.AfterList,
 > `AfterList` is never bypassed.
 
 For the common case of per-user row scoping, use
-`EntityConfig.OwnerField` instead — it's a single line and covers
+`EntityConfig.Scope.OwnerField` instead — it's a single line and covers
 all four read/write operations. See
 [`framework/docs/content/entity-declarations.md`](entity-declarations.md#per-user-scoping-ownerfield).
 

--- a/framework/docs/content/i18n.md
+++ b/framework/docs/content/i18n.md
@@ -102,6 +102,11 @@ during development than silently empty.
 Pass a numeric `count` (or `n`) in params; the Translator picks the
 category for the request locale and interpolates.
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/core/i18n"
+import "context"
+var ctx = context.Background()
+-->
 ```go
 i18n.T(ctx, "cart.items", map[string]any{"count": 3})
 // "3 items in cart" (en, "other")
@@ -161,8 +166,13 @@ app := framework.NewApp(
 
 A "change language" handler just sets the cookie and redirects:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+var app = framework.NewApp()
+import "net/http"
+-->
 ```go
-app.Router().Post("/locale", func(w http.ResponseWriter, r *http.Request) {
+app.Router().PostFunc("/locale", func(w http.ResponseWriter, r *http.Request) {
     lang := r.FormValue("lang") // validate against your catalog
     http.SetCookie(w, &http.Cookie{
         Name:  "locale",

--- a/framework/docs/content/idempotency.md
+++ b/framework/docs/content/idempotency.md
@@ -8,13 +8,24 @@ back instead of a duplicated side effect.
 ## Wiring
 
 The simplest form is `framework.WithIdempotency` — the middleware
-slots into the default chain between `Logging` and `SecurityHeaders`:
+slots into the default chain between `RequestID` and
+`SecurityHeaders`:
 
+<!-- gofastr:compile
+stmt: _ = app
+import "github.com/DonaldMurillo/gofastr/framework"
+import "github.com/DonaldMurillo/gofastr/core/middleware"
+import "net/http"
+import "github.com/DonaldMurillo/gofastr/battery/auth"
+-->
 ```go
 app := framework.NewApp(framework.WithIdempotency(middleware.IdempotencyConfig{
     Principal: func(r *http.Request) string {
         // Extract the authenticated subject — user-id, tenant-id, or both.
-        return auth.UserID(r.Context())
+        if u, ok := auth.SessionFrom(r.Context()); ok {
+            return u.GetID()
+        }
+        return ""
     },
 }))
 ```
@@ -33,7 +44,12 @@ app.Use(router.Middleware(middleware.Idempotency(middleware.IdempotencyConfig{
     // Methods:          []string{POST, PUT, PATCH, DELETE},
     // Required:         false,
     // FailOpen:         false, // default: fail closed (503) on store error
-    Principal: func(r *http.Request) string { return auth.UserID(r.Context()) },
+    Principal: func(r *http.Request) string {
+        if u, ok := auth.SessionFrom(r.Context()); ok {
+            return u.GetID()
+        }
+        return ""
+    },
 })))
 ```
 

--- a/framework/docs/content/image.md
+++ b/framework/docs/content/image.md
@@ -147,6 +147,11 @@ If the images arrive as CRUD uploads on a `schema.Image` field, you do not
 need to call any of this by hand. One app option makes every upload produce
 renditions plus a BlurHash and writes them to sibling columns:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+import "github.com/DonaldMurillo/gofastr/framework/imagefield"
+import "github.com/DonaldMurillo/gofastr/framework/image"
+-->
 ```go
 framework.WithImagePipeline(imagefield.MustNew(imagefield.Config{
     Variants:  []image.Variant{{Width: 960, Format: image.FormatWebP, Suffix: "md"}},

--- a/framework/docs/content/interactive-patterns.md
+++ b/framework/docs/content/interactive-patterns.md
@@ -599,6 +599,9 @@ dot colors come from the status tokens, so a themed app recolors them
 for free. `StatusLabel` overrides the dot's accessible name (default:
 the status word).
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework/ui"
+-->
 ```go
 ui.AvatarGroup(ui.AvatarGroupConfig{
     Avatars: []ui.AvatarConfig{
@@ -701,6 +704,11 @@ byte-identical — prefer it over the `OnClick`/`OnSubmit` wrappers whenever the
 element already carries other attributes, since the wrappers splice at the
 tag's first `>` and can reorder attributes relative to a sorted map.
 
+<!-- gofastr:compile
+stmt: _ = del
+import "github.com/DonaldMurillo/gofastr/framework/ui"
+import "github.com/DonaldMurillo/gofastr/core-ui/interactive"
+-->
 ```go
 del := ui.Button(ui.ButtonConfig{Label: "Delete", Variant: ui.ButtonDanger,
     ExtraAttrs: interactive.Delete("/api/items/42").
@@ -718,6 +726,10 @@ a widget only after a successful RPC (`data-fui-rpc-open`).
 `data-fui-toast` (compact JSON of the non-zero `Toast` fields: `variant`,
 `title`, `body`, `stack`, `ttl`).
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/core-ui/interactive"
+import "github.com/DonaldMurillo/gofastr/framework/ui"
+-->
 ```go
 interactive.OpenOnClick(ui.Button(ui.ButtonConfig{Label: "Edit"}), "edit-drawer")
 interactive.ToastOnClick(ui.Button(ui.ButtonConfig{Label: "Saved!"}),

--- a/framework/docs/content/isolation.md
+++ b/framework/docs/content/isolation.md
@@ -48,6 +48,12 @@ explicit env overrides untouched.
 Use `framework/isolation` when app code opens resources before calling
 `App.Start`:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework/isolation"
+import "log"
+stmt: _ = db
+import "database/sql"
+-->
 ```go
 runtimeIsolation, err := isolation.Resolve(".")
 if err != nil {

--- a/framework/docs/content/log.md
+++ b/framework/docs/content/log.md
@@ -69,16 +69,18 @@ or isn't a `*log.Plugin` — see [plugins](plugins.md) → Typed lookups.
 ## Real-time debugging via MCP
 
 When `Config.EnableMCP` is set, the plugin installs an in-memory
-RingSink (capacity `MCPRingSize`, default 1000) and registers four
-tools on the App's MCP server. Connected agents (Claude Code, Cursor,
-etc.) can call these to inspect the running app live:
+RingSink (capacity `MCPRingSize`, default 1000) and registers three
+tools on the App's MCP server; a fourth, `log_set_level`, is
+registered only when `Config.AllowMCPMutation` is also set. Connected
+agents (Claude Code, Cursor, etc.) can call these to inspect the
+running app live:
 
 | Tool            | Use                                                                                                  |
 |-----------------|------------------------------------------------------------------------------------------------------|
 | `log_recent`    | Last N entries from the ring, optional level filter.                                                 |
 | `log_filter`    | Match by `msg`/`path`/`request_id`/`since_ts`/`until_ts`/`level`. `historical=true` tails the file sink for entries evicted from the ring. |
 | `log_metrics`   | Current counter snapshot — same data as `Plugin.Metrics()`.                                          |
-| `log_set_level` | Mutate the runtime log level (e.g. flip to DEBUG for an investigation, back to INFO afterwards).     |
+| `log_set_level` | Mutate the runtime log level (e.g. flip to DEBUG for an investigation, back to INFO afterwards). Only registered when `AllowMCPMutation` is set. |
 
 Opt-in because these tools reveal a lot about the running app —
 weigh the disclosure before enabling on a production MCP server
@@ -247,6 +249,9 @@ app.RegisterPlugin(log.New(log.Config{
 
 Implement the `Sink` interface:
 
+<!-- gofastr:compile
+import "io"
+-->
 ```go
 type Sink interface {
     io.Closer

--- a/framework/docs/content/log.md
+++ b/framework/docs/content/log.md
@@ -80,7 +80,7 @@ running app live:
 | `log_recent`    | Last N entries from the ring, optional level filter.                                                 |
 | `log_filter`    | Match by `msg`/`path`/`request_id`/`since_ts`/`until_ts`/`level`. `historical=true` tails the file sink for entries evicted from the ring. |
 | `log_metrics`   | Current counter snapshot — same data as `Plugin.Metrics()`.                                          |
-| `log_set_level` | Mutate the runtime log level (e.g. flip to DEBUG for an investigation, back to INFO afterwards). Only registered when `AllowMCPMutation` is set. |
+| `log_set_level` | Mutate the runtime log level (e.g. flip to DEBUG for an investigation, back to INFO afterward). Only registered when `AllowMCPMutation` is set. |
 
 Opt-in because these tools reveal a lot about the running app —
 weigh the disclosure before enabling on a production MCP server

--- a/framework/docs/content/migrations.md
+++ b/framework/docs/content/migrations.md
@@ -380,6 +380,12 @@ not to declare entities. `migrate.Table` is a raw schema declaration that
 migrates, diffs, and generates **alongside** entities in the same registry —
 including foreign keys that cross between an entity and a raw table.
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+var app = framework.NewApp()
+import migrate "github.com/DonaldMurillo/gofastr/framework/migrate"
+import "github.com/DonaldMurillo/gofastr/core/schema"
+-->
 ```go
 app.Table(migrate.Table{
     Name: "user_roles", // also the FK reference name
@@ -407,6 +413,11 @@ boot (idempotent `CREATE OR REPLACE`) after tables migrate, and `migrate
 generate` tracks it so a changed body produces a reversible versioned
 migration (its `Down` restores the previous definition).
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+var app = framework.NewApp()
+import migrate "github.com/DonaldMurillo/gofastr/framework/migrate"
+-->
 ```go
 app.Routine(migrate.Routine{
     Name: "double_it",
@@ -657,6 +668,12 @@ gofastr migrate up --create-db --driver=postgres --db-url=$DATABASE_URL
 
 Or programmatically before `App.Start` / `migrate up`:
 
+<!-- gofastr:compile
+import migrate "github.com/DonaldMurillo/gofastr/core/migrate"
+var dsn string
+stmt: _ = created
+stmt: _ = err
+-->
 ```go
 created, err := migrate.EnsureDatabase("postgres", dsn)
 ```
@@ -807,6 +824,12 @@ because both derive column types from the same entity schema.
 For deployments whose policy forbids **any** unattended schema change on
 boot, make migrations the single, explicit path:
 
+<!-- gofastr:compile
+stmt: _ = app
+import "github.com/DonaldMurillo/gofastr/framework"
+import "database/sql"
+var db *sql.DB
+-->
 ```go
 app := framework.NewApp(
     framework.WithDB(db),

--- a/framework/docs/content/modules.md
+++ b/framework/docs/content/modules.md
@@ -80,6 +80,15 @@ pass through the gates unchecked. Attribution is an Init-time concept.
 
 ## Runtime enable/disable
 
+<!-- gofastr:compile
+stmt: _ = err
+import "github.com/DonaldMurillo/gofastr/framework"
+var app = framework.NewApp()
+import "context"
+var ctx = context.Background()
+stmt: _ = enabled
+stmt: _ = list
+-->
 ```go
 // Toggle at runtime — no restart:
 err := app.Modules().Disable(ctx, "feature")

--- a/framework/docs/content/multi-tenant.md
+++ b/framework/docs/content/multi-tenant.md
@@ -2,7 +2,8 @@
 
 Marking an entity multi-tenant adds a `tenant_id` column, auto-injects
 it on writes, filters reads by it, and scopes lifecycle events to it.
-The tenant ID is extracted from a request header by middleware.
+The tenant ID is resolved server-side from the authenticated context —
+never from a client-sent header.
 
 ## Quickstart
 
@@ -14,8 +15,9 @@ app.Entity("posts", framework.EntityConfig{
     },
 })
 
-// Default header is X-Tenant-ID. Add the middleware once on the app:
-app.Use(framework.TenantMiddleware("X-Tenant-ID"))
+// Add the middleware once on the app. The argument is ignored —
+// no header is ever read (see "How tenants get into the request"):
+app.Use(framework.TenantMiddleware(""))
 ```
 
 Once both are wired:
@@ -31,13 +33,26 @@ Once both are wired:
 func TenantMiddleware(header string) func(http.Handler) http.Handler
 ```
 
-The middleware reads the named header on every request and, if
-non-empty, attaches the value to the request context. Downstream
-handlers and hooks call `framework.GetTenantID(ctx)` to read it.
+The middleware never reads a request header. The `header` parameter
+is ignored — it is retained only so call sites from the era when the
+header was consulted keep compiling. Trusting a client-sent header
+would let any caller impersonate any tenant by setting one header, so
+the tenant is resolved exclusively from server-side authenticated
+state.
 
-If your tenants come from JWT claims, a subdomain, or anywhere else,
-write your own middleware that calls `framework.SetTenantID(ctx, id)`
-— the framework only cares that the context value is set.
+What the middleware does: when the authenticated context resolves a
+tenant (`handler.GetTenant`, a non-empty string), it copies that value
+to the tenant context that CRUD scoping reads. Framework auth paths
+that resolve a tenant set it via a server-side lookup keyed on the
+authenticated subject — grant-authenticated embeds do this through
+their tenant resolver; nothing the request carried chooses the tenant.
+Downstream handlers and hooks call `framework.GetTenantID(ctx)` to
+read it.
+
+If your tenants come from JWT claims, a subdomain, a session lookup,
+or anywhere else, write your own middleware that calls
+`framework.SetTenantID(ctx, id)` — the framework only cares that the
+context value is set.
 
 ## Custom tenant column
 
@@ -68,13 +83,15 @@ automatically.
 
 ## Configuration
 
-`TenantConfig` / `DefaultTenantConfig()` carry the header name and
-`AutoScope`. The defaults are:
+`TenantConfig` / `DefaultTenantConfig()` carry the tenant column and
+`AutoScope`. `Header` is a legacy field retained for API compatibility
+— it is not read anywhere, and setting it changes no behavior. The
+defaults are:
 
 | Field        | Default       |
 |--------------|---------------|
 | `Field`      | `tenant_id`   |
-| `Header`     | `X-Tenant-ID` |
+| `Header`     | `X-Tenant-ID` (legacy, ignored) |
 | `AutoScope`  | `true`        |
 
 `AutoScope=false` lets you read across tenants from admin routes
@@ -121,6 +138,11 @@ To read or write across tenants deliberately (admin tooling), mark the
 context with `tenant.AllowCrossTenant` — **server-side only**, never
 from a client-controlled header:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework/tenant"
+import "net/http"
+var r *http.Request
+-->
 ```go
 // inside an admin-gated handler / middleware, AFTER your own role check:
 ctx := tenant.AllowCrossTenant(r.Context())
@@ -154,13 +176,15 @@ every read.
 - **Adding `MultiTenant: true` to an existing entity without
   backfilling `tenant_id`.** Existing rows have empty string and
   match every tenant. Backfill before flipping the flag.
-- **Setting the tenant from a request body field.** Trivially
-  spoofable. Use a signed header, JWT claim, or session lookup.
-- **Forgetting `TenantMiddleware`.** Auto-scope only fires when the
-  context has a tenant — without the middleware every request now gets a
-  `401` (secure by default), not silent cross-tenant access. Mount the
-  middleware, or set `tenant.AllowCrossTenant` deliberately on admin
-  routes.
+- **Setting the tenant from a client-controlled value.** A request
+  body field, a plain header, anything the caller sends is trivially
+  spoofable. Resolve the tenant server-side (a verified JWT claim, a
+  session lookup) and call `SetTenantID` from your own middleware.
+- **Forgetting tenant resolution.** Auto-scope only fires when the
+  context has a tenant — without one every request now gets a `401`
+  (secure by default), not silent cross-tenant access. Seed the tenant
+  from your auth layer or your own middleware, or set
+  `tenant.AllowCrossTenant` deliberately on admin routes.
 - **Cross-tenant joins via `?include=`.** If both parent and child
   are multi-tenant, includes scope on the parent's tenant only.
   Non-multi-tenant child entities are returned unfiltered — model

--- a/framework/docs/content/observability.md
+++ b/framework/docs/content/observability.md
@@ -8,6 +8,12 @@ produce them are wired. Tracing is opt-in via `WithTracing()`.
 
 ## Metrics (Prometheus)
 
+<!-- gofastr:compile
+stmt: _ = app
+import "github.com/DonaldMurillo/gofastr/framework"
+import "database/sql"
+var db *sql.DB
+-->
 ```go
 app := framework.NewApp(
     framework.WithDB(db),
@@ -116,6 +122,10 @@ convenience.
 
 ## Tracing (OpenTelemetry)
 
+<!-- gofastr:compile
+stmt: _ = app
+import "github.com/DonaldMurillo/gofastr/framework"
+-->
 ```go
 app := framework.NewApp(framework.WithTracing())
 ```
@@ -187,6 +197,8 @@ The framework does not depend on an OTLP exporter (so your app stays free of
 the OpenTelemetry exporter modules until you want them). Add the exporter to
 **your own app** and wire it once at startup:
 
+<!-- gofastr:compile
+-->
 ```go
 import (
     "context"
@@ -210,7 +222,7 @@ func installTracer(ctx context.Context, endpoint string) (func(context.Context) 
     if err != nil {
         return nil, err
     }
-    res, err := sdkresource.New(ctx, semconv.ServiceName("myapp"))
+    res, err := sdkresource.New(ctx, sdkresource.WithAttributes(semconv.ServiceName("myapp")))
     if err != nil {
         return nil, err
     }

--- a/framework/docs/content/optimistic-ui.md
+++ b/framework/docs/content/optimistic-ui.md
@@ -299,6 +299,9 @@ and reverts. The `error` shake animation respects `prefers-reduced-motion`.
 
 **Compose (the value-independent optimistic half):**
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework/ui"
+-->
 ```go
 ui.OptimisticAction(ui.OptimisticActionConfig{
     Endpoint:     "/api/rename/validate",
@@ -490,6 +493,15 @@ endpoint). Runtime: `sortablelist.js`.
 response triggers `ConflictRPC` (a GET), whose response body replaces the
 destination column's `innerHTML`.
 
+<!-- gofastr:compile
+import "fmt"
+import patternsSortablelist "github.com/DonaldMurillo/gofastr/core-ui/patterns/sortablelist"
+type w4Col struct{ Title, ID string }
+type w4Board struct{ Version int }
+var col = w4Col{Title: "todo", ID: "col-1"}
+var board = w4Board{Version: 2}
+var items []patternsSortablelist.Item
+-->
 ```go
 patternsSortablelist.Render(patternsSortablelist.Config{
     Label:       col.Title,

--- a/framework/docs/content/overview.md
+++ b/framework/docs/content/overview.md
@@ -25,6 +25,11 @@ GoFastr is two layers, and you can work at either one.
 query, schema, render, mcp, openapi (core); HTML primitives, signals, the
 runtime (core-ui). Each works on its own, no framework required:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/core/router"
+import "github.com/DonaldMurillo/gofastr/core/render"
+import "net/http"
+-->
 ```go
 // core only — a router and a handler.
 r := router.New()
@@ -39,6 +44,12 @@ primitives. Declare an entity and the framework wires them together for you — 
 migrated table, a REST API with filtering/sorting/pagination, MCP tools, and an
 OpenAPI spec:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+import "database/sql"
+var db *sql.DB
+import "github.com/DonaldMurillo/gofastr/core/schema"
+-->
 ```go
 // framework — one entity, wired end to end.
 app := framework.NewApp(framework.WithDB(db))

--- a/framework/docs/content/pane-host.md
+++ b/framework/docs/content/pane-host.md
@@ -133,7 +133,7 @@ closed pane and then pops it open. Read the parameter with
 `ui.PaneDeepLink` and build the page from it:
 
 ```go
-slot, key, ok := ui.PaneDeepLink(app.QueryFromContext(ctx), "pane")
+slot, key, ok := ui.PaneDeepLink(r.URL.Query(), "pane")
 detail := emptyState
 open := false
 if ok && slot == "secondary" {

--- a/framework/docs/content/plugins.md
+++ b/framework/docs/content/plugins.md
@@ -104,6 +104,11 @@ other shutdown code emits its final entries.
 listener is actually up — a startup banner, a "register with service
 discovery" call — use `App.OnReady`:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+var app = framework.NewApp()
+import "fmt"
+-->
 ```go
 app.OnReady(func(addr string) {
     fmt.Printf("listening on http://%s\n", addr)
@@ -208,6 +213,14 @@ log.Fatal(app.Start(":8080"))
 
 ## Lookups
 
+<!-- gofastr:compile
+stmt: _ = p
+stmt: _ = err
+import "github.com/DonaldMurillo/gofastr/framework"
+var app = framework.NewApp()
+stmt: _ = all
+stmt: _ = names
+-->
 ```go
 p, err := app.Plugins.Get("webhooks")
 all := app.Plugins.All()      // []Plugin, registration order

--- a/framework/docs/content/process-modules.md
+++ b/framework/docs/content/process-modules.md
@@ -49,7 +49,7 @@ The fields:
   Digests are byte-compared against `module.tool.list` at handshake.
 - **RequestedGrants** — the verbatim `resource:verb` list the operator
   reviews at install. Effective grants = requested ∩ approved.
-- **TrustTier** — selects the runner: `TrustedTrusted` (crash isolation
+- **TrustTier** — selects the runner: `TrustTrusted` (crash isolation
   only, for dev or in-house modules) or `TrustUntrusted` (requires a
   probe-passing sandbox, fail-closed otherwise).
 - **MigrationGroup** — the `#33` migration group the module owns.

--- a/framework/docs/content/pwa.md
+++ b/framework/docs/content/pwa.md
@@ -98,15 +98,18 @@ The generated worker is deliberately conservative:
   with `DenyPaths` (blueprint-generated apps do this automatically for
   a custom `api_prefix` / auth `base_path`).
 - **Cache names are versioned deterministically.** The name is
-  `gofastr-pwa-<app-slug>-<fingerprint>` where the fingerprint hashes
+  `gofastr-pwa-<slug>.<name-hash>.<fingerprint>` — `<name-hash>` is
+  12 hex chars derived from the app name, and the fingerprint hashes
   the manifest, the precache URL list, the shell asset bodies, and the
   bytes of every precache entry served from the host's static
   storage — swapping an icon in place rotates the version. A new
   deployment installs a fresh cache; on activation the worker deletes
-  only obsolete caches carrying this app's `gofastr-pwa-<app-slug>-`
-  prefix. (An asset served from outside static storage — a reverse
-  proxy, say — contributes only its URL; give it a new path or query
-  when it changes.)
+  only obsolete caches carrying this app's
+  `gofastr-pwa-<slug>.<name-hash>.` prefix, and reaps leftover
+  `gofastr-pwa-<slug>-<hex>` caches from the older dashed naming.
+  (An asset served from outside static storage — a reverse proxy,
+  say — contributes only its URL; give it a new path or query when it
+  changes.)
 
 ## Static exports: the full-site worker
 

--- a/framework/docs/content/queue.md
+++ b/framework/docs/content/queue.md
@@ -93,9 +93,9 @@ for {
         continue
     }
     if err := handle(ctx, job); err != nil {
-        _ = q.Nack(ctx, job.ID)
+        _ = q.Nack(ctx, job)
     } else {
-        _ = q.Ack(ctx, job.ID)
+        _ = q.Ack(ctx, job)
     }
 }
 ```
@@ -106,6 +106,10 @@ Dequeue/Ack/Nack yourself, or integrate with a third-party pool. Call
 
 ## Job struct
 
+<!-- gofastr:compile
+import "encoding/json"
+import "time"
+-->
 ```go
 type Job struct {
     ID          string          // auto-filled by Enqueue if empty
@@ -179,6 +183,10 @@ eligible again (next `Dequeue` can pick it up).
 
 `WithBackoff(base, max)` turns on exponential backoff for `DBQueue`:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/battery/queue"
+import "time"
+-->
 ```go
 queue.WithBackoff(5*time.Second, 5*time.Minute)
 ```

--- a/framework/docs/content/rate-limit.md
+++ b/framework/docs/content/rate-limit.md
@@ -115,6 +115,15 @@ PostgreSQL); one store instance backs many limiters, with keys namespaced by
 `Config.Scope` so a login limiter and a checkout limiter sharing one store never
 collide:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/battery/auth"
+import "database/sql"
+var db *sql.DB
+stmt: _ = loginLimit
+import "github.com/DonaldMurillo/gofastr/framework/ratelimit"
+import "time"
+stmt: _ = checkoutLimit
+-->
 ```go
 shared := auth.NewSQLRateLimitStore(db, "rate_limits")
 // One store, two independent budgets:

--- a/framework/docs/content/runtime-contract.md
+++ b/framework/docs/content/runtime-contract.md
@@ -341,6 +341,11 @@ SPA navigator (no hard refresh between same-app pages), falling back
 to `window.location.assign`. For the non-intercepted default path,
 redirect-following is the browser's own job — same result.
 
+<!-- gofastr:compile
+import "net/http"
+var w http.ResponseWriter
+var r *http.Request
+-->
 ```go
 http.Redirect(w, r, "/dashboard", http.StatusSeeOther)
 ```

--- a/framework/docs/content/scaling.md
+++ b/framework/docs/content/scaling.md
@@ -63,6 +63,10 @@ The first scaling step for a self-hosted app is one web process + one
 worker process, same binary — before replicas, before Redis. The role
 is picked at deploy time:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework"
+var app = framework.NewApp()
+-->
 ```go
 app.Start(":8080") // role from GOFASTR_ROLE: all | serve | worker
 ```

--- a/framework/docs/content/search.md
+++ b/framework/docs/content/search.md
@@ -137,6 +137,12 @@ tsvector if they don't already exist, so it's safe to call on every startup.
 The document body (`Document.Text`) is always indexed at weight `'A'`. Promote
 structured fields so a hit in a title outranks one in the body:
 
+<!-- gofastr:compile
+stmt: _ = idx
+import "github.com/DonaldMurillo/gofastr/battery/search"
+import "database/sql"
+var db *sql.DB
+-->
 ```go
 idx, _ := search.NewPostgres(db, search.PostgresConfig{
     WeightedFields: map[string]byte{"title": 'A', "summary": 'B'},

--- a/framework/docs/content/security.md
+++ b/framework/docs/content/security.md
@@ -12,6 +12,10 @@ middleware to the chain — it does not replace or disable the defaults;
 use `WithoutDefaultMiddleware()` when you want to build the chain
 yourself.)
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/core/middleware"
+import "time"
+-->
 ```go
 middleware.Recovery()
 middleware.RequestID()
@@ -34,6 +38,9 @@ both would double-log every request.
 
 ## SecurityHeaders
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/core/middleware"
+-->
 ```go
 middleware.SecurityHeaders(middleware.SecurityHeadersConfig{
     ContentSecurityPolicy: "default-src 'self'; img-src 'self' https://cdn.example.com",
@@ -101,6 +108,11 @@ single directive — e.g. allow `style-src 'unsafe-inline'` for a
 third-party CSS dependency — without shadowing the whole chain with your
 own `SecurityHeaders` middleware:
 
+<!-- gofastr:compile
+stmt: _ = app
+import "github.com/DonaldMurillo/gofastr/framework"
+import "github.com/DonaldMurillo/gofastr/core/middleware"
+-->
 ```go
 app := framework.NewApp(framework.WithSecurityHeaders(middleware.SecurityHeadersConfig{
     ContentSecurityPolicy: "default-src 'self'; style-src 'unsafe-inline'; img-src 'self' data:",
@@ -114,6 +126,10 @@ strict defaults exactly.
 
 ## CORS
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/core/middleware"
+import "net/http"
+-->
 ```go
 middleware.CORS(middleware.CORSConfig{
     AllowedOrigins: []string{"https://app.example.com"},
@@ -211,6 +227,10 @@ a non-empty `JWTSecret`; a previous-only configuration is rejected at Init.
 
 ## Rate limiting
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/core/middleware"
+import "time"
+-->
 ```go
 middleware.RateLimit(middleware.RateLimitConfig{
     Capacity:    100,         // peak burst

--- a/framework/docs/content/semantic-search.md
+++ b/framework/docs/content/semantic-search.md
@@ -253,6 +253,12 @@ Two are wired:
 
 For anything else (OpenAI Embeddings API, a private microservice, a CGO-bound model), implement the three-method `Embedder` interface and pass it via `Options.Embedder`. The rest of the package is embedder-agnostic.
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/battery/semantic"
+import "context"
+var ctx = context.Background()
+import "log"
+-->
 ```go
 // Swap from stub to Ollama:
 embedder := semantic.NewOllamaEmbedder(semantic.OllamaConfig{

--- a/framework/docs/content/signal-store.md
+++ b/framework/docs/content/signal-store.md
@@ -93,6 +93,10 @@ the JS reducer registered under its name. Register reducers as real functions â€
 derive the signal name and stamp the slice's declared default â€” one source of
 truth instead of a hardcoded initial value:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework/ui"
+import "github.com/DonaldMurillo/gofastr/core-ui/store"
+-->
 ```go
 ui.Counter(ui.CounterConfig{Slice: store.New("cart").Int("count", 0)})
 ```

--- a/framework/docs/content/storage.md
+++ b/framework/docs/content/storage.md
@@ -22,6 +22,10 @@ app := framework.NewApp(
 
 ## The Storage interface
 
+<!-- gofastr:compile
+import "context"
+import "io"
+-->
 ```go
 type Storage interface {
 	Save(ctx context.Context, key string, r io.Reader) error
@@ -39,6 +43,10 @@ rewrite the key.
 
 ## Local backend
 
+<!-- gofastr:compile
+stmt: _ = store
+import "github.com/DonaldMurillo/gofastr/battery/storage"
+-->
 ```go
 store := storage.NewLocalStorage("./uploads",
 	storage.WithPermissions(0o644),

--- a/framework/docs/content/strict-mode.md
+++ b/framework/docs/content/strict-mode.md
@@ -96,6 +96,9 @@ Absence and drift are treated differently, on purpose:
 every field is the strictest setting, so configuration only ever
 *relaxes*, and every relaxation is visible in review:
 
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework/uihost"
+-->
 ```go
 uihost.WithStrict(uihost.StrictConfig{
     ScreenDescriptions: uihost.StrictWarn,          // log, don't fail

--- a/framework/docs/content/testkit.md
+++ b/framework/docs/content/testkit.md
@@ -123,6 +123,11 @@ err = testkit.ValidateAdminDSN("mysql://...")
 Exposed for white-box testing of the DSN-rewrite logic. Not for production
 callers:
 
+<!-- gofastr:compile
+stmt: _ = out
+stmt: _ = err
+import "github.com/DonaldMurillo/gofastr/framework/testkit"
+-->
 ```go
 out, err := testkit.RewriteDBNameForTest("postgres://u:p@host/db", "new_db")
 ```

--- a/framework/docs/content/tutorial-blueprint-app.md
+++ b/framework/docs/content/tutorial-blueprint-app.md
@@ -308,6 +308,8 @@ sqlite3 notes.db "UPDATE auth_users SET roles='[\"admin\"]' WHERE email='ana@exa
 Add a hand-written screen in a new file at the root — same package, same
 `Screen` interface the generated ones implement:
 
+<!-- gofastr:compile
+-->
 ```go
 // about.go — your own file, package main, alongside the generated ones.
 package main

--- a/framework/docs/content/ui-getting-started.md
+++ b/framework/docs/content/ui-getting-started.md
@@ -107,6 +107,8 @@ With `gofastr dev` running, visit <http://localhost:8080/__gofastr/app.css> to c
 
 A screen is just a Go type implementing `component.Component`. Add `screens/about.go`:
 
+<!-- gofastr:compile
+-->
 ```go
 package screens
 
@@ -362,6 +364,9 @@ A screen's `Render(ctx)` / `Load(ctx)` needs a way to reach the same `*sql.DB`
 the framework already holds. The current idiom is a **package-level handle
 captured at `main()` time**:
 
+<!-- gofastr:compile
+import "database/sql"
+-->
 ```go
 // in package screens (or wherever your screens live)
 var dbHandle *sql.DB

--- a/framework/docs/content/uploads.md
+++ b/framework/docs/content/uploads.md
@@ -39,8 +39,11 @@ curl -X POST http://localhost:8080/users \
 
 The framework:
 
-1. Parses the multipart form (up to `MaxMultipartMemory = 32 MiB` in
-   memory, spills the rest to temp files).
+1. Rejects the request `413` if the body exceeds
+   `crud.MaxMultipartBodyBytes = 64 MiB`, then parses the multipart form
+   (up to `MaxMultipartMemory = 32 MiB` in memory, spills the rest to
+   temp files). The two limits are different things: the first caps the
+   wire body, the second is only the in-RAM spill threshold.
 2. Coerces non-file values to the schema field's Go type
    (`Int` → `int64`, `Bool` → `bool`, etc.).
 3. Streams each file part matching an `Image`/`File` field through
@@ -66,12 +69,18 @@ Every key is **camelCase**, like the rest of the framework:
   "size": 11,
   "mimeType": "text/plain; charset=utf-8",
   "uploadedAt": "2026-07-30T18:04:07.567319Z",
-  "key": "report.txt" }
+  "key": "report_1786943913322678000_bcdc0d8ff1d03054.txt" }
 ```
 
 `mimeType` is the content type sniffed from the bytes (never the
-attacker-controlled multipart header), and `key` is the sanitized storage
-key the backend wrote the file under.
+attacker-controlled multipart header), and `key` is the storage key the
+backend wrote the file under.
+
+The key is not the client's filename. `upload.UniqueFilename` sanitizes
+the name and appends a nanosecond timestamp and 8 random bytes, so two
+users uploading `report.txt` get two objects instead of the second
+silently overwriting the first. Read `key` from the response — do not
+reconstruct it from `originalName`.
 
 ## Field-name casing
 
@@ -216,6 +225,11 @@ concrete type. `imagefield` is one implementation; implement the interface
 directly to crop to a focal point, watermark, push to a CDN, or name keys
 your own way:
 
+<!-- gofastr:compile
+import "context"
+import "github.com/DonaldMurillo/gofastr/core/upload"
+import "github.com/DonaldMurillo/gofastr/framework/file"
+-->
 ```go
 type ImageDeriver interface {
     DeriveImage(ctx context.Context, store upload.Storage,
@@ -363,6 +377,10 @@ filename can't force unbounded pre-truncation work (DoS).
 
 `upload.Storage` is the interface:
 
+<!-- gofastr:compile
+import "context"
+import "io"
+-->
 ```go
 type Storage interface {
     Save(ctx context.Context, key string, r io.Reader) error
@@ -412,6 +430,10 @@ echoes no filesystem path on any error.
 `http.ServeContent` needs an `io.ReadSeeker` to answer a `Range:` header.
 Backends that hold their bytes locally declare the capability instead:
 
+<!-- gofastr:compile
+import "context"
+import "io"
+-->
 ```go
 type RangeGetter interface {
     GetRange(ctx context.Context, key string) (io.ReadSeekCloser, error)

--- a/framework/docs/content/webhooks.md
+++ b/framework/docs/content/webhooks.md
@@ -192,8 +192,12 @@ Two stores are bundled:
   - `WithSQLSubscribersTable(name)` / `WithSQLDeliveriesTable(name)`
     — override table names.
   - `WithSQLSecretCodec(codec)` — encrypt subscriber secrets at rest
-    (see Secret encryption below). Default is `NoopSecretCodec`
-    (plaintext).
+    (see Secret encryption below).
+  - `WithSQLAllowPlaintext()` — opt into plaintext storage
+    (`NoopSecretCodec`).
+
+`NewSQLStore` fails closed: given neither option it returns an error
+rather than silently storing subscriber secrets in cleartext.
 
 Both bundled stores implement the optional `LeasedStore` interface:
 

--- a/framework/docs/example_compile_test.go
+++ b/framework/docs/example_compile_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 )
 
+// packageClause detects a snippet that is a complete Go file.
+var packageClause = regexp.MustCompile(`(?m)^package\s+\w+`)
+
 // Compiling the Go examples embedded in the guides, so a snippet cannot rot
 // into something that does not build. TestDocsAvoidKnownWrongAPIs is the cheap
 // denylist half of this; it cannot catch a scope or signature error, which is
@@ -79,6 +82,19 @@ func splitImports(src string) (imports, rest string) {
 }
 
 func assemble(directive, code string) string {
+	// A snippet that carries its own `package` clause is a complete Go
+	// file (docs sometimes show the whole file — package, imports, decls).
+	// It is emitted verbatim: the directive contributes nothing, because
+	// its imports and decls would have to merge inside the snippet's own
+	// declarations. A `package main` file with no main function (the doc
+	// shows only the interesting declarations) gets an empty main so the
+	// package links.
+	if packageClause.MatchString(code) {
+		if strings.Contains(code, "package main") && !strings.Contains(code, "func main(") {
+			return code + "\n\nfunc main() {}\n"
+		}
+		return code
+	}
 	var extraImports, decls, stmts []string
 	for _, l := range strings.Split(directive, "\n") {
 		t := strings.TrimSpace(l)

--- a/framework/file/filefield.go
+++ b/framework/file/filefield.go
@@ -3,15 +3,12 @@ package file
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/DonaldMurillo/gofastr/core/upload"
 )
@@ -581,39 +578,14 @@ func DeleteFileField(ctx context.Context, store upload.Storage, ff *FileField) e
 // whose clock does not advance every nanosecond) would resolve to the same
 // path and one upload would silently overwrite the other.
 func GenerateFilePath(entityName, fieldName, filename string) string {
-	// Sanitize the filename to prevent path traversal
-	safe := upload.SanitizeFilename(filename)
-
-	// Split into name and extension
-	ext := filepath.Ext(safe)
-	nameWithoutExt := strings.TrimSuffix(safe, ext)
-
-	// Generate a unique name from the timestamp plus a random suffix. The
-	// random suffix is the real uniqueness guarantee; the timestamp is
-	// retained only for human-readable ordering. crypto/rand.Read on a
-	// fixed-size buffer never returns a short read without an error, but
-	// if the platform RNG fails we fall back to the timestamp alone rather
-	// than panicking mid-upload.
-	uniqueName := fmt.Sprintf("%s_%d_%s%s", nameWithoutExt, time.Now().UnixNano(), randomSuffix(), ext)
-
-	// Build the path using filepath.Join for cross-platform safety
-	path := filepath.Join("uploads", entityName, fieldName, uniqueName)
+	// The unique-name component (sanitized base + timestamp + crypto/rand
+	// suffix) lives in core/upload.UniqueFilename so every upload surface
+	// shares one scheme; this helper just scopes it under the entity and
+	// field so auto-CRUD storage stays organised per field.
+	path := filepath.Join("uploads", entityName, fieldName, upload.UniqueFilename(filename))
 
 	// Normalize to forward slashes for storage consistency
 	return filepath.ToSlash(path)
-}
-
-// randomSuffix returns a hex-encoded 8-byte crypto-random token used to
-// guarantee storage-path uniqueness independent of clock resolution. If
-// the platform RNG fails it returns an empty string; the caller still has
-// the timestamp, so a failure degrades to the old behaviour rather than
-// aborting an upload.
-func randomSuffix() string {
-	var b [8]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return ""
-	}
-	return hex.EncodeToString(b[:])
 }
 
 // detectMIMEFromName attempts to detect MIME type from filename extension.

--- a/framework/filter/filter.go
+++ b/framework/filter/filter.go
@@ -12,15 +12,39 @@ import (
 	"github.com/DonaldMurillo/gofastr/core/schema"
 )
 
-// maxINListEntries bounds the number of values a single ?field_in=…
-// parameter can expand to. Generous for legitimate use (most DBs cap
-// IN-list at a few thousand parameters) but small enough that an
+// MaxINListEntries bounds the number of values a single ?field_in=…
+// parameter can expand to — counting repeated occurrences of the
+// parameter as one list. Generous for legitimate use (most DBs cap
+// IN-lists at a few thousand parameters) but small enough that an
 // adversarial 10K-element list can't drive memory or statement-cache
-// growth.
-const maxINListEntries = 1000
+// growth. Exposed so sibling surfaces (nested ?rel.field_in=) enforce
+// the same cap instead of growing a private one.
+const MaxINListEntries = 1000
+
+// SplitINValues expands every occurrence of a repeated _in parameter
+// into one flat, comma-split value list: ?tag_in=a&tag_in=b,c yields
+// [a b c]. Reading only values[0] silently narrowed the filter to the
+// first key's values — a client asking for a union got a subset with no
+// error. Repeated keys and comma-separated values are treated as the
+// same list, so the cap (MaxINListEntries) can't be bypassed by
+// splitting one huge list across several occurrences either.
+func SplitINValues(values []string) []string {
+	if len(values) == 1 {
+		return strings.Split(values[0], ",")
+	}
+	n := 0
+	for _, v := range values {
+		n += strings.Count(v, ",") + 1
+	}
+	parts := make([]string, 0, n)
+	for _, v := range values {
+		parts = append(parts, strings.Split(v, ",")...)
+	}
+	return parts
+}
 
 // maxSortFields bounds the number of ORDER BY clauses a single request
-// can generate. Mirrors maxINListEntries: without it, a repeated
+// can generate. Mirrors MaxINListEntries: without it, a repeated
 // allow-listed ?sort=title (N copies) produces N "ORDER BY title"
 // fragments, inflating SQL text, burning statement-parse CPU, and
 // polluting the statement cache from one small request. 16 is far more
@@ -325,7 +349,7 @@ func ParseFiltersValues(q url.Values, fields []schema.Field, opts ...FilterOptio
 	blocked := ""
 
 	// overCapField/overCapCount record the lexically-smallest ?field_in= list
-	// that exceeds maxINListEntries, surfaced as a single deterministic error
+	// that exceeds MaxINListEntries, surfaced as a single deterministic error
 	// after the loop for the same reason unknown/blocked are. Silent
 	// truncation (parts[:cap]) narrows the predicate — rows past entry N drop
 	// out of the result set without the caller knowing — so it fails closed,
@@ -376,8 +400,8 @@ func ParseFiltersValues(q url.Values, fields []schema.Field, opts ...FilterOptio
 			}
 			consumed[col] = true
 			if s.Op == OpIn {
-				parts := strings.Split(values[0], ",")
-				if len(parts) > maxINListEntries {
+				parts := SplitINValues(values)
+				if len(parts) > MaxINListEntries {
 					// Fail closed: a truncated list silently narrows the
 					// predicate (rows past entry N drop out of results)
 					// without telling the caller. Record the lexically-
@@ -450,7 +474,7 @@ func ParseFiltersValues(q url.Values, fields []schema.Field, opts ...FilterOptio
 	// An over-cap ?field_in= list narrows results silently; fail closed
 	// with a message shaped like the include path's scoped-IN cap.
 	if overCapField != "" {
-		return nil, fmt.Errorf("in-list on %q has %d entries (max %d)", overCapField, overCapCount, maxINListEntries)
+		return nil, fmt.Errorf("in-list on %q has %d entries (max %d)", overCapField, overCapCount, MaxINListEntries)
 	}
 
 	return filters, nil

--- a/framework/filter/filter.go
+++ b/framework/filter/filter.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -29,18 +30,52 @@ const MaxINListEntries = 1000
 // same list, so the cap (MaxINListEntries) can't be bypassed by
 // splitting one huge list across several occurrences either.
 func SplitINValues(values []string) []string {
-	if len(values) == 1 {
-		return strings.Split(values[0], ",")
-	}
+	parts, _ := SplitINValuesBounded(values, math.MaxInt)
+	return parts
+}
+
+// SplitINValuesBounded is SplitINValues with an allocation bound for the
+// HTTP filter paths that enforce MaxINListEntries: it never materializes
+// more than max+1 entries. SplitINValues built the entire list before the
+// caller compared it against the cap, so one request carrying hundreds of
+// thousands of commas allocated that many strings just to earn a 400 —
+// repeated per request. Here the total is counted first (strings.Count,
+// no allocation) and the list is only built in full when it fits; an
+// over-cap input yields a max+1-entry prefix plus the exact total, which
+// is everything the rejection error needs. parts holds the complete list
+// iff total <= max.
+func SplitINValuesBounded(values []string, max int) (parts []string, total int) {
 	n := 0
 	for _, v := range values {
 		n += strings.Count(v, ",") + 1
 	}
-	parts := make([]string, 0, n)
-	for _, v := range values {
-		parts = append(parts, strings.Split(v, ",")...)
+	if n <= max {
+		out := make([]string, 0, n)
+		for _, v := range values {
+			out = append(out, strings.Split(v, ",")...)
+		}
+		return out, n
 	}
-	return parts
+	out := make([]string, 0, max+1)
+outer:
+	for _, v := range values {
+		for {
+			// Check before appending so the slice never exceeds max+1
+			// entries — the no-comma tail append must respect the bound
+			// just like the comma-split pieces.
+			if len(out) > max {
+				break outer
+			}
+			if i := strings.IndexByte(v, ','); i >= 0 {
+				out = append(out, v[:i])
+				v = v[i+1:]
+			} else {
+				out = append(out, v)
+				break
+			}
+		}
+	}
+	return out, n
 }
 
 // maxSortFields bounds the number of ORDER BY clauses a single request
@@ -400,8 +435,8 @@ func ParseFiltersValues(q url.Values, fields []schema.Field, opts ...FilterOptio
 			}
 			consumed[col] = true
 			if s.Op == OpIn {
-				parts := SplitINValues(values)
-				if len(parts) > MaxINListEntries {
+				parts, total := SplitINValuesBounded(values, MaxINListEntries)
+				if total > MaxINListEntries {
 					// Fail closed: a truncated list silently narrows the
 					// predicate (rows past entry N drop out of results)
 					// without telling the caller. Record the lexically-
@@ -409,7 +444,7 @@ func ParseFiltersValues(q url.Values, fields []schema.Field, opts ...FilterOptio
 					// randomized map iteration and error after the loop.
 					if overCapField == "" || col < overCapField {
 						overCapField = col
-						overCapCount = len(parts)
+						overCapCount = total
 					}
 				} else {
 					for _, p := range parts {

--- a/framework/filter/in_cap_test.go
+++ b/framework/filter/in_cap_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 // TestTopLevelINListOverCapErrors pins that a top-level ?field_in= list
-// longer than maxINListEntries is REJECTED with an error, not silently
-// truncated. Silent truncation (parts[:maxINListEntries]) narrows the
+// longer than MaxINListEntries is REJECTED with an error, not silently
+// truncated. Silent truncation (parts[:MaxINListEntries]) narrows the
 // predicate — every row past entry N drops out of the result set without
 // the caller being told. The include-scoped sibling (parseScopedFilters)
 // errors on its cap for the same reason; the top-level path must match.
@@ -21,7 +21,7 @@ func TestTopLevelINListOverCapErrors(t *testing.T) {
 
 	var b strings.Builder
 	b.WriteString("/?tag_in=")
-	for i := range maxINListEntries + 1 { // maxINListEntries+1 entries
+	for i := range MaxINListEntries + 1 { // MaxINListEntries+1 entries
 		if i > 0 {
 			b.WriteString(",")
 		}
@@ -32,7 +32,7 @@ func TestTopLevelINListOverCapErrors(t *testing.T) {
 	filters, err := ParseFilters(req, fields)
 	if err == nil {
 		t.Fatalf("ParseFilters silently truncated an IN list of %d entries to %d (got %d filters); want a 400-shaped error",
-			maxINListEntries+1, maxINListEntries, len(filters))
+			MaxINListEntries+1, MaxINListEntries, len(filters))
 	}
 
 	// Message style mirrors parseScopedFilters' cap: names the field and
@@ -41,7 +41,7 @@ func TestTopLevelINListOverCapErrors(t *testing.T) {
 	if !strings.Contains(msg, "tag") {
 		t.Errorf("error does not name the field: %q", msg)
 	}
-	if !strings.Contains(msg, fmt.Sprintf("%d", maxINListEntries+1)) || !strings.Contains(msg, fmt.Sprintf("%d", maxINListEntries)) {
+	if !strings.Contains(msg, fmt.Sprintf("%d", MaxINListEntries+1)) || !strings.Contains(msg, fmt.Sprintf("%d", MaxINListEntries)) {
 		t.Errorf("error does not report actual+max counts: %q", msg)
 	}
 }
@@ -53,7 +53,7 @@ func TestTopLevelINListAtCapAccepted(t *testing.T) {
 
 	var b strings.Builder
 	b.WriteString("/?tag_in=")
-	for i := range maxINListEntries { // exactly maxINListEntries
+	for i := range MaxINListEntries { // exactly MaxINListEntries
 		if i > 0 {
 			b.WriteString(",")
 		}
@@ -63,9 +63,9 @@ func TestTopLevelINListAtCapAccepted(t *testing.T) {
 
 	filters, err := ParseFilters(req, fields)
 	if err != nil {
-		t.Fatalf("IN list at exactly the cap (%d) should parse, got: %v", maxINListEntries, err)
+		t.Fatalf("IN list at exactly the cap (%d) should parse, got: %v", MaxINListEntries, err)
 	}
-	if len(filters) != maxINListEntries {
-		t.Fatalf("expected %d filters, got %d", maxINListEntries, len(filters))
+	if len(filters) != MaxINListEntries {
+		t.Fatalf("expected %d filters, got %d", MaxINListEntries, len(filters))
 	}
 }

--- a/framework/filter/predicate.go
+++ b/framework/filter/predicate.go
@@ -200,6 +200,13 @@ func parseNode(msg json.RawMessage, allow, noQuery map[string]bool, alias map[st
 	if op == OpIn {
 		vals := rp.Values
 		if len(vals) == 0 && rp.Value != "" {
+			// Count separators before splitting. The where-body is size-bounded,
+			// so this is defence in depth rather than a live DoS, but the
+			// allocate-then-reject shape is the same one SplitINValuesBounded
+			// exists to avoid on the ?field_in= path — keep them consistent.
+			if strings.Count(rp.Value, ",")+1 > MaxINListEntries {
+				return Predicate{}, fmt.Errorf("where: in-list exceeds %d entries", MaxINListEntries)
+			}
 			vals = strings.Split(rp.Value, ",")
 		}
 		if len(vals) == 0 {

--- a/framework/filter/predicate.go
+++ b/framework/filter/predicate.go
@@ -205,8 +205,8 @@ func parseNode(msg json.RawMessage, allow, noQuery map[string]bool, alias map[st
 		if len(vals) == 0 {
 			return Predicate{}, fmt.Errorf("where: %q with op in requires values", rp.Field)
 		}
-		if len(vals) > maxINListEntries {
-			return Predicate{}, fmt.Errorf("where: in-list exceeds %d entries", maxINListEntries)
+		if len(vals) > MaxINListEntries {
+			return Predicate{}, fmt.Errorf("where: in-list exceeds %d entries", MaxINListEntries)
 		}
 		leaf.Values = vals
 	} else {

--- a/framework/filter/repeat_in_test.go
+++ b/framework/filter/repeat_in_test.go
@@ -40,7 +40,7 @@ func TestRepeatedInKeysUnion(t *testing.T) {
 
 // TestRepeatedInKeysOverCapErrors: the 1000-entry cap counts the UNION of
 // all occurrences, so a caller can't bypass it by splitting one huge list
-// across repeated keys (1101 entries as 2 keys must fail like 1 key does).
+// across repeated keys (1002 entries as 2 keys must fail like 1 key does).
 func TestRepeatedInKeysOverCapErrors(t *testing.T) {
 	fields := []schema.Field{{Name: "tag", Type: schema.String}}
 

--- a/framework/filter/repeat_in_test.go
+++ b/framework/filter/repeat_in_test.go
@@ -1,0 +1,64 @@
+package filter
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+)
+
+// TestRepeatedInKeysUnion pins the repeated-query-param contract: every
+// occurrence of ?field_in= contributes its values. Standard HTTP clients
+// (Rails/axios/jQuery arrays) naturally emit ?tag_in=a&tag_in=b for a
+// multi-select; reading only values[0] silently narrowed the filter to
+// "a" — the client asked for a union and got a subset without any error.
+// Union semantics equal the comma form: ?tag_in=a&tag_in=b,c ≡ ?tag_in=a,b,c.
+func TestRepeatedInKeysUnion(t *testing.T) {
+	fields := []schema.Field{{Name: "tag", Type: schema.String}}
+
+	req := httptest.NewRequest(http.MethodGet, "/?tag_in=a&tag_in=b,c", nil)
+	filters, err := ParseFilters(req, fields)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, f := range filters {
+		if f.Op == OpIn {
+			got[f.Value] = true
+		}
+	}
+	for _, want := range []string{"a", "b", "c"} {
+		if !got[want] {
+			t.Errorf("?tag_in=a&tag_in=b,c lost value %q — repeated keys must union, parsed: %v", want, filters)
+		}
+	}
+}
+
+// TestRepeatedInKeysOverCapErrors: the 1000-entry cap counts the UNION of
+// all occurrences, so a caller can't bypass it by splitting one huge list
+// across repeated keys (1101 entries as 2 keys must fail like 1 key does).
+func TestRepeatedInKeysOverCapErrors(t *testing.T) {
+	fields := []schema.Field{{Name: "tag", Type: schema.String}}
+
+	var b1, b2 strings.Builder
+	for i := range MaxINListEntries {
+		if i > 0 {
+			b1.WriteString(",")
+		}
+		b1.WriteString("v")
+	}
+	b2.WriteString("extra1,extra2") // +2 over the cap across both keys
+
+	req := httptest.NewRequest(http.MethodGet, "/?tag_in="+b1.String()+"&tag_in="+b2.String(), nil)
+	_, err := ParseFilters(req, fields)
+	if err == nil {
+		t.Fatal("repeated ?tag_in= keys totalling over the cap must error, not silently narrow")
+	}
+	if !strings.Contains(err.Error(), "max") || !strings.Contains(err.Error(), fmt.Sprint(MaxINListEntries)) {
+		t.Errorf("error does not report the cap: %v", err)
+	}
+}

--- a/framework/filter/split_in_bounded_test.go
+++ b/framework/filter/split_in_bounded_test.go
@@ -1,0 +1,39 @@
+package filter
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSplitINValuesBoundedStopsAtCap pins the allocation bound: an
+// over-cap ?field_in= value (here 100_000 comma entries against a 1000
+// cap) must cost at most max+1 materialized entries, not the whole list,
+// while total still reports the exact count the over-cap error names.
+// SplitINValues built the full slice before the caller compared against
+// MaxINListEntries, so a hostile comma bomb allocated 500k strings to
+// earn a 400.
+func TestSplitINValuesBoundedStopsAtCap(t *testing.T) {
+	huge := strings.Repeat("v,", 100_000-1) + "v" // exactly 100_000 entries
+	parts, total := SplitINValuesBounded([]string{huge}, MaxINListEntries)
+	if total != 100_000 {
+		t.Fatalf("total = %d, want the exact count 100000", total)
+	}
+	if len(parts) != MaxINListEntries+1 {
+		t.Fatalf("len(parts) = %d, want max+1 = %d — the full list must not be built", len(parts), MaxINListEntries+1)
+	}
+
+	// Under the cap the bounded result is exactly SplitINValues' list.
+	in := []string{"a,b", "c"}
+	parts, total = SplitINValuesBounded(in, MaxINListEntries)
+	want, wantTotal := SplitINValues(in), 3
+	if total != wantTotal || strings.Join(parts, ",") != strings.Join(want, ",") {
+		t.Fatalf("under-cap split = %v (total %d), want %v / %d", parts, total, want, wantTotal)
+	}
+
+	// Repeated keys union into the same total, bounded the same way.
+	parts, total = SplitINValuesBounded([]string{strings.Repeat("a,", MaxINListEntries-1) + "a", "b,c"}, MaxINListEntries)
+	if total != MaxINListEntries+2 || len(parts) != MaxINListEntries+1 {
+		t.Fatalf("repeated keys: total = %d len(parts) = %d, want %d / %d",
+			total, len(parts), MaxINListEntries+2, MaxINListEntries+1)
+	}
+}

--- a/framework/owner/owner.go
+++ b/framework/owner/owner.go
@@ -6,7 +6,7 @@
 //
 // The default state is "no extractor" — owner.Get always returns
 // (nil, false). Hosts that never wire an extractor see no behavioural
-// change: EntityConfig.OwnerField stays inert and CRUD operates as
+// change: EntityConfig.Scope.OwnerField stays inert and CRUD operates as
 // before. Hosts that import battery/auth pick up the extractor
 // automatically.
 package owner

--- a/framework/pagination/cursor_fidelity_test.go
+++ b/framework/pagination/cursor_fidelity_test.go
@@ -1,0 +1,80 @@
+package pagination
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+// TestCursorValueRoundTripIsLossless pins the keyset contract: whatever a
+// sortable column can store must survive EncodeCursor → DecodeCursor
+// byte-for-byte. The value half of the token is compared against the
+// DATABASE (a bound SQL arg), not interpolated into SQL, so it is data,
+// not an identifier — stripping zero-width/bidi codepoints on decode made
+// a row whose sort key contains e.g. U+200B resume paging BEFORE that
+// row, re-serving it on the next page. Field names stay stripped: they
+// do reach ORDER BY.
+func TestCursorValueRoundTripIsLossless(t *testing.T) {
+	values := []string{
+		"a\u200bb",     // zero-width space
+		"a\ufeffb",     // BOM
+		"a\u202Eb",     // RLO bidi override
+		"a\nb", "a\rb", // newlines — inert as a bound arg
+		"a\x00b",           // NUL
+		"plain", "", "日本的", // sanity + empty + non-Latin
+	}
+	for _, v := range values {
+		cur := EncodeCursor("title", v)
+		gotField, gotValue, err := DecodeCursor(cur)
+		if err != nil {
+			t.Fatalf("decode %q: %v", v, err)
+		}
+		if gotField != "title" {
+			t.Errorf("field = %q, want title", gotField)
+		}
+		if gotValue != v {
+			t.Errorf("value round-trip lost fidelity: got %q want %q", gotValue, v)
+		}
+	}
+}
+
+// TestMultiCursorValueRoundTripIsLossless: the composite-cursor encoding
+// must round-trip values losslessly for the same reason as the
+// single-field cursor above — tuple comparison binds the values, so a
+// stripped value resumes the keyset at the wrong row.
+func TestMultiCursorValueRoundTripIsLossless(t *testing.T) {
+	row := map[string]any{
+		"title":   "a\u200bb",
+		"payload": "x\u202Ey",
+		"id":      "n-1",
+	}
+	cur := EncodeMultiCursor([]string{"title", "payload", "id"}, row)
+	fields, err := DecodeMultiCursor(cur)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(fields) != 3 {
+		t.Fatalf("fields = %d, want 3", len(fields))
+	}
+	for i, want := range []struct{ name, value string }{
+		{"title", "a\u200bb"}, {"payload", "x\u202Ey"}, {"id", "n-1"},
+	} {
+		if fields[i].Name != want.name || fields[i].Value != want.value {
+			t.Errorf("field %d = (%q, %q), want (%q, %q)", i, fields[i].Name, fields[i].Value, want.name, want.value)
+		}
+	}
+}
+
+// TestCursorFieldNamesStillStripped keeps the security half of the old
+// behavior: the FIELD name reaches ORDER BY / allow-lists, so control
+// bytes and invisible codepoints must not survive a decode.
+func TestCursorFieldNamesStillStripped(t *testing.T) {
+	payload, _ := json.Marshal(cursorToken{Field: "ti\u200btle\n", Value: "v"})
+	field, _, err := DecodeCursor(base64.StdEncoding.EncodeToString(payload))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if field != "title" {
+		t.Errorf("field = %q, want stripped %q", field, "title")
+	}
+}

--- a/framework/pagination/fuzz_test.go
+++ b/framework/pagination/fuzz_test.go
@@ -3,9 +3,12 @@ package pagination
 import "testing"
 
 // FuzzDecodeMultiCursor verifies the decoder never panics on a malformed
-// cursor and, on success, control-scrubs every decoded column name and
-// value — those names/values feed ORDER BY and the WHERE tuple, so a
-// surviving C0 control byte is a query-shaping primitive (#185 scrub).
+// cursor and, on success, control-scrubs every decoded column NAME —
+// names feed ORDER BY / allow-lists, so a surviving C0 control byte is a
+// query-shaping primitive (#185 scrub). VALUES are deliberately not
+// scrubbed: they are bound SQL args compared against stored data, and
+// scrubbing them breaks the keyset round-trip for any sort key that
+// legitimately contains a control byte (see DecodeCursor).
 func FuzzDecodeMultiCursor(f *testing.F) {
 	for _, s := range []string{
 		"", "not-base64!!", "eyJmaWVsZHMiOltdfQ==",
@@ -24,11 +27,6 @@ func FuzzDecodeMultiCursor(f *testing.F) {
 			for _, r := range fld.Name {
 				if r < 0x20 || r == 0x7f {
 					t.Fatalf("decoded name retains control %#x: %q", r, fld.Name)
-				}
-			}
-			for _, r := range fld.Value {
-				if r < 0x20 || r == 0x7f {
-					t.Fatalf("decoded value retains control %#x: %q", r, fld.Value)
 				}
 			}
 		}

--- a/framework/pagination/offset_for_page_test.go
+++ b/framework/pagination/offset_for_page_test.go
@@ -1,0 +1,35 @@
+package pagination
+
+import (
+	"math"
+	"testing"
+)
+
+// TestOffsetForPage pins the page→offset arithmetic including the
+// overflow guard. A client-supplied page multiplied by hand wraps int
+// arithmetic: MaxInt64 with limit 2 yields -4 (negative OFFSET — an
+// error on Postgres, silently page 1 on SQLite), and 2^62+2 with limit
+// 4 yields +4 (the wrong window served without any error). The guard
+// clamps both to the first window; ordinary pages must stay exact.
+func TestOffsetForPage(t *testing.T) {
+	cases := []struct {
+		name        string
+		page, limit int
+		want        int
+	}{
+		{"page1", 1, 20, 0},
+		{"page2", 2, 20, 20},
+		{"page3-limit1", 3, 1, 2},
+		{"limit1-huge-exact", math.MaxInt, 1, math.MaxInt - 1}, // ×1 cannot wrap; a huge positive offset just yields an empty window
+		{"maxint-limit2", math.MaxInt, 2, 0},                   // wraps to -4 unguarded
+		{"wrap-positive", 1<<62 + 2, 4, 0},                     // wraps to +4 unguarded
+		{"just-over-boundary", math.MaxInt/100 + 2, 100, 0},    // product exceeds MaxInt
+		{"at-boundary-exact", math.MaxInt / 100, 100, (math.MaxInt/100 - 1) * 100},
+		{"negative-page", -5, 20, 0},
+	}
+	for _, c := range cases {
+		if got := OffsetForPage(c.page, c.limit); got != c.want {
+			t.Errorf("%s: OffsetForPage(%d, %d) = %d, want %d", c.name, c.page, c.limit, got, c.want)
+		}
+	}
+}

--- a/framework/pagination/offset_for_page_test.go
+++ b/framework/pagination/offset_for_page_test.go
@@ -26,6 +26,8 @@ func TestOffsetForPage(t *testing.T) {
 		{"just-over-boundary", math.MaxInt/100 + 2, 100, 0},    // product exceeds MaxInt
 		{"at-boundary-exact", math.MaxInt / 100, 100, (math.MaxInt/100 - 1) * 100},
 		{"negative-page", -5, 20, 0},
+		{"limit0-page2", 2, 0, 0},    // MaxInt/limit was a division by zero panic
+		{"negative-limit", 2, -3, 0}, // a non-positive page size has no offset math
 	}
 	for _, c := range cases {
 		if got := OffsetForPage(c.page, c.limit); got != c.want {

--- a/framework/pagination/pagination.go
+++ b/framework/pagination/pagination.go
@@ -15,8 +15,10 @@ import (
 // formatting codepoints. The bidi/zero-width chars are particularly
 // dangerous in cursor *field names*, because a parser that sees "name"
 // and a downstream allow-list that sees "na​me" will disagree.
-// Applied to any user-controlled cursor token field after decoding and
-// to cursor direction strings before they reach downstream consumers.
+// Applied to cursor FIELD names after decoding and to cursor direction
+// strings before they reach downstream consumers — never to cursor
+// VALUES, which are bound SQL args and must round-trip byte-for-byte
+// (see DecodeCursor).
 func stripControls(s string) string {
 	if s == "" {
 		return s
@@ -105,19 +107,31 @@ func ParsePagination(r *http.Request) (cursor string, limit int, offset int) {
 	if page < 1 {
 		page = 1
 	}
-	// Guard against integer overflow: a malicious caller can request a
-	// huge page number (e.g. math.MaxInt) which wraps to a negative
-	// offset when multiplied by limit. Negative offsets are undefined
-	// in most SQL dialects and can yield wraparound pagination bypass.
-	// page>=1 and limit>=1 here, so (page-1)*limit overflows iff
-	// (page-1) > math.MaxInt/limit. Compute the threshold without the
-	// `+1` that previously wrapped to math.MinInt when limit==1.
-	if page-1 > math.MaxInt/limit {
-		offset = 0
-	} else {
-		offset = (page - 1) * limit
-	}
+	offset = OffsetForPage(page, limit)
 	return cursor, limit, offset
+}
+
+// OffsetForPage returns the row offset for a 1-based page number and a
+// page size, with the integer-overflow guard applied. A caller can
+// request a huge page number (e.g. math.MaxInt) whose (page-1)*limit
+// product wraps: to a negative offset — undefined in most SQL dialects
+// (Postgres rejects it outright) and treated as 0 by SQLite — or, for
+// carefully chosen values, to a small POSITIVE offset that silently
+// serves the wrong window. page>=1 and limit>=1 required, so
+// (page-1)*limit overflows iff (page-1) > math.MaxInt/limit; compute
+// the threshold without the `+1` that previously wrapped to
+// math.MinInt when limit==1. Overflow clamps to 0 (the first window),
+// matching ParsePagination's historical behaviour. Every offset-math
+// call site (buffered list, streaming list, admin table) must go
+// through this — never multiply a client-supplied page by hand.
+func OffsetForPage(page, limit int) int {
+	if page < 2 {
+		return 0
+	}
+	if page-1 > math.MaxInt/limit {
+		return 0
+	}
+	return (page - 1) * limit
 }
 
 // ParseCursorPagination extracts cursor, limit, and direction from query parameters.
@@ -154,6 +168,15 @@ func EncodeCursor(field string, value any) string {
 }
 
 // DecodeCursor decodes a base64 cursor string into its field and value components.
+//
+// The field name is stripped of control / invisible codepoints: it flows
+// into SQL identifiers (ORDER BY) and allow-lists, where a smuggled
+// zero-width or bidi codepoint makes a parser and a downstream
+// allow-list disagree. The VALUE is returned verbatim — it is compared
+// against the database as a bound arg, never interpolated, so stripping
+// it would not harden anything while breaking the keyset contract: a
+// sort key containing e.g. U+200B must round-trip losslessly or paging
+// resumes before that row and re-serves it.
 func DecodeCursor(cursor string) (field string, value string, err error) {
 	b, err := base64.StdEncoding.DecodeString(cursor)
 	if err != nil {
@@ -163,11 +186,7 @@ func DecodeCursor(cursor string) (field string, value string, err error) {
 	if err := json.Unmarshal(b, &token); err != nil {
 		return "", "", err
 	}
-	// Cursors are opaque to the caller but their contents flow back into
-	// SQL identifiers (Field → ORDER BY column) and predicate values.
-	// Strip control bytes so a tampered cursor can't poison ORDER/WHERE
-	// clauses, log lines, or metrics labels.
-	return stripControls(token.Field), stripControls(token.Value), nil
+	return stripControls(token.Field), token.Value, nil
 }
 
 // multiCursorToken is the wire shape for cursors that keyset on multiple
@@ -211,11 +230,12 @@ func DecodeMultiCursor(cursor string) ([]multiCursorField, error) {
 	if err := json.Unmarshal(b, &tok); err != nil {
 		return nil, err
 	}
-	// Same control-byte scrub as DecodeCursor — multi-column cursors
-	// feed both column names (ORDER BY) and values (WHERE tuple comparison).
+	// Names reach ORDER BY / allow-lists, so they get the same
+	// control-byte scrub as DecodeCursor. Values are bound SQL args —
+	// kept verbatim so the tuple comparison resumes at the exact row
+	// (see DecodeCursor for the round-trip contract).
 	for i := range tok.Fields {
 		tok.Fields[i].Name = stripControls(tok.Fields[i].Name)
-		tok.Fields[i].Value = stripControls(tok.Fields[i].Value)
 	}
 	return tok.Fields, nil
 }

--- a/framework/pagination/pagination.go
+++ b/framework/pagination/pagination.go
@@ -125,7 +125,12 @@ func ParsePagination(r *http.Request) (cursor string, limit int, offset int) {
 // call site (buffered list, streaming list, admin table) must go
 // through this — never multiply a client-supplied page by hand.
 func OffsetForPage(page, limit int) int {
-	if page < 2 {
+	// limit < 1 guards the MaxInt/limit division below (limit == 0 is an
+	// integer-division panic; negative limit is nonsense arithmetic).
+	// OffsetForPage is exported, so it protects its own inputs even though
+	// every in-repo caller floors its page size — ServeStreamingList, for
+	// one, is also exported and takes an arbitrary limit.
+	if page < 2 || limit < 1 {
 		return 0
 	}
 	if page-1 > math.MaxInt/limit {

--- a/framework/pagination/pagination_security_test.go
+++ b/framework/pagination/pagination_security_test.go
@@ -123,7 +123,16 @@ func TestDecodeMultiCursor_StripsNULFromFieldNames(t *testing.T) {
 	}
 }
 
-func TestDecodeCursor_StripsNewlinesFromValue(t *testing.T) {
+// TestDecodeCursor_ValueIsBoundDataNotSanitized: cursor values are
+// compared against the database as bound SQL args — never interpolated
+// into SQL, headers, or logs — so they are decoded verbatim. Stripping
+// control bytes there broke the keyset round-trip: a row whose sort key
+// contains a newline (or a zero-width codepoint) resumed paging BEFORE
+// itself and was served twice. Field names stay stripped; values are
+// data. Round-trip fidelity is pinned in cursor_fidelity_test.go; this
+// test pins that the newline specifically — the classic header/log
+// injection byte — survives because it is inert as a bind arg.
+func TestDecodeCursor_ValueIsBoundDataNotSanitized(t *testing.T) {
 	t.Parallel()
 	cursor := EncodeCursor("id", "42\nadmin")
 
@@ -131,12 +140,15 @@ func TestDecodeCursor_StripsNewlinesFromValue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DecodeCursor: %v", err)
 	}
-	if value != "42admin" {
-		t.Fatalf("SECURITY: [pagination] DecodeCursor retained newline-bearing value %q. Attack: cursor-value poisoning into downstream predicates or logs.", value)
+	if value != "42\nadmin" {
+		t.Fatalf("DecodeCursor mutated the value %q — keyset values are bound args and must round-trip verbatim", value)
 	}
 }
 
-func TestDecodeMultiCursor_StripsNewlinesFromValues(t *testing.T) {
+// TestDecodeMultiCursor_ValueIsBoundDataNotSanitized: same contract as
+// above for the composite encoding — the value half feeds a tuple
+// comparison as bind args, so it decodes verbatim.
+func TestDecodeMultiCursor_ValueIsBoundDataNotSanitized(t *testing.T) {
 	t.Parallel()
 	raw, err := json.Marshal(multiCursorToken{
 		Fields: []multiCursorField{{Name: "id", Value: "42\nadmin"}},
@@ -149,7 +161,7 @@ func TestDecodeMultiCursor_StripsNewlinesFromValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DecodeMultiCursor: %v", err)
 	}
-	if fields[0].Value != "42admin" {
-		t.Fatalf("SECURITY: [pagination] DecodeMultiCursor retained newline-bearing value %q. Attack: multi-column cursor-value poisoning.", fields[0].Value)
+	if fields[0].Value != "42\nadmin" {
+		t.Fatalf("DecodeMultiCursor mutated the value %q — keyset values are bound args and must round-trip verbatim", fields[0].Value)
 	}
 }

--- a/framework/pagination/unicode_security_test.go
+++ b/framework/pagination/unicode_security_test.go
@@ -33,30 +33,37 @@ func TestDecodeCursor_StripsInvisibles(t *testing.T) {
 	for _, tc := range invisibleCodepoints {
 		t.Run("field/"+tc.name, func(t *testing.T) {
 			payload, _ := json.Marshal(cursorToken{Field: "na" + string(tc.r) + "me", Value: "v"})
-			field, value, err := DecodeCursor(base64.StdEncoding.EncodeToString(payload))
+			field, _, err := DecodeCursor(base64.StdEncoding.EncodeToString(payload))
 			if err != nil {
 				t.Fatalf("decode: %v", err)
 			}
-			if field != "name" || value != "v" {
-				t.Fatalf("invisible %U survived: field=%q value=%q", tc.r, field, value)
+			if field != "name" {
+				t.Fatalf("invisible %U survived in field: field=%q", tc.r, field)
 			}
 		})
+		// Values are bound SQL args, not identifiers — they decode
+		// verbatim so the keyset round-trip stays lossless. Stripping
+		// here made a row whose sort key contains the codepoint resume
+		// paging before itself and get served twice.
 		t.Run("value/"+tc.name, func(t *testing.T) {
-			payload, _ := json.Marshal(cursorToken{Field: "name", Value: "val" + string(tc.r) + "ue"})
-			field, value, err := DecodeCursor(base64.StdEncoding.EncodeToString(payload))
+			want := "val" + string(tc.r) + "ue"
+			payload, _ := json.Marshal(cursorToken{Field: "name", Value: want})
+			_, value, err := DecodeCursor(base64.StdEncoding.EncodeToString(payload))
 			if err != nil {
 				t.Fatalf("decode: %v", err)
 			}
-			if field != "name" || value != "value" {
-				t.Fatalf("invisible %U survived: field=%q value=%q", tc.r, field, value)
+			if value != want {
+				t.Fatalf("invisible %U was stripped from value: got %q want %q", tc.r, value, want)
 			}
 		})
 	}
 }
-
 func TestDecodeMultiCursor_StripsInvisibles(t *testing.T) {
 	for _, tc := range invisibleCodepoints {
 		t.Run(tc.name, func(t *testing.T) {
+			// Names are identifiers and stay scrubbed; values are
+			// bind args and round-trip verbatim (see the single-field
+			// test above for why).
 			payload, _ := json.Marshal(multiCursorToken{
 				Fields: []multiCursorField{
 					{Name: "na" + string(tc.r) + "me", Value: "val" + string(tc.r) + "ue"},
@@ -66,8 +73,8 @@ func TestDecodeMultiCursor_StripsInvisibles(t *testing.T) {
 			if err != nil {
 				t.Fatalf("decode: %v", err)
 			}
-			if len(fields) != 1 || fields[0].Name != "name" || fields[0].Value != "value" {
-				t.Fatalf("invisible %U survived: %#v", tc.r, fields)
+			if len(fields) != 1 || fields[0].Name != "name" || fields[0].Value != "val"+string(tc.r)+"ue" {
+				t.Fatalf("name not scrubbed or value not preserved: %#v", fields)
 			}
 		})
 	}

--- a/framework/ui/resource/pagination_overflow_test.go
+++ b/framework/ui/resource/pagination_overflow_test.go
@@ -1,0 +1,39 @@
+package resource
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	appui "github.com/DonaldMurillo/gofastr/core-ui/app"
+)
+
+// TestTableHugePageOffsetGuarded: the admin table computes
+// Offset: (page-1)*limit from ?p= with no upper bound on page. For
+// page = 2^62+2 and a page size of 4, (page-1)*limit wraps int
+// arithmetic to +4 — the grid silently renders the second window while
+// its pager claims the astronomically-large page. The offset handed to
+// ListAll must be overflow-guarded (0), matching pagination's guard.
+func TestTableHugePageOffsetGuarded(t *testing.T) {
+	source := &stubSource{}
+	cfg := Config{
+		Entity:   "orders",
+		Title:    "Orders",
+		Singular: "Order",
+		BasePath: "/orders",
+		APIPath:  "/api/orders",
+		Crud:     source,
+		PageSize: 4,
+		Fields:   []Field{{Key: "name", Label: "Name", Type: "string"}},
+	}
+	req := httptest.NewRequest("GET", fmt.Sprintf("/orders?p=%d", int64(1)<<62+2), nil)
+	cfg.List(appui.WithRequest(context.Background(), req))
+
+	if len(source.listCalls) != 1 {
+		t.Fatalf("ListAll calls = %d, want 1", len(source.listCalls))
+	}
+	if got := source.listCalls[0].Offset; got != 0 {
+		t.Fatalf("?p=2^62+2 with page size 4 wrapped (page-1)*limit to offset %d, want 0 (overflow-guarded)", got)
+	}
+}

--- a/framework/ui/resource/resource.go
+++ b/framework/ui/resource/resource.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/framework/crud"
 	"github.com/DonaldMurillo/gofastr/framework/filter"
 	"github.com/DonaldMurillo/gofastr/framework/internal/casing"
+	fwpagination "github.com/DonaldMurillo/gofastr/framework/pagination"
 	"github.com/DonaldMurillo/gofastr/framework/ui"
 )
 
@@ -363,7 +364,7 @@ func (c Config) table(ctx context.Context, total int) render.HTML {
 		total, _ = c.Crud.CountAll(ctx, crud.ListOptions{Filters: filters})
 	}
 	// WithReadHooks: these rows are rendered to an end user.
-	rows, err := c.Crud.ListAll(crud.WithReadHooks(ctx), crud.ListOptions{Filters: filters, Sorts: sorts, Limit: limit, Offset: (page - 1) * limit})
+	rows, err := c.Crud.ListAll(crud.WithReadHooks(ctx), crud.ListOptions{Filters: filters, Sorts: sorts, Limit: limit, Offset: fwpagination.OffsetForPage(page, limit)})
 	if err != nil {
 		return ui.Callout(ui.CalloutConfig{Title: "Couldn't load " + c.Title, Variant: ui.StatusDanger}, render.Text("See server logs."))
 	}

--- a/stability/stability_test.go
+++ b/stability/stability_test.go
@@ -7,11 +7,27 @@ import (
 )
 
 // modulePackages returns every package in the module via `go list ./...`.
+//
+// The `go list` runs from the MODULE ROOT, not from this package's
+// directory. `go test` sets the working directory to the package under
+// test, so a bare `go list ./...` here would enumerate exactly one package
+// — stability itself — and TestEveryPackageIsClassified would pass no
+// matter how many unclassified trees the module grew.
 func modulePackages(t *testing.T) []string {
 	t.Helper()
-	out, err := exec.Command("go", "list", "./...").Output()
+	rootOut, err := exec.Command("go", "list", "-m", "-f", "{{.Dir}}").Output()
 	if err != nil {
-		t.Fatalf("go list ./...: %v", err)
+		t.Fatalf("go list -m: %v", err)
+	}
+	root := strings.TrimSpace(string(rootOut))
+	if root == "" {
+		t.Fatal("go list -m returned no module directory")
+	}
+	cmd := exec.Command("go", "list", "./...")
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("go list ./... in %s: %v", root, err)
 	}
 	var pkgs []string
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
@@ -39,6 +55,20 @@ func TestEveryPackageIsClassified(t *testing.T) {
 	if len(unclassified) > 0 {
 		t.Fatalf("packages missing a stability tier — add each to the manifest in stability.go:\n  %s",
 			strings.Join(unclassified, "\n  "))
+	}
+}
+
+// TestGateSeesWholeModule pins the breadth of the enumeration, not its
+// contents. TestEveryPackageIsClassified was vacuous for its whole life
+// because `go list ./...` inherited the package's own directory and
+// returned exactly one package; the gate ran, reported green, and would
+// have missed an entire unclassified top-level tree. A count assertion is
+// the only thing that catches that class of regression, since a gate over
+// one package looks identical to a gate over all of them.
+func TestGateSeesWholeModule(t *testing.T) {
+	const floor = 50 // the module had 219 packages when this was written
+	if got := len(modulePackages(t)); got < floor {
+		t.Fatalf("modulePackages returned %d packages, want >= %d — the enumeration is scoped too narrowly and every gate built on it is vacuous", got, floor)
 	}
 }
 


### PR DESCRIPTION
Fixes every verified finding from a clean-room assessment of v0.65.0 (five
independent analysts plus a strategy panel; each finding re-verified by hand
before it was acted on).

## Why this is a minor and not a patch

One fix is breaking. `Queue.Ack`/`Nack` take a `Job` instead of a job ID
string, because the string form carries no claim identity and therefore
cannot fence a stale lease holder. Keeping it would mean keeping an API
whose behaviour is "sometimes silently loses your job". Nothing in this
repo outside `battery/queue` calls it, `gofastr-plugins` does not use the
queue, and pkg.go.dev reports no importers, so the real-world cost is
close to zero — but it cannot honestly be labelled a patch.

## The two that mattered most

**The flagship blueprint generated an app that would not boot.**
`examples/blog/gofastr.yml` seeded `post_id: 1` against UUID string primary
keys. The app compiled, then died at startup with `seed comments: validation
failed` — and that message was unactionable because the generated seed
discarded `ValidationError.Fields()`, where `post_id: ["must be a string
reference"]` lived. It survived because the gate ladder stopped at
compilation: `TestExampleBlueprintsLoad` parses every blueprint and
`TestExampleBlueprintsGenerateAndCompile` compiles each one, but nothing ran
one. Meanwhile the committed `examples/blog/main.go` is hand-written and
seeds via raw `db.Exec`, so it worked while its blueprint rotted beside it.

`TestExampleBlueprintsBoot` adds the missing rung, and caught a second
defect on its first run: `blueprintScreenMountStmt` chained `WithTitle` but
not `WithDescription` for policy-gated screens, so every screen with a
declared description tripped strict mode and meridian's generated app could
not start.

**Both durable queues lost jobs in ordinary crash sequences,** and neither
failure was visible from `Stats` or `Replay`. Reproductions and root causes
are in the commit message for 6d7702a7.

## Everything else

Multipart uploads over 1 MiB (a 1 MiB reader wrapped the body before the
content type was checked); cursor pagination re-serving rows whose sort key
held zero-width characters; repeated `?field_in=` keys dropping all but the
first; nested `?rel.field_in=` with no cap while three sibling paths capped
at 1000; `?page=` near `MaxInt64` wrapping negative through a guard that
existed but was never called; two users overwriting each other by uploading
the same filename.

Eight documentation claims contradicted the code. The worst,
`multi-tenant.md`, taught reading the tenant from a request header —
`TenantMiddleware` ignores any client header precisely because trusting one
lets a caller impersonate a tenant, so the page documented a vulnerability
the code refuses to have.

Two gates ran without gating. `TestEveryPackageIsClassified` ran `go list
./...` from its own package directory, so it checked 1 package instead of
219; verified by mutation that an unclassified tree passed before and fails
now. The doc-example compile gate covered 2 of 445 fenced Go blocks;
enabling 83 more surfaced ten real breaks, including `new(0)` for a
`*time.Duration` and `Post` given an `http.HandlerFunc`.

## Deliberately not done

- **YAML flow mappings still refused.** af5f56f3 records the minimal-subset
  parser as an architectural choice; the diagnostic is the fix. The change
  `core/yaml` would need is named in the branch notes.
- **`TestT2CursorDuplicateKeys` left failing.** `cursor-pagination.md:107`
  documents it: a non-unique single cursor field stalls on ties, use
  `CursorFields` for a tiebreak. Fixing it would change documented semantics.
- **chromedp and sqlmock stay in the module graph.** `cmd/gofastr` imports
  chromedp for `audit a11y`, so removing them means splitting the CLI into
  its own module. A scaffold binary links 19 deps and neither of these, so
  the cost is `go.sum` size, not runtime.

## Verification

`go build`, `go vet`, `gofmt`, and `./scripts/coverage-floors.sh` all clean
against Postgres on :5433 — no floor was lowered; `framework/crud` rose to
97.0 against a 96.9 floor. `./scripts/test-all.sh` green. `examples/site`
re-run isolated after a chromedp-under-load cascade: 821s, zero failures.
Each commit vets standalone.

## Needs a maintainer action this PR cannot take

`historical upgrade fixtures (blocking)` is required by
`scripts/release-required-checks.txt` but is missing from branch
protection's ten contexts, so a PR can merge with it red and the break only
surfaces at release:

```
gh api --method POST \
  repos/DonaldMurillo/gofastr/branches/main/protection/required_status_checks/contexts \
  -f 'contexts[]=historical upgrade fixtures (blocking)'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer queue processing with stale-claim protection and final-attempt dead-lettering.
  * Added unique upload storage keys and a 64 MiB multipart upload limit.
  * Improved repeated `_in` filters, cursor handling, and overflow-safe pagination.
  * Added comprehensive blueprint seed validation and clearer error reporting.
* **Bug Fixes**
  * Prevented upload filename collisions, pagination errors, cursor data loss, and blueprint boot failures.
  * Corrected generated home-page titles and documentation URLs.
* **Documentation**
  * Expanded compile checks across Go examples and updated guidance for uploads, security, tenants, queues, and feature flags.
* **Tests**
  * Added broad coverage for queue recovery, uploads, pagination, blueprints, and example application boot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->