### PR TITLE
Pin and document the default entity exposure surface

### DIFF
--- a/framework/docs/content/entity-declarations.md
+++ b/framework/docs/content/entity-declarations.md
@@ -90,16 +90,24 @@ To publish nothing at all, say so:
 noCRUD := false
 app.Entity("posts", framework.EntityConfig{
     Fields:   []schema.Field{ /* … */ },
-    Exposure: &framework.ExposureConfig{CRUD: &noCRUD}, // no routes, no MCP tools
+    Exposure: &framework.ExposureConfig{CRUD: &noCRUD}, // no generated routes or tools
 })
 ```
 
 The entity is still registered, migrated, and usable from Go
-(`app.CrudHandler("posts")` builds a handler from the registry whether or not
-routes were mounted, and hooks and typed queries work as usual); it just has
-no HTTP or MCP surface. Setting `MCP: true` alongside `CRUD: false` is a
-registration error, not a silent mismatch: MCP tools dispatch through the
-routes.
+(`app.CrudHandler("posts")` builds a handler from the registry whether routes
+were mounted or not, and hooks and typed queries work as usual). Setting
+`MCP: true` alongside `CRUD: false` is a registration error, not a silent
+mismatch: MCP CRUD tools dispatch through the routes.
+
+`CRUD: false` turns off the **generated** surface, and only that. Anything in
+the entity's `Endpoints` list is registered either way, so an entity with
+`CRUD: false` and a declared endpoint still answers HTTP on that endpoint's
+path, and an `Endpoint` with `MCP: true` still registers its tool regardless
+of `Exposure.MCP`. To end up with no surface at all, the entity needs
+`CRUD: false` **and** no endpoints; if it keeps endpoints, they carry their
+own access rules (an `Endpoint`'s HTTP handler inherits the route's
+middleware chain, its MCP twin does not — see `Endpoint.MCPGate`).
 
 Default-on routes are not default-open routes. Every one of them refuses an
 anonymous caller with 401 unless the entity declares `OwnerField`, `Access`,

--- a/framework/docs/content/entity-declarations.md
+++ b/framework/docs/content/entity-declarations.md
@@ -69,7 +69,7 @@ app.Entity("posts", framework.EntityConfig{
 })
 ```
 
-### What registering an entity publishes
+## What registering an entity publishes
 
 That declaration has no `Exposure` block, and it still mounts the whole REST
 surface: `GET /posts`, `GET /posts/{id}`, `POST /posts`, `PUT` and `PATCH` on

--- a/framework/docs/content/entity-declarations.md
+++ b/framework/docs/content/entity-declarations.md
@@ -69,6 +69,45 @@ app.Entity("posts", framework.EntityConfig{
 })
 ```
 
+### What registering an entity publishes
+
+That declaration has no `Exposure` block, and it still mounts the whole REST
+surface: `GET /posts`, `GET /posts/{id}`, `POST /posts`, `PUT` and `PATCH` on
+`/posts/{id}`, `DELETE /posts/{id}`, the batch endpoints on `/posts/_batch`,
+the `/posts/_events` stream, and `/posts/llm.md`. Route generation is **on by
+default**: `Exposure.CRUD` is a `*bool`, and nil means generate. Omitting the
+block is not "declare no surface"; it is "take the default surface".
+
+MCP tools are the opposite. They are **off by default** and need
+`Exposure: &framework.ExposureConfig{MCP: true}`. The one exception is the dev
+loop: under `gofastr dev`, every CRUD-enabled entity also serves its data
+tools so a local agent can read and write app data without a per-entity
+opt-in. A production binary registers none of them without the explicit flag.
+
+To publish nothing at all, say so:
+
+```go
+noCRUD := false
+app.Entity("posts", framework.EntityConfig{
+    Fields:   []schema.Field{ /* … */ },
+    Exposure: &framework.ExposureConfig{CRUD: &noCRUD}, // no routes, no MCP tools
+})
+```
+
+The entity is still registered, migrated, and usable from Go
+(`app.CrudHandler("posts")` builds a handler from the registry whether or not
+routes were mounted, and hooks and typed queries work as usual); it just has
+no HTTP or MCP surface. Setting `MCP: true` alongside `CRUD: false` is a
+registration error, not a silent mismatch: MCP tools dispatch through the
+routes.
+
+Default-on routes are not default-open routes. Every one of them refuses an
+anonymous caller with 401 unless the entity declares `OwnerField`, `Access`,
+or `Public`. See **Default CRUD authentication** below, and note the limit
+called out in the banner at the top of this page: a session requirement is
+not row scoping. Without `OwnerField`, every authenticated user reads and can
+overwrite every other user's rows.
+
 The same entity shape can also be **declared in a `gofastr.yml` blueprint**
 and emitted as Go by the CLI; see [Blueprints](blueprints.md), the single
 declaration format the `gofastr generate` codegen pipeline reads. The

--- a/framework/exposure_default_test.go
+++ b/framework/exposure_default_test.go
@@ -179,15 +179,20 @@ func TestExplicitCRUDFalseMountsNothing(t *testing.T) {
 			Fields:   []schema.Field{{Name: "title", Type: schema.String, Required: true}},
 			Exposure: &entity.ExposureConfig{CRUD: &off},
 		})
-		for _, c := range []struct{ method, path string }{
-			{http.MethodGet, "/posts"},
-			{http.MethodPost, "/posts"},
-			{http.MethodDelete, "/posts/p1"},
-		} {
+		// Same enumeration as the positive case, so the control cannot
+		// check a narrower set than the default it is controlling for.
+		// 404 (not 405) is right here: with nothing mounted the path
+		// itself does not exist.
+		for _, pattern := range crud.CrudRoutePatterns("/posts") {
+			method, path, ok := strings.Cut(pattern, " ")
+			if !ok {
+				t.Fatalf("unparseable route pattern %q", pattern)
+			}
+			path = strings.ReplaceAll(path, "{id}", "p1")
 			rec := httptest.NewRecorder()
-			app.Router().ServeHTTP(rec, httptest.NewRequest(c.method, c.path, strings.NewReader(`{"title":"x"}`)))
+			app.Router().ServeHTTP(rec, httptest.NewRequest(method, path, strings.NewReader(`{"title":"x"}`)))
 			if rec.Code != http.StatusNotFound {
-				t.Errorf("SECURITY: [exposure] CRUD:false still answers %s %s with %d", c.method, c.path, rec.Code)
+				t.Errorf("SECURITY: [exposure] CRUD:false still answers %s %s with %d", method, path, rec.Code)
 			}
 		}
 		for _, tool := range app.MCP.ListTools() {

--- a/framework/exposure_default_test.go
+++ b/framework/exposure_default_test.go
@@ -1,0 +1,194 @@
+package framework
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// bareEntityApp registers "posts" with NO Exposure block at all: the exact
+// shape the report describes as "I declared no surface, so nothing should be
+// published".
+func bareEntityApp(t *testing.T, db *sql.DB) *App {
+	t.Helper()
+	createPostsTable(t, db)
+	app := NewApp(WithDB(db))
+	app.Entity("posts", entity.EntityConfig{Table: "posts", Fields: []schema.Field{
+		{Name: "title", Type: schema.String, Required: true},
+		{Name: "body", Type: schema.Text},
+	}})
+	return app
+}
+
+// Leg 1 of the report: an entity with no Exposure block still gets the full
+// REST CRUD route set. This is the DEFAULT-ON half, and it is real.
+func TestBareEntityMountsCRUDRoutes(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, db *sql.DB, _ Dialect) {
+		app := bareEntityApp(t, db)
+		for _, c := range []struct{ method, path string }{
+			{http.MethodGet, "/posts"},
+			{http.MethodGet, "/posts/some-id"},
+			{http.MethodPost, "/posts"},
+			{http.MethodPatch, "/posts/some-id"},
+			{http.MethodDelete, "/posts/some-id"},
+		} {
+			rec := httptest.NewRecorder()
+			app.Router().ServeHTTP(rec, httptest.NewRequest(c.method, c.path, strings.NewReader(`{"title":"x"}`)))
+			if rec.Code == http.StatusNotFound {
+				t.Errorf("%s %s = 404: no route is mounted, so the default is NOT exposing CRUD", c.method, c.path)
+			}
+		}
+	})
+}
+
+// Leg 2 of the report: those default-on routes are not an open door. Every
+// verb must refuse an anonymous caller with 401 — the secure-by-default
+// session gate in framework/crud (requireAuthenticated).
+func TestBareEntityCRUDRefusesAnonymous(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, db *sql.DB, _ Dialect) {
+		app := bareEntityApp(t, db)
+		if _, err := db.Exec("INSERT INTO posts (id, title, body) VALUES ('p1','seeded','b')"); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		for _, c := range []struct{ method, path, body string }{
+			{http.MethodGet, "/posts", ""},
+			{http.MethodGet, "/posts/p1", ""},
+			{http.MethodPost, "/posts", `{"title":"anon"}`},
+			{http.MethodPatch, "/posts/p1", `{"title":"anon"}`},
+			{http.MethodDelete, "/posts/p1", ""},
+		} {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(c.method, c.path, strings.NewReader(c.body))
+			req.Header.Set("Content-Type", "application/json")
+			app.Router().ServeHTTP(rec, req)
+			if rec.Code != http.StatusUnauthorized {
+				t.Errorf("SECURITY: [authz] anonymous %s %s = %d, want 401\nbody: %s",
+					c.method, c.path, rec.Code, rec.Body.String())
+			}
+		}
+		// The refusal has to be a refusal, not a 401 after the write landed.
+		var n int
+		if err := db.QueryRow("SELECT COUNT(*) FROM posts").Scan(&n); err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		if n != 1 {
+			t.Errorf("SECURITY: [authz] anonymous writes mutated the table: %d rows, want the 1 seeded", n)
+		}
+	})
+}
+
+// Leg 3 of the report: MCP tools. The claim is that a bare entity also gets
+// MCP tools. Outside the dev loop it does not — Exposure.MCP is the only path.
+func TestBareEntityRegistersNoMCPTools(t *testing.T) {
+	t.Setenv("GOFASTR_DEV", "0")
+	t.Setenv("GOFASTR_ENV", "")
+	forEachDialect(t, func(t *testing.T, db *sql.DB, _ Dialect) {
+		app := bareEntityApp(t, db)
+		for _, tool := range app.MCP.ListTools() {
+			if strings.HasPrefix(tool.Name, "posts_") {
+				t.Errorf("SECURITY: [exposure] bare entity registered MCP tool %q with no Exposure.MCP", tool.Name)
+			}
+		}
+	})
+}
+
+// ...and the other side of that same guard: inside the dev loop every
+// CRUD-enabled entity DOES get its data tools with no per-entity opt-in.
+// That is deliberate (app.go: "Production keeps the explicit flag as the
+// only path"), and it is what an observer running `gofastr dev` sees.
+func TestDevModeAddsMCPToolsToBareEntity(t *testing.T) {
+	t.Setenv("GOFASTR_DEV", "1")
+	t.Setenv("GOFASTR_ENV", "")
+	t.Setenv("GOFASTR_DEV_MCP", "")
+	forEachDialect(t, func(t *testing.T, db *sql.DB, _ Dialect) {
+		app := bareEntityApp(t, db)
+		var got []string
+		for _, tool := range app.MCP.ListTools() {
+			if strings.HasPrefix(tool.Name, "posts_") {
+				got = append(got, tool.Name)
+			}
+		}
+		if len(got) == 0 {
+			t.Fatal("dev mode registered no entity MCP tools; the dev-implied path is gone")
+		}
+	})
+}
+
+// The dev-implied tools inherit the REST gate: an anonymous tools/call is
+// refused. Without this, dev auto-registration would be a second, unguarded
+// auth path onto the same data.
+func TestDevMCPToolRefusesAnonymousCall(t *testing.T) {
+	t.Setenv("GOFASTR_DEV", "1")
+	t.Setenv("GOFASTR_ENV", "")
+	t.Setenv("GOFASTR_DEV_MCP", "")
+	forEachDialect(t, func(t *testing.T, db *sql.DB, _ Dialect) {
+		app := bareEntityApp(t, db)
+		if _, err := db.Exec("INSERT INTO posts (id, title, body) VALUES ('p1','seeded','b')"); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		ctx := context.Background() // no user: anonymous
+		for _, call := range []struct {
+			tool   string
+			params map[string]any
+		}{
+			{"posts_list", map[string]any{"limit": 10}},
+			{"posts_get", map[string]any{"id": "p1"}},
+			{"posts_create", map[string]any{"title": "anon"}},
+			{"posts_update", map[string]any{"id": "p1", "title": "anon"}},
+			{"posts_delete", map[string]any{"id": "p1"}},
+		} {
+			out, err := app.MCP.CallTool(ctx, call.tool, call.params)
+			if err == nil {
+				t.Errorf("SECURITY: [authz] anonymous MCP %s was not refused, returned %#v", call.tool, out)
+				continue
+			}
+			if !strings.Contains(err.Error(), "401") && !strings.Contains(err.Error(), "authentication required") {
+				t.Errorf("anonymous MCP %s error = %v, want a 401/authentication-required refusal", call.tool, err)
+			}
+		}
+		var n int
+		if err := db.QueryRow("SELECT COUNT(*) FROM posts").Scan(&n); err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		if n != 1 {
+			t.Errorf("SECURITY: [authz] anonymous MCP writes mutated the table: %d rows, want the 1 seeded", n)
+		}
+	})
+}
+
+// The opt-out that the report's author expected to be the default. This is
+// the control for TestBareEntityMountsCRUDRoutes: it shows the 404 check
+// there has teeth, and that CRUD:false really does mount nothing.
+func TestExplicitCRUDFalseMountsNothing(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, db *sql.DB, _ Dialect) {
+		createPostsTable(t, db)
+		off := false
+		app := NewApp(WithDB(db))
+		app.Entity("posts", entity.EntityConfig{Table: "posts",
+			Fields:   []schema.Field{{Name: "title", Type: schema.String, Required: true}},
+			Exposure: &entity.ExposureConfig{CRUD: &off},
+		})
+		for _, c := range []struct{ method, path string }{
+			{http.MethodGet, "/posts"},
+			{http.MethodPost, "/posts"},
+			{http.MethodDelete, "/posts/p1"},
+		} {
+			rec := httptest.NewRecorder()
+			app.Router().ServeHTTP(rec, httptest.NewRequest(c.method, c.path, strings.NewReader(`{"title":"x"}`)))
+			if rec.Code != http.StatusNotFound {
+				t.Errorf("SECURITY: [exposure] CRUD:false still answers %s %s with %d", c.method, c.path, rec.Code)
+			}
+		}
+		for _, tool := range app.MCP.ListTools() {
+			if strings.HasPrefix(tool.Name, "posts_") {
+				t.Errorf("SECURITY: [exposure] CRUD:false entity still registered MCP tool %q", tool.Name)
+			}
+		}
+	})
+}

--- a/framework/exposure_default_test.go
+++ b/framework/exposure_default_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/crud"
 	"github.com/DonaldMurillo/gofastr/framework/entity"
 )
 
@@ -31,17 +32,21 @@ func bareEntityApp(t *testing.T, db *sql.DB) *App {
 func TestBareEntityMountsCRUDRoutes(t *testing.T) {
 	forEachDialect(t, func(t *testing.T, db *sql.DB, _ Dialect) {
 		app := bareEntityApp(t, db)
-		for _, c := range []struct{ method, path string }{
-			{http.MethodGet, "/posts"},
-			{http.MethodGet, "/posts/some-id"},
-			{http.MethodPost, "/posts"},
-			{http.MethodPatch, "/posts/some-id"},
-			{http.MethodDelete, "/posts/some-id"},
-		} {
+		// Drive the table from the framework's own enumeration of what
+		// RegisterCrudRoutes mounts, so this test cannot drift from the
+		// route set (or from the docs that list it). Reject 405 as well
+		// as 404: with one method dropped, the PATH still resolves and a
+		// bare not-404 check would pass while the verb is gone.
+		for _, pattern := range crud.CrudRoutePatterns("/posts") {
+			method, path, ok := strings.Cut(pattern, " ")
+			if !ok {
+				t.Fatalf("unparseable route pattern %q", pattern)
+			}
+			path = strings.ReplaceAll(path, "{id}", "some-id")
 			rec := httptest.NewRecorder()
-			app.Router().ServeHTTP(rec, httptest.NewRequest(c.method, c.path, strings.NewReader(`{"title":"x"}`)))
-			if rec.Code == http.StatusNotFound {
-				t.Errorf("%s %s = 404: no route is mounted, so the default is NOT exposing CRUD", c.method, c.path)
+			app.Router().ServeHTTP(rec, httptest.NewRequest(method, path, strings.NewReader(`{"title":"x"}`)))
+			if rec.Code == http.StatusNotFound || rec.Code == http.StatusMethodNotAllowed {
+				t.Errorf("%s %s = %d: not mounted, so the default is NOT exposing it", method, path, rec.Code)
 			}
 		}
 	})
@@ -189,6 +194,54 @@ func TestExplicitCRUDFalseMountsNothing(t *testing.T) {
 			if strings.HasPrefix(tool.Name, "posts_") {
 				t.Errorf("SECURITY: [exposure] CRUD:false entity still registered MCP tool %q", tool.Name)
 			}
+		}
+	})
+}
+
+// CRUD:false turns off the GENERATED surface. It does not touch
+// Endpoints: those register unconditionally (framework/app.go, and the
+// GroupEntity mirror), so an entity can have CRUD:false and still answer
+// HTTP. Documenting CRUD:false as "no HTTP surface" without that caveat
+// would be wrong, so pin the caveat.
+func TestCRUDFalseStillServesEndpoints(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, db *sql.DB, _ Dialect) {
+		createPostsTable(t, db)
+		off := false
+		app := NewApp(WithDB(db))
+		app.Entity("posts", entity.EntityConfig{Table: "posts",
+			Fields:   []schema.Field{{Name: "title", Type: schema.String, Required: true}},
+			Exposure: &entity.ExposureConfig{CRUD: &off},
+			Endpoints: []entity.Endpoint{{
+				Method: http.MethodGet, Path: "stats", Name: "posts_stats", // relative: mounts under the entity
+				MCP: true,
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"ok":true}`))
+				}),
+				MCPHandler: func(context.Context, map[string]any) (any, error) {
+					return map[string]any{"ok": true}, nil
+				},
+			}},
+		})
+		// The generated routes are gone...
+		rec := httptest.NewRecorder()
+		app.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/posts", nil))
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("generated list route = %d, want 404 under CRUD:false", rec.Code)
+		}
+		// ...but the declared endpoint still answers.
+		rec = httptest.NewRecorder()
+		app.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/posts/stats", nil))
+		if rec.Code == http.StatusNotFound {
+			t.Fatal("custom endpoint 404s under CRUD:false; the docs' caveat about Endpoints would be unnecessary")
+		}
+		if rec.Code != http.StatusOK {
+			t.Errorf("custom endpoint = %d, want 200", rec.Code)
+		}
+		// Same for the endpoint's MCP twin: it does not consult
+		// Exposure.MCP, which is unset here.
+		if !app.MCP.HasTool("posts_stats") {
+			t.Error("endpoint MCP twin was not registered; the docs' Exposure.MCP caveat would be unnecessary")
 		}
 	})
 }


### PR DESCRIPTION
## What prompted this

A report came in claiming that an entity registered without an `Exposure`
block gets both REST CRUD routes and MCP tools published, and calling the
default insecure. It was filed as an advisory.

I checked it. Half of it is right, and neither half was pinned by a test.

**Routes: yes, by default.** `Exposure.CRUD` is a `*bool` and nil means
generate (`framework/entity/entity.go:130`, gate at `framework/app.go:1747`).
Documented, but only at line 548 of `entity-declarations.md`, inside a
paragraph about blueprint PII linting.

**MCP tools: no.** `framework/app.go:1764` registers them only for
`Exposure.MCP` or under `dev.DevMCPEnabled()`. A production binary registers
none without the explicit flag. Whoever filed this was on `gofastr dev`.

**Not a hole.** `requireAuthenticated` (`framework/crud/owner.go:388`) 401s
every verb when the entity declares none of `OwnerField` / `Access` /
`Public`, and entity MCP tools re-dispatch through the same router, so they
inherit it.

No code change. The default stays as it is: the gate holds, `CRUD: false` is
a real opt-out, and `framework/contracts/catalog.go:717` already lints the
exposed-CRUD-with-no-auth shape.

## What's here

**Tests** (`framework/exposure_default_test.go`, six over the bare-entity
shape): routes mount by default and `CRUD:false` mounts nothing; all five
verbs 401 anonymously *and leave the table unchanged*, so the refusal isn't a
401 written after the write landed; no MCP tools without `Exposure.MCP`
outside dev; under `GOFASTR_DEV` the tools do appear and 401 anonymously too.

**Docs**: a "What registering an entity publishes" section directly under the
page's own bare `app.Entity` example — the exact shape that got misread. It
names the whole mounted surface (list, get, create, PUT and PATCH update,
delete, `/_batch`, `/_events`, `llm.md`), states that MCP is the opposite
default, shows `CRUD: false` as the way to publish nothing, and says
default-on is not default-open while pointing at the row-scoping limit the
page's banner already carries.

## Guards proven, not argued

Each guard was made to fail before being kept:

| mutation | result |
| --- | --- |
| CRUD default flipped off | all five routes 404; mount test fails |
| `requireAuthenticated` → `return true` | row data on list, 201 create, 200 update, 204 delete, over REST **and** MCP |
| dev gate dropped from `mcpToolsEnabled` | bare entity registers 5 tools |
| dev-implied path removed | dev registers none |

The second one is what an actual vulnerability here would look like. It does
not reproduce on the real code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX4wtfjUH8A8yarHTYLzSc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented default REST and MCP exposure for registered entities.
  * Clarified development-mode behavior, authentication requirements, and how to disable CRUD exposure.
  * Documented that custom endpoints remain available when generated CRUD exposure is disabled.

* **Tests**
  * Added coverage for default REST CRUD routes and authentication enforcement.
  * Verified production and development MCP behavior, including protection against unauthorized data changes.
  * Verified that disabled CRUD exposure removes generated routes and tools while preserving custom endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->