### PR TITLE
v0.69.0: seven v0.67.0 field reports on silent failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.69.0] - 2026-08-23
+
 ### Added
 
 - **`gofastr verify` catches a theme token that does not exist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,10 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   declaration only inside a rule block and outside parentheses, so the
   condition of a feature query (`@supports (--brand: red)`, which asks whether
   the browser can parse that declaration rather than making one) no longer
-  marks the token known; `@property --name` registrations do count. `style.TokenNames()` is
+  marks the token known; `@property --name` registrations do count. The
+  `var(` and `@property` keywords match case-insensitively, as CSS does, while
+  the token name stays case-sensitive, as CSS also does: `VAR(--radii-lg)`
+  resolves, and `var(--mixed)` against a declared `--Mixed` does not. `style.TokenNames()` is
   the manifest it checks against, built from the same reflection walk that
   emits the CSS, so the two cannot drift apart. The scan is string-aware:
   `content: "var(--x)"` is content rather than a reference, and a quoted `/*`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   when one is within an edit distance of two. It stays quiet for a reference
   carrying a fallback, because `var(--x, 8px)` degrades instead of dropping
   the declaration; for a custom property declared in any scanned stylesheet;
-  and for the `--ui-*` and `--fui-*` component knobs. `style.TokenNames()` is
+  and for the `--ui-*` and `--fui-*` component knobs. A `--name:` counts as a
+  declaration only inside a rule block and outside parentheses, so the
+  condition of a feature query (`@supports (--brand: red)`, which asks whether
+  the browser can parse that declaration rather than making one) no longer
+  marks the token known; `@property --name` registrations do count. `style.TokenNames()` is
   the manifest it checks against, built from the same reflection walk that
   emits the CSS, so the two cannot drift apart. The scan is string-aware:
   `content: "var(--x)"` is content rather than a reference, and a quoted `/*`
@@ -67,6 +71,15 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   becomes a hard page load, and then does nothing else. No `pushState`, no
   partial fetch, no intercept overlay.
 
+  The same guard now matches the `target` keywords the way HTML does,
+  ASCII-case-insensitively: `target="_SELF"` names the current browsing
+  context exactly as `_self` does, and comparing the attribute raw sent it
+  down the skip path, turning a soft navigation into a full page load. The
+  core runtime's level-1 budget moved 128 bytes (14336 to 14464) to carry the
+  five bytes that costs, and the reason sits beside the constant: the usual
+  answer of carving a feature into a demand module is the one thing
+  unavailable for a guard that IS the click path.
+
 - **`data-fui-activelink-skip` opts a nav link out of active-route
   highlighting.** The `activelink` module neither sets nor clears
   `aria-current` or `.active` on a link carrying it, at load or after
@@ -84,11 +97,14 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   both compile, and nothing said which one was being read.
   `style.DarkPaletteGaps` returns the color tokens a non-empty `DarkColors`
   has no usable dark value for, missing keys and keys present with an empty
-  value alike (an empty one emits `--color-surface: ;`, which the browser
-  drops, so it fails exactly as a missing key does), and the UI host logs them
-  once at boot: those tokens keep their light
-  values in dark mode, which is usually a contrast bug. An empty `DarkColors`
-  is a light-only theme by design and stays silent. The framework theme now
+  value alike, and the UI host logs them once at boot. A missing key leaves
+  the light value painting in dark mode, which is usually a contrast bug. An
+  empty value is worse: an empty custom property is valid CSS, so
+  `--color-surface: ;` overrides the light declaration and every
+  `var(--color-surface)` substitutes to nothing, dropping the consuming
+  declaration at computed-value time. The token paints transparent rather
+  than light. An empty `DarkColors` is a light-only theme by design and stays
+  silent. The framework theme now
   declares dark values for `code-surface`, `code-text`, and `code-border`
   matching its light ones, which was always the intent and existed only as an
   omission.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   the declaration; for a custom property declared in any scanned stylesheet;
   and for the `--ui-*` and `--fui-*` component knobs. `style.TokenNames()` is
   the manifest it checks against, built from the same reflection walk that
-  emits the CSS, so the two cannot drift apart. A stylesheet can waive it with
+  emits the CSS, so the two cannot drift apart. The scan is string-aware:
+  `content: "var(--x)"` is content rather than a reference, and a quoted `/*`
+  does not open a comment that swallows the rest of the file along with the
+  real typos in it. A stylesheet can waive it with
   `/* gofastr:allow(GOFASTR1806) reason */`, which meant teaching the
   suppression scanner to read `.css` files at all: it walked Go source only,
   leaving the one rule that fires on stylesheets with no escape hatch in the
@@ -43,10 +46,14 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   `layout--sticky-header` modifier and `LayoutBaseCSS` sticks the wrapper on
   the theme's `--z-sticky` layer, with a background from
   `--ui-layout-header-bg` so page content does not scroll visibly through it.
-  The wrapper and its banner role stay. `layouts.md` now writes down what each
-  layout slot is wrapped in, which is the fact whose absence cost the time.
+  The wrapper and its banner role stay. The sticky shell is also a flex column
+  that fills the viewport rather than exceeding it: `.layout-body` carries
+  `min-height: 100vh`, so a header above it made a short page scroll by exactly
+  the header's height with nothing in the overflow, which under a pinned header
+  reads as broken. `layouts.md` now writes down what each layout slot is wrapped
+  in, which is the fact whose absence cost the time.
 
-- **`gofastr:beforenavigate`, a cancellable event the SPA router fires before
+- **`gofastr:beforenavigate`, a cancelable event the SPA router fires before
   it takes a click.** A userland click handler that checked
   `e.defaultPrevented` and stood down, which is the polite thing for a
   userland handler to do, never ran: the router had already called
@@ -76,7 +83,10 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   dark, editing `Colors` changes nothing on screen. Both maps are valid Go,
   both compile, and nothing said which one was being read.
   `style.DarkPaletteGaps` returns the color tokens a non-empty `DarkColors`
-  omits, and the UI host logs them once at boot: those tokens keep their light
+  has no usable dark value for, missing keys and keys present with an empty
+  value alike (an empty one emits `--color-surface: ;`, which the browser
+  drops, so it fails exactly as a missing key does), and the UI host logs them
+  once at boot: those tokens keep their light
   values in dark mode, which is usually a contrast bug. An empty `DarkColors`
   is a light-only theme by design and stays silent. The framework theme now
   declares dark values for `code-surface`, `code-text`, and `code-border`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,118 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+
+- **`gofastr verify` catches a theme token that does not exist
+  (`GOFASTR1806`).** An invalid `var()` is not a CSS error. It resolves to
+  nothing, the browser drops the declaration, and nothing reports it: not the
+  build, not the console, not the linter. One reporter wrote `--radius-lg`
+  where the theme emits `--radii-lg`, and every rounded corner on the site
+  rendered square for days. The typed theme already checked the definition,
+  since a `style.Radius` is compiler-checked, but a reference in a stylesheet
+  is just a string and nothing connected the two. `contracts.Pass` now
+  discovers `.css` files alongside Go source and hands them out through
+  `StyleFiles()`; `Files()`, `AppFiles()`, and `TestFiles()` stay Go-only, so
+  no analyzer that assumes Go source ever sees one. The rule reports a
+  `var(--name)` whose name the theme does not emit and names the nearest token
+  when one is within an edit distance of two. It stays quiet for a reference
+  carrying a fallback, because `var(--x, 8px)` degrades instead of dropping
+  the declaration; for a custom property declared in any scanned stylesheet;
+  and for the `--ui-*` and `--fui-*` component knobs. `style.TokenNames()` is
+  the manifest it checks against, built from the same reflection walk that
+  emits the CSS, so the two cannot drift apart. A stylesheet can waive it with
+  `/* gofastr:allow(GOFASTR1806) reason */`, which meant teaching the
+  suppression scanner to read `.css` files at all: it walked Go source only,
+  leaving the one rule that fires on stylesheets with no escape hatch in the
+  file it fires in. The catalog is now 51 rules.
+
+- **`Layout.WithStickyHeader()` pins the header wrapper the layout emits.** A
+  header component given `position: sticky; top: 0` stuck for exactly its own
+  height and then scrolled away. `app.Layout` renders the header component
+  inside a `<header role="banner">` of its own, and a sticky element only
+  travels inside its parent's box, so the component was sticky inside a box
+  65px tall. It looked deliberate, which is why it survived so long. The fix
+  belongs in the layout: the app-side workaround is a project CSS rule against
+  a wrapper the app does not own. `WithStickyHeader()` adds a
+  `layout--sticky-header` modifier and `LayoutBaseCSS` sticks the wrapper on
+  the theme's `--z-sticky` layer, with a background from
+  `--ui-layout-header-bg` so page content does not scroll visibly through it.
+  The wrapper and its banner role stay. `layouts.md` now writes down what each
+  layout slot is wrapped in, which is the fact whose absence cost the time.
+
+- **`gofastr:beforenavigate`, a cancellable event the SPA router fires before
+  it takes a click.** A userland click handler that checked
+  `e.defaultPrevented` and stood down, which is the polite thing for a
+  userland handler to do, never ran: the router had already called
+  `preventDefault` on its way past. Winning meant a capture-phase listener
+  plus `stopPropagation`, racing the router rather than cooperating with it.
+  The router now dispatches `gofastr:beforenavigate` on the anchor (bubbling,
+  cancelable) after every fall-through check, so it fires only for clicks the
+  router would actually handle. `detail` carries `href`, the resolved `path`,
+  the `hash`, and the `anchor`. A listener that cancels it claims the click:
+  the router still suppresses the browser default, so a cancelled click never
+  becomes a hard page load, and then does nothing else. No `pushState`, no
+  partial fetch, no intercept overlay.
+
+- **`data-fui-activelink-skip` opts a nav link out of active-route
+  highlighting.** The `activelink` module neither sets nor clears
+  `aria-current` or `.active` on a link carrying it, at load or after
+  navigation. The escape hatch for a link whose current-state belongs to
+  something else: a hand-set attribute, app code, a signal binding. Both
+  attribute tables now state what `activelink` writes (`aria-current="page"`,
+  the ARIA-correct value for a page link, so an `[aria-current="true"]`
+  selector will not match it), what it removes, and which links it leaves
+  alone.
+
+- **A theme with a partial dark palette says which tokens it left out.**
+  `Theme.Colors` paints the light scheme and `Theme.DarkColors` re-declares
+  the same custom properties under a dark preference, so on a page rendering
+  dark, editing `Colors` changes nothing on screen. Both maps are valid Go,
+  both compile, and nothing said which one was being read.
+  `style.DarkPaletteGaps` returns the color tokens a non-empty `DarkColors`
+  omits, and the UI host logs them once at boot: those tokens keep their light
+  values in dark mode, which is usually a contrast bug. An empty `DarkColors`
+  is a light-only theme by design and stays silent. The framework theme now
+  declares dark values for `code-surface`, `code-text`, and `code-border`
+  matching its light ones, which was always the intent and existed only as an
+  omission.
+
+### Fixed
+
+- **`gofastr dev` served project JavaScript and CSS that the browser then
+  ignored.** Editing a project `.js` file and hard-reloading kept running the
+  old code. `fetch('/nav.js', {cache:'reload'})` returned the new bytes while
+  the executing script was the old one, and only restarting `gofastr dev`
+  cleared it. Framework assets are content-versioned
+  (`/__gofastr/runtime.js?v=…`), but project assets serve at plain URLs with a
+  bare `Last-Modified`, which invites heuristic caching. Under `gofastr dev`
+  they now go out with `Cache-Control: no-store`, from both the static
+  directory and the embedded static FS. Production is untouched: with dev mode
+  off, no header is set. The cost was out of proportion to the fix, because
+  you do not doubt the cache, you doubt your own change and go looking in the
+  wrong file.
+
+- **`activelink` cleared an `aria-current` the scrollspy module had just
+  set.** The module walks every `nav a` and removes `aria-current` from any
+  link whose href is not the current path, which an in-page anchor never is. A
+  scrollspy rail is a `<nav>` of `#section` links, so every navigation wiped
+  the section indicator scrollspy had written. Links inside a
+  `[data-fui-scrollspy]` wrapper are now left alone, the same hands-off rule
+  href-less links already had. The `data-fui-scrollspy-target` rows in both
+  attribute tables were wrong while this went unnoticed: it is a selector on
+  the wrapper naming additional target elements, not a marker on a link.
+
+- **GOFASTR1801 reported a Go short variable declaration as a stylesheet.**
+  `fill := "var(--color-surface)"` failed the build. `fill` and `stroke` are
+  CSS property names and legal Go identifiers, so the `:` of `:=` satisfied
+  the property colon, `= "` filled the value gap, and the token reference
+  matched the value shape. A CSS declaration never carries `=` directly after
+  its colon, so a match containing `:=` is now rejected; the hyphenated
+  properties need no such guard, since a hyphen cannot occur in a Go
+  identifier. The diagnostic also names the fragment that matched, because the
+  reporter read "a CSS rule is defined outside the design system" as being
+  about the value and went looking at what they had assigned.
+
 ## [0.68.0] - 2026-08-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ them offline, and the `framework_docs_*` MCP tools expose them to agents
 connected to a running app.
 
 - [The gofastr CLI](framework/docs/content/cli.md): init, dev, migrate, generate, verify, audit, and upgrade, each subcommand mapped to its doc
-- [Contracts](framework/docs/content/contracts.md): **`gofastr verify`**, the 50 rules that say whether an app is still an idiomatic GoFastr app, semantic coverage beyond line coverage, and how an existing codebase adopts the gate with a baseline
+- [Contracts](framework/docs/content/contracts.md): **`gofastr verify`**, the 51 rules that say whether an app is still an idiomatic GoFastr app, semantic coverage beyond line coverage, and how an existing codebase adopts the gate with a baseline
 - [Blueprint tutorial](framework/docs/content/tutorial-blueprint-app.md): **generate a whole app from one file**. Blueprint → generated UI + API → auth + owner scoping + RBAC → customize in plain Go → deploy
 - [Kiln (experimental)](framework/docs/content/kiln.md): agent-driven build mode
 - [UI capability map](framework/docs/content/ui-capability-map.md): **start from the job**. Architecture, state ownership, delivery/scaling semantics, runnable proof, and explicit non-goals

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ Honest expectations:
 
 ## Supported versions
 
-GoFastr is pre-1.0. Only the **latest minor release** (currently `0.68.x`)
+GoFastr is pre-1.0. Only the **latest minor release** (currently `0.69.x`)
 receives security fixes. Older `0.x` lines are not patched. Upgrade to
 the latest release to stay supported.
 

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.68.0
+through: v0.69.0
 
 releases:
   - version: v0.3.0
@@ -774,3 +774,17 @@ releases:
       - change: Exposure.ReadScope narrows which rows a caller may read
         breaking: false
         guidance: "New, so nothing changes until an entity declares it. A read scope carries predicates on the entity's own columns plus the permission that lifts them, and one builder feeds every read: list and count, get, cursor, stream, the in-process API, typed queries, the upsert read-back, and the include and eager loaders at every depth. A row outside the scope answers 404 rather than 403. Writes are deliberately not filtered. Three shipped example blueprints served their own draft and unapproved rows to anonymous callers before this and now declare a scope."
+  - version: v0.69.0
+    title: "Silent failures made loud: inert theme tokens, dark-palette gaps, stale dev assets"
+    notes:
+      - change: "gofastr verify gains GOFASTR1806: a var(--name) the theme does not emit"
+        breaking: false
+        guidance: "A new ERROR-severity rule that can fail a verify run which passed before, because an invalid var() is not a CSS error: it resolves to nothing, the declaration is dropped, and nothing reported it. The pass now reads .css files as well as Go source. It flags a reference the theme does not emit and names the nearest token; it stays quiet for a reference carrying a fallback, a custom property declared in any scanned stylesheet, and the --ui-*/--fui-* component knobs. Fix the spelling (style.TokenNames lists what the theme emits), add a fallback, declare the property yourself, or waive it in the stylesheet with a /* gofastr:allow(GOFASTR1806) reason */ directive."
+      - change: A theme with a partial dark palette warns once at boot
+        breaking: false
+        guidance: "An app whose Theme.DarkColors is non-empty but missing color tokens now gets one WARN at startup naming them. Those tokens were already painting their light values under a dark preference, which is usually a contrast bug; the warning is new, the rendering is not. A key present with an EMPTY value counts too, and is the worse case: an empty custom property is valid CSS, so it overrides the light declaration and the consuming declaration is dropped rather than falling back. An empty DarkColors is a light-only theme by design and stays silent."
+        detect: "DarkColors"
+      - change: "GOFASTR1801 no longer reports a Go short variable declaration as a stylesheet"
+        breaking: false
+        guidance: "fill := \"var(--color-surface)\" failed the build: fill and stroke are CSS property names and legal Go identifiers, so the colon of := satisfied the property colon. Only a fix, so nothing to do on upgrade, but a suppression added to work around it is now stale and gofastr verify will report it as such."
+        detect: "gofastr:allow\\(GOFASTR1801"

--- a/core-ui/ARCHITECTURE.md
+++ b/core-ui/ARCHITECTURE.md
@@ -179,11 +179,12 @@ server side and the runtime does the work.
 | `data-fui-menu` | Marks a `<details data-fui-disclosure>` as a `framework/ui.Menu` dropdown. The runtime focuses the first `[role=menuitem]` when the disclosure opens; arrow keys / Home / End / type-ahead navigate within the panel; Tab closes the menu and lets focus escape naturally. |
 | `data-fui-menu-panel` | Emitted by `framework/ui.Menu` on the `role="menu"` panel `<div>`. No runtime or CSS consumer today (the menu module scopes by `data-fui-menu` + `.ui-menu__panel`); emit-only structural marker. |
 | `data-fui-match-prefix` | On a `<nav> <a>` link: opts the link into prefix-matching for active-route highlighting. The runtime tags it `aria-current="page"` + `.active` when the current path equals the link's href or continues it at a segment boundary: `/docs` and `/docs/` both light up on `/docs` and `/docs/getting-started`, and neither matches `/docs-old`. Without this attribute the runtime does exact-href matching only, so breadcrumbs and sidebars (where multiple links share prefixes) keep the server-rendered single active item. Root `/` is never a prefix match. |
+| `data-fui-activelink-skip` | On a `<nav> <a>` link: opts OUT of active-route highlighting entirely. The `activelink` runtime module neither sets nor clears `aria-current` or `.active` on it, at load or after SPA navigation. The escape hatch for a link whose current-state is owned by something else: a hand-set attribute (`aria-current="location"` on an in-page anchor), app JS, a signal binding. Same hands-off treatment as href-less links. |
 | `data-fui-fileupload` | Marks the drag-drop zone surrounding a `framework/ui.FileUpload` `<input type="file">`. The runtime wires dragover/dragleave/drop handlers that forward dropped File objects into the input's `files` property and dispatch a `change` event so form RPC pipelines fire uniformly whether the user clicked-to-pick or dragged-to-drop. |
 | `data-fui-popover-anchor` | On a `data-fui-open` trigger button: opt the opened widget into trigger-anchored positioning. The value is the preferred side: `"top"`, `"bottom"`, `"left"`, `"right"`, or empty / `"auto"` (= bottom-first, then top, right, left). The runtime measures both rects after open and applies inline `position: fixed; top; left` so the popover sits next to the trigger; if the preferred side would overflow the viewport (8px margin), it auto-flips to the opposite. Re-runs on `window.resize` AND `window.scroll` (capture, rAF-throttled) so the popover tracks the trigger when the page scrolls. Distinct from `preset.Modal`'s deep-link affordances: popovers are click-driven and don't deep-link. |
 | `data-fui-banner-dismiss` | On the X button inside a `framework/ui.Banner`: clicking sets `hidden` on the nearest `[data-fui-comp="ui-banner"]` ancestor. The runtime delegates the click globally so dismissal survives partial-island swaps. |
-| `data-fui-scrollspy` | Marks a scrollspy container. The runtime observes section heading targets via IntersectionObserver and tags the matching `data-fui-scrollspy-target` link with `aria-current="true"` as the user scrolls. |
-| `data-fui-scrollspy-target` | On a nav link inside a scrollspy: the value identifies the section heading the link tracks. Updated to `aria-current="true"` when its target enters the active band. |
+| `data-fui-scrollspy` | Marks a scrollspy wrapper (`core-ui/patterns/scrollspy.Wrap` emits a `<div>` around a nav of `<a href="#id">` anchors). The runtime demand-loads the scrollspy module, which IntersectionObserves the anchored targets inside the configured region and tags the link whose target is in the active band with `aria-current="true"` + `.is-active`. The `activelink` module leaves these links alone: scrollspy owns their current-state. |
+| `data-fui-scrollspy-target` | On the scrollspy wrapper: a CSS selector for ADDITIONAL target elements when sections aren't headings (default `h2[id], h3[id]`, e.g. `section[id]`). Only anchors whose `href="#id"` resolves to an element inside the observed region participate; the active link is still whichever anchored target is in view. |
 | `data-fui-optimistic-idle` / `data-fui-optimistic-success` / `data-fui-optimistic-endpoint` / `data-fui-optimistic-method` | On an OptimisticAction button: the runtime flips the visible label between the idle and success copy as it dispatches a fetch to the endpoint+method, rolling back on error. Used by `framework/ui.OptimisticAction` for "Save / Saved!" patterns without per-button JS. |
 | `data-fui-toggle-endpoint` / `data-fui-toggle-method` / `data-fui-toggle-allow-untoggle` / `data-fui-toggle-untoggle-endpoint` | On a three-state ToggleAction button (`framework/ui.ToggleAction`, `framework/ui/toggleaction.go`): `endpoint`+`method` (default POST) hit when toggling from idle → committed; `allow-untoggle="true"` lets a second click reverse the action, hitting `untoggle-endpoint` (same method) if set. With NO untoggle endpoint configured the button flips back to idle locally without issuing any request. Driven by `runtime/src/toggleaction.js` with a three-state mutex so rapid clicks can't race. |
 | `data-fui-toggle-idle` / `data-fui-toggle-committed` | Markers on the two label spans inside a ToggleAction button. The runtime shows/hides them as the button transitions between idle and committed states. SSR ships the initial visible state. |
@@ -330,6 +331,21 @@ tab actually navigates. Surfaces that must stay fresh across tabs
 belong on the polling rung (`data-fui-poll`), not on cache eviction.
 The embed composition ships no nav fragment, hence no cache, so the
 header is a no-op there by construction.
+
+**Active-link highlighting.** After every navigation (and at module
+load) the idle-loaded `activelink` module walks every `nav a` with an
+`href` and tags the one matching the current path with
+`aria-current="page"` and the `active` class — the value is `page`, the
+ARIA-correct value for a page link, NOT `true`, so
+`[aria-current="true"]` selectors do not match it. Every other `nav a`
+with an href that does not match loses both. Left completely untouched
+(neither set nor cleared): href-less links (server-managed), links
+inside a `[data-fui-scrollspy]` wrapper (the scrollspy module owns
+their `aria-current="true"`), and links carrying
+`data-fui-activelink-skip` (the opt-out for a current-state owned by
+app code or a hand-set attribute). `data-fui-match-prefix` opts a link
+into segment-prefix matching: `/docs` lights up on `/docs` and
+`/docs/getting-started`, never on `/docs-old`.
 
 **The flow for an in-page update** (e.g. clicking "page 2" on a pagination island):
 

--- a/core-ui/ARCHITECTURE.md
+++ b/core-ui/ARCHITECTURE.md
@@ -333,7 +333,7 @@ The embed composition ships no nav fragment, hence no cache, so the
 header is a no-op there by construction.
 
 **Cancelling a navigation (`gofastr:beforenavigate`).** The router
-dispatches this cancellable event on the anchor element (`bubbles`,
+dispatches this cancelable event on the anchor element (`bubbles`,
 `cancelable`, so a `document`-level listener sees it and `target` is the
 link) immediately before committing an intercepted click — after every
 fall-through check, so it fires only for clicks the router would

--- a/core-ui/ARCHITECTURE.md
+++ b/core-ui/ARCHITECTURE.md
@@ -332,6 +332,27 @@ belong on the polling rung (`data-fui-poll`), not on cache eviction.
 The embed composition ships no nav fragment, hence no cache, so the
 header is a no-op there by construction.
 
+**Cancelling a navigation (`gofastr:beforenavigate`).** The router
+dispatches this cancellable event on the anchor element (`bubbles`,
+`cancelable`, so a `document`-level listener sees it and `target` is the
+link) immediately before committing an intercepted click — after every
+fall-through check, so it fires only for clicks the router would
+actually handle. `detail` carries `href` (the raw attribute value),
+`path` (the resolved path+search the router would navigate to), `hash`
+(the `#fragment`, `''` when there is none), and `anchor` (the element).
+A listener calling `preventDefault()` on it claims the click: the
+router still suppresses the browser default (a cancelled click never
+becomes a hard page load) and then does nothing — no `pushState`, no
+partial fetch, no intercept overlay. This is the supported way for
+userland to take over a link (e.g. smooth-scroll to an in-page section)
+instead of racing the router with a capture-phase click listener. The
+event does NOT fire for clicks the router ignores: modifier-key clicks,
+external / `mailto:` / `tel:` links, `<a download>`, non-`_self`
+targets, unknown routes, `data-fui-rpc` anchors, and links to the
+current path — including a link whose only difference from the current
+URL is the `#fragment`; that click falls through to native hash
+behavior.
+
 **Active-link highlighting.** After every navigation (and at module
 load) the idle-loaded `activelink` module walks every `nav a` with an
 `href` and tags the one matching the current path with

--- a/core-ui/app/layout.go
+++ b/core-ui/app/layout.go
@@ -24,6 +24,14 @@ type Layout struct {
 	// vertical rhythm, the calm editorial shape for marketing/content pages.
 	// Width is themeable via --ui-layout-container-width. Off by default.
 	Container bool
+	// StickyHeader, when true, makes the layout's own <header> wrapper stick
+	// to the top of the viewport for the whole page. A header component
+	// cannot do this itself: the layout renders it inside the wrapper, and a
+	// sticky element only travels inside its parent's box, so its own
+	// position:sticky lasts exactly the header's height. Background is
+	// themeable via --ui-layout-header-bg, stacking via the --z-sticky theme
+	// layer. Off by default.
+	StickyHeader bool
 }
 
 // NewLayout creates a named layout.
@@ -54,6 +62,16 @@ func (l *Layout) WithFooter(c component.Component) *Layout {
 // chaining. The calm editorial shape for marketing/content pages.
 func (l *Layout) WithContainer() *Layout {
 	l.Container = true
+	return l
+}
+
+// WithStickyHeader makes the layout's own <header> wrapper stick to the top
+// of the viewport for the whole page and returns the layout for chaining.
+// Use it instead of giving the header component position: sticky — a sticky
+// element only travels inside its parent's box, and the component's parent
+// is the wrapper, whose height is the header itself.
+func (l *Layout) WithStickyHeader() *Layout {
+	l.StickyHeader = true
 	return l
 }
 
@@ -177,6 +195,9 @@ func (l *Layout) wrapLayer(ctx context.Context, content render.HTML, outermost b
 	}
 	if l.Sidebar != nil {
 		cls += " layout--has-sidebar"
+	}
+	if l.StickyHeader {
+		cls += " layout--sticky-header"
 	}
 	// Every layer is marked: data-fui-layout names the shell (CSS/debug
 	// contract), data-fui-layout-key is the identity the runtime compares

--- a/core-ui/app/layout_css.go
+++ b/core-ui/app/layout_css.go
@@ -96,6 +96,21 @@ func LayoutBaseCSS() string {
   background-color: var(--color-surface, #fff);
   border-bottom: 1px solid var(--color-border, #e4e4e7);
 }
+
+/* Sticky header (WithStickyHeader): a header component cannot stick to the
+   page from inside the wrapper, because a sticky element only travels
+   inside its parent's box and the component's parent is the wrapper, whose
+   height is the header itself. The WRAPPER is the element that sticks.
+   Background: the wrapper is transparent by default, so without one the
+   page content scrolls visibly underneath it. --ui-layout-header-bg
+   follows the --ui-layout-* override convention; stacking uses the
+   theme's --z-sticky layer (200, above app chrome, below overlays). */
+.layout--sticky-header > header {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-sticky, 200);
+  background-color: var(--ui-layout-header-bg, var(--color-background, #fff));
+}
 /* .layout-body is min-height: 100vh, so a banner above it makes every page
    scroll by exactly the header height with nothing in the overflow; the
    body under a sidebar-shell banner subtracts it. */

--- a/core-ui/app/layout_css.go
+++ b/core-ui/app/layout_css.go
@@ -111,6 +111,23 @@ func LayoutBaseCSS() string {
   z-index: var(--z-sticky, 200);
   background-color: var(--ui-layout-header-bg, var(--color-background, #fff));
 }
+/* A sticky header makes the shell's dead scroll visible. .layout-body is
+   min-height: 100vh, so a header above it means a short page scrolls by
+   exactly the header's height with nothing in the overflow — under a
+   pinned header that reads as broken rather than as a stray pixel. The
+   contained and sidebar shells each fix this their own way already
+   (min-height: 0 there, a calc() subtracting a FIXED header height here);
+   a flex column fixes it for a header of any height, which is what a
+   caller-supplied component is. */
+.layout--sticky-header {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+.layout--sticky-header > .layout-body {
+  flex: 1 0 auto;
+  min-height: 0;
+}
 /* .layout-body is min-height: 100vh, so a banner above it makes every page
    scroll by exactly the header height with nothing in the overflow; the
    body under a sidebar-shell banner subtracts it. */

--- a/core-ui/app/layout_sticky_test.go
+++ b/core-ui/app/layout_sticky_test.go
@@ -53,6 +53,41 @@ func TestStickyHeaderCSSRule(t *testing.T) {
 	}
 }
 
+// A sticky header makes the shell's dead scroll visible: .layout-body is
+// min-height: 100vh, so a header above it makes a short page scroll by
+// exactly the header's height with nothing in the overflow. Under a
+// pinned header that reads as broken. The sticky shell is a flex column
+// so it fills the viewport instead of exceeding it.
+//
+// Measured in a browser at 900x800 with a 64px header and one paragraph:
+// scrollHeight 864 before this rule, 800 after, while a long page still
+// scrolls (3440) with the header at rect.top 0.
+func TestStickyShellDoesNotOverflow(t *testing.T) {
+	css := LayoutBaseCSS()
+	_, after, found := strings.Cut(css, ".layout--sticky-header {")
+	if !found {
+		t.Fatal("LayoutBaseCSS has no .layout--sticky-header shell rule: a short page scrolls by the header's height")
+	}
+	shell, _, _ := strings.Cut(after, "}")
+	for _, decl := range []string{"display: flex", "flex-direction: column", "min-height: 100vh"} {
+		if !strings.Contains(shell, decl) {
+			t.Errorf("sticky shell must set %s, got: %s", decl, shell)
+		}
+	}
+	_, after, found = strings.Cut(css, ".layout--sticky-header > .layout-body {")
+	if !found {
+		t.Fatal("the sticky shell's body cell has no rule, so it keeps min-height: 100vh and the overflow stays")
+	}
+	body, _, _ := strings.Cut(after, "}")
+	// flex-grow keeps a short page full-height; min-height: 0 drops the
+	// 100vh floor that caused the overflow. Both are load-bearing.
+	for _, decl := range []string{"flex: 1 0 auto", "min-height: 0"} {
+		if !strings.Contains(body, decl) {
+			t.Errorf("sticky shell body must set %s, got: %s", decl, body)
+		}
+	}
+}
+
 // Modifiers compose: a contained layout with a sticky header carries both
 // classes on the same wrapper, the way layout--has-sidebar does today.
 func TestStickyComposesWithContainer(t *testing.T) {

--- a/core-ui/app/layout_sticky_test.go
+++ b/core-ui/app/layout_sticky_test.go
@@ -1,0 +1,88 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+// A header component given `position: sticky; top: 0` only travels inside
+// its parent's box, and the layout renders that component inside a <header>
+// wrapper of its own whose box is exactly the header's height: it sticks for
+// 65px and scrolls away. WithStickyHeader makes the LAYOUT'S wrapper the
+// sticky element instead, so it travels down the whole page. (#216)
+func TestStickyHeaderClassOnWrapper(t *testing.T) {
+	l := NewLayout("site").
+		WithHeader(&stubComponent{html: render.Raw("<h1>Header</h1>")}).
+		WithStickyHeader()
+	html := string(l.Wrap(render.Raw("<p>Content</p>")))
+
+	if !strings.Contains(html, "layout--sticky-header") {
+		t.Errorf("expected layout--sticky-header modifier on the wrapper, got: %s", html)
+	}
+}
+
+// The modifier is opt-in: a plain layout must not carry it, or every header
+// would stick without the app asking for it.
+func TestNoStickyClassByDefault(t *testing.T) {
+	l := NewLayout("site").
+		WithHeader(&stubComponent{html: render.Raw("<h1>Header</h1>")})
+	html := string(l.Wrap(render.Raw("<p>Content</p>")))
+
+	if strings.Contains(html, "layout--sticky-header") {
+		t.Errorf("layout without WithStickyHeader must not carry layout--sticky-header, got: %s", html)
+	}
+}
+
+// The class alone does nothing; LayoutBaseCSS must style the wrapper's
+// direct <header> child sticky with an offset from the top edge.
+func TestStickyHeaderCSSRule(t *testing.T) {
+	css := LayoutBaseCSS()
+	_, after, found := strings.Cut(css, ".layout--sticky-header > header {")
+	if !found {
+		t.Fatal("LayoutBaseCSS has no .layout--sticky-header > header rule: the sticky modifier styles nothing")
+	}
+	// Assert inside the rule's own braces. A repo-wide Contains would pass
+	// on any other rule that happened to set the same property.
+	block, _, _ := strings.Cut(after, "}")
+	for _, decl := range []string{"position: sticky", "top: 0", "z-index:", "background-color:"} {
+		if !strings.Contains(block, decl) {
+			t.Errorf("sticky header rule must set %s, got: %s", decl, block)
+		}
+	}
+}
+
+// Modifiers compose: a contained layout with a sticky header carries both
+// classes on the same wrapper, the way layout--has-sidebar does today.
+func TestStickyComposesWithContainer(t *testing.T) {
+	l := NewLayout("site").
+		WithHeader(&stubComponent{html: render.Raw("<h1>Header</h1>")}).
+		WithContainer().
+		WithStickyHeader()
+	html := string(l.Wrap(render.Raw("<p>Content</p>")))
+
+	if !strings.Contains(html, "layout--contained") {
+		t.Errorf("expected layout--contained modifier, got: %s", html)
+	}
+	if !strings.Contains(html, "layout--sticky-header") {
+		t.Errorf("expected layout--sticky-header alongside layout--contained, got: %s", html)
+	}
+}
+
+// The sticky wrapper IS the banner landmark. Making the wrapper sticky must
+// not drop the <header role="banner"> the layout emits around the header
+// component; removing it would break the page's landmark structure.
+func TestStickyKeepsBannerLandmark(t *testing.T) {
+	l := NewLayout("site").
+		WithHeader(&stubComponent{html: render.Raw("<h1>Header</h1>")}).
+		WithStickyHeader()
+	html := string(l.Wrap(render.Raw("<p>Content</p>")))
+
+	if !strings.Contains(html, "<header") {
+		t.Errorf("sticky layout must still wrap the header component in <header>, got: %s", html)
+	}
+	if !strings.Contains(html, `role="banner"`) {
+		t.Errorf("sticky layout must keep the banner role on its header wrapper, got: %s", html)
+	}
+}

--- a/core-ui/runtime/activelink_skip_e2e_test.go
+++ b/core-ui/runtime/activelink_skip_e2e_test.go
@@ -25,11 +25,12 @@ func activelinkSkipPage() string {
   <nav aria-label="Primary">
     <a id="home" href="/">Home</a>
     <a id="other" href="/other">Other</a>
-    <a id="pinned" href="/somewhere" data-fui-activelink-skip aria-current="location">Pinned</a>
+    <a id="pinned" href="/somewhere" data-fui-activelink-skip aria-current="location" class="active">Pinned</a>
+    <a id="bare" href="/elsewhere" data-fui-activelink-skip>Bare</a>
   </nav>
   <div data-fui-scrollspy="main" data-fui-scrollspy-target="section[id]">
     <nav aria-label="On this page">
-      <a id="spy1" href="#s1" aria-current="true">Section one</a>
+      <a id="spy1" href="#s1" aria-current="true" class="active">Section one</a>
       <a id="spy2" href="#s2">Section two</a>
     </nav>
   </div>
@@ -90,7 +91,10 @@ func TestActiveLinkSkipKeepsAuthorState(t *testing.T) {
 			path: location.pathname,
 			pinned: document.getElementById('pinned').getAttribute('aria-current'),
 			pinnedActive: document.getElementById('pinned').classList.contains('active'),
+			bare: document.getElementById('bare').getAttribute('aria-current'),
+			bareActive: document.getElementById('bare').classList.contains('active'),
 			spy1: document.getElementById('spy1').getAttribute('aria-current'),
+			spy1Active: document.getElementById('spy1').classList.contains('active'),
 			other: document.getElementById('other').getAttribute('aria-current'),
 			otherActive: document.getElementById('other').classList.contains('active'),
 			home: document.getElementById('home').getAttribute('aria-current'),
@@ -109,11 +113,20 @@ func TestActiveLinkSkipKeepsAuthorState(t *testing.T) {
 	if got["pinned"] != "location" {
 		t.Errorf("data-fui-activelink-skip link lost its author-set aria-current (got %v); activelink must neither set nor clear it", got["pinned"])
 	}
-	if got["pinnedActive"] != false {
-		t.Error("activelink added .active to a data-fui-activelink-skip link")
+	// Retention, not just non-addition: activelink clears `.active` in the
+	// same branch it clears aria-current, so a skip link that starts with
+	// the class has to keep it. Asserting only that the class is absent
+	// would pass against a module that had stripped it.
+	if got["pinnedActive"] != true {
+		t.Error("data-fui-activelink-skip link lost its author-set .active class")
 	}
-	if got["spy1"] != "true" {
-		t.Errorf(`scrollspy link's aria-current="true" was cleared by activelink (got %v); the scrollspy module owns that link's state`, got["spy1"])
+	// The other direction, on a skip link that starts with neither: the
+	// module must not stamp state onto it either.
+	if got["bare"] != nil || got["bareActive"] != false {
+		t.Errorf("activelink stamped state onto a bare data-fui-activelink-skip link, got %v / active=%v", got["bare"], got["bareActive"])
+	}
+	if got["spy1"] != "true" || got["spy1Active"] != true {
+		t.Errorf(`scrollspy link lost the state its own module owns, got aria-current=%v / active=%v`, got["spy1"], got["spy1Active"])
 	}
 	if got["other"] != "page" || got["otherActive"] != true {
 		t.Errorf(`exact-match link must gain aria-current="page" + .active, got %v / active=%v`, got["other"], got["otherActive"])

--- a/core-ui/runtime/activelink_skip_e2e_test.go
+++ b/core-ui/runtime/activelink_skip_e2e_test.go
@@ -1,0 +1,124 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// Page for the activelink ownership contract (#218): a primary nav
+// with an ordinary exact-match link, an opt-out link carrying a
+// hand-set aria-current, and a scrollspy rail (wrap div + inner nav +
+// in-page anchors, the shape core-ui/patterns/scrollspy emits) whose
+// active state another module owns. The scrollspy module itself is
+// inert here (no matching targets in <main>), so the aria-current
+// values below stand in for what it would set while scrolling.
+func activelinkSkipPage() string {
+	return `<!doctype html><html><head><title>activelink</title>
+  <script type="application/json" id="gofastr-routes">[{"path":"/"},{"path":"/other"}]</script>
+</head><body>
+  <nav aria-label="Primary">
+    <a id="home" href="/">Home</a>
+    <a id="other" href="/other">Other</a>
+    <a id="pinned" href="/somewhere" data-fui-activelink-skip aria-current="location">Pinned</a>
+  </nav>
+  <div data-fui-scrollspy="main" data-fui-scrollspy-target="section[id]">
+    <nav aria-label="On this page">
+      <a id="spy1" href="#s1" aria-current="true">Section one</a>
+      <a id="spy2" href="#s2">Section two</a>
+    </nav>
+  </div>
+  <main>home screen <span id="ready">ready</span></main>
+  <script src="/__gofastr/runtime.js"></script>
+</body></html>`
+}
+
+func activelinkSkipServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	js, err := RuntimeJS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/__gofastr/runtime.js", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Write([]byte(js))
+	})
+	// Highlighting lives in the idle-loaded activelink module; the
+	// scrollspy marker demand-loads that module too.
+	handleRuntimeModules(t, mux)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		if r.Header.Get("X-Gofastr-Navigate") == "1" {
+			w.Header().Set("X-Gofastr-Partial", "true")
+			w.Header().Set("X-Gofastr-Title", "other")
+			fmt.Fprint(w, `<p>other screen</p>`)
+			return
+		}
+		fmt.Fprint(w, activelinkSkipPage())
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestActiveLinkSkipKeepsAuthorState: across a SPA navigation,
+// data-fui-activelink-skip keeps a hand-set aria-current untouched,
+// links inside a [data-fui-scrollspy] wrap keep their
+// aria-current="true", and the ordinary exact-match contract still
+// holds (aria-current="page" + .active move to the new path's link).
+func TestActiveLinkSkipKeepsAuthorState(t *testing.T) {
+	srv := activelinkSkipServer(t)
+	ctx := newSeedBrowserCtx(t)
+
+	var state string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`#ready`, chromedp.ByID),
+		// Let the idle-loaded activelink module run its initial pass
+		// before navigating, so the test also covers its load-time
+		// clearing, not just the gofastr:navigate pass.
+		chromedp.Sleep(500*time.Millisecond),
+		chromedp.Click(`#other`, chromedp.ByID),
+		chromedp.Sleep(700*time.Millisecond),
+		chromedp.Evaluate(`JSON.stringify({
+			path: location.pathname,
+			pinned: document.getElementById('pinned').getAttribute('aria-current'),
+			pinnedActive: document.getElementById('pinned').classList.contains('active'),
+			spy1: document.getElementById('spy1').getAttribute('aria-current'),
+			other: document.getElementById('other').getAttribute('aria-current'),
+			otherActive: document.getElementById('other').classList.contains('active'),
+			home: document.getElementById('home').getAttribute('aria-current'),
+			homeActive: document.getElementById('home').classList.contains('active'),
+		})`, &state),
+	); err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(state), &got); err != nil {
+		t.Fatalf("state did not parse: %v (%s)", err, state)
+	}
+	if got["path"] != "/other" {
+		t.Fatalf("SPA navigation did not reach /other, at %v — test is vacuous", got["path"])
+	}
+	if got["pinned"] != "location" {
+		t.Errorf("data-fui-activelink-skip link lost its author-set aria-current (got %v); activelink must neither set nor clear it", got["pinned"])
+	}
+	if got["pinnedActive"] != false {
+		t.Error("activelink added .active to a data-fui-activelink-skip link")
+	}
+	if got["spy1"] != "true" {
+		t.Errorf(`scrollspy link's aria-current="true" was cleared by activelink (got %v); the scrollspy module owns that link's state`, got["spy1"])
+	}
+	if got["other"] != "page" || got["otherActive"] != true {
+		t.Errorf(`exact-match link must gain aria-current="page" + .active, got %v / active=%v`, got["other"], got["otherActive"])
+	}
+	if got["home"] != nil || got["homeActive"] != false {
+		t.Errorf("previously-active link must lose aria-current + .active, got %v / active=%v", got["home"], got["homeActive"])
+	}
+}

--- a/core-ui/runtime/beforenavigate_e2e_test.go
+++ b/core-ui/runtime/beforenavigate_e2e_test.go
@@ -26,6 +26,9 @@ func beforeNavigatePage() string {
     <a id="upper" href="/other" target="_SELF">Other, shouting</a>
     <a id="blank" href="/other" target="_blank">Other, new tab</a>
   </nav>
+  <svg width="20" height="20" aria-hidden="true"><a id="svglink" href="/other"><rect id="svgrect" width="20" height="20" fill="#ccc"></rect></a></svg>
+  <nav aria-label="Secondary">
+  </nav>
   <main>home screen</main>
   <span id="ready">ready</span>
   <script src="/__gofastr/runtime.js"></script>
@@ -250,5 +253,52 @@ func TestBlankTargetStillEscapesTheRouter(t *testing.T) {
 	}
 	if n := fetches.Load(); n != 0 {
 		t.Errorf("target=\"_blank\" must not fetch a partial, got %d", n)
+	}
+}
+
+// An SVG <a href> matches a[href] and closest() reaches it from a child,
+// but SVGAElement.target is an SVGAnimatedString rather than a string.
+// Calling .toLowerCase() on it throws, which aborts the router's handling
+// of that click and surfaces as an uncaught error. The guard stringifies
+// first.
+//
+// The stringified object cannot equal '_self', so the click still falls
+// through to the browser exactly as it did before: the router has never
+// claimed SVG links and this does not start. The test suppresses only the
+// browser's navigation (so the error collector survives long enough to be
+// read) and asserts nothing threw.
+func TestSVGAnchorDoesNotBreakTheClickPath(t *testing.T) {
+	var fetches atomic.Int32
+	srv := beforeNavigateServer(t, &fetches)
+	ctx := newSeedBrowserCtx(t)
+
+	var errs, path string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`#ready`, chromedp.ByID),
+		// Collect uncaught errors, and stop the browser from actually
+		// leaving the page on the SVG click. The runtime's own listener
+		// is registered first and has already run by this point in the
+		// dispatch, so its guard is exercised either way.
+		chromedp.Evaluate(`window.__errs = [];
+			window.addEventListener('error', function (e) { window.__errs.push(String(e.message)); });
+			document.addEventListener('click', function (e) {
+				if (e.target.closest && e.target.closest('svg')) e.preventDefault();
+			});`, nil),
+		chromedp.Click(`#svgrect`, chromedp.ByID),
+		chromedp.Sleep(400*time.Millisecond),
+		chromedp.Evaluate(`JSON.stringify(window.__errs || ['COLLECTOR-GONE'])`, &errs),
+		chromedp.Evaluate(`location.pathname`, &path),
+	); err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+	if errs != "[]" {
+		t.Errorf("clicking an SVG link threw in the router's click handler: %s", errs)
+	}
+	if path != "/" {
+		t.Errorf("SVG link was navigated in place, at %q; the router does not claim SVG anchors", path)
+	}
+	if n := fetches.Load(); n != 0 {
+		t.Errorf("SVG link fetched a partial, got %d", n)
 	}
 }

--- a/core-ui/runtime/beforenavigate_e2e_test.go
+++ b/core-ui/runtime/beforenavigate_e2e_test.go
@@ -1,0 +1,183 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// Pages for the gofastr:beforenavigate contract (#217): two known
+// routes, #go is a link the router intercepts (different path plus a
+// fragment), #selfhash differs from the current URL by fragment only,
+// which the router does NOT intercept (native hash behavior).
+func beforeNavigatePage() string {
+	return `<!doctype html><html><head><title>beforenavigate</title>
+  <script type="application/json" id="gofastr-routes">[{"path":"/"},{"path":"/other"}]</script>
+</head><body>
+  <nav aria-label="Primary">
+    <a id="selfhash" href="/#top">Top</a>
+    <a id="go" href="/other#section">Other</a>
+  </nav>
+  <main>home screen</main>
+  <span id="ready">ready</span>
+  <script src="/__gofastr/runtime.js"></script>
+</body></html>`
+}
+
+func beforeNavigateServer(t *testing.T, spaFetches *atomic.Int32) *httptest.Server {
+	t.Helper()
+	js, err := RuntimeJS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/__gofastr/runtime.js", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Write([]byte(js))
+	})
+	handleRuntimeModules(t, mux)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		if r.Header.Get("X-Gofastr-Navigate") == "1" {
+			spaFetches.Add(1)
+			w.Header().Set("X-Gofastr-Partial", "true")
+			w.Header().Set("X-Gofastr-Title", "other")
+			fmt.Fprint(w, `<p>other screen</p>`)
+			return
+		}
+		fmt.Fprint(w, beforeNavigatePage())
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestBeforeNavigateCancelStopsRouter: a listener that cancels
+// gofastr:beforenavigate claims the click. The router must not touch
+// the URL, must not fetch the target partial, and must still suppress
+// the browser default so the cancelled click is not a hard page load.
+func TestBeforeNavigateCancelStopsRouter(t *testing.T) {
+	var fetches atomic.Int32
+	srv := beforeNavigateServer(t, &fetches)
+	ctx := newSeedBrowserCtx(t)
+
+	var path, stamp string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`#ready`, chromedp.ByID),
+		chromedp.Evaluate(`window.__bnStamp = 'alive';
+			document.addEventListener('gofastr:beforenavigate', function (e) { e.preventDefault(); });`, nil),
+		chromedp.Click(`#go`, chromedp.ByID),
+		chromedp.Sleep(700*time.Millisecond),
+		chromedp.Evaluate(`location.pathname`, &path),
+		chromedp.Evaluate(`window.__bnStamp || 'gone'`, &stamp),
+	); err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+	if path != "/" {
+		t.Errorf("cancelled gofastr:beforenavigate must leave the URL alone, at %q", path)
+	}
+	if n := fetches.Load(); n != 0 {
+		t.Errorf("cancelled gofastr:beforenavigate must not fetch the target partial, got %d SPA fetches", n)
+	}
+	if stamp != "alive" {
+		t.Error("cancelled gofastr:beforenavigate must not become a hard page load — window stamp was wiped")
+	}
+}
+
+// TestBeforeNavigateDetailProceeds: without cancellation the event
+// fires on the anchor with href/path/hash/anchor in detail, and the
+// SPA navigation proceeds exactly as before.
+func TestBeforeNavigateDetailProceeds(t *testing.T) {
+	var fetches atomic.Int32
+	srv := beforeNavigateServer(t, &fetches)
+	ctx := newSeedBrowserCtx(t)
+
+	var detail, path string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`#ready`, chromedp.ByID),
+		chromedp.Evaluate(`window.__bn = [];
+			document.addEventListener('gofastr:beforenavigate', function (e) {
+				window.__bn.push({
+					href: e.detail.href, path: e.detail.path, hash: e.detail.hash,
+					anchorId: e.detail.anchor && e.detail.anchor.id,
+					bubbles: e.bubbles, cancelable: e.cancelable,
+				});
+			});`, nil),
+		chromedp.Click(`#go`, chromedp.ByID),
+		chromedp.Sleep(700*time.Millisecond),
+		chromedp.Evaluate(`JSON.stringify(window.__bn[0] || null)`, &detail),
+		chromedp.Evaluate(`location.pathname + location.hash`, &path),
+	); err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+	if detail == "" || detail == "null" {
+		t.Fatal("gofastr:beforenavigate never fired for a click the router intercepts")
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(detail), &got); err != nil {
+		t.Fatalf("detail did not parse: %v (%s)", err, detail)
+	}
+	for k, w := range map[string]string{
+		"href":     "/other#section",
+		"path":     "/other",
+		"hash":     "#section",
+		"anchorId": "go",
+	} {
+		if got[k] != w {
+			t.Errorf("detail.%s = %v, want %q", k, got[k], w)
+		}
+	}
+	if got["bubbles"] != true || got["cancelable"] != true {
+		t.Errorf("event must bubble and be cancelable, got bubbles=%v cancelable=%v", got["bubbles"], got["cancelable"])
+	}
+	if path != "/other#section" {
+		t.Errorf("uncancelled gofastr:beforenavigate must let the navigation proceed, at %q", path)
+	}
+	if n := fetches.Load(); n < 1 {
+		t.Error("uncancelled navigation must fetch the target partial — test is vacuous")
+	}
+}
+
+// TestBeforeNavigateSkipsSamePathFragment: a link whose only diff
+// from the current URL is the #fragment is NOT intercepted, so
+// gofastr:beforenavigate must not fire for it; native hash behavior
+// applies (same-document navigation, no reload).
+func TestBeforeNavigateSkipsSamePathFragment(t *testing.T) {
+	var fetches atomic.Int32
+	srv := beforeNavigateServer(t, &fetches)
+	ctx := newSeedBrowserCtx(t)
+
+	var seen, path, stamp string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`#ready`, chromedp.ByID),
+		chromedp.Evaluate(`window.__bnStamp = 'alive';
+			document.addEventListener('gofastr:beforenavigate', function () {
+				window.__bnSeen = (window.__bnSeen || 0) + 1;
+			});`, nil),
+		chromedp.Click(`#selfhash`, chromedp.ByID),
+		chromedp.Sleep(500*time.Millisecond),
+		chromedp.Evaluate(`String(window.__bnSeen || 0)`, &seen),
+		chromedp.Evaluate(`location.pathname + location.hash`, &path),
+		chromedp.Evaluate(`window.__bnStamp || 'gone'`, &stamp),
+	); err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+	if seen != "0" {
+		t.Errorf("gofastr:beforenavigate fired %s time(s) for a same-path #fragment click the router does not intercept", seen)
+	}
+	if path != "/#top" {
+		t.Errorf("same-path #fragment click must fall through to native hash behavior, at %q", path)
+	}
+	if stamp != "alive" {
+		t.Error("same-path #fragment click must stay a same-document navigation — window stamp was wiped")
+	}
+}

--- a/core-ui/runtime/beforenavigate_e2e_test.go
+++ b/core-ui/runtime/beforenavigate_e2e_test.go
@@ -23,6 +23,8 @@ func beforeNavigatePage() string {
   <nav aria-label="Primary">
     <a id="selfhash" href="/#top">Top</a>
     <a id="go" href="/other#section">Other</a>
+    <a id="upper" href="/other" target="_SELF">Other, shouting</a>
+    <a id="blank" href="/other" target="_blank">Other, new tab</a>
   </nav>
   <main>home screen</main>
   <span id="ready">ready</span>
@@ -179,5 +181,74 @@ func TestBeforeNavigateSkipsSamePathFragment(t *testing.T) {
 	}
 	if stamp != "alive" {
 		t.Error("same-path #fragment click must stay a same-document navigation — window stamp was wiped")
+	}
+}
+
+// TestUppercaseSelfTargetIsSoftNavigated: HTML matches the underscore
+// target keywords ASCII-case-insensitively, so `target="_SELF"` names
+// the current browsing context exactly as `_self` does. Comparing the
+// attribute raw sent it down the skip path, and a link that should have
+// been a soft navigation became a full page load.
+//
+// The window stamp is the assertion that matters: a full load wipes it,
+// so it distinguishes "the router handled this" from "the browser did,
+// and happened to land on the same URL".
+func TestUppercaseSelfTargetIsSoftNavigated(t *testing.T) {
+	var fetches atomic.Int32
+	srv := beforeNavigateServer(t, &fetches)
+	ctx := newSeedBrowserCtx(t)
+
+	var path, stamp string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`#ready`, chromedp.ByID),
+		chromedp.Evaluate(`window.__upStamp = 'alive'`, nil),
+		chromedp.Click(`#upper`, chromedp.ByID),
+		chromedp.Sleep(700*time.Millisecond),
+		chromedp.Evaluate(`location.pathname`, &path),
+		chromedp.Evaluate(`window.__upStamp || 'gone'`, &stamp),
+	); err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+	if path != "/other" {
+		t.Errorf("target=\"_SELF\" did not navigate, at %q", path)
+	}
+	if stamp != "alive" {
+		t.Error(`target="_SELF" became a full page load; the underscore keywords match case-insensitively, so it is _self and the router owns it`)
+	}
+	if n := fetches.Load(); n < 1 {
+		t.Error("no SPA partial was fetched — the router did not take the click")
+	}
+}
+
+// The other half, and the reason the guard is not simply deleted: a real
+// non-_self target must still fall through to the browser. Without this,
+// a fix for the case above could quietly hijack every target.
+func TestBlankTargetStillEscapesTheRouter(t *testing.T) {
+	var fetches atomic.Int32
+	srv := beforeNavigateServer(t, &fetches)
+	ctx := newSeedBrowserCtx(t)
+
+	var path, fired string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`#ready`, chromedp.ByID),
+		chromedp.Evaluate(`window.__bnFired = 'no';
+			document.addEventListener('gofastr:beforenavigate', function () { window.__bnFired = 'yes'; });`, nil),
+		chromedp.Click(`#blank`, chromedp.ByID),
+		chromedp.Sleep(500*time.Millisecond),
+		chromedp.Evaluate(`location.pathname`, &path),
+		chromedp.Evaluate(`window.__bnFired`, &fired),
+	); err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+	if path != "/" {
+		t.Errorf("target=\"_blank\" must not be soft-navigated in place, at %q", path)
+	}
+	if fired != "no" {
+		t.Error(`gofastr:beforenavigate fired for a target="_blank" click; the router must not claim it`)
+	}
+	if n := fetches.Load(); n != 0 {
+		t.Errorf("target=\"_blank\" must not fetch a partial, got %d", n)
 	}
 }

--- a/core-ui/runtime/budget_test.go
+++ b/core-ui/runtime/budget_test.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	coreGoalGZ             = 12*1024 + 512
-	coreCongestionWindowGZ = 14 * 1024
+	coreCongestionWindowGZ = 14*1024 + 128
 )
 
 func coreBudgetViolation(t *testing.T, src string, budget int) (level, got, limit int) {
@@ -147,14 +147,22 @@ func TestComputeModuleSizeBudget(t *testing.T) {
 // must stay in core: a demand module costs one request at first use,
 // which is fine for drag-dismiss and fatal for the click path.
 //
-// The line moved once, from 12 KB to 12.5 KB, when the measurement was
-// corrected from gzip level 9 to level 6 (see gzipSize). That was a
-// ruler correction, not a concession, the artifact did not grow. Treat
-// it as the last one: the cliff is a property of TCP, not of taste.
-// At nginx's default gzip level 1 the core is 14156 bytes. The binding
-// assertion in TestRuntimeModuleSizeBudgets caps that wire form at 14336 bytes,
-// so the level-6 budget's remaining slack cannot carry core past the cliff
-// unnoticed.
+// The level-6 line moved once, from 12 KB to 12.5 KB, when the
+// measurement was corrected from gzip level 9 to level 6 (see gzipSize).
+// That was a ruler correction, not a concession: the artifact did not
+// grow.
+//
+// The level-1 line moved once too, from 14336 to 14464 bytes, and that
+// one WAS a concession, so it is written down. It bought a correctness
+// fix in the anchor-click guard: HTML matches the underscore target
+// keywords ASCII-case-insensitively, so `target="_SELF"` is `_self`, and
+// comparing raw turned a soft navigation into a full page load. The fix
+// costs 5 gzipped bytes and the core had 2. The usual answer, carving
+// the feature into a demand module, is the one thing unavailable here:
+// this guard is the click path, which this comment already says must
+// stay in core. 14464 stays under the physical figure the cliff comes
+// from (10 packets at a 1460-byte MSS is ~14600 bytes); the next request
+// for room should be met with a carve, not another 128 bytes.
 func TestTypicalPagePayloadBudget(t *testing.T) {
 	const typicalBudgetGZ = 20 * 1024
 

--- a/core-ui/runtime/frag/nav.js
+++ b/core-ui/runtime/frag/nav.js
@@ -631,7 +631,15 @@
     // ASCII-case-insensitively: target="_SELF" IS _self, and comparing
     // raw sent it down the skip path, so a link that should have been a
     // soft navigation became a full page load.
-    if (anchor.target && anchor.target.toLowerCase() !== '_self') return;
+    //
+    // String() first because this is not always an HTMLAnchorElement.
+    // An SVG <a href> matches a[href] and closest() reaches it, and
+    // SVGAElement.target is an SVGAnimatedString, not a string: calling
+    // .toLowerCase() on it throws, and a throw here kills the whole
+    // delegated click handler. Stringifying keeps the old outcome for
+    // those (it cannot equal '_self', so the click falls through to the
+    // browser) instead of turning a rare element into a broken page.
+    if (anchor.target && String(anchor.target).toLowerCase() !== '_self') return;
     if (!isKnownRoute(href)) return;
     // data-fui-rpc anchors are RPC triggers, not navigation.
     if (anchor.hasAttribute('data-fui-rpc')) return;

--- a/core-ui/runtime/frag/nav.js
+++ b/core-ui/runtime/frag/nav.js
@@ -627,7 +627,11 @@
     // Skip any non-_self target (covers _blank, _top, _parent, named
     // frames). Previously only _blank was checked, so <a target="_top">
     // inside an iframe got hijacked instead of breaking out.
-    if (anchor.target && anchor.target !== '_self') return;
+    // Lowercased because HTML matches the underscore keywords
+    // ASCII-case-insensitively: target="_SELF" IS _self, and comparing
+    // raw sent it down the skip path, so a link that should have been a
+    // soft navigation became a full page load.
+    if (anchor.target && anchor.target.toLowerCase() !== '_self') return;
     if (!isKnownRoute(href)) return;
     // data-fui-rpc anchors are RPC triggers, not navigation.
     if (anchor.hasAttribute('data-fui-rpc')) return;

--- a/core-ui/runtime/frag/nav.js
+++ b/core-ui/runtime/frag/nav.js
@@ -627,7 +627,7 @@
     // Skip any non-_self target (covers _blank, _top, _parent, named
     // frames). Previously only _blank was checked, so <a target="_top">
     // inside an iframe got hijacked instead of breaking out.
-    if (anchor.target && anchor.target !== '' && anchor.target !== '_self') return;
+    if (anchor.target && anchor.target !== '_self') return;
     if (!isKnownRoute(href)) return;
     // data-fui-rpc anchors are RPC triggers, not navigation.
     if (anchor.hasAttribute('data-fui-rpc')) return;
@@ -637,18 +637,31 @@
       // Already there, let the browser handle the click (focus, scroll, etc.).
       return;
     }
-    e.preventDefault();
-    // Eagerly close an enclosing dismissible disclosure (mobile nav
-    // hamburger). Without this, the menu floats over stale content
-    // for the entire SPA fetch duration, the user perceives the
-    // click as "didn't take".
-    anchor.closest('details[data-fui-disclosure]:not([data-fui-disclosure-persist])')?.removeAttribute('open');
     // Preserve the #fragment: resolvePath strips it (path-only is what
     // route matching + cache keys want), but the URL bar and the
     // post-nav scroll target need it. loadPage reads location.hash, so
     // pushState must carry the fragment.
     let navHash = '';
     try { navHash = new URL(href, location.href).hash; } catch (_) { /* malformed href */ }
+    // Suppress the browser default up front: with or without a
+    // cancellation below, an intercepted click never becomes a hard
+    // page load.
+    e.preventDefault();
+    // gofastr:beforenavigate: cancellable hook fired on the anchor
+    // (bubbles, cancelable) only for clicks the router is about to
+    // intercept, after every fall-through check above. A listener that
+    // calls preventDefault() claims the click: the router stands down
+    // entirely (no pushState, no partial fetch, no intercept overlay)
+    // and userland owns the URL and the scroll from that point.
+    if (!anchor.dispatchEvent(new CustomEvent('gofastr:beforenavigate', {
+      bubbles: true, cancelable: true,
+      detail: { href, path: fullPath, hash: navHash, anchor },
+    }))) return;
+    // Eagerly close an enclosing dismissible disclosure (mobile nav
+    // hamburger). Without this, the menu floats over stale content
+    // for the entire SPA fetch duration, the user perceives the
+    // click as "didn't take".
+    anchor.closest('details[data-fui-disclosure]:not([data-fui-disclosure-persist])')?.removeAttribute('open');
     // An intercepting route presents as an overlay when reached from its
     // declared origin. The module owns the URL and the fetch in that
     // case; returning true means it took the navigation.

--- a/core-ui/runtime/fragments.go
+++ b/core-ui/runtime/fragments.go
@@ -195,8 +195,10 @@ var fragmentAttrs = map[string][]string{
 var moduleAttrs = map[string][]string{
 	"activelink": {
 		// Carved out of the nav fragment (level-1 budget): the idle-loaded
-		// module owns prefix-matched aria-current highlighting.
+		// module owns prefix-matched aria-current highlighting and the
+		// data-fui-activelink-skip opt-out from it.
 		"data-fui-match-prefix",
+		"data-fui-activelink-skip",
 	},
 	"animate": {
 		"data-fui-animate-signal",

--- a/core-ui/runtime/runtime.js
+++ b/core-ui/runtime/runtime.js
@@ -1445,7 +1445,7 @@
     // Skip any non-_self target (covers _blank, _top, _parent, named
     // frames). Previously only _blank was checked, so <a target="_top">
     // inside an iframe got hijacked instead of breaking out.
-    if (anchor.target && anchor.target !== '' && anchor.target !== '_self') return;
+    if (anchor.target && anchor.target !== '_self') return;
     if (!isKnownRoute(href)) return;
     // data-fui-rpc anchors are RPC triggers, not navigation.
     if (anchor.hasAttribute('data-fui-rpc')) return;
@@ -1455,18 +1455,31 @@
       // Already there, let the browser handle the click (focus, scroll, etc.).
       return;
     }
-    e.preventDefault();
-    // Eagerly close an enclosing dismissible disclosure (mobile nav
-    // hamburger). Without this, the menu floats over stale content
-    // for the entire SPA fetch duration, the user perceives the
-    // click as "didn't take".
-    anchor.closest('details[data-fui-disclosure]:not([data-fui-disclosure-persist])')?.removeAttribute('open');
     // Preserve the #fragment: resolvePath strips it (path-only is what
     // route matching + cache keys want), but the URL bar and the
     // post-nav scroll target need it. loadPage reads location.hash, so
     // pushState must carry the fragment.
     let navHash = '';
     try { navHash = new URL(href, location.href).hash; } catch (_) { /* malformed href */ }
+    // Suppress the browser default up front: with or without a
+    // cancellation below, an intercepted click never becomes a hard
+    // page load.
+    e.preventDefault();
+    // gofastr:beforenavigate: cancellable hook fired on the anchor
+    // (bubbles, cancelable) only for clicks the router is about to
+    // intercept, after every fall-through check above. A listener that
+    // calls preventDefault() claims the click: the router stands down
+    // entirely (no pushState, no partial fetch, no intercept overlay)
+    // and userland owns the URL and the scroll from that point.
+    if (!anchor.dispatchEvent(new CustomEvent('gofastr:beforenavigate', {
+      bubbles: true, cancelable: true,
+      detail: { href, path: fullPath, hash: navHash, anchor },
+    }))) return;
+    // Eagerly close an enclosing dismissible disclosure (mobile nav
+    // hamburger). Without this, the menu floats over stale content
+    // for the entire SPA fetch duration, the user perceives the
+    // click as "didn't take".
+    anchor.closest('details[data-fui-disclosure]:not([data-fui-disclosure-persist])')?.removeAttribute('open');
     // An intercepting route presents as an overlay when reached from its
     // declared origin. The module owns the URL and the fetch in that
     // case; returning true means it took the navigation.

--- a/core-ui/runtime/runtime.js
+++ b/core-ui/runtime/runtime.js
@@ -1445,7 +1445,11 @@
     // Skip any non-_self target (covers _blank, _top, _parent, named
     // frames). Previously only _blank was checked, so <a target="_top">
     // inside an iframe got hijacked instead of breaking out.
-    if (anchor.target && anchor.target !== '_self') return;
+    // Lowercased because HTML matches the underscore keywords
+    // ASCII-case-insensitively: target="_SELF" IS _self, and comparing
+    // raw sent it down the skip path, so a link that should have been a
+    // soft navigation became a full page load.
+    if (anchor.target && anchor.target.toLowerCase() !== '_self') return;
     if (!isKnownRoute(href)) return;
     // data-fui-rpc anchors are RPC triggers, not navigation.
     if (anchor.hasAttribute('data-fui-rpc')) return;

--- a/core-ui/runtime/runtime.js
+++ b/core-ui/runtime/runtime.js
@@ -1449,7 +1449,15 @@
     // ASCII-case-insensitively: target="_SELF" IS _self, and comparing
     // raw sent it down the skip path, so a link that should have been a
     // soft navigation became a full page load.
-    if (anchor.target && anchor.target.toLowerCase() !== '_self') return;
+    //
+    // String() first because this is not always an HTMLAnchorElement.
+    // An SVG <a href> matches a[href] and closest() reaches it, and
+    // SVGAElement.target is an SVGAnimatedString, not a string: calling
+    // .toLowerCase() on it throws, and a throw here kills the whole
+    // delegated click handler. Stringifying keeps the old outcome for
+    // those (it cannot equal '_self', so the click falls through to the
+    // browser) instead of turning a rare element into a broken page.
+    if (anchor.target && String(anchor.target).toLowerCase() !== '_self') return;
     if (!isKnownRoute(href)) return;
     // data-fui-rpc anchors are RPC triggers, not navigation.
     if (anchor.hasAttribute('data-fui-rpc')) return;

--- a/core-ui/runtime/src/activelink.js
+++ b/core-ui/runtime/src/activelink.js
@@ -16,13 +16,20 @@
   // Prefix matching is OFF by default so breadcrumbs and sidebars (where
   // multiple links share a path prefix) keep their server-rendered
   // single aria-current. Non-matching links get aria-current cleared.
-  // Links with NO href (server-rendered MatchPath items in a sidebar
-  // where the active determination is prefix-based) are left untouched,
-  // only the server has the prefix-match context for those.
+  // Links whose current-state another party owns are left untouched,
+  // the same hands-off rule as href-less links: links with NO href
+  // (server-rendered MatchPath items in a sidebar where the active
+  // determination is prefix-based, only the server has the prefix-match
+  // context), links inside a [data-fui-scrollspy] wrap (the scrollspy
+  // module tracks scroll position and writes aria-current="true"), and
+  // links carrying data-fui-activelink-skip (an author-side escape
+  // hatch for a highlight owned by app code or a hand-set attribute).
   const update = (path) => {
     for (const link of document.querySelectorAll('nav a')) {
       const href = link.getAttribute('href');
       if (!href) continue; // server-managed (MatchPath, dynamic), hands off
+      if (link.hasAttribute('data-fui-activelink-skip')) continue;
+      if (link.closest('[data-fui-scrollspy]')) continue;
       let active = href === path;
       if (!active && link.hasAttribute('data-fui-match-prefix')) {
         const hrefPath = href.split('?')[0].split('#')[0];

--- a/core-ui/style/darkpalette.go
+++ b/core-ui/style/darkpalette.go
@@ -6,7 +6,10 @@ import (
 )
 
 // DarkPaletteGaps returns the color tokens a theme declares in Colors but
-// omits from a non-empty DarkColors, sorted by token name.
+// has no usable dark value for, sorted by token name. A key present with
+// an EMPTY value counts as a gap: darkSchemeCSS writes it out as
+// `--color-surface: ;`, a malformed declaration the browser drops, so the
+// token falls back to its light value exactly as a missing key would.
 //
 // An empty DarkColors is a supported, deliberate configuration (a
 // light-only theme, see Theme.DarkColors) and returns nil. A non-empty
@@ -31,7 +34,7 @@ func DarkPaletteGaps(t Theme) []string {
 			continue
 		}
 		name := strings.TrimPrefix(key, "color-")
-		if _, ok := t.DarkColors[name]; !ok {
+		if strings.TrimSpace(t.DarkColors[name]) == "" {
 			gaps = append(gaps, name)
 		}
 	}

--- a/core-ui/style/darkpalette.go
+++ b/core-ui/style/darkpalette.go
@@ -1,0 +1,40 @@
+package style
+
+import (
+	"sort"
+	"strings"
+)
+
+// DarkPaletteGaps returns the color tokens a theme declares in Colors but
+// omits from a non-empty DarkColors, sorted by token name.
+//
+// An empty DarkColors is a supported, deliberate configuration (a
+// light-only theme, see Theme.DarkColors) and returns nil. A non-empty
+// DarkColors with holes is the case that bites (#215): under a dark
+// preference the omitted tokens silently keep their light values, usually
+// a contrast bug, and nothing in the render path says so.
+//
+// Token names come from ThemeToTokens filtered to the "color-" prefix
+// rather than a hand-copied field list: the map is built by the same
+// reflection walk the CSS emitter uses (walkTokens), so a token added to
+// ColorSet shows up here without a second list to keep in sync. Light
+// colors key as "color-<name>" and dark entries as "dark.color-<name>",
+// so the prefix selects exactly the light palette names DarkColors is
+// keyed by.
+func DarkPaletteGaps(t Theme) []string {
+	if len(t.DarkColors) == 0 {
+		return nil
+	}
+	var gaps []string
+	for key := range ThemeToTokens(t) {
+		if !strings.HasPrefix(key, "color-") {
+			continue
+		}
+		name := strings.TrimPrefix(key, "color-")
+		if _, ok := t.DarkColors[name]; !ok {
+			gaps = append(gaps, name)
+		}
+	}
+	sort.Strings(gaps)
+	return gaps
+}

--- a/core-ui/style/darkpalette.go
+++ b/core-ui/style/darkpalette.go
@@ -6,10 +6,18 @@ import (
 )
 
 // DarkPaletteGaps returns the color tokens a theme declares in Colors but
-// has no usable dark value for, sorted by token name. A key present with
-// an EMPTY value counts as a gap: darkSchemeCSS writes it out as
-// `--color-surface: ;`, a malformed declaration the browser drops, so the
-// token falls back to its light value exactly as a missing key would.
+// has no usable dark value for, sorted by token name.
+//
+// A key present with an EMPTY value counts as a gap, and is in fact the
+// worse of the two cases. An empty custom property is valid CSS, not a
+// malformed declaration the browser discards, so darkSchemeCSS writing
+// `--color-surface: ;` OVERRIDES the light declaration with an empty
+// value. Every `var(--color-surface)` then substitutes to nothing, which
+// makes the consuming declaration invalid at computed-value time and
+// drops it to the property's inherited or initial value. Measured in
+// Chrome against a green light value: a re-declared empty token paints
+// `rgba(0, 0, 0, 0)`, while a token simply left out of the dark map
+// paints the light green. Missing falls back; empty does not.
 //
 // An empty DarkColors is a supported, deliberate configuration (a
 // light-only theme, see Theme.DarkColors) and returns nil. A non-empty

--- a/core-ui/style/darkpalette_test.go
+++ b/core-ui/style/darkpalette_test.go
@@ -45,3 +45,18 @@ func TestDarkPaletteGapsSortedMissing(t *testing.T) {
 		t.Errorf("DarkPaletteGaps = %v, want %v", got, want)
 	}
 }
+
+// A key present with an empty value is a gap, not a declaration.
+// darkSchemeCSS writes it as `--color-surface: ;`, which the browser
+// drops, so the token keeps its light value exactly as a missing key
+// would. Counting only missing keys called a broken palette complete.
+func TestEmptyDarkValueIsAGap(t *testing.T) {
+	th := DefaultTheme()
+	th.DarkColors = completeDarkMap()
+	th.DarkColors["surface"] = ""
+	th.DarkColors["text"] = "   "
+	got := DarkPaletteGaps(th)
+	if len(got) != 2 || got[0] != "surface" || got[1] != "text" {
+		t.Errorf("DarkPaletteGaps = %v, want [surface text]", got)
+	}
+}

--- a/core-ui/style/darkpalette_test.go
+++ b/core-ui/style/darkpalette_test.go
@@ -46,10 +46,12 @@ func TestDarkPaletteGapsSortedMissing(t *testing.T) {
 	}
 }
 
-// A key present with an empty value is a gap, not a declaration.
-// darkSchemeCSS writes it as `--color-surface: ;`, which the browser
-// drops, so the token keeps its light value exactly as a missing key
-// would. Counting only missing keys called a broken palette complete.
+// A key present with an empty value is a gap, and a worse one than a
+// missing key. An empty custom property is valid CSS: it overrides the
+// light declaration, so `var(--color-surface)` substitutes to nothing and
+// the consuming declaration is dropped at computed-value time rather than
+// falling back. Counting only missing keys called a broken palette
+// complete.
 func TestEmptyDarkValueIsAGap(t *testing.T) {
 	th := DefaultTheme()
 	th.DarkColors = completeDarkMap()

--- a/core-ui/style/darkpalette_test.go
+++ b/core-ui/style/darkpalette_test.go
@@ -1,0 +1,47 @@
+package style
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// completeDarkMap builds a DarkColors entry for every light color token of
+// the default theme, so tests can punch exact holes in it.
+func completeDarkMap() map[string]string {
+	m := map[string]string{}
+	for key := range ThemeToTokens(DefaultTheme()) {
+		if strings.HasPrefix(key, "color-") {
+			m[strings.TrimPrefix(key, "color-")] = "#0A0A0A"
+		}
+	}
+	return m
+}
+
+func TestDarkPaletteGapsLightOnlyNil(t *testing.T) {
+	// DefaultTheme is light-only by design; that must never warn.
+	if got := DarkPaletteGaps(DefaultTheme()); got != nil {
+		t.Errorf("light-only theme: DarkPaletteGaps = %v, want nil", got)
+	}
+}
+
+func TestDarkPaletteGapsCompleteNil(t *testing.T) {
+	th := DefaultTheme()
+	th.DarkColors = completeDarkMap()
+	if got := DarkPaletteGaps(th); got != nil {
+		t.Errorf("complete dark map: DarkPaletteGaps = %v, want nil", got)
+	}
+}
+
+func TestDarkPaletteGapsSortedMissing(t *testing.T) {
+	th := DefaultTheme()
+	th.DarkColors = completeDarkMap()
+	delete(th.DarkColors, "surface-soft")
+	delete(th.DarkColors, "code-border")
+
+	got := DarkPaletteGaps(th)
+	want := []string{"code-border", "surface-soft"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("DarkPaletteGaps = %v, want %v", got, want)
+	}
+}

--- a/core-ui/style/tokennames.go
+++ b/core-ui/style/tokennames.go
@@ -1,0 +1,28 @@
+package style
+
+import (
+	"sort"
+	"strings"
+)
+
+// TokenNames returns every CSS custom-property name a theme emits,
+// without the leading "--", sorted.
+//
+// It is derived from ThemeToTokens(DefaultTheme()), not hand-copied, so
+// the manifest cannot drift from the emitter: a token added to the theme
+// appears here, and a removed one disappears. The "dark."-prefixed keys
+// are dropped — the dark palette re-declares the SAME property names
+// under a dark-scheme block, so keeping them would double every colour
+// entry.
+func TokenNames() []string {
+	tokens := ThemeToTokens(DefaultTheme())
+	out := make([]string, 0, len(tokens))
+	for k := range tokens {
+		if strings.HasPrefix(k, "dark.") {
+			continue
+		}
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/core-ui/style/tokennames_test.go
+++ b/core-ui/style/tokennames_test.go
@@ -1,0 +1,62 @@
+package style
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The manifest exists so GOFASTR1806 can tell a token reference the theme
+// really emits from one it does not (issue #214: `--radius-lg` where the
+// theme emits `--radii-lg`, inert for days because an invalid var() is
+// not a CSS error). Every property here is load-bearing.
+
+func TestTokenNamesSortedAndComplete(t *testing.T) {
+	names := TokenNames()
+	if len(names) == 0 {
+		t.Fatal("TokenNames is empty — every var() reference would be unknown")
+	}
+	if !sort.StringsAreSorted(names) {
+		t.Errorf("TokenNames is not sorted")
+	}
+	seen := map[string]bool{}
+	for _, n := range names {
+		if seen[n] {
+			t.Errorf("duplicate token %q", n)
+		}
+		seen[n] = true
+	}
+	if !seen["radii-lg"] {
+		t.Errorf("radii-lg missing — the exact token issue #214's typo needed")
+	}
+	if seen["radius-lg"] {
+		t.Errorf("radius-lg present — that is the issue #214 typo, not a token")
+	}
+	for n := range seen {
+		if strings.HasPrefix(n, "dark.") {
+			t.Errorf("dark-scheme key %q leaked into the manifest: it re-declares the same property name", n)
+		}
+	}
+}
+
+// The anti-drift assertion: the manifest must be exactly ThemeToTokens
+// minus the dark block, so a token added to the theme can never be
+// missing from the lint and a removed one can never linger.
+func TestTokenNamesMatchThemeToTokens(t *testing.T) {
+	want := map[string]bool{}
+	for k := range ThemeToTokens(DefaultTheme()) {
+		if strings.HasPrefix(k, "dark.") {
+			continue
+		}
+		want[k] = true
+	}
+	got := TokenNames()
+	if len(got) != len(want) {
+		t.Errorf("TokenNames has %d entries, ThemeToTokens (dark excluded) has %d", len(got), len(want))
+	}
+	for _, n := range got {
+		if !want[n] {
+			t.Errorf("TokenNames lists %q, which ThemeToTokens does not emit", n)
+		}
+	}
+}

--- a/framework/contracts/analyzers/analyzers_test.go
+++ b/framework/contracts/analyzers/analyzers_test.go
@@ -621,6 +621,60 @@ func TestCSSInACommentIsNotReported(t *testing.T) {
 	assertNot(t, ds, contracts.RuleBespokeCSS, "prose about CSS is not CSS")
 }
 
+func TestShortVarDeclarationIsNotCSS(t *testing.T) {
+	// Issue #220: `fill` and `stroke` are CSS property names AND legal Go
+	// identifiers. In a short variable declaration the `:` of `:=`
+	// satisfied the property-colon and the token reference satisfied the
+	// value shape, so assigning a design-system token to a local read as
+	// bespoke CSS — the exact thing this rule exists to encourage,
+	// reported as the thing to stop doing.
+	ds := fixture(t, map[string]string{
+		"x.go": `package app
+
+func f() string {
+	fill := "var(--color-surface)"
+	stroke := "var(--color-border)"
+	_ = stroke
+	return fill
+}
+`,
+	})
+	assertNot(t, ds, contracts.RuleBespokeCSS, "a Go short variable declaration assigning a token reference is not CSS")
+}
+
+func TestCSSVarValueInGoStringIsReported(t *testing.T) {
+	// The := rejection must not widen into "any single-word property is
+	// fine": a real declaration in a Go string, with no := anywhere near
+	// the colon, still fires. This one only matches through the
+	// CSS-shaped-value path (padding + var(--…)), not the hyphen rule.
+	ds := fixture(t, map[string]string{
+		"page.go": "package main\n\nconst css = `.my-card { padding: var(--spacing-md); }`\n",
+	})
+	assertHas(t, ds, contracts.RuleBespokeCSS)
+}
+
+func TestStructLiteralWithCSSValueIsReported(t *testing.T) {
+	// A struct literal with a lowercase field name and a CSS-shaped
+	// value has no := inside the match, so the := narrowing must leave
+	// it caught. (A QUOTED map key, `{"color": "#fff"}`, does not match
+	// at all — the quote between key and colon breaks property-colon
+	// contiguity — and that is fine: a quoted key is data, not CSS.)
+	ds := fixture(t, map[string]string{
+		"m.go": "package main\n\ntype palette struct{ color string }\n\nvar p = palette{color: \"#fff\"}\n",
+	})
+	assertHas(t, ds, contracts.RuleBespokeCSS)
+}
+
+func TestBespokeCSSMessageNamesTheTrigger(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"page.go": "package main\n\nconst css = `.my-card { border-radius: 8px; }`\n",
+	})
+	d := assertHas(t, ds, contracts.RuleBespokeCSS)
+	if !strings.Contains(d.Message, "matched") || !strings.Contains(d.Message, "border-radius:") {
+		t.Errorf("message does not name the trigger that matched: %q", d.Message)
+	}
+}
+
 func TestHardNavigationIsReported(t *testing.T) {
 	ds := fixture(t, map[string]string{
 		"js.go": "package main\n\nconst script = `document.getElementById('x').onclick = () => { location.href = '/orders' }`\n",

--- a/framework/contracts/analyzers/catalog_examples_test.go
+++ b/framework/contracts/analyzers/catalog_examples_test.go
@@ -155,6 +155,7 @@ var examplesNeedingMoreContext = map[string]string{
 	contracts.RuleNoCoverageManifest:     "fires on the ABSENCE of a manifest; its example is the absence, not a snippet",
 	contracts.RuleHandrolledBattery:      "needs the hand-rolled subsystem's imports, which a snippet does not carry",
 	contracts.RuleRawSQLOverRepo:         "needs an entity declaration whose table the raw query targets",
+	contracts.RuleUnknownThemeToken:      "fires on a .css file; its example is CSS, which no Go snippet can carry", // not-a-secret: a rule id, flagged only because the constant name ends in "Token"
 }
 
 // The other half: a rule whose bad example does NOT produce it has either

--- a/framework/contracts/analyzers/cssblank_test.go
+++ b/framework/contracts/analyzers/cssblank_test.go
@@ -1,0 +1,40 @@
+package analyzers
+
+import (
+	"strings"
+	"testing"
+)
+
+// The whole risk in the string-aware pre-pass is that a blanked span
+// changes length or drops a newline, which silently misattributes every
+// later finding's line number. Assert the invariant directly.
+func TestBlankPreservesOffsetsAndLines(t *testing.T) {
+	cases := []string{
+		"",
+		".a{color:red}\n",
+		"/* c */ .a{}\n",
+		"/* unterminated\n.a{color:var(--x)}\n",
+		".x::after{content:\"/*\"}\n.y{color:var(--z)}\n",
+		".x::after{content:'a\\'b'}\n",
+		".x::after{content:\"a\\\nb\"}\n",
+		".x::after{content:\"raw\nnewline\"}\n",
+		".x{content:\"hi\";color:var(--q)}\n",
+		"a\\",
+		"/*/*nested-looking*/ .a{}\n",
+		"\"unterminated string",
+	}
+	for _, in := range cases {
+		out := blankCSSCommentsAndStrings(in)
+		if len(out) != len(in) {
+			t.Errorf("length changed: %d -> %d for %q", len(in), len(out), in)
+		}
+		if a, b := strings.Count(in, "\n"), strings.Count(out, "\n"); a != b {
+			t.Errorf("newline count changed: %d -> %d for %q", a, b, in)
+		}
+		for i := range in {
+			if in[i] == '\n' && out[i] != '\n' {
+				t.Errorf("newline at %d moved for %q -> %q", i, in, out)
+			}
+		}
+	}
+}

--- a/framework/contracts/analyzers/rendering.go
+++ b/framework/contracts/analyzers/rendering.go
@@ -336,7 +336,10 @@ var reCSSCustomProp = regexp.MustCompile(`--([A-Za-z0-9_-]+)\s*:`)
 // colon after the name, so reCSSCustomProp cannot see it, and a project
 // that registers a property this way and then reads it would otherwise
 // be told the token does not exist.
-var reAtProperty = regexp.MustCompile(`@property\s+--([A-Za-z0-9_-]+)`)
+//
+// Case-insensitive on the at-rule keyword for the same reason reVarRef
+// is on the function name; the captured NAME keeps its case.
+var reAtProperty = regexp.MustCompile(`(?i)@property\s+--([A-Za-z0-9_-]+)`)
 
 // collectDeclared adds every custom property a stylesheet DECLARES to
 // into. Position matters: `--name:` only declares inside a rule block and
@@ -380,7 +383,17 @@ func collectDeclared(clean string, into map[string]bool) {
 
 // reVarRef matches a var() reference; the captured group is the
 // referenced name without the leading dashes.
-var reVarRef = regexp.MustCompile(`var\(\s*--([A-Za-z0-9_-]+)`)
+//
+// The FUNCTION name folds case, because CSS function names are ASCII
+// case-insensitive: `VAR(--radii-lg)` and `Var(--radii-lg)` both resolve
+// in a browser, so a case-sensitive match let an uppercase reference to a
+// nonexistent token through unreported.
+//
+// The custom-property NAME does not fold, and must not: property names
+// ARE case-sensitive. Measured in Chrome, `var(--mixed)` against a
+// declared `--Mixed` resolves to nothing, so treating the two as the same
+// token would call a real miss a match.
+var reVarRef = regexp.MustCompile(`(?i)var\(\s*--([A-Za-z0-9_-]+)`)
 
 // varRefHasFallback reports whether the var() reference whose name ends
 // at s[i-1] carries a fallback: a comma at the TOP level of its

--- a/framework/contracts/analyzers/rendering.go
+++ b/framework/contracts/analyzers/rendering.go
@@ -291,7 +291,7 @@ func checkStyleTokens(p *contracts.Pass) []contracts.Diagnostic {
 		if !ok {
 			continue
 		}
-		clean := stripCSSComments(string(body))
+		clean := blankCSSCommentsAndStrings(string(body))
 		cleaned[f.Rel] = clean
 		for _, m := range reCSSCustomProp.FindAllStringSubmatch(clean, -1) {
 			declared[m[1]] = true
@@ -361,39 +361,94 @@ func varRefHasFallback(s string, i int) bool {
 	return false
 }
 
-// stripCSSComments removes `/* */` comments from a stylesheet,
-// preserving the line structure so offsets still map to original line
-// numbers. Unlike the Go stripper it does NOT treat `//` as a comment:
-// that would truncate `url(https://…)` and every protocol-relative URL
+// blankCSSCommentsAndStrings blanks the bodies of `/* */` comments and
+// of '…' / "…" strings, replacing their characters with spaces so every
+// byte offset and newline position survives: checkStyleTokens computes
+// reported line numbers from the cleaned text, and anything that moves
+// would misattribute a finding.
+//
+// One left-to-right scan over four states (text, comment, 'string',
+// "string") is the whole job, because the only ambiguity in CSS is
+// which of those four a character belongs to:
+//
+//   - `/*` opens a comment in text ONLY; inside a string it is content
+//     (the false negative: an unterminated "comment" used to swallow
+//     the rest of the file, hiding real references after it);
+//   - a quote opens a string in text ONLY; inside a comment it is
+//     prose (the inverse: a quoted `*/` must not close a comment);
+//   - a backslash inside a string escapes the next character, so
+//     `"a\"b"` is one string; a backslash before a newline continues
+//     the string onto the next line, which CSS allows.
+//
+// A RAW newline inside a string terminates it rather than continuing
+// the scan to EOF: that is the spec's bad-string recovery, and it is
+// the safe reading for a pre-pass, since the text after the newline
+// resumes as ordinary CSS instead of being swallowed. Blanked bytes
+// become spaces, newlines stay newlines.
+//
+// Unlike the Go stripper it does NOT treat `//` as a comment: that
+// would truncate `url(https://…)` and every protocol-relative URL
 // mid-line, hiding real references after it.
-func stripCSSComments(src string) string {
+func blankCSSCommentsAndStrings(src string) string {
 	var b strings.Builder
 	b.Grow(len(src))
-	inBlock := false
-	for _, line := range strings.Split(src, "\n") {
-		out := line
-		if inBlock {
-			if i := strings.Index(out, "*/"); i >= 0 {
-				out, inBlock = out[i+2:], false
-			} else {
+	const (
+		stText = iota
+		stComment
+		stSingle
+		stDouble
+	)
+	state := stText
+	for i := 0; i < len(src); i++ {
+		c := src[i]
+		switch state {
+		case stText:
+			switch {
+			case c == '/' && i+1 < len(src) && src[i+1] == '*':
+				b.WriteString("  ")
+				i++
+				state = stComment
+			case c == '"':
+				b.WriteByte(' ')
+				state = stDouble
+			case c == '\'':
+				b.WriteByte(' ')
+				state = stSingle
+			default:
+				b.WriteByte(c)
+			}
+		case stComment:
+			if c == '*' && i+1 < len(src) && src[i+1] == '/' {
+				b.WriteString("  ")
+				i++
+				state = stText
+			} else if c == '\n' {
 				b.WriteByte('\n')
-				continue
+			} else {
+				b.WriteByte(' ')
+			}
+		default: // stSingle / stDouble
+			switch {
+			case c == '\\' && i+1 < len(src):
+				// Escaped character: blank both without interpreting
+				// the second (a quote, a newline, anything).
+				b.WriteByte(' ')
+				if src[i+1] == '\n' {
+					b.WriteByte('\n')
+				} else {
+					b.WriteByte(' ')
+				}
+				i++
+			case state == stDouble && c == '"', state == stSingle && c == '\'':
+				b.WriteByte(' ')
+				state = stText
+			case c == '\n': // unescaped newline: bad-string recovery
+				b.WriteByte('\n')
+				state = stText
+			default:
+				b.WriteByte(' ')
 			}
 		}
-		for {
-			bs := strings.Index(out, "/*")
-			if bs < 0 {
-				break
-			}
-			if e := strings.Index(out[bs+2:], "*/"); e >= 0 {
-				out = out[:bs] + out[bs+2+e+2:]
-				continue
-			}
-			out, inBlock = out[:bs], true
-			break
-		}
-		b.WriteString(out)
-		b.WriteByte('\n')
 	}
 	return b.String()
 }

--- a/framework/contracts/analyzers/rendering.go
+++ b/framework/contracts/analyzers/rendering.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/framework/contracts"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/check"
+	"github.com/DonaldMurillo/gofastr/core-ui/style"
 )
 
 func init() {
@@ -20,6 +21,7 @@ func init() {
 			contracts.RuleBespokeEventSource,
 			contracts.RuleInlineStyle,
 			contracts.RuleInlineScript,
+			contracts.RuleUnknownThemeToken,
 		},
 		Run: runRendering,
 	})
@@ -250,7 +252,188 @@ func runRendering(p *contracts.Pass) ([]contracts.Diagnostic, error) {
 		}
 	}
 	out = append(out, checkInlineScripts(p)...)
+	out = append(out, checkStyleTokens(p)...)
 	return out, nil
+}
+
+// checkStyleTokens reports var(--name) references in project
+// stylesheets whose name the theme does not emit (GOFASTR1806).
+//
+// The typed theme checks the DEFINITION (a style.Radius is
+// compiler-checked), but a reference in a stylesheet is just a string,
+// and nothing connects the two. An invalid var() is not a CSS error: it
+// resolves to nothing, the declaration is silently dropped, and the
+// only symptom is missing styling (issue #214: `--radius-lg` for
+// `--radii-lg`, every rounded corner square for days).
+//
+// A reference is left alone when any of these hold:
+//
+//   - it carries a fallback, `var(--x, 8px)`: the declaration degrades
+//     instead of being dropped, so the failure this rule exists to
+//     catch cannot happen;
+//   - the name is declared as a custom property in any scanned
+//     stylesheet: the set is built across all of them, because a base
+//
+// sheet declaring what another sheet uses is normal;
+//   - it starts with `ui-` or `fui-`: per-component override knobs and
+//     runtime-owned properties, not theme tokens (see the theming doc's
+//     `--ui-*` section);
+//   - it is one of the names style.TokenNames() says the theme emits.
+func checkStyleTokens(p *contracts.Pass) []contracts.Diagnostic {
+	files := p.StyleFiles()
+	if len(files) == 0 {
+		return nil
+	}
+	declared := map[string]bool{}
+	cleaned := make(map[string]string, len(files))
+	for _, f := range files {
+		body, ok := p.Source(f.Rel)
+		if !ok {
+			continue
+		}
+		clean := stripCSSComments(string(body))
+		cleaned[f.Rel] = clean
+		for _, m := range reCSSCustomProp.FindAllStringSubmatch(clean, -1) {
+			declared[m[1]] = true
+		}
+	}
+	known := make(map[string]bool)
+	names := style.TokenNames()
+	for _, n := range names {
+		known[n] = true
+	}
+
+	var out []contracts.Diagnostic
+	for _, f := range files {
+		clean := cleaned[f.Rel]
+		for _, loc := range reVarRef.FindAllStringSubmatchIndex(clean, -1) {
+			name := clean[loc[2]:loc[3]]
+			if varRefHasFallback(clean, loc[3]) ||
+				declared[name] ||
+				strings.HasPrefix(name, "ui-") || strings.HasPrefix(name, "fui-") ||
+				known[name] {
+				continue
+			}
+			msg := fmt.Sprintf("theme emits no `--%s`", name)
+			if fix, ok := closestToken(name, names); ok {
+				msg += fmt.Sprintf("; did you mean `--%s`?", fix)
+			}
+			out = append(out, contracts.Diagnostic{
+				RuleID:  contracts.RuleUnknownThemeToken,
+				File:    f.Rel,
+				Line:    1 + strings.Count(clean[:loc[0]], "\n"),
+				Message: msg,
+				Snippet: p.Line(f.Rel, 1+strings.Count(clean[:loc[0]], "\n")),
+			})
+		}
+	}
+	return out
+}
+
+// reCSSCustomProp matches a custom-property declaration, `--name:`; the
+// captured group is the name without the leading dashes.
+var reCSSCustomProp = regexp.MustCompile(`--([A-Za-z0-9_-]+)\s*:`)
+
+// reVarRef matches a var() reference; the captured group is the
+// referenced name without the leading dashes.
+var reVarRef = regexp.MustCompile(`var\(\s*--([A-Za-z0-9_-]+)`)
+
+// varRefHasFallback reports whether the var() reference whose name ends
+// at s[i-1] carries a fallback: a comma at the TOP level of its
+// arguments, before the matching close paren. `var(--a, var(--b))` has
+// one; `var(--a)` does not. Parentheses nest, so depth is counted.
+func varRefHasFallback(s string, i int) bool {
+	depth := 1 // already inside the var( the name belongs to
+	for ; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth--; depth == 0 {
+				return false
+			}
+		case ',':
+			if depth == 1 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// stripCSSComments removes `/* */` comments from a stylesheet,
+// preserving the line structure so offsets still map to original line
+// numbers. Unlike the Go stripper it does NOT treat `//` as a comment:
+// that would truncate `url(https://…)` and every protocol-relative URL
+// mid-line, hiding real references after it.
+func stripCSSComments(src string) string {
+	var b strings.Builder
+	b.Grow(len(src))
+	inBlock := false
+	for _, line := range strings.Split(src, "\n") {
+		out := line
+		if inBlock {
+			if i := strings.Index(out, "*/"); i >= 0 {
+				out, inBlock = out[i+2:], false
+			} else {
+				b.WriteByte('\n')
+				continue
+			}
+		}
+		for {
+			bs := strings.Index(out, "/*")
+			if bs < 0 {
+				break
+			}
+			if e := strings.Index(out[bs+2:], "*/"); e >= 0 {
+				out = out[:bs] + out[bs+2+e+2:]
+				continue
+			}
+			out, inBlock = out[:bs], true
+			break
+		}
+		b.WriteString(out)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// closestToken returns the token within edit distance 2 of name, if any.
+// names must be sorted, so equal distances resolve deterministically to
+// the first. Distance 2 is enough for the typo class this rule exists
+// for (`radius-lg` vs `radii-lg` is 2) without proposing nonsense for
+// every unknown name.
+func closestToken(name string, names []string) (string, bool) {
+	best, bestDist := "", 3
+	for _, cand := range names {
+		if d := levenshtein(name, cand); d < bestDist {
+			best, bestDist = cand, d
+		}
+	}
+	return best, best != ""
+}
+
+// levenshtein returns the edit distance between a and b: the smallest
+// number of single-character insertions, deletions, and substitutions
+// that turns one into the other.
+func levenshtein(a, b string) int {
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(curr[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
 }
 
 func hasPrefixAny(rel string, prefixes []string) bool {

--- a/framework/contracts/analyzers/rendering.go
+++ b/framework/contracts/analyzers/rendering.go
@@ -85,6 +85,17 @@ var (
 	// Without this, `&t.Colors.Background: "#15141B"` was reported as a
 	// stylesheet. That is a theme token assignment, the exact thing this
 	// rule exists to encourage.
+	//
+	// Matches containing `:=` are rejected IN CODE (looksLikeCSS), not
+	// here: Go's regexp is RE2 and has no lookahead, so `:(?!=)` cannot
+	// be written. The guard is needed because `fill` and `stroke` are
+	// property names AND legal Go identifiers, and in `fill :=
+	// "var(--color-surface)"` (issue #220) the `:` of `:=` satisfied
+	// the colon, `= "` the value gap, and the token reference the value
+	// shape. A stylesheet declaration never carries `=` directly after
+	// its colon, so a match containing `:=` is Go, not CSS.
+	// reCSSHyphenRule needs no such guard: a hyphen cannot occur in a
+	// Go identifier, so no Go construct can match it.
 	reCSSValueRule = regexp.MustCompile(notPropChar + `(?:` + cssPlainProps + `)\s*:\s*[^;{}]*` + cssValueShape)
 	reCSSAtRule    = regexp.MustCompile(`(?i)@(?:font-face|media|keyframes|supports|layer)\b`)
 	// A `<style>` block opened inside a string.
@@ -107,11 +118,34 @@ var (
 	reEventSource = regexp.MustCompile(`\bnew\s+EventSource\s*\(`)
 )
 
-// looksLikeCSS reports whether a line carries a stylesheet declaration.
-func looksLikeCSS(line string) bool {
-	return reCSSAtRule.MatchString(line) ||
-		reCSSHyphenRule.MatchString(line) ||
-		reCSSValueRule.MatchString(line)
+// looksLikeCSS reports whether a line carries a stylesheet declaration,
+// returning the text that matched so the diagnostic can name the trigger
+// (empty string: nothing did). A reCSSValueRule match containing `:=` is
+// rejected: see the comment above that regex.
+func looksLikeCSS(line string) string {
+	if m := reCSSAtRule.FindString(line); m != "" {
+		return m
+	}
+	if m := reCSSHyphenRule.FindString(line); m != "" {
+		return m
+	}
+	if m := reCSSValueRule.FindString(line); m != "" && !strings.Contains(m, ":=") {
+		return m
+	}
+	return ""
+}
+
+// clipTrigger trims a matched fragment and caps it, so a long line
+// produces a readable diagnostic rather than a wall of text.
+func clipTrigger(m string) string {
+	m = strings.TrimSpace(m)
+	r := []rune(m)
+	// Cut on runes, not bytes: a CSS value can hold any UTF-8, and
+	// slicing mid-rune puts invalid bytes in the diagnostic.
+	if len(r) > 48 {
+		return string(r[:45]) + "…"
+	}
+	return m
 }
 
 // designSystemPrefixes are the trees that OWN styling. CSS there is the
@@ -170,14 +204,22 @@ func runRendering(p *contracts.Pass) ([]contracts.Diagnostic, error) {
 			}
 
 			if !ownsStyling {
-				if reStyleTag.MatchString(line) || looksLikeCSS(line) {
+				if trigger := looksLikeCSS(line); trigger != "" || reStyleTag.MatchString(line) {
 					what := "a CSS rule"
+					// Issue #220: the reporter read "a CSS rule is defined
+					// outside the design system" as being about the value on
+					// the line and went looking at what was assigned, when
+					// the match was on the property name. Name the half of
+					// the line that matched. The <style> wording is already
+					// unambiguous, so it stays as it was.
+					detail := fmt.Sprintf(": matched `%s`", clipTrigger(trigger))
 					if reStyleTag.MatchString(line) {
 						what = "a <style> block"
+						detail = ""
 					}
 					out = append(out, contracts.Diagnostic{
 						RuleID: contracts.RuleBespokeCSS, File: f.Rel, Line: lineNo,
-						Message: fmt.Sprintf("%s is defined outside the design system", what),
+						Message: fmt.Sprintf("%s is defined outside the design system%s", what, detail),
 						Snippet: strings.TrimSpace(lines[i]),
 					})
 				}

--- a/framework/contracts/analyzers/rendering.go
+++ b/framework/contracts/analyzers/rendering.go
@@ -293,9 +293,7 @@ func checkStyleTokens(p *contracts.Pass) []contracts.Diagnostic {
 		}
 		clean := blankCSSCommentsAndStrings(string(body))
 		cleaned[f.Rel] = clean
-		for _, m := range reCSSCustomProp.FindAllStringSubmatch(clean, -1) {
-			declared[m[1]] = true
-		}
+		collectDeclared(clean, declared)
 	}
 	known := make(map[string]bool)
 	names := style.TokenNames()
@@ -333,6 +331,52 @@ func checkStyleTokens(p *contracts.Pass) []contracts.Diagnostic {
 // reCSSCustomProp matches a custom-property declaration, `--name:`; the
 // captured group is the name without the leading dashes.
 var reCSSCustomProp = regexp.MustCompile(`--([A-Za-z0-9_-]+)\s*:`)
+
+// reAtProperty matches an `@property --name` registration. It has no
+// colon after the name, so reCSSCustomProp cannot see it, and a project
+// that registers a property this way and then reads it would otherwise
+// be told the token does not exist.
+var reAtProperty = regexp.MustCompile(`@property\s+--([A-Za-z0-9_-]+)`)
+
+// collectDeclared adds every custom property a stylesheet DECLARES to
+// into. Position matters: `--name:` only declares inside a rule block and
+// outside parentheses.
+//
+// The case that forced this is `@supports (--brand: red) { … }`. A feature
+// query's condition asks whether the browser can PARSE that declaration;
+// it does not make one. Counting it marked `--brand` declared and silenced
+// every real finding for it, which is the failure mode this rule exists to
+// prevent, arrived at from the other side.
+//
+// Depth is counted on the cleaned text, where comments and strings are
+// already blanked, so a brace or paren inside either cannot skew it.
+func collectDeclared(clean string, into map[string]bool) {
+	for _, m := range reAtProperty.FindAllStringSubmatch(clean, -1) {
+		into[m[1]] = true
+	}
+	var brace, paren, pos int
+	for _, m := range reCSSCustomProp.FindAllStringSubmatchIndex(clean, -1) {
+		for ; pos < m[0]; pos++ {
+			switch clean[pos] {
+			case '{':
+				brace++
+			case '}':
+				if brace > 0 {
+					brace--
+				}
+			case '(':
+				paren++
+			case ')':
+				if paren > 0 {
+					paren--
+				}
+			}
+		}
+		if brace > 0 && paren == 0 {
+			into[clean[m[2]:m[3]]] = true
+		}
+	}
+}
 
 // reVarRef matches a var() reference; the captured group is the
 // referenced name without the leading dashes.

--- a/framework/contracts/analyzers/themetoken_test.go
+++ b/framework/contracts/analyzers/themetoken_test.go
@@ -1,0 +1,134 @@
+package analyzers_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/framework/contracts"
+)
+
+// GOFASTR1806: a `var(--…)` reference in project CSS that the theme does
+// not emit. Issue #214's reporter wrote `--radius-lg` where the theme
+// emits `--radii-lg`; an invalid var() is not a CSS error, the
+// declaration is silently dropped, and the only symptom was every
+// rounded corner rendering square for days.
+
+func countRule(t *testing.T, ds []contracts.Diagnostic, rule string) []contracts.Diagnostic {
+	t.Helper()
+	var out []contracts.Diagnostic
+	for _, d := range ds {
+		if d.RuleID == rule {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+func TestUnknownThemeTokenIsReported(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": ".card { border-radius: var(--radius-lg); }\n",
+	})
+	found := countRule(t, ds, contracts.RuleUnknownThemeToken)
+	if len(found) != 1 {
+		t.Fatalf("want exactly 1 GOFASTR1806, got %d: %v", len(found), found)
+	}
+	d := found[0]
+	if !strings.Contains(d.Message, "radius-lg") {
+		t.Errorf("message does not name the unknown token: %q", d.Message)
+	}
+	if !strings.Contains(d.Message, "radii-lg") {
+		t.Errorf("message does not suggest the close match: %q", d.Message)
+	}
+	if d.File != "app.css" || d.Line != 1 {
+		t.Errorf("finding at %s:%d, want app.css:1", d.File, d.Line)
+	}
+}
+
+func TestKnownThemeTokenIsClean(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": ".card { border-radius: var(--radii-lg); color: var(--color-text); }\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "radii-lg and color-text are emitted by the theme")
+}
+
+func TestVarWithFallbackIsClean(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": ".card { border-radius: var(--radius-lg, 8px); }\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "a fallback degrades instead of dropping the declaration")
+}
+
+func TestLocallyDeclaredPropertyIsClean(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": ":root { --brand: #fff; }\n.header { color: var(--brand); }\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "--brand is declared by the stylesheet itself")
+}
+
+func TestPropertyDeclaredInAnotherFileIsClean(t *testing.T) {
+	// The declared set is built across all style files: a base sheet
+	// declaring a custom property another sheet uses is normal.
+	ds := fixture(t, map[string]string{
+		"base.css": ":root { --brand: #fff; }\n",
+		"app.css":  ".header { color: var(--brand); }\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "--brand is declared in base.css")
+}
+
+func TestUiKnobReferenceIsClean(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": ".shell { max-width: var(--ui-layout-container-width); }\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "ui-* knobs are per-component overrides, not theme tokens")
+}
+
+func TestCSSFileDoesNotTripGoRules(t *testing.T) {
+	// A stylesheet is not an app shipping CSS from Go. It must not fire
+	// the bespoke-CSS rule; the file IS a stylesheet, outside the design
+	// system or not, and GOFASTR1806 is the rule that governs it.
+	ds := fixture(t, map[string]string{
+		"app.css": ".card { padding: 16px; border-radius: 8px; color: #fff; }\n",
+	})
+	assertNot(t, ds, contracts.RuleBespokeCSS, "a stylesheet is not Go source carrying CSS in strings")
+}
+
+func TestNestedFallbackIsClean(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": ".card { border-radius: var(--nope, var(--radii-lg)); }\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "--nope carries a nested fallback, so nothing is dropped")
+}
+
+func TestTokenInCSSCommentIsClean(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": "/* do not use var(--radius-lg), it is a typo */\n.card { margin: 0 }\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "prose in a comment is not a reference")
+}
+
+// A stylesheet is the one place GOFASTR1806 fires, so it has to be a
+// place a suppression can be written. collectSuppressions read Go files
+// only, which left the rule with no escape hatch in the file it reports.
+func TestCSSAllowDirectiveSuppresses(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"static/app.css": "/* gofastr:allow(GOFASTR1806) --brand-x is set inline by the host page */\n.a { color: var(--brand-x); }\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "an allow directive in the stylesheet must waive it")
+}
+
+// The file-scoped hammer works in CSS too.
+func TestCSSAllowFileDirective(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"static/app.css": "/* gofastr:allow-file(GOFASTR1806) vendored third-party sheet */\n.a { color: var(--brand-x); }\n.b { gap: var(--brand-y); }\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "an allow-file directive in the stylesheet must waive it")
+}
+
+// Absence of a directive still reports: the escape hatch must not have
+// widened into "stylesheets are exempt".
+func TestCSSWithoutDirectiveStillReports(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"static/app.css": ".a { color: var(--brand-x); }\n",
+	})
+	assertHas(t, ds, contracts.RuleUnknownThemeToken)
+}

--- a/framework/contracts/analyzers/themetoken_test.go
+++ b/framework/contracts/analyzers/themetoken_test.go
@@ -106,6 +106,72 @@ func TestTokenInCSSCommentIsClean(t *testing.T) {
 	assertNot(t, ds, contracts.RuleUnknownThemeToken, "prose in a comment is not a reference")
 }
 
+// Text inside a CSS string is content, not a token reference. Nothing
+// is dropped, so an Error here would fail a build on valid CSS.
+func TestTokenInCSSStringIsClean(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": `.x::after { content: "var(--not-a-token)"; }` + "\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "text inside a CSS string is content, not a reference")
+}
+
+// A `/*` inside a string used to open a comment that never closed,
+// swallowing the rest of the file and hiding a real typo on a later
+// line. The line number is asserted because preserving it is the whole
+// risk of blanking spans in the pre-pass.
+func TestTokenAfterStringWithOpenComment(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": `.x::after { content: "/*"; }
+.y { color: var(--radius-lg); }
+`,
+	})
+	found := countRule(t, ds, contracts.RuleUnknownThemeToken)
+	if len(found) != 1 {
+		t.Fatalf("want exactly 1 GOFASTR1806, got %d: %v", len(found), found)
+	}
+	if found[0].File != "app.css" || found[0].Line != 2 {
+		t.Errorf("finding at %s:%d, want app.css:2", found[0].File, found[0].Line)
+	}
+}
+
+// Both regex scans run on the blanked text: a declaration after a
+// string must still count, and the reference it satisfies stays clean.
+func TestDeclarationAfterStringStillCounts(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": `.x::after { content: "/*"; }
+:root { --brand: #fff; }
+.a { color: var(--brand); }
+`,
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "--brand is declared on line 2, after the string")
+}
+
+func TestEscapedQuoteDoesNotEndString(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": `.x::after { content: "a\"var(--nope)b"; }` + "\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "the escaped quote does not end the string")
+}
+
+func TestSingleQuotedStringIsClean(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": `.x::after { content: 'var(--not-a-token)'; }` + "\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "single-quoted strings are strings too")
+}
+
+// The case a naive "blank from the first quote to end of line" fix
+// would break: a real reference after a closed string on the same line.
+func TestReferenceAfterClosedStringReports(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": `.x { content: "hi"; color: var(--radius-lg); }` + "\n",
+	})
+	found := countRule(t, ds, contracts.RuleUnknownThemeToken)
+	if len(found) != 1 || found[0].Line != 1 {
+		t.Fatalf("want exactly 1 GOFASTR1806 at app.css:1, got %d: %v", len(found), found)
+	}
+}
+
 // A stylesheet is the one place GOFASTR1806 fires, so it has to be a
 // place a suppression can be written. collectSuppressions read Go files
 // only, which left the rule with no escape hatch in the file it reports.

--- a/framework/contracts/analyzers/themetoken_test.go
+++ b/framework/contracts/analyzers/themetoken_test.go
@@ -236,3 +236,41 @@ func TestAtPropertyRegistrationCounts(t *testing.T) {
 	})
 	assertNot(t, ds, contracts.RuleUnknownThemeToken, "--brand is registered with @property")
 }
+
+// CSS function names are ASCII case-insensitive: `VAR(--x)` resolves in a
+// browser exactly as `var(--x)` does. Matching the keyword case-sensitively
+// let an uppercase reference to a nonexistent token through unreported.
+func TestUppercaseVarIsReported(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": ".a { border-radius: VAR(--radius-lg); }\n.b { color: Var(--nope-at-all); }\n",
+	})
+	found := countRule(t, ds, contracts.RuleUnknownThemeToken)
+	if len(found) != 2 {
+		t.Fatalf("want both uppercase/mixed-case references reported, got %d: %v", len(found), found)
+	}
+}
+
+// The at-rule keyword folds case for the same reason.
+func TestUppercaseAtPropertyCounts(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": "@PROPERTY --brand {\n  syntax: \"<color>\";\n}\n.b { color: var(--brand); }\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "@PROPERTY registers --brand; the at-rule keyword is case-insensitive")
+}
+
+// The property NAME is the half that must NOT fold. Custom property names
+// are case-sensitive: measured in Chrome, `var(--mixed)` against a declared
+// `--Mixed` resolves to nothing. Folding them would call a real miss a
+// match and hide exactly the bug this rule exists for.
+func TestCustomPropertyNameStaysCaseSensitive(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": ":root { --Mixed: #fff; }\n.b { color: var(--mixed); }\n",
+	})
+	found := countRule(t, ds, contracts.RuleUnknownThemeToken)
+	if len(found) != 1 {
+		t.Fatalf("want --mixed reported as unknown despite --Mixed being declared, got %d: %v", len(found), found)
+	}
+	if !strings.Contains(found[0].Message, "mixed") {
+		t.Errorf("message should name the referenced token: %q", found[0].Message)
+	}
+}

--- a/framework/contracts/analyzers/themetoken_test.go
+++ b/framework/contracts/analyzers/themetoken_test.go
@@ -198,3 +198,41 @@ func TestCSSWithoutDirectiveStillReports(t *testing.T) {
 	})
 	assertHas(t, ds, contracts.RuleUnknownThemeToken)
 }
+
+// A feature query's condition asks whether the browser can PARSE a
+// declaration; it does not make one. Counting `@supports (--radius-lg: 0)`
+// as a declaration marked the token known and silenced the real typo
+// below it — the rule's own failure mode, reached from the other side.
+func TestSupportsConditionDoesNotDeclare(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": "@supports (--radius-lg: 0) {\n  .a { border-radius: var(--radius-lg); }\n}\n",
+	})
+	found := countRule(t, ds, contracts.RuleUnknownThemeToken)
+	if len(found) != 1 {
+		t.Fatalf("want the typo inside the feature query reported once, got %d: %v", len(found), found)
+	}
+	if found[0].Line != 2 {
+		t.Errorf("finding at line %d, want 2", found[0].Line)
+	}
+}
+
+// The other direction, which a careless fix breaks: a declaration INSIDE
+// an at-rule block is a real declaration, however deeply nested. Losing
+// this turns valid CSS into a build failure, which is worse than the
+// missed finding above.
+func TestDeclarationInsideAtRuleCounts(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": "@media screen {\n  @supports (display: grid) {\n    :root { --brand: #fff; }\n  }\n}\n.b { color: var(--brand); }\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "--brand is declared inside the nested at-rule blocks")
+}
+
+// `@property --name { … }` registers a custom property with no colon
+// after the name, so the declaration scan cannot see it. Reading a
+// registered property is not a typo.
+func TestAtPropertyRegistrationCounts(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"app.css": "@property --brand {\n  syntax: \"<color>\";\n  inherits: false;\n  initial-value: #fff;\n}\n.b { color: var(--brand); }\n",
+	})
+	assertNot(t, ds, contracts.RuleUnknownThemeToken, "--brand is registered with @property")
+}

--- a/framework/contracts/catalog.go
+++ b/framework/contracts/catalog.go
@@ -736,15 +736,20 @@ func renderingRules() []Rule {
 	return []Rule{{
 		ID: RuleBespokeCSS, Slug: "rendering/bespoke-css",
 		Title: "CSS outside the design system", Capability: CapRendering, Severity: SeverityError,
-		Summary: "An app or generator ships its own CSS rules.",
+		Summary: "An app or generator ships its own CSS rules: CSS declarations in strings, not Go assigning token values.",
 		Why: "Two styling surfaces means every future change has to be made twice and stays consistent " +
 			"by luck. Bespoke CSS also loads in an order you do not control relative to component CSS, " +
-			"so it wins or loses by specificity accident rather than by intent.",
+			"so it wins or loses by specificity accident rather than by intent. The rule matches CSS " +
+			"declarations, a property-colon-value shape in a string; a Go assignment of a design-system " +
+			"token reference to a variable, `fill := \"var(--color-surface)\"`, is not one and does not fire.",
 		Fix: "Compose `framework/ui` components and `core-ui/style` tokens. If the design system genuinely lacks what you need, add the component or token upstream and use it here. That is the fix, not a local rule.",
 		Doc: "ui-getting-started",
 		Examples: []Example{{
 			Bad:  "const baseCSS = `.my-card { padding: 16px; border-radius: 8px; }`",
 			Good: `ui.Card(ui.CardConfig{Padding: style.SpaceMD})`,
+		}, {
+			Bad:  "const btnCSS = `.btn { padding: var(--spacing-md); }`",
+			Good: "fill := \"var(--color-surface)\" // a token reference assigned in Go is the encouraged shape",
 		}},
 	}, {
 		ID: RuleHardNavigation, Slug: "rendering/hard-navigation",

--- a/framework/contracts/catalog.go
+++ b/framework/contracts/catalog.go
@@ -137,6 +137,7 @@ const (
 	RuleBespokeEventSource = "GOFASTR1803"
 	RuleInlineStyle        = "GOFASTR1804"
 	RuleInlineScript       = "GOFASTR1805"
+	RuleUnknownThemeToken  = "GOFASTR1806" // not-a-secret: a rule id, flagged only because the name ends in "Token"
 )
 
 // Permission rules.
@@ -789,6 +790,21 @@ func renderingRules() []Rule {
 		Examples: []Example{{
 			Bad:  "html.Raw(`<div style=\"margin-top: 12px\">…</div>`)",
 			Good: "ui.Stack(ui.StackConfig{Gap: \"md\"}, children...)",
+		}},
+	}, {
+		ID: RuleUnknownThemeToken, Slug: "rendering/unknown-theme-token",
+		Title: "var() references a token the theme does not emit", Capability: CapRendering, Severity: SeverityError,
+		Summary: "Project CSS reads `var(--name)` where `name` is not a theme token.",
+		Why: "An invalid var() is not a CSS error: it resolves to nothing and the declaration is " +
+			"silently dropped, so a typo is invisible to the build, the browser console, and every " +
+			"linter, and the only symptom is the styling not applying. Issue #214's reporter wrote " +
+			"`--radius-lg` where the theme emits `--radii-lg`, and every rounded corner on the site " +
+			"rendered square for days.",
+		Fix: "Spell the token the theme emits (see `style.TokenNames()` or `gofastr docs theming`), declare the custom property in your own stylesheet if it is yours, or add a fallback: `var(--x, 8px)` degrades instead of dropping the declaration.",
+		Doc: "theming",
+		Examples: []Example{{
+			Bad:  "border-radius: var(--radius-lg);",
+			Good: "border-radius: var(--radii-lg);",
 		}},
 	}}
 }

--- a/framework/contracts/pass.go
+++ b/framework/contracts/pass.go
@@ -32,6 +32,12 @@ type SourceFile struct {
 	Abs string
 	// IsTest is true for _test.go files.
 	IsTest bool
+	// IsCSS is true for stylesheet files (.css). Discovery reads them
+	// like any source file, but they are not Go: Files/AppFiles/
+	// TestFiles exclude them and StyleFiles returns them, so no analyzer
+	// that assumes Go source ever sees one. AST parsing is refused
+	// rather than attempted (and recorded as a parse failure).
+	IsCSS bool
 	// IsGenerated is true when the file carries a `Code generated … DO NOT
 	// EDIT` header. Analyzers skip these by default: the developer cannot
 	// fix a finding there, only the generator can.
@@ -125,7 +131,9 @@ func (p *Pass) discover() error {
 			}
 			return nil
 		}
-		if !strings.HasSuffix(path, ".go") {
+		isGo := strings.HasSuffix(path, ".go")
+		isCSS := strings.HasSuffix(path, ".css")
+		if !isGo && !isCSS {
 			return nil
 		}
 		rel, relErr := filepath.Rel(p.Root, path)
@@ -138,12 +146,17 @@ func (p *Pass) discover() error {
 			return nil
 		}
 		p.sources[rel] = body
+		pkg := ""
+		if isGo {
+			pkg = importPathFor(p.ModulePath, p.Root, filepath.Dir(path))
+		}
 		p.files = append(p.files, SourceFile{
 			Rel:         rel,
 			Abs:         path,
-			IsTest:      strings.HasSuffix(rel, "_test.go"),
+			IsTest:      isGo && strings.HasSuffix(rel, "_test.go"),
+			IsCSS:       isCSS,
 			IsGenerated: IsGeneratedSource(body),
-			Package:     importPathFor(p.ModulePath, p.Root, filepath.Dir(path)),
+			Package:     pkg,
 		})
 		return nil
 	})
@@ -154,15 +167,26 @@ func (p *Pass) discover() error {
 	return nil
 }
 
-// Files returns every discovered Go file, in path order.
-func (p *Pass) Files() []SourceFile { return p.files }
+// Files returns every discovered Go file, in path order. Stylesheets are
+// excluded: every analyzer in the tree assumes the files handed to it
+// parse as Go.
+func (p *Pass) Files() []SourceFile {
+	var out []SourceFile
+	for _, f := range p.files {
+		if f.IsCSS {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
 
 // AppFiles returns the files analyzers care about by default: non-test,
 // non-generated Go source that configuration has not exempted.
 func (p *Pass) AppFiles() []SourceFile {
 	var out []SourceFile
 	for _, f := range p.files {
-		if f.IsTest || f.IsGenerated || p.Config.ExemptPath(f.Rel) {
+		if f.IsCSS || f.IsTest || f.IsGenerated || p.Config.ExemptPath(f.Rel) {
 			continue
 		}
 		out = append(out, f)
@@ -175,7 +199,24 @@ func (p *Pass) AppFiles() []SourceFile {
 func (p *Pass) TestFiles() []SourceFile {
 	var out []SourceFile
 	for _, f := range p.files {
-		if !f.IsTest || f.IsGenerated || p.Config.ExemptPath(f.Rel) {
+		if f.IsCSS || !f.IsTest || f.IsGenerated || p.Config.ExemptPath(f.Rel) {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// StyleFiles returns the .css files configuration has not exempted.
+// They get the same discovery rules as Go source (skipDirs, hidden
+// directories, generated headers, global exemptions) and are readable
+// through Source; the difference is that no Go accessor will hand them
+// out. Per-rule exemptions are applied later, at diagnostic filtering,
+// exactly as for Go files.
+func (p *Pass) StyleFiles() []SourceFile {
+	var out []SourceFile
+	for _, f := range p.files {
+		if !f.IsCSS || f.IsGenerated || p.Config.ExemptPath(f.Rel) {
 			continue
 		}
 		out = append(out, f)
@@ -218,15 +259,21 @@ func (p *Pass) FileSet() *token.FileSet {
 	return p.fset
 }
 
-// AST parses a discovered file once and caches the result. Comments are
+// AST parses a discovered Go file once and caches the result. Comments are
 // retained because suppression directives live in them. A file that fails
 // to parse returns (nil, false) rather than an error: a project mid-edit
-// should still get findings from every file that *does* parse.
+// should still get findings from every file that *does* parse. A
+// stylesheet is refused outright: parsing CSS as Go would fail and land
+// in Unparsed, reporting every discovered stylesheet as unreadable.
 func (p *Pass) AST(rel string) (*ast.File, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if f, ok := p.asts[rel]; ok {
 		return f, f != nil
+	}
+	if strings.HasSuffix(rel, ".css") {
+		p.asts[rel] = nil
+		return nil, false
 	}
 	body, ok := p.sources[rel]
 	if !ok {

--- a/framework/contracts/pass_test.go
+++ b/framework/contracts/pass_test.go
@@ -1,0 +1,83 @@
+package contracts
+
+import (
+	"strings"
+	"testing"
+)
+
+// The pass discovers stylesheets as well as Go, but the Go analyzers'
+// accessors must stay Go-only: every existing analyzer assumes a file it
+// is handed parses as Go, and quietly feeding it a stylesheet is the
+// failure mode this test exists to make loud.
+func TestStyleFilesAreSeparateFromGoFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeTemp(t, dir, "go.mod", "module example.com/app\n\ngo 1.26\n")
+	writeTemp(t, dir, "main.go", "package main\n")
+	writeTemp(t, dir, "app.css", "body { margin: 0 }\n")
+	writeTemp(t, dir, "static/site.css", ".a { color: red }\n")
+	writeTemp(t, dir, "dist/skipped.css", "body { margin: 0 }\n")
+	writeTemp(t, dir, ".hidden/skipped.css", "body { margin: 0 }\n")
+
+	p, err := NewPass(dir, DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rel := func(fs []SourceFile) []string {
+		var out []string
+		for _, f := range fs {
+			out = append(out, f.Rel)
+		}
+		return out
+	}
+
+	for _, f := range p.Files() {
+		if strings.HasSuffix(f.Rel, ".css") {
+			t.Errorf("Files() included stylesheet %s — it is documented as Go-only", f.Rel)
+		}
+	}
+	for _, f := range p.AppFiles() {
+		if strings.HasSuffix(f.Rel, ".css") {
+			t.Errorf("AppFiles() included stylesheet %s — the Go analyzers assume Go source", f.Rel)
+		}
+	}
+	for _, f := range p.TestFiles() {
+		if strings.HasSuffix(f.Rel, ".css") {
+			t.Errorf("TestFiles() included stylesheet %s", f.Rel)
+		}
+	}
+
+	got := strings.Join(rel(p.StyleFiles()), ",")
+	want := "app.css,static/site.css"
+	if got != want {
+		t.Errorf("StyleFiles() = %q, want %q (skip rules must apply: dist/ and hidden dirs)", got, want)
+	}
+
+	// The stylesheet's bytes must be readable like any discovered file.
+	if _, ok := p.Source("app.css"); !ok {
+		t.Error("Source(app.css) unavailable — discovery read it but did not keep it")
+	}
+}
+
+// Configuration exemptions apply to stylesheets exactly as to Go source.
+func TestStyleFilesHonourExemptPath(t *testing.T) {
+	dir := t.TempDir()
+	writeTemp(t, dir, "go.mod", "module example.com/app\n\ngo 1.26\n")
+	writeTemp(t, dir, "app.css", "body { margin: 0 }\n")
+	writeTemp(t, dir, "vendor-pkg/lib.css", ".a { color: red }\n")
+
+	cfg := DefaultConfig()
+	cfg.Exempt = []string{"vendor-pkg/**"}
+	p, err := NewPass(dir, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := p.StyleFiles()
+	if len(got) != 1 || got[0].Rel != "app.css" {
+		var rels []string
+		for _, f := range got {
+			rels = append(rels, f.Rel)
+		}
+		t.Errorf("StyleFiles() = %v, want [app.css] — the exempt path was not honoured", rels)
+	}
+}

--- a/framework/contracts/suppress.go
+++ b/framework/contracts/suppress.go
@@ -66,9 +66,9 @@ type suppressionSet struct {
 	issues []Diagnostic
 }
 
-// collectSuppressions scans every discovered file, including test and
-// generated files, since a directive may legitimately sit in either, for
-// allow directives.
+// collectSuppressions scans every discovered file for allow directives:
+// Go source and stylesheets alike, including test and generated files,
+// since a directive may legitimately sit in any of them.
 //
 // Only text inside a *comment* counts. That distinction is load-bearing:
 // a directive spelled out in a string literal is documentation about the
@@ -79,7 +79,11 @@ type suppressionSet struct {
 // mid-edit still honours its suppressions.
 func collectSuppressions(p *Pass) *suppressionSet {
 	set := &suppressionSet{byFile: map[string][]*suppression{}}
-	for _, f := range p.Files() {
+	// p.files, not p.Files(): that accessor is Go-only, and a stylesheet
+	// needs the same escape hatch as any other source. Without this,
+	// GOFASTR1806 (the one rule that fires on .css) had no way to be
+	// waived in the file it fires in.
+	for _, f := range p.files {
 		body, ok := p.Source(f.Rel)
 		if !ok {
 			continue
@@ -126,7 +130,11 @@ func commentRanges(p *Pass, rel string, lines []string) []commentText {
 	var out []commentText
 	for i, raw := range lines {
 		trimmed := strings.TrimSpace(raw)
-		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "*") {
+		// `/*` belongs here even though the AST path covers it for Go:
+		// this branch is also how a stylesheet's comments are read, and
+		// CSS has no other comment syntax.
+		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "#") ||
+			strings.HasPrefix(trimmed, "*") || strings.HasPrefix(trimmed, "/*") {
 			out = append(out, commentText{line: i + 1, text: trimmed})
 		}
 	}

--- a/framework/docs/content/contracts.md
+++ b/framework/docs/content/contracts.md
@@ -28,7 +28,7 @@ Rules are grouped into capabilities, and each capability is also a filter:
 | `data` | writes whose result and error are both discarded |
 | `entities` | MCP tools on an entity with CRUD disabled, entities opted into anonymous access, a CRUD entity exposed with no auth wired (every operation 401s) |
 | `architecture` | imports that point up the layer stack, explicitly forbidden edges |
-| `rendering` | CSS outside the design system, `location.href` used as navigation, bespoke `EventSource`, inline `style=`, `<script>` with an inline body |
+| `rendering` | CSS outside the design system, `location.href` used as navigation, bespoke `EventSource`, inline `style=`, `<script>` with an inline body, `var(--…)` in project CSS naming a token the theme does not emit |
 | `accessibility` | the static WCAG floor: missing alt text, unnamed controls and landmarks, incomplete form controls, implicit heading levels, elements missing required metadata |
 | `performance` | regexps compiled per call, N+1 queries, reflection on the request path |
 | `testing` | routes, permissions, roles, entity operations, lifecycle hooks, and event subscribers no test exercised; disabled tests; a line-coverage floor; an unreadable coverage manifest |

--- a/framework/docs/content/dev-livereload.md
+++ b/framework/docs/content/dev-livereload.md
@@ -60,6 +60,18 @@ When enabled:
 One persistent SSE connection per tab, near-zero idle traffic, no
 polling.
 
+### Project static assets are served uncached
+
+Framework assets are content-versioned (`/__gofastr/runtime.js?v=…`),
+but project files serve at plain URLs (`/nav.js`, `/app.css`), where a
+bare `Last-Modified` invites heuristic caching: the browser keeps
+executing the old bytes after an edit even though a fresh fetch returns
+the new ones. Under `gofastr dev`, files served from the static dir or
+the embedded static FS go out with `Cache-Control: no-store`, so an
+edited `.js` or `.css` is picked up on reload without a server restart.
+Production caching is unchanged: when dev mode is off, no header is
+set at all.
+
 ## How `gofastr dev` wires it
 
 `cmd/gofastr/dev.go` injects `GOFASTR_DEV=1` into the child binary's

--- a/framework/docs/content/dev-livereload.md
+++ b/framework/docs/content/dev-livereload.md
@@ -67,8 +67,16 @@ but project files serve at plain URLs (`/nav.js`, `/app.css`), where a
 bare `Last-Modified` invites heuristic caching: the browser keeps
 executing the old bytes after an edit even though a fresh fetch returns
 the new ones. Under `gofastr dev`, files served from the static dir or
-the embedded static FS go out with `Cache-Control: no-store`, so an
-edited `.js` or `.css` is picked up on reload without a server restart.
+the embedded static FS go out with `Cache-Control: no-store`, so the
+browser asks the server for them instead of replaying what it cached.
+
+That is the whole of what the header buys, and what it buys differs by
+where the file comes from. A file in the static dir is read from disk
+on every request, so editing it and reloading is enough. A file in an
+embedded static FS is compiled into the binary, so an edit there still
+needs a rebuild; `no-store` only guarantees you are looking at what the
+running binary holds rather than at a stale copy of it.
+
 Production caching is unchanged: when dev mode is off, no header is
 set at all.
 

--- a/framework/docs/content/layouts.md
+++ b/framework/docs/content/layouts.md
@@ -68,6 +68,37 @@ name, so a per-screen layout override inside a group compares as a
 different layer than its siblings and gets its shell re-rendered on
 navigation instead of silently keeping whichever was on screen.
 
+Each level also wraps its slots in elements of its own: the header
+component renders inside a `<header role="banner">`, the sidebar inside
+a `<nav aria-label="Sidebar">`, the footer inside a
+`<footer role="contentinfo">`, and the content cell is the page's
+single `<main id="main-content">` at the root layer or a
+`.layout-content` div below it. Your components supply the inner
+content; the landmark elements belong to the layout.
+
+That wrapper matters for CSS. A sticky element only travels inside its
+parent's box, so a header component with `position: sticky` sticks for
+the header's own height and then scrolls away: its parent is the
+layout's `<header>`, whose box ends where the header ends. To pin the
+header for the whole page, make the layout's wrapper the sticky
+element:
+
+```go
+site := app.NewLayout("site").
+    WithHeader(header).
+    WithFooter(footer).
+    WithStickyHeader()
+```
+
+`WithStickyHeader()` sticks the layout's own `<header role="banner">`
+wrapper to the top of the viewport (the landmark stays, the component
+keeps supplying the content) and gives the wrapper a background so
+page content does not scroll visibly underneath it. Stacking uses the
+theme's `--z-sticky` layer; the background comes from
+`--ui-layout-header-bg`, overridable per app like the other
+`--ui-layout-*` variables. It composes with `WithContainer()` and
+`WithSidebar()` (both modifiers land on the same wrapper).
+
 ## What the client swaps
 
 On navigation the runtime compares the target's chain against the
@@ -123,6 +154,12 @@ unaware of the change and breaks both behaviors above.
   it.** An explicit layout on `Register` replaces the default; only
   `ScreenGroup` screens nest under it. To add a section sidebar inside
   the site shell, put the screen in a group.
+- **Giving the header component `position: sticky` and watching it
+  scroll away.** The layout renders the component inside its own
+  `<header>` wrapper, and a sticky element only travels inside its
+  parent's box, so it sticks for exactly the header's height and then
+  leaves. Call `WithStickyHeader()` on the layout; the wrapper is the
+  element that sticks.
 - **Reusing one layout name for two different layouts.** Layer keys
   embed the name; two distinct `*Layout` values named `"docs"` at the
   same depth compare as the same layer, and navigation between them

--- a/framework/docs/content/runtime-contract.md
+++ b/framework/docs/content/runtime-contract.md
@@ -161,11 +161,12 @@ server side and the runtime does the work.
 | `data-fui-menu` | Marks a `<details data-fui-disclosure>` as a `framework/ui.Menu` dropdown. The runtime focuses the first `[role=menuitem]` when the disclosure opens; arrow keys / Home / End / type-ahead navigate within the panel; Tab closes the menu and lets focus escape naturally. |
 | `data-fui-menu-panel` | Emitted by `framework/ui.Menu` on the `role="menu"` panel `<div>`. No runtime or CSS consumer today (the menu module scopes by `data-fui-menu` + `.ui-menu__panel`); emit-only structural marker. |
 | `data-fui-match-prefix` | On a `<nav> <a>` link: opts the link into prefix-matching for active-route highlighting. The runtime tags it `aria-current="page"` + `.active` when the current path equals the link's href or continues it at a segment boundary: `/docs` and `/docs/` both light up on `/docs` and `/docs/getting-started`, and neither matches `/docs-old`. Without this attribute the runtime does exact-href matching only, so breadcrumbs and sidebars (where multiple links share prefixes) keep the server-rendered single active item. Root `/` is never a prefix match. |
+| `data-fui-activelink-skip` | On a `<nav> <a>` link: opts OUT of active-route highlighting entirely. The `activelink` runtime module neither sets nor clears `aria-current` or `.active` on it, at load or after SPA navigation. The escape hatch for a link whose current-state is owned by something else: a hand-set attribute (`aria-current="location"` on an in-page anchor), app JS, a signal binding. Same hands-off treatment as href-less links. |
 | `data-fui-fileupload` | Marks the drag-drop zone surrounding a `framework/ui.FileUpload` `<input type="file">`. The runtime wires dragover/dragleave/drop handlers that forward dropped File objects into the input's `files` property and dispatch a `change` event so form RPC pipelines fire uniformly whether the user clicked-to-pick or dragged-to-drop. |
 | `data-fui-popover-anchor` | On a `data-fui-open` trigger button: opt the opened widget into trigger-anchored positioning. The value is the preferred side: `"top"`, `"bottom"`, `"left"`, `"right"`, or empty / `"auto"` (= bottom-first, then top, right, left). The runtime measures both rects after open and applies inline `position: fixed; top; left` so the popover sits next to the trigger; if the preferred side would overflow the viewport (8px margin), it auto-flips to the opposite. Re-runs on `window.resize` AND `window.scroll` (capture, rAF-throttled) so the popover tracks the trigger when the page scrolls. Distinct from `preset.Modal`'s deep-link affordances; popovers are click-driven and don't deep-link. |
 | `data-fui-banner-dismiss` | On the X button inside a `framework/ui.Banner`: clicking sets `hidden` on the nearest `[data-fui-comp="ui-banner"]` ancestor. The runtime delegates the click globally so dismissal survives partial-island swaps. |
-| `data-fui-scrollspy` | Marks a scrollspy container. The runtime observes section heading targets via IntersectionObserver and tags the matching `data-fui-scrollspy-target` link with `aria-current="true"` as the user scrolls. |
-| `data-fui-scrollspy-target` | On a nav link inside a scrollspy: the value identifies the section heading the link tracks. Updated to `aria-current="true"` when its target enters the active band. |
+| `data-fui-scrollspy` | Marks a scrollspy wrapper (`core-ui/patterns/scrollspy.Wrap` emits a `<div>` around a nav of `<a href="#id">` anchors). The runtime demand-loads the scrollspy module, which IntersectionObserves the anchored targets inside the configured region and tags the link whose target is in the active band with `aria-current="true"` + `.is-active`. The `activelink` module leaves these links alone: scrollspy owns their current-state. |
+| `data-fui-scrollspy-target` | On the scrollspy wrapper: a CSS selector for ADDITIONAL target elements when sections aren't headings (default `h2[id], h3[id]`, e.g. `section[id]`). Only anchors whose `href="#id"` resolves to an element inside the observed region participate; the active link is still whichever anchored target is in view. |
 | `data-fui-optimistic-idle` / `data-fui-optimistic-success` / `data-fui-optimistic-endpoint` / `data-fui-optimistic-method` | On an OptimisticAction button: the runtime flips the visible label between the idle and success copy as it dispatches a fetch to the endpoint+method, rolling back on error. Used by `framework/ui.OptimisticAction` for "Save / Saved!" patterns without per-button JS. |
 | `data-fui-toggle-endpoint` / `data-fui-toggle-method` / `data-fui-toggle-allow-untoggle` / `data-fui-toggle-untoggle-endpoint` | On a three-state ToggleAction button (`framework/ui.ToggleAction`, `framework/ui/toggleaction.go`): `endpoint`+`method` (default POST) hit when toggling from idle → committed; `allow-untoggle="true"` lets a second click reverse the action, hitting `untoggle-endpoint` (same method) if set; with NO untoggle endpoint configured the button flips back to idle locally without issuing any request. Driven by `runtime/src/toggleaction.js` with a three-state mutex so rapid clicks can't race. |
 | `data-fui-toggle-idle` / `data-fui-toggle-committed` | Markers on the two label spans inside a ToggleAction button. The runtime shows/hides them as the button transitions between idle and committed states. SSR ships the initial visible state. |
@@ -298,6 +299,21 @@ whose request carried it, and an evicted entry costs nothing until that
 tab actually navigates; surfaces that must stay fresh across tabs
 belong on the polling rung (`data-fui-poll`), not on cache eviction.
 Iframe embeds have no screen cache, so the header is a no-op there.
+
+**Active-link highlighting.** After every navigation (and at module
+load) the idle-loaded `activelink` module walks every `nav a` with an
+`href` and tags the one matching the current path with
+`aria-current="page"` and the `active` class — the value is `page`, the
+ARIA-correct value for a page link, NOT `true`, so
+`[aria-current="true"]` selectors do not match it. Every other `nav a`
+with an href that does not match loses both. Left completely untouched
+(neither set nor cleared): href-less links (server-managed), links
+inside a `[data-fui-scrollspy]` wrapper (the scrollspy module owns
+their `aria-current="true"`), and links carrying
+`data-fui-activelink-skip` (the opt-out for a current-state owned by
+app code or a hand-set attribute). `data-fui-match-prefix` opts a link
+into segment-prefix matching: `/docs` lights up on `/docs` and
+`/docs/getting-started`, never on `/docs-old`.
 
 **The flow for an in-page update** (e.g. clicking "page 2" on a pagination island):
 

--- a/framework/docs/content/runtime-contract.md
+++ b/framework/docs/content/runtime-contract.md
@@ -300,6 +300,27 @@ tab actually navigates; surfaces that must stay fresh across tabs
 belong on the polling rung (`data-fui-poll`), not on cache eviction.
 Iframe embeds have no screen cache, so the header is a no-op there.
 
+**Cancelling a navigation (`gofastr:beforenavigate`).** The router
+dispatches this cancellable event on the anchor element (`bubbles`,
+`cancelable`, so a `document`-level listener sees it and `target` is the
+link) immediately before committing an intercepted click — after every
+fall-through check, so it fires only for clicks the router would
+actually handle. `detail` carries `href` (the raw attribute value),
+`path` (the resolved path+search the router would navigate to), `hash`
+(the `#fragment`, `''` when there is none), and `anchor` (the element).
+A listener calling `preventDefault()` on it claims the click: the
+router still suppresses the browser default (a cancelled click never
+becomes a hard page load) and then does nothing — no `pushState`, no
+partial fetch, no intercept overlay. This is the supported way for
+userland to take over a link (e.g. smooth-scroll to an in-page section)
+instead of racing the router with a capture-phase click listener. The
+event does NOT fire for clicks the router ignores: modifier-key clicks,
+external / `mailto:` / `tel:` links, `<a download>`, non-`_self`
+targets, unknown routes, `data-fui-rpc` anchors, and links to the
+current path — including a link whose only difference from the current
+URL is the `#fragment`; that click falls through to native hash
+behavior.
+
 **Active-link highlighting.** After every navigation (and at module
 load) the idle-loaded `activelink` module walks every `nav a` with an
 `href` and tags the one matching the current path with

--- a/framework/docs/content/runtime-contract.md
+++ b/framework/docs/content/runtime-contract.md
@@ -301,7 +301,7 @@ belong on the polling rung (`data-fui-poll`), not on cache eviction.
 Iframe embeds have no screen cache, so the header is a no-op there.
 
 **Cancelling a navigation (`gofastr:beforenavigate`).** The router
-dispatches this cancellable event on the anchor element (`bubbles`,
+dispatches this cancelable event on the anchor element (`bubbles`,
 `cancelable`, so a `document`-level listener sees it and `target` is the
 link) immediately before committing an intercepted click — after every
 fall-through check, so it fires only for clicks the router would

--- a/framework/docs/content/theming.md
+++ b/framework/docs/content/theming.md
@@ -190,6 +190,20 @@ hasn't forced light mode. The **`data-color-scheme` attribute on
 bootstrap set it (and remember the choice), and any element reading a
 theme CSS variable picks up the new color the moment it flips.
 
+Which map is read when: `Colors` paints the light scheme, and
+`DarkColors` re-declares the same custom properties under a dark
+preference. Under a dark preference, editing `Colors` alone changes
+nothing on screen; the dark value wins wherever one exists.
+
+A partial `DarkColors` is not an error: tokens you leave out keep
+their light values in dark mode, which is usually a contrast bug. The
+UI host warns once at boot listing exactly which tokens those are
+(`style.DarkPaletteGaps` computes the list), so the omission is
+visible instead of silent.
+
+The framework theme (`framework/ui/theme.Default()`) ships a complete
+dark palette; `style.DefaultTheme()` is light-only by design.
+
 Follow these rules:
 
 1. **Never gate your own light/dark styling on

--- a/framework/ui/theme/theme.go
+++ b/framework/ui/theme/theme.go
@@ -80,19 +80,27 @@ func baseTheme() style.Theme {
 		"background":    "#111113",
 		"border":        "#3F3F46",
 		"border-strong": "#71717A",
-		"danger":        "#F87171",
-		"info":          "#60A5FA",
-		"primary":       "#A5B4FC",
-		"primary-fg":    "#111827",
-		"secondary":     "#D4D4D8",
-		"secondary-fg":  "#18181B",
-		"success":       "#4ADE80",
-		"surface":       "#18181B",
-		"surface-soft":  "#27272A",
-		"text":          "#FAFAFA",
-		"text-muted":    "#D4D4D8",
-		"text-subtle":   "#A1A1AA",
-		"warning":       "#FBBF24",
+		// Code-surface tokens: the dark values match the light ones on
+		// purpose — the code surface is already dark in both schemes
+		// (see style.ColorSet.CodeSurface), so dark mode reuses the
+		// inkwell. Declared explicitly so the dark-gap boot check sees
+		// the theme as complete rather than warning about an omission.
+		"code-border":  "#27272A",
+		"code-surface": "#18181B",
+		"code-text":    "#E4E4E7",
+		"danger":       "#F87171",
+		"info":         "#60A5FA",
+		"primary":      "#A5B4FC",
+		"primary-fg":   "#111827",
+		"secondary":    "#D4D4D8",
+		"secondary-fg": "#18181B",
+		"success":      "#4ADE80",
+		"surface":      "#18181B",
+		"surface-soft": "#27272A",
+		"text":         "#FAFAFA",
+		"text-muted":   "#D4D4D8",
+		"text-subtle":  "#A1A1AA",
+		"warning":      "#FBBF24",
 	}
 	return t
 }

--- a/framework/ui/theme/theme_test.go
+++ b/framework/ui/theme/theme_test.go
@@ -3,6 +3,8 @@ package theme
 import (
 	"strings"
 	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/style"
 )
 
 func TestDefaultHasCanonicalTokens(t *testing.T) {
@@ -100,5 +102,14 @@ func TestDefaultShipsAdaptiveDarkPalette(t *testing.T) {
 		if !strings.Contains(css, want) {
 			t.Errorf("adaptive theme CSS missing %q\n%s", want, css)
 		}
+	}
+}
+
+// The framework default must stay silent under the host's dark-gap boot
+// check (#215): every color token needs a dark value, including the
+// code-surface trio that deliberately reuses its light values.
+func TestDefaultDarkPaletteComplete(t *testing.T) {
+	if gaps := style.DarkPaletteGaps(Default()); len(gaps) != 0 {
+		t.Errorf("Default() dark palette gaps: %v", gaps)
 	}
 }

--- a/framework/uihost/static_cache_test.go
+++ b/framework/uihost/static_cache_test.go
@@ -1,0 +1,101 @@
+package uihost
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/app"
+)
+
+// newStaticDirHost serves one project static file (nav.js) out of a temp
+// static dir on the same shape a generated project uses.
+func newStaticDirHost(t *testing.T) *httptest.Server {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "nav.js"), []byte("console.log('nav v2')"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	a := app.NewApp("static-cache-test")
+	a.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+	server := httptest.NewServer(New(a, WithStaticDir(dir)))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// getStatic fetches url and returns the response with a drained body.
+func getStatic(t *testing.T, url string) *http.Response {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	return resp
+}
+
+// --- #219: project static assets must not be heuristically cached in dev ---
+
+func TestDevServesStaticWithNoStore(t *testing.T) {
+	server := newStaticDirHost(t)
+	// Pin both vars so the outcome doesn't depend on the outer env.
+	t.Setenv("GOFASTR_DEV", "1")
+	t.Setenv("GOFASTR_ENV", "")
+
+	resp := getStatic(t, server.URL+"/nav.js")
+	if cc := resp.Header.Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("dev static response Cache-Control = %q, want no-store", cc)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "console.log('nav v2')" {
+		t.Errorf("dev static body = %q, want the file bytes", body)
+	}
+}
+
+func TestDevServesStaticFSWithNoStore(t *testing.T) {
+	fsys := fstest.MapFS{"app.css": &fstest.MapFile{Data: []byte("body{margin:0}")}}
+	a := app.NewApp("static-cache-fs-test")
+	a.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+	ds := New(a)
+	ds.SetStaticFS(fsys)
+	server := httptest.NewServer(ds)
+	t.Cleanup(server.Close)
+
+	t.Setenv("GOFASTR_DEV", "1")
+	t.Setenv("GOFASTR_ENV", "")
+
+	resp := getStatic(t, server.URL+"/app.css")
+	if cc := resp.Header.Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("dev static-FS response Cache-Control = %q, want no-store", cc)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "body{margin:0}" {
+		t.Errorf("dev static-FS body = %q, want the file bytes", body)
+	}
+}
+
+func TestProdStaticSetsNoCacheControl(t *testing.T) {
+	server := newStaticDirHost(t)
+
+	// dev.Enabled() is evaluated per request, so one host can serve both
+	// non-dev configurations.
+	t.Run("dev flag off", func(t *testing.T) {
+		t.Setenv("GOFASTR_DEV", "0")
+		resp := getStatic(t, server.URL+"/nav.js")
+		if cc := resp.Header.Get("Cache-Control"); cc != "" {
+			t.Errorf("non-dev static response Cache-Control = %q, want empty", cc)
+		}
+	})
+	t.Run("production env wins", func(t *testing.T) {
+		t.Setenv("GOFASTR_ENV", "production")
+		t.Setenv("GOFASTR_DEV", "1")
+		resp := getStatic(t, server.URL+"/nav.js")
+		if cc := resp.Header.Get("Cache-Control"); cc != "" {
+			t.Errorf("production static response Cache-Control = %q, want empty", cc)
+		}
+	})
+}

--- a/framework/uihost/theme_darkgap_test.go
+++ b/framework/uihost/theme_darkgap_test.go
@@ -1,0 +1,107 @@
+package uihost
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/framework/ui/theme"
+)
+
+// recordingHandler collects every record routed to the default logger so
+// tests can assert on boot-time warnings.
+type recordingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+
+func (h *recordingHandler) WithGroup(_ string) slog.Handler { return h }
+
+func (h *recordingHandler) warns() []slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var out []slog.Record
+	for _, r := range h.records {
+		if r.Level == slog.LevelWarn {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// installRecordingLogger swaps slog's default for a recorder and restores
+// the original on cleanup.
+func installRecordingLogger(t *testing.T) *recordingHandler {
+	t.Helper()
+	h := &recordingHandler{}
+	old := slog.Default()
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() { slog.SetDefault(old) })
+	return h
+}
+
+// --- #215: partial DarkColors warns once at boot ---
+
+func TestBootWarnsOnPartialDarkPalette(t *testing.T) {
+	h := installRecordingLogger(t)
+
+	th := theme.Default()
+	delete(th.DarkColors, "surface-soft")
+	delete(th.DarkColors, "code-border")
+
+	a := app.NewApp("dark-gap-test")
+	a.WithTheme(th)
+	a.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+	New(a)
+
+	warns := h.warns()
+	if len(warns) != 1 {
+		t.Fatalf("got %d warnings, want exactly 1 (records: %v)", len(warns), h.records)
+	}
+	msg := warns[0].Message
+	if !strings.Contains(msg, "no dark value") || !strings.Contains(msg, "Theme.DarkColors") {
+		t.Errorf("warning message = %q, want it to name the gap and the fix", msg)
+	}
+	var tokens []string
+	warns[0].Attrs(func(a slog.Attr) bool {
+		if a.Key == "tokens" {
+			if v, ok := a.Value.Any().([]string); ok {
+				tokens = v
+			}
+		}
+		return true
+	})
+	for _, want := range []string{"surface-soft", "code-border"} {
+		if !slices.Contains(tokens, want) {
+			t.Errorf("warning tokens %v omit %q", tokens, want)
+		}
+	}
+}
+
+func TestBootNoWarnOnCompleteDarkPalette(t *testing.T) {
+	h := installRecordingLogger(t)
+
+	a := app.NewApp("dark-complete-test")
+	a.WithTheme(theme.Default())
+	a.RegisterScreen(app.NewScreen("/", &testHomeComp{}).WithTitle("Home"), nil)
+	New(a)
+
+	if warns := h.warns(); len(warns) != 0 {
+		t.Fatalf("complete dark palette warned at boot: %v", warns)
+	}
+}

--- a/framework/uihost/uihost.go
+++ b/framework/uihost/uihost.go
@@ -2786,6 +2786,19 @@ func (ds *UIHost) serveMethodNotAllowedPage(w http.ResponseWriter, r *http.Reque
 	fmt.Fprint(w, page)
 }
 
+// devStaticNoStore marks a project static response uncacheable while the
+// process runs under `gofastr dev` (#219). Project assets serve at
+// unversioned URLs (/nav.js, /app.css) with Last-Modified but no explicit
+// freshness, so browsers apply heuristic caching and keep executing the OLD
+// script after an edit even though a fresh fetch returns the new bytes.
+// Only a dev restart cleared it. no-store closes that loop; production is
+// untouched: when dev.Enabled() is false no header is set at all.
+func devStaticNoStore(w http.ResponseWriter) {
+	if dev.Enabled() {
+		w.Header().Set("Cache-Control", "no-store")
+	}
+}
+
 // serveOrRender is the catch-all NotFound handler. It first tries static
 // file resolution (filesystem or embedded FS), and if no file matches it
 // falls through to page rendering. Resolution steps are mirrored by
@@ -2820,6 +2833,7 @@ func (ds *UIHost) serveOrRender(w http.ResponseWriter, r *http.Request) {
 			absStatic, _ := filepath.Abs(ds.staticDir)
 			if strings.HasPrefix(absPath, absStatic+string(filepath.Separator)) || absPath == absStatic {
 				if info, err := os.Stat(filePath); err == nil && !info.IsDir() {
+					devStaticNoStore(w)
 					http.ServeFile(w, r, filePath)
 					return
 				}
@@ -2830,6 +2844,7 @@ func (ds *UIHost) serveOrRender(w http.ResponseWriter, r *http.Request) {
 			if cleanPath != "" {
 				if f, err := ds.staticFS.Open(cleanPath); err == nil {
 					f.Close()
+					devStaticNoStore(w)
 					http.ServeFileFS(w, r, ds.staticFS, cleanPath)
 					return
 				}

--- a/framework/uihost/uihost.go
+++ b/framework/uihost/uihost.go
@@ -792,6 +792,15 @@ func New(application *app.App, opts ...Option) *UIHost {
 	if dev.LiveReloadEnabled() {
 		ds.extraScripts = append(ds.extraScripts, dev.LiveReloadScriptURL)
 	}
+	// #215: a partial DarkColors silently keeps light values in dark mode
+	// (the map is what renders under a dark preference; editing Colors
+	// alone changes nothing on screen). One warning naming the exact
+	// tokens, so the fix loop doesn't dead-end at "nothing happened".
+	if gaps := style.DarkPaletteGaps(ds.activeTheme()); len(gaps) > 0 {
+		slog.Default().Warn(fmt.Sprintf(
+			"uihost: theme declares a dark palette but %d color tokens have no dark value; under a dark preference they keep their light value. Add them to Theme.DarkColors.",
+			len(gaps)), "tokens", gaps)
+	}
 	return ds
 }
 


### PR DESCRIPTION
Closes #214, #215, #216, #217, #218, #219, #220.

Seven reports from one session of building against v0.67.0. Most of them
cost hours because the failure was silent: an invalid `var()`, an edit to
the palette nobody reads, a cache nobody suspects, a linter naming the
wrong half of the line. One commit each.

## What changed

**#219 — `gofastr dev` served stale project JS/CSS.** Framework assets are
content-versioned; project assets serve at plain URLs with a bare
`Last-Modified`, which invites heuristic caching. The browser kept running
the old script while a fresh fetch returned the new bytes. Under
`gofastr dev` they now go out `no-store`, from both the static dir and the
embedded FS. Production is untouched.

**#215 — editing `Colors` did nothing when `DarkColors` is what renders.**
`style.DarkPaletteGaps` returns the tokens a non-empty `DarkColors` omits
and the host logs them once at boot. The framework theme now declares dark
values for the three code-surface tokens it had been leaving out on
purpose, so the default stays silent and the intent is written down rather
than implied by an omission.

**#216 — `app.Layout`'s `<header>` wrapper stopped a sticky header.** A
sticky element only travels inside its parent's box, and that parent was
65px tall. `WithStickyHeader()` makes the wrapper the sticky element, on
the theme's `--z-sticky` layer with a background so content does not scroll
through it. The banner landmark stays.

**#217 — the router `preventDefault`ed before userland saw the click.**
New cancellable `gofastr:beforenavigate`, fired on the anchor after every
fall-through check. Cancelling it means the router stands down completely
while still suppressing the browser default, so a claimed click never
becomes a hard page load.

**#218 — `activelink` cleared an `aria-current` another module owned.**
Links inside a `[data-fui-scrollspy]` wrapper are now left alone, and
`data-fui-activelink-skip` is the general opt-out. Both attribute tables
now state what the module writes, what value it uses, and what it removes.

**#220 — GOFASTR1801 read `fill := "var(--color-surface)"` as CSS.** The
`:` of `:=` satisfied the property colon. Matches containing `:=` are
rejected, and the message names the fragment that matched.

**#214 — a misspelled theme token was inert and nothing said so.** New
`GOFASTR1806`. `contracts.Pass` discovers `.css` files and serves them
through `StyleFiles()`; the Go accessors stay Go-only. The rule reports a
`var(--name)` the theme does not emit and suggests the nearest token.

## Three things worth a reviewer's attention

**#215 is deliberately a partial fix.** The reporter's exact case, editing
the light value and forgetting the dark one, is not detectable at runtime:
nothing records what a token used to be, so there is no baseline. What
ships is the detectable half (an incomplete dark palette) plus docs. I did
not merge the two palettes into one `Palette{Light, Dark}` type, which is
what would actually close the class; that is a breaking redesign and wants
its own decision.

**#220 turned out to be a false positive, not a wording problem.** The
issue asked for a clearer message on the assumption the rule was right.
It was not: the line is Go, and reporting it was a bug. Both halves are
fixed, and I would rather the issue be closed on the larger finding.

**#214 needed a suppression fix to be usable.** `collectSuppressions`
walked Go files only, so the one rule that fires on stylesheets had no
escape hatch in the file it fires in, and the non-Go comment scanner did
not recognise `/*`. Both fixed, with tests.

Two smaller judgement calls: `data-fui-scrollspy-target`'s rows in both
attribute tables were wrong (it is a selector on the wrapper, not a marker
on a link) and are corrected here; and a dead `anchor.target !== ''` clause
came out of the nav click handler to keep the level-1 runtime budget under
its cap rather than raising the cap.

## Verification

- Every guard proven by mutation, not by argument: inverted the dev
  predicate and watched the production tests fail; deleted the `:=`
  rejection, the `TokenNames` membership check, the fallback check, the
  beforenavigate bail-out, the activelink skip, the sticky modifier, and
  the CSS suppression fix, and watched exactly the intended tests fail
  each time.
- `./scripts/test-all.sh` green with `TEST_POSTGRES_DSN` set, including
  coverage floors and `gofastr verify --no-vet --strict`.
- The `core-ui/runtime` chromedp suite run isolated: 218s, green.
- #216 checked in a browser, not only in assertions: after scrolling
  1200px the header's `getBoundingClientRect().top` is 0 with the modifier
  and -1200 without, and the background occludes the content beneath it.
- Every commit builds, vets, and passes its gates on its own, checked in a
  detached worktree, because several were staged by hunk and the pre-commit
  hook only ever sees the full worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX4wtfjUH8A8yarHTYLzSc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional sticky layout headers with themed positioning, layering, and backgrounds.
  - Added CSS theme-token validation with typo suggestions and stylesheet scanning.
  - Added dark-palette gap detection and startup warnings for incomplete palettes.
  - Added cancellable pre-navigation events, active-link opt-outs, and improved scrollspy support.

- **Bug Fixes**
  - Prevented development assets from being cached.
  - Reduced false-positive CSS findings.
  - Improved case-insensitive CSS keyword matching while preserving custom-property name sensitivity.
  - Improved handling of unsupported and SVG link targets.
  - Prevented scrollspy and active-link state interference.

- **Documentation**
  - Expanded guidance for layouts, navigation, theming, live reload, CSS scanning, and the 51-rule catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->