### PR TITLE
First-party analytics mechanisms: uihost script rail, battery/relay, recipes, e2e

### DIFF
--- a/.claude/skills/gofastr-host/SKILL.md
+++ b/.claude/skills/gofastr-host/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gofastr-host
-description: Auto-loads when working on a *host application* that imports the GoFastr framework (not the framework itself). Encodes the "don't reinvent: reach for the battery first" rule and the import paths an agent needs. Triggers on edits to Go files in repos that import `github.com/DonaldMurillo/gofastr/...`, on `main.go` files calling `framework.NewApp`, and on phrases like "login", "signup", "session", "user table", "log out", "magic link", "forgot password", "reset password", "add admin page", "back office", "audit log", "audit trail", "compliance log", "send email", "transactional email", "welcome email", "send a notification", "notify the user", "background job", "async task", "schedule", "cron", "run every hour", "retry on failure", "upload", "store images", "store files", "S3", "MinIO", "attachments", "avatar", "full-text search", "find records containing", "outbound webhook", "signed callback", "POST to a customer URL", "cache", "memoize", "remember for N seconds", "CSRF", "RBAC", "require admin", "roles", "rate limit", "throttle", "request log", "access log", "panic recovery", "structured logging", "live debug", "per-test isolated DB", "test fixture", "favicon", "app icon", "SEO", "meta tags", "Open Graph", "JSON-LD", "structured data", "sitemap", "robots.txt", "accessibility", "a11y", "WCAG", "aria-label", "upgrade gofastr", "bump the framework version", "migrate to the new version", "live updates", "auto-refresh", "real-time", "websocket", "polling", "multiple replicas", "horizontal scaling".
+description: Auto-loads when working on a *host application* that imports the GoFastr framework (not the framework itself). Encodes the "don't reinvent: reach for the battery first" rule and the import paths an agent needs. Triggers on edits to Go files in repos that import `github.com/DonaldMurillo/gofastr/...`, on `main.go` files calling `framework.NewApp`, and on phrases like "login", "signup", "session", "user table", "log out", "magic link", "forgot password", "reset password", "add admin page", "back office", "audit log", "audit trail", "compliance log", "send email", "transactional email", "welcome email", "send a notification", "notify the user", "background job", "async task", "schedule", "cron", "run every hour", "retry on failure", "upload", "store images", "store files", "S3", "MinIO", "attachments", "avatar", "full-text search", "find records containing", "outbound webhook", "signed callback", "POST to a customer URL", "cache", "memoize", "remember for N seconds", "CSRF", "RBAC", "require admin", "roles", "rate limit", "throttle", "request log", "access log", "panic recovery", "structured logging", "live debug", "per-test isolated DB", "test fixture", "favicon", "app icon", "SEO", "meta tags", "Open Graph", "JSON-LD", "structured data", "sitemap", "robots.txt", "accessibility", "a11y", "WCAG", "aria-label", "upgrade gofastr", "bump the framework version", "migrate to the new version", "live updates", "auto-refresh", "real-time", "websocket", "polling", "multiple replicas", "horizontal scaling", "PostHog", "Statsig", "Plausible", "analytics", "product analytics", "A/B test", "experiment", "feature flag vendor", "ad blocker", "first-party proxy", "reverse proxy a vendor".
 ---
 
 # GoFastr host-app: load this before writing app code
@@ -70,6 +70,7 @@ generated guidance.
 | image upload wanting thumbnails, srcset, blur placeholder | `framework.WithImagePipeline(imagefield.MustNew(...))`: every `schema.Image` upload gets renditions + a BlurHash, written to `<field>_blurhash` / `<field>_variants` / `<field>_placeholder` sibling columns you declare. Render with `image.BlurHashDataURL` + `ui.PipelineImage`. Per-field variation via `WithImagePipelineFor`. Never hand-roll resize/encode in an upload handler |
 | full-text search | `battery/search` |
 | outbound signed webhooks with retry | `battery/webhook` |
+| PostHog, Statsig, Plausible, product analytics, A/B test, experiment behind a vendor, ad blocker eating the vendor script, first-party proxy | `battery/relay` + a host-authored bootstrap: `gofastr docs analytics-recipes` (relay routes, `uihost.ScriptHandler` + `RegisterExternalScript(uihost.ScriptURL(...))`, one pageview per `gofastr:navigate`, `{"id":...}` endpoint over `handler.GetUser`) |
 | cache key/value, memoize, "remember for N seconds" | `battery/cache` |
 | UI components, page layout, forms, tables, theming, dark mode | `framework/ui` (~100 components): `gofastr docs ui-composition-recipes` for page grammar, `gofastr docs ui-new-components` for the catalog, live demos at `/components/<slug>` on the docs site (`examples/site`) |
 | live/auto-refreshing dashboard, counter, status ("websockets"?) | the reactivity ladder (`gofastr docs reactivity`): passive freshness = `data-fui-poll` / widget `Builder.Poll` (no connection, no infra); SSE bus ONLY for presence/collab/sub-second; never WebSockets, never a bespoke `EventSource` |
@@ -88,6 +89,22 @@ generated guidance.
 | upgrading the framework version, migration notes between releases | install the target CLI first, then `gofastr upgrade [--to vX.Y.Z] [--apply]`. It shows every migration-relevant change in range with file:line hits in your app; `gofastr docs upgrading`; finish with `gofastr agents sync` |
 | customer-facing CLI, "ship a terminal client", stripe/gh-style CLI for my API | `gofastr generate cli`: standalone stdlib binary, scoped `gfsk_` token auth, `custom.go` extension seam; `gofastr docs app-cli` |
 | client SDKs, "publish an SDK", downloadable Go/JS/TS client, API docs site for customers | `gofastr generate sdk` (Go module zip + client.js/client.d.ts under `gen/sdk/`) + `sdkdocs.Mount(site, app.Router(), sdkdocs.Config{Registry: app.Registry, Artifacts: os.DirFS("gen/sdk/dist")})` for the hosted docs site + downloads; `gofastr docs sdk` |
+
+## First-party analytics and experiments
+
+When the task is wiring a hosted analytics or experimentation vendor
+(PostHog, Statsig, Plausible), do not link their CDN and do not punch
+`script-src`/`connect-src` holes into the CSP. The shipped pattern:
+`battery/relay` mounts the vendor's SDK and endpoints under one
+same-origin path with fixed upstreams; your own bootstrap JS is served
+via `uihost.ScriptHandler` and registered with
+`RegisterExternalScript(uihost.ScriptURL(...))`, so it ships on every
+full-page render and survives client-side navigation; pageviews ride the
+runtime's `gofastr:navigate` event (fire the initial one yourself; never
+count on `gofastr:beforenavigate`, it is cancelable and pre-commit);
+identity comes from a same-origin endpoint over `handler.GetUser`.
+`gofastr docs analytics-recipes` has both vendors wired end to end, plus
+a `featureflag.Store` adapter for server-side boolean gates.
 
 ## Hard rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+
+- **uihost: host-page scripts registered before serving.**
+  `RegisterExternalScript` adds a same-origin external `<script src>` to
+  every full-page render, emitted just before `</body>` after runtime.js.
+  It exists for plugins and batteries wiring in `Init`, after
+  construction-time options froze, and refuses registration once a page
+  has been served so a script cannot ship on some pages and not others.
+  `ScriptHandler` serves the bytes with the framework's versioned-script
+  policy (strong ETag, immutable on a matching `?v=`), and `ScriptURL`
+  produces that hash-versioned URL.
+- **battery/relay: first-party relay for third-party services.** A
+  declarative reverse proxy: one mount path, a fixed route table of
+  prefix → upstream, per-route method allow-lists and body caps. Vendor
+  scripts and beacons become same-origin, so the strict default CSP
+  needs no script-src/connect-src exceptions and domain-based ad
+  blocking no longer severs a page from its analytics. Not an open proxy
+  by construction: upstreams are fixed at `New`, credentials are
+  stripped both directions, inbound `X-Forwarded-*` is never trusted,
+  and upstream redirects are refused rather than leaked.
+- **Analytics recipes** (`framework/docs/content/analytics-recipes.md`):
+  the first-party pattern for PostHog and Statsig end to end — relay
+  route tables, a host-authored bootstrap served via
+  `ScriptHandler`/`ScriptURL` and registered with
+  `RegisterExternalScript`, pageviews on the runtime's `gofastr:navigate`
+  event, a same-origin identity endpoint over `handler.GetUser`, and a
+  `featureflag.Store` adapter that surfaces the vendor's boolean gates
+  server-side.
+
 ## [0.70.0] - 2026-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ uploads, and sparse updates. Hooks run inside the write's transaction
 | `core/` | Stdlib-only primitives: router, query, schema, render, mcp, openapi, migrate. Each usable on its own. | you want plain Go building blocks, no framework. |
 | `framework/` | The opinionated entity layer (`App`, `EntityConfig`, CRUD, hooks, migrations). A thin facade re-exporting its focused runtime subpackages. | you want one declaration → SQL + REST + OpenAPI + MCP. |
 | `core-ui/` | Server-driven UI runtime: `html` primitives, `patterns`, `widget` islands, signals, the vanilla-JS runtime. Independently usable. | you're rendering HTML from Go. |
-| `battery/` | Opt-in infrastructure: admin, auth, cache, email, semantic, log, notify, print, queue, search, setup, storage, webhook. Each behind a small interface. | you need a real subsystem; import only the ones you use. |
+| `battery/` | Opt-in infrastructure: admin, auth, cache, email, semantic, log, notify, print, queue, relay, search, setup, storage, webhook. Each behind a small interface. | you need a real subsystem; import only the ones you use. |
 | `cmd/gofastr` | The CLI: `init`, `generate`, `pack` (lossy app→blueprint snapshot), `migrate`, `build`, `dev`, `verify`, `docs`, and more. | you're scaffolding, generating, or checking code. |
 | `kiln` | Experimental agent build-mode runtime (mutate an in-memory IR over HTTP). | you're driving the app from an agent. |
 | `examples/` | Runnable reference apps: the `meridian` blueprint flagship (a SaaS billing console + marketing site), the `ecommerce` blueprint pipeline, plus blog, api-tour, spa, and the docs site. | you want to see it wired end-to-end. |
@@ -387,6 +387,7 @@ connected to a running app.
 - [Authentication](framework/docs/content/auth.md): the `battery/auth` reference. Password login, magic links, OAuth (Google + GitHub built in, any OIDC IdP), 2FA, password reset, sessions, scoped API tokens. Each method is an opt-in plugin
 - [Access control](framework/docs/content/access-control.md): permission-based RBAC. `RequirePermission` on your own routes, `AccessMiddleware`, gating auto-CRUD per entity, and where owner scoping fits alongside it
 - [Security](framework/docs/content/security.md): defaults, headers, and limits
+- [Analytics recipes](framework/docs/content/analytics-recipes.md): PostHog and Statsig first-party via `battery/relay` + a host bootstrap script: pageviews on `gofastr:navigate`, same-origin identity over `handler.GetUser`, and a `featureflag.Store` adapter for server-side gates
 - [Deployment](framework/docs/content/deploy.md): single-binary build, graceful shutdown, production checklist
 - [Horizontal scaling](framework/docs/content/scaling.md): what's process-local by default and the replica-safe alternative for each
 - [Observability](framework/docs/content/observability.md): metrics and tracing

--- a/battery/relay/agents.go
+++ b/battery/relay/agents.go
@@ -1,0 +1,19 @@
+package relay
+
+import (
+	_ "embed"
+
+	"github.com/DonaldMurillo/gofastr/framework/agentsinv"
+)
+
+//go:embed agents.md
+var agentsMarkdown string
+
+func init() {
+	agentsinv.Register(agentsinv.Entry{
+		Name:       "relay",
+		Kind:       agentsinv.KindBattery,
+		ImportPath: "github.com/DonaldMurillo/gofastr/battery/relay",
+		Markdown:   agentsMarkdown,
+	})
+}

--- a/battery/relay/agents.md
+++ b/battery/relay/agents.md
@@ -1,0 +1,46 @@
+# battery/relay
+
+Declarative, hardened same-origin reverse proxy: serve third-party
+services (analytics vendors, chat widgets, error trackers) from the
+app's own origin so the strict default CSP stays untouched and the
+app's cookies never reach the vendor.
+
+**Use this when** the prompt mentions: analytics proxy, first-party
+proxy, reverse proxy to a vendor, PostHog/Plausible/Statsig behind
+your own domain, ad-blocker-resistant tracking, "keep CSP strict but
+load a third-party script", CSP `connect-src` exceptions.
+
+**Import:** `github.com/DonaldMurillo/gofastr/battery/relay`
+
+**Shape:**
+```go
+r := relay.New(relay.Config{
+    // Path defaults to "/__gofastr/t".
+    Routes: []relay.Route{
+        {Prefix: "e/", Upstream: "https://vendor.example/api/event",
+         Methods: []string{"POST"}},                    // subtree
+        {Prefix: "js/", Upstream: "https://vendor.example/js",
+         Methods: []string{"GET"}, CacheOK: true},      // versioned assets
+    },
+})
+app.RegisterPlugin(r)
+base := r.Base() // point SDKs/templates here, don't hard-code the path
+```
+
+**Rules that will bite you if ignored:**
+- One fixed upstream per route, compiled at `New`; request data never
+  selects scheme/host/port. `New` PANICS on: non-https upstreams
+  (http is loopback-only), private/internal hosts, empty `Methods`,
+  duplicate prefixes, a `Path` colliding with a reserved
+  `/__gofastr/...` route.
+- Credentials are stripped both directions (Cookie/Authorization in,
+  Set-Cookie out) and inbound `X-Forwarded-*` is never trusted. Do
+  not "fix" a vendor integration by re-adding headers.
+- Bodies are capped (8 MiB default, `MaxBodyBytes` per route);
+  responses default to `Cache-Control: no-store` unless
+  `CacheOK: true`.
+- A global `app.Use(auth.CSRF(...))` 403s the relay's POST beacons —
+  exempt the mount with `auth.WithCSRFSkipPaths`. Do not gate the
+  relay behind `RequireSession` (beacons fire logged-out).
+
+Full doc: `framework/docs/content/relay.md` (`gofastr docs relay`).

--- a/battery/relay/proxy.go
+++ b/battery/relay/proxy.go
@@ -1,0 +1,214 @@
+package relay
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// requestDeadline bounds one proxied request end to end. The effective
+// deadline is min(inherited request context, 30s) so an app-level
+// timeout or an impatient client can always cut a stuck upstream off.
+const requestDeadline = 30 * time.Second
+
+// stripInboundHeaders never reach the upstream. The relay is a public
+// edge: the app's session cookie, bearer tokens, CSRF material, and
+// API keys have no business at a third-party service, and inbound
+// X-Forwarded-* is trivially spoofable by direct clients.
+var stripInboundHeaders = []string{
+	http.CanonicalHeaderKey("Cookie"),
+	http.CanonicalHeaderKey("Authorization"),
+	http.CanonicalHeaderKey("Proxy-Authorization"),
+	http.CanonicalHeaderKey("X-CSRF-Token"),
+	http.CanonicalHeaderKey("X-API-Key"),
+}
+
+// stripOutboundHeaders never reach the client. Set-Cookie and the
+// authenticate challenges are the vendor trying to establish identity
+// the relay deliberately withholds; Access-Control-* would make the
+// app origin advertise a third party's CORS policy.
+var stripOutboundHeaders = []string{
+	http.CanonicalHeaderKey("Set-Cookie"),
+	http.CanonicalHeaderKey("WWW-Authenticate"),
+	http.CanonicalHeaderKey("Proxy-Authenticate"),
+}
+
+// reverseProxy keeps the concrete type in one place; the handler layer
+// speaks http.Handler.
+type reverseProxy = httputil.ReverseProxy
+
+// newTransport builds the shared outbound transport for all routes.
+// One transport, one connection pool: per-route pools would multiply
+// idle sockets by the number of vendors for no benefit.
+func newTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   16,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		ForceAttemptHTTP2:     true,
+	}
+}
+
+// handler wraps one route's proxy with the request-side guards:
+// tail validation, body cap, and the per-request deadline. Method
+// allow-listing (405 + Allow) and unknown-tail 404s come from the
+// ServeMux patterns registered in Init.
+func (r *Relay) handler(rt *routeRuntime) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if rt.subtree {
+			tail := req.PathValue("rest")
+			if err := validateTail(tail, req.URL.RawPath != ""); err != nil {
+				r.logger.Warn("relay: refused hostile tail", "err", err.Error(), "path", req.URL.EscapedPath())
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+		}
+		// Declared-length bodies are refused before anything is read;
+		// chunked bodies trip the reader mid-copy and surface through
+		// the proxy's error handler, which maps them to 413 too.
+		if req.ContentLength > rt.maxBody {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		req.Body = http.MaxBytesReader(w, req.Body, rt.maxBody)
+
+		ctx, cancel := context.WithTimeout(req.Context(), requestDeadline)
+		defer cancel()
+		req = req.WithContext(ctx)
+
+		rt.proxy.ServeHTTP(w, req)
+	})
+}
+
+// newProxy builds the ReverseProxy for one route. The Rewrite hook (not
+// the deprecated Director) means the outbound request is built from
+// scratch: scheme, host, and port come ONLY from the route's parsed
+// upstream; request data can influence at most the path tail and the
+// query string.
+func (r *Relay) newProxy(rt *routeRuntime) *reverseProxy {
+	return &httputil.ReverseProxy{
+		Transport: r.transport,
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			in, out := pr.In, pr.Out
+			out.URL = &url.URL{
+				Scheme:   rt.upstream.Scheme,
+				Host:     rt.upstream.Host,
+				Path:     joinUpstreamPath(rt.upstream.Path, in.PathValue("rest")),
+				RawQuery: in.URL.RawQuery,
+			}
+			out.Host = rt.upstream.Host
+
+			stripInbound(out.Header)
+			// Forwarded metadata is derived from the connection, never
+			// relayed from the client.
+			out.Header.Set("X-Forwarded-For", r.clientIP(in))
+			out.Header.Set("X-Forwarded-Proto", forwardedProto(in))
+		},
+		ErrorHandler:   r.proxyError,
+		ModifyResponse: func(resp *http.Response) error { r.modifyResponse(rt, resp); return nil },
+	}
+}
+
+// stripInbound removes credentials and spoofable forwarding metadata
+// from the outbound header set. ReverseProxy itself removes hop-by-hop
+// headers; this is the application-layer denylist on top.
+func stripInbound(h http.Header) {
+	for _, name := range stripInboundHeaders {
+		h.Del(name)
+	}
+	for name := range h {
+		if strings.HasPrefix(name, "X-Forwarded-") {
+			h.Del(name)
+		}
+	}
+}
+
+// forwardedProto reports the scheme of the CLIENT->app leg from the
+// actual TLS state, not from any header.
+func forwardedProto(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}
+
+// proxyError maps outbound failures to plain client answers. Upstream
+// error detail and relay configuration never enter the response; they
+// go to the log.
+func (r *Relay) proxyError(w http.ResponseWriter, req *http.Request, err error) {
+	var maxErr *http.MaxBytesError
+	if errors.As(err, &maxErr) {
+		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+	if errors.Is(err, context.DeadlineExceeded) || isTimeoutError(err) {
+		r.logger.Warn("relay: upstream timeout", "method", req.Method, "path", req.URL.EscapedPath(), "err", err.Error())
+		http.Error(w, "upstream timeout", http.StatusGatewayTimeout)
+		return
+	}
+	r.logger.Warn("relay: upstream unreachable", "method", req.Method, "path", req.URL.EscapedPath(), "err", err.Error())
+	http.Error(w, "upstream unavailable", http.StatusBadGateway)
+}
+
+func isTimeoutError(err error) bool {
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
+}
+
+// modifyResponse applies the response-side contract: refuse redirects
+// that would leak the upstream origin, strip vendor identity/CORS
+// headers, pin nosniff, and force no-store unless the route opted into
+// upstream cache headers.
+func (r *Relay) modifyResponse(rt *routeRuntime, resp *http.Response) {
+	// Redirect-following is off by design (ReverseProxy does not
+	// follow), and a Location header must never LEAK either: an
+	// absolute or protocol-relative Location hands the client the
+	// vendor origin, defeating the first-party posture, and a relative
+	// one resolves against the mount path into a guaranteed 404. A 3xx
+	// carrying Location is replaced wholesale with a plain 502;
+	// Location-less 3xx (304 Not Modified) passes through untouched.
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 && resp.Header.Get("Location") != "" {
+		r.logger.Warn("relay: refused upstream redirect",
+			"status", resp.StatusCode,
+			"location", resp.Header.Get("Location"),
+			"upstream", rt.upstream.Host)
+		body := "upstream redirect refused\n"
+		resp.StatusCode = http.StatusBadGateway
+		resp.Status = http.StatusText(http.StatusBadGateway)
+		resp.Body = io.NopCloser(strings.NewReader(body))
+		resp.ContentLength = int64(len(body))
+		resp.Header = http.Header{}
+	}
+
+	for _, name := range stripOutboundHeaders {
+		resp.Header.Del(name)
+	}
+	for name := range resp.Header {
+		if strings.HasPrefix(name, "Access-Control-") {
+			resp.Header.Del(name)
+		}
+	}
+	resp.Header.Set("X-Content-Type-Options", "nosniff")
+	if !rt.cacheOK {
+		resp.Header.Set("Cache-Control", "no-store")
+	}
+}
+
+// loggerBeforeInit is the pre-Init fallback so a Relay constructed but
+// not yet Init'ed (unit tests driving handlers directly) never nil-d.
+func discardLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }

--- a/battery/relay/proxy.go
+++ b/battery/relay/proxy.go
@@ -187,6 +187,12 @@ func (r *Relay) modifyResponse(rt *routeRuntime, resp *http.Response) {
 			"status", resp.StatusCode,
 			"location", resp.Header.Get("Location"),
 			"upstream", rt.upstream.Host)
+		// Drain-and-close the discarded upstream body: ReverseProxy only
+		// closes the body present when ModifyResponse returns, so leaving
+		// the original open would leak one connection per refused
+		// redirect. The bounded drain lets the transport reuse the conn.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+		_ = resp.Body.Close()
 		body := "upstream redirect refused\n"
 		resp.StatusCode = http.StatusBadGateway
 		resp.Status = http.StatusText(http.StatusBadGateway)

--- a/battery/relay/relay.go
+++ b/battery/relay/relay.go
@@ -94,10 +94,12 @@ type Route struct {
 	// development work; any other http:// upstream panics at New.
 	// Private/internal non-loopback hosts (RFC1918, link-local
 	// including cloud metadata, CGNAT, IPv6 unique-local,
-	// *.internal, *.localhost, metadata.google.internal) are refused
-	// at New regardless of scheme: the relay has no per-customer
-	// SSRF story yet, so it refuses to point at anything that smells
-	// like internal infrastructure.
+	// *.internal, metadata.google.internal) are refused at New
+	// regardless of scheme: the relay has no per-customer SSRF story
+	// yet, so it refuses to point at anything that smells like
+	// internal infrastructure. localhost and *.localhost count as
+	// loopback, so they are ACCEPTED (that's how tests and local dev
+	// point at an httptest upstream).
 	Upstream string
 
 	// Methods is the allow-list of HTTP methods the route answers.

--- a/battery/relay/relay.go
+++ b/battery/relay/relay.go
@@ -1,0 +1,433 @@
+// Package relay serves third-party services (analytics vendors, chat
+// widgets, error trackers) first-party: a declarative, hardened
+// same-origin reverse proxy mounted under one path on the host app.
+//
+// The point is the Content-Security-Policy. A host that links
+// https://vendor.example/collect.js must punch script-src/connect-src
+// holes into its strict default CSP and hand every visitor's browser a
+// direct channel to the vendor's origin. A host that relays the vendor
+// through /__gofastr/t/... keeps `default-src 'self'` untouched: the
+// browser only ever talks to the app's own origin.
+//
+// This is a proxy, not a tunnel. Every route names ONE fixed upstream
+// at construction; request data (path tail, query, headers, body)
+// never selects scheme, host, or port. See the hardening contract in
+// framework/docs/content/relay.md.
+package relay
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/DonaldMurillo/gofastr/core/netguard"
+	"github.com/DonaldMurillo/gofastr/framework"
+)
+
+// DefaultPath is the mount prefix used when Config.Path is empty.
+const DefaultPath = "/__gofastr/t"
+
+// reservedGoFastrSegments are the path segments directly under
+// /__gofastr that the framework and its batteries already serve
+// (runtime.js, app.css, the SSE bus, compute workers, …). Mounting a
+// relay route onto one of them collides at registration time, so New
+// refuses the Config up front instead of letting the ServeMux panic
+// without context during Init.
+var reservedGoFastrSegments = map[string]bool{
+	"sse": true, "session": true, "action": true, "widgets": true,
+	"widget": true, "embed": true, "embed.js": true, "embed-runtime.js": true,
+	"runtime.js": true, "runtime": true, "app.css": true, "comp": true,
+	"color-scheme.js": true, "compute": true, "pwa": true, "icons": true,
+}
+
+// defaultMaxBodyBytes caps request bodies per route when
+// Route.MaxBodyBytes is zero. 8 MiB is generous for analytics beacons
+// and chat/widget uploads while keeping a single request from turning
+// the relay into an egress firehose.
+const defaultMaxBodyBytes int64 = 8 << 20
+
+// Config constructs a Relay. The zero value is invalid: routes are the
+// whole point and must be declared explicitly (empty Methods is a
+// configuration error, not "allow everything").
+type Config struct {
+	// Path is the local mount prefix. Default "/__gofastr/t".
+	//
+	// Validated at New: absolute, no trailing slash, no traversal, no
+	// percent-encoding, and no collision with a reserved /__gofastr
+	// route. Any other absolute path works ("/firstparty", "/fp", …).
+	Path string
+
+	// Routes declare what gets proxied. Required, non-empty.
+	Routes []Route
+
+	// ClientIP resolves the client IP written into X-Forwarded-For.
+	// Default: the host part of r.RemoteAddr.
+	//
+	// Inbound X-Forwarded-For is NEVER trusted, on any setting: the
+	// relay sits on the public edge where that header is one
+	// `curl -H` away from arbitrary values. Override this only with a
+	// resolver backed by a trusted proxy layer (e.g. a PROXY-protocol
+	// or unix-socket peer), never with a header-reading function.
+	ClientIP func(*http.Request) string
+}
+
+// Route is one fixed upstream mounted under Config.Path.
+type Route struct {
+	// Prefix is the local path segment under Path, e.g. "assets/" or
+	// "e".
+	//
+	// A trailing slash declares a subtree: Path + "/" + Prefix +
+	// "{rest...}" maps the sanitized remainder of the request path
+	// onto the same remainder of Upstream. Without a trailing slash
+	// the route matches exactly Path + "/" + Prefix and nothing
+	// deeper.
+	Prefix string
+
+	// Upstream is the absolute https:// URL (scheme, host, optional
+	// base path) the route proxies to. The subtree rest (sanitized) is
+	// appended to the base path; the query string passes through.
+	//
+	// http:// is accepted ONLY for loopback hosts so tests and local
+	// development work; any other http:// upstream panics at New.
+	// Private/internal non-loopback hosts (RFC1918, link-local
+	// including cloud metadata, CGNAT, IPv6 unique-local,
+	// *.internal, *.localhost, metadata.google.internal) are refused
+	// at New regardless of scheme: the relay has no per-customer
+	// SSRF story yet, so it refuses to point at anything that smells
+	// like internal infrastructure.
+	Upstream string
+
+	// Methods is the allow-list of HTTP methods the route answers.
+	// Empty is invalid — be explicit. Anything else gets 405 with an
+	// Allow header.
+	Methods []string
+
+	// MaxBodyBytes caps the request body per route. Default 8 MiB
+	// when zero; both declared Content-Length and chunked bodies are
+	// enforced, with 413 on overflow.
+	MaxBodyBytes int64
+
+	// CacheOK selects the response caching posture.
+	//
+	// false (default): responses carry Cache-Control: no-store. The
+	// relay is for beacons and dynamic endpoints; caching vendor
+	// responses under the app's own origin is rarely what anyone
+	// wants.
+	//
+	// true: upstream cache headers pass through unchanged, for
+	// immutable versioned assets (/t/assets/sdk@1.2.3.js).
+	CacheOK bool
+}
+
+// Relay is the first-party relay plugin. Construct with New, register
+// with App.RegisterPlugin. Implements framework.Plugin.
+type Relay struct {
+	cfg       Config
+	path      string
+	clientIP  func(*http.Request) string
+	transport *http.Transport
+	logger    *slog.Logger
+	routes    []*routeRuntime
+}
+
+// routeRuntime is a Route with everything pre-resolved at New so the
+// request path does validation and no parsing.
+type routeRuntime struct {
+	prefix   string
+	subtree  bool
+	methods  []string
+	maxBody  int64
+	cacheOK  bool
+	upstream *url.URL
+	proxy    *reverseProxy
+}
+
+// New validates cfg and constructs the Relay. It panics on invalid
+// configuration with a message prefixed "relay:": a bad relay Config is
+// a construction-time programmer error (same posture as
+// framework.NewApp's registration panics), not a runtime condition the
+// process should limp along with.
+func New(cfg Config) *Relay {
+	if cfg.Path == "" {
+		cfg.Path = DefaultPath
+	}
+	validatePath(cfg.Path)
+
+	if len(cfg.Routes) == 0 {
+		panic("relay: Config.Routes is empty: declare at least one fixed upstream")
+	}
+
+	seen := make(map[string]bool, len(cfg.Routes))
+	routes := make([]*routeRuntime, 0, len(cfg.Routes))
+	for i := range cfg.Routes {
+		r := &cfg.Routes[i]
+		validatePrefix(r.Prefix)
+		if seen[r.Prefix] {
+			panic(fmt.Sprintf("relay: route prefix %q declared twice: each prefix must map to exactly one upstream", r.Prefix))
+		}
+		seen[r.Prefix] = true
+		if len(r.Methods) == 0 {
+			panic(fmt.Sprintf("relay: route %q: Methods is empty: declare the allowed methods explicitly", r.Prefix))
+		}
+		for _, m := range r.Methods {
+			if !validMethod(m) {
+				panic(fmt.Sprintf("relay: route %q: method %q is not an uppercase HTTP token", r.Prefix, m))
+			}
+		}
+		if r.MaxBodyBytes < 0 {
+			panic(fmt.Sprintf("relay: route %q: negative MaxBodyBytes", r.Prefix))
+		}
+		if err := validateUpstreamURL(r.Upstream, net.LookupIP); err != nil {
+			panic(fmt.Sprintf("relay: route %q: %v", r.Prefix, err))
+		}
+		u, err := url.Parse(r.Upstream)
+		if err != nil {
+			panic(fmt.Sprintf("relay: route %q: %v", r.Prefix, err))
+		}
+		maxBody := r.MaxBodyBytes
+		if maxBody == 0 {
+			maxBody = defaultMaxBodyBytes
+		}
+		routes = append(routes, &routeRuntime{
+			prefix:   r.Prefix,
+			subtree:  strings.HasSuffix(r.Prefix, "/"),
+			methods:  r.Methods,
+			maxBody:  maxBody,
+			cacheOK:  r.CacheOK,
+			upstream: u,
+		})
+	}
+
+	clientIP := cfg.ClientIP
+	if clientIP == nil {
+		clientIP = remoteAddrHost
+	}
+
+	r := &Relay{
+		cfg:       cfg,
+		path:      cfg.Path,
+		clientIP:  clientIP,
+		transport: newTransport(),
+		logger:    discardLogger(),
+		routes:    routes,
+	}
+	for _, rt := range routes {
+		rt.proxy = r.newProxy(rt)
+	}
+	return r
+}
+
+// Name implements framework.Plugin.
+func (r *Relay) Name() string { return "relay" }
+
+// Base returns the mount path (Config.Path, or the default). Use it to
+// point server-side SDKs and page templates at the relay without
+// hard-coding the prefix:
+//
+//	plausibleBase := relay.Base() + "/e"
+func (r *Relay) Base() string { return r.path }
+
+// Init registers the routes on the App's router and wires transport
+// cleanup into shutdown. One ServeMux pattern per (route, method):
+// exact routes register Path + "/" + Prefix, subtree routes register
+// Path + "/" + Prefix + "{rest...}".
+func (r *Relay) Init(app *framework.App) error {
+	// Route the guard logs through the App's logger so a logging
+	// plugin's sinks see refused-tail / redirect events too.
+	r.logger = app.Logger()
+	for _, rt := range r.routes {
+		pattern := r.path + "/" + rt.prefix
+		if rt.subtree {
+			pattern += "{rest...}"
+		}
+		h := r.handler(rt)
+		for _, m := range rt.methods {
+			app.Router().Handle(m, pattern, h)
+		}
+	}
+	// The shared transport holds keep-alive connections to every
+	// upstream; close them when the app drains so a graceful shutdown
+	// doesn't block on idle sockets.
+	app.OnStop(func() error {
+		r.transport.CloseIdleConnections()
+		return nil
+	})
+	return nil
+}
+
+// validatePath enforces the mount contract: absolute, clean, no
+// percent-encoding, and clear of the framework's reserved
+// /__gofastr namespace.
+func validatePath(p string) {
+	if !strings.HasPrefix(p, "/") {
+		panic(fmt.Sprintf("relay: Config.Path %q must be absolute (start with /)", p))
+	}
+	if p == "/" {
+		panic(`relay: Config.Path "/" would capture the whole app`)
+	}
+	if strings.HasSuffix(p, "/") {
+		panic(fmt.Sprintf("relay: Config.Path %q must not end with a slash", p))
+	}
+	if err := validateSegments("Config.Path", p); err != nil {
+		panic(err.Error())
+	}
+	if p == "/__gofastr" {
+		panic(`relay: Config.Path "/__gofastr" is the framework's reserved namespace root; mount under a subpath like "/__gofastr/t" or a custom path`)
+	}
+	if rest, ok := strings.CutPrefix(p, "/__gofastr/"); ok && rest != "" {
+		seg := rest
+		if i := strings.IndexByte(rest, '/'); i >= 0 {
+			seg = rest[:i]
+		}
+		if reservedGoFastrSegments[seg] {
+			panic(fmt.Sprintf("relay: Config.Path %q collides with the reserved framework route /__gofastr/%s", p, seg))
+		}
+	}
+}
+
+// validateSegments rejects traversal, empty segments, percent-encoding,
+// and control bytes in an absolute path.
+func validateSegments(what, p string) error {
+	for i := range len(p) {
+		c := p[i]
+		if c <= 0x20 || c == 0x7f {
+			return fmt.Errorf("relay: %s %q contains a control character or space", what, p)
+		}
+		if c == '%' || c == '#' || c == '?' || c == '\\' {
+			return fmt.Errorf("relay: %s %q contains %q; percent-encoding and fragments are not valid here", what, p, string(c))
+		}
+	}
+	for _, seg := range strings.Split(p[1:], "/") {
+		if seg == "" {
+			return fmt.Errorf("relay: %s %q contains an empty path segment", what, p)
+		}
+		if seg == "." || seg == ".." {
+			return fmt.Errorf("relay: %s %q contains a traversal segment", what, p)
+		}
+	}
+	return nil
+}
+
+// validatePrefix enforces the route prefix contract: relative to Path,
+// clean, no encoding tricks.
+func validatePrefix(prefix string) {
+	if prefix == "" {
+		panic("relay: route prefix must not be empty")
+	}
+	if strings.HasPrefix(prefix, "/") {
+		panic(fmt.Sprintf("relay: route prefix %q must be relative to Config.Path, not absolute", prefix))
+	}
+	// A trailing slash is the subtree marker, not an empty segment;
+	// validate the name with it stripped.
+	name := strings.TrimSuffix(prefix, "/")
+	if name == "" {
+		panic(`relay: route prefix "/" would shadow the whole mount path`)
+	}
+	if err := validateSegments("route prefix", "/"+name); err != nil {
+		panic(err.Error())
+	}
+}
+
+// validMethod: uppercase HTTP token, at least one character. The
+// canonical verbs plus extension methods (REPORT, PROPFIND, …) all
+// fit; lowercase or spaces are configuration typos.
+func validMethod(m string) bool {
+	if m == "" {
+		return false
+	}
+	for i := range len(m) {
+		c := m[i]
+		if c < 'A' || c > 'Z' {
+			return false
+		}
+	}
+	return true
+}
+
+// validateUpstreamURL refuses anything the relay must not proxy to.
+// lookup is injectable for tests. DNS failures defer to request time
+// (mirrors battery/webhook's posture): construction shouldn't require
+// the vendor to be resolvable right now.
+func validateUpstreamURL(raw string, lookup func(string) ([]net.IP, error)) error {
+	if raw == "" {
+		return fmt.Errorf("upstream URL required")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parse URL: %w", err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("scheme %q not allowed (need http or https)", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("URL missing host")
+	}
+	if u.User != nil {
+		return fmt.Errorf("URL with embedded userinfo not allowed (credential leakage)")
+	}
+	if u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+		return fmt.Errorf("upstream must be scheme+host+optional base path, no query or fragment")
+	}
+
+	host := u.Hostname()
+	lower := strings.ToLower(host)
+
+	// Loopback: the one internal class that is allowed, so tests and
+	// local dev can point at httptest servers and localhost
+	// sidecars. http:// is restricted to exactly this class.
+	isLoopback := lower == "localhost" || strings.HasSuffix(lower, ".localhost")
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		isLoopback = true
+	}
+	if scheme == "http" && !isLoopback {
+		return fmt.Errorf("http:// upstream %q refused: plaintext is only allowed for loopback hosts; use https", u.Host)
+	}
+	if isLoopback {
+		return nil
+	}
+
+	// Internal-hostname denylist, cheaper than DNS and catches the
+	// cloud-metadata names regardless of how they resolve.
+	if strings.HasSuffix(lower, ".internal") || lower == "metadata.google.internal" {
+		return fmt.Errorf("host %q targets internal infrastructure", host)
+	}
+	// Literal IPs: no DNS needed.
+	if ip := net.ParseIP(host); ip != nil {
+		return refuseInternal(ip)
+	}
+	// Hostname: resolve and check every address.
+	addrs, err := lookup(host)
+	if err != nil {
+		// Unresolvable now is not refused-now; request time will
+		// surface the failure as a 502.
+		return nil
+	}
+	for _, ip := range addrs {
+		if err := refuseInternal(ip); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// refuseInternal rejects non-loopback internal addresses via the
+// single repo-wide predicate.
+func refuseInternal(ip net.IP) error {
+	if netguard.IsInternal(ip) && !ip.IsLoopback() {
+		return fmt.Errorf("host targets internal infrastructure (%s)", netguard.Reason(ip))
+	}
+	return nil
+}
+
+// remoteAddrHost is the default ClientIP: the host part of the peer
+// address on the wire.
+func remoteAddrHost(r *http.Request) string {
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}

--- a/battery/relay/relay_test.go
+++ b/battery/relay/relay_test.go
@@ -1,0 +1,621 @@
+package relay
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/DonaldMurillo/gofastr/framework"
+)
+
+// captured records everything a fake upstream saw.
+type captured struct {
+	mu     sync.Mutex
+	hits   int
+	method string
+	uri    string // r.URL.RequestURI (path + query)
+	host   string // r.Host the request was addressed to
+	body   []byte
+	header http.Header
+}
+
+func (c *captured) record(w http.ResponseWriter, r *http.Request) {
+	b, _ := io.ReadAll(r.Body)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.hits++
+	c.method = r.Method
+	c.uri = r.URL.RequestURI()
+	c.host = r.Host
+	c.body = b
+	c.header = r.Header.Clone()
+	w.WriteHeader(http.StatusOK)
+}
+
+func (c *captured) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.hits
+}
+
+func (c *captured) snapshot() (method, uri, host string, body []byte, header http.Header) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.method, c.uri, c.host, c.body, c.header
+}
+
+// startRelay wires a Relay through a real framework App, serves the
+// App's router, and returns the client-facing base URL. build receives
+// the fake upstream's base URL (mounted under /cdn) so configs can
+// point routes at it.
+func startRelay(t *testing.T, build func(upstreamBase string) Config, upstream http.HandlerFunc) string {
+	t.Helper()
+	up := httptest.NewServer(upstream)
+	t.Cleanup(up.Close)
+
+	cfg := build(up.URL + "/cdn")
+	app := framework.NewApp(framework.WithoutDefaultMiddleware())
+	app.RegisterPlugin(New(cfg))
+	if err := app.InitPlugins(); err != nil {
+		t.Fatalf("InitPlugins: %v", err)
+	}
+	srv := httptest.NewServer(app.Router())
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func startRelayCap(t *testing.T, build func(upstreamBase string) Config) (clientBase string, cap *captured) {
+	t.Helper()
+	cap = &captured{}
+	base := startRelay(t, build, http.HandlerFunc(cap.record))
+	return base, cap
+}
+
+func defaultCfg(upstreamBase string) Config {
+	return Config{
+		Routes: []Route{{
+			Prefix:   "e/",
+			Upstream: upstreamBase,
+			Methods:  []string{http.MethodGet, http.MethodPost},
+		}},
+	}
+}
+
+func TestSubtreeForwardsPathAndQuery(t *testing.T) {
+	base, cap := startRelayCap(t, defaultCfg)
+
+	res, err := http.Get(base + "/__gofastr/t/e/lib/app.js?v=2")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", res.StatusCode)
+	}
+	method, uri, _, _, _ := cap.snapshot()
+	if method != http.MethodGet {
+		t.Fatalf("upstream method = %q", method)
+	}
+	if uri != "/cdn/lib/app.js?v=2" {
+		t.Fatalf("upstream uri = %q, want /cdn/lib/app.js?v=2", uri)
+	}
+}
+
+func TestExactRouteMatchesOnlyItsPath(t *testing.T) {
+	base, cap := startRelayCap(t, func(up string) Config {
+		return Config{Routes: []Route{{
+			Prefix:   "ping",
+			Upstream: up,
+			Methods:  []string{http.MethodGet},
+		}}}
+	})
+
+	res, err := http.Get(base + "/__gofastr/t/ping")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusOK || cap.count() != 1 {
+		t.Fatalf("exact hit: status=%d hits=%d", res.StatusCode, cap.count())
+	}
+
+	res, err = http.Get(base + "/__gofastr/t/ping/extra")
+	if err != nil {
+		t.Fatalf("get extra: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusNotFound || cap.count() != 1 {
+		t.Fatalf("subpath of exact route: status=%d hits=%d, want 404 and no extra upstream hit", res.StatusCode, cap.count())
+	}
+}
+
+func TestUnknownTailReturns404(t *testing.T) {
+	base, cap := startRelayCap(t, defaultCfg)
+
+	res, err := http.Get(base + "/__gofastr/t/nosuch/deep.js")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", res.StatusCode)
+	}
+	if cap.count() != 0 {
+		t.Fatalf("upstream hit %d times for unknown tail", cap.count())
+	}
+}
+
+func TestUndeclaredMethodGives405Allow(t *testing.T) {
+	base, cap := startRelayCap(t, defaultCfg)
+
+	req, _ := http.NewRequest(http.MethodDelete, base+"/__gofastr/t/e/x", nil)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", res.StatusCode)
+	}
+	allow := res.Header.Get("Allow")
+	if !strings.Contains(allow, "GET") || !strings.Contains(allow, "POST") {
+		t.Fatalf("Allow = %q, want GET and POST", allow)
+	}
+	if cap.count() != 0 {
+		t.Fatalf("upstream hit %d times for undeclared method", cap.count())
+	}
+}
+
+func TestInboundCredentialsStripped(t *testing.T) {
+	base, cap := startRelayCap(t, defaultCfg)
+
+	req, _ := http.NewRequest(http.MethodPost, base+"/__gofastr/t/e/ev", strings.NewReader(`{"a":1}`))
+	req.Header.Set("Cookie", "session=secret")
+	req.Header.Set("Authorization", "Bearer app-secret")
+	req.Header.Set("Proxy-Authorization", "Basic zzz")
+	req.Header.Set("X-CSRF-Token", "csrf-token")
+	req.Header.Set("X-API-Key", "app-api-key")
+	req.Header.Set("X-Forwarded-For", "1.2.3.4, 5.6.7.8")
+	req.Header.Set("X-Forwarded-Host", "evil.example")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Custom", "spoof")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	res.Body.Close()
+
+	_, _, _, _, h := cap.snapshot()
+	for _, name := range []string{
+		"Cookie", "Authorization", "Proxy-Authorization",
+		"X-Csrf-Token", "X-Api-Key",
+	} {
+		if got := h.Get(name); got != "" {
+			t.Errorf("%s reached upstream: %q", name, got)
+		}
+	}
+	// Inbound-only X-Forwarded-* names are dropped outright; the two
+	// derived ones are asserted by value below.
+	for _, name := range []string{"X-Forwarded-Host", "X-Forwarded-Custom"} {
+		if got := h.Get(name); got != "" {
+			t.Errorf("inbound %s reached upstream: %q", name, got)
+		}
+	}
+	// X-Forwarded-For must be the connection's actual peer, never the
+	// spoofed inbound value.
+	if got := h.Get("X-Forwarded-For"); got == "1.2.3.4, 5.6.7.8" || got == "" {
+		t.Fatalf("X-Forwarded-For = %q, want the real peer address", got)
+	}
+	if got := h.Get("X-Forwarded-Proto"); got != "http" {
+		t.Fatalf("X-Forwarded-Proto = %q, want http on a plain leg", got)
+	}
+}
+
+func TestForwardedProtoHTTPSOnTLSLeg(t *testing.T) {
+	cap := &captured{}
+	up := httptest.NewServer(http.HandlerFunc(cap.record))
+	t.Cleanup(up.Close)
+
+	app := framework.NewApp(framework.WithoutDefaultMiddleware())
+	app.RegisterPlugin(New(defaultCfg(up.URL + "/cdn")))
+	if err := app.InitPlugins(); err != nil {
+		t.Fatalf("InitPlugins: %v", err)
+	}
+	srv := httptest.NewTLSServer(app.Router())
+	t.Cleanup(srv.Close)
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+
+	res, err := client.Get(srv.URL + "/__gofastr/t/e/x")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	res.Body.Close()
+	_, _, _, _, h := cap.snapshot()
+	if got := h.Get("X-Forwarded-Proto"); got != "https" {
+		t.Fatalf("X-Forwarded-Proto = %q, want https behind TLS", got)
+	}
+}
+
+func TestClientIPOverride(t *testing.T) {
+	base, cap := startRelayCap(t, func(up string) Config {
+		cfg := defaultCfg(up)
+		cfg.ClientIP = func(r *http.Request) string { return "203.0.113.9" }
+		return cfg
+	})
+
+	res, err := http.Get(base + "/__gofastr/t/e/x")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	res.Body.Close()
+	_, _, _, _, h := cap.snapshot()
+	if got := h.Get("X-Forwarded-For"); got != "203.0.113.9" {
+		t.Fatalf("X-Forwarded-For = %q, want 203.0.113.9", got)
+	}
+}
+
+func TestPreservedHeadersReachUpstream(t *testing.T) {
+	base, cap := startRelayCap(t, defaultCfg)
+
+	req, _ := http.NewRequest(http.MethodPost, base+"/__gofastr/t/e/ev", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept-Encoding", "gzip")
+	req.Header.Set("User-Agent", "VendorSDK/1.2")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	res.Body.Close()
+
+	_, _, _, _, h := cap.snapshot()
+	for name, want := range map[string]string{
+		"Content-Type":     "application/json",
+		"Content-Encoding": "gzip",
+		"Accept":           "application/json",
+		"Accept-Encoding":  "gzip",
+		"User-Agent":       "VendorSDK/1.2",
+	} {
+		if got := h.Get(name); got != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestOutboundAuthHeadersStripped(t *testing.T) {
+	base := startRelay(t, defaultCfg, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Set-Cookie", "vendor=1; Path=/")
+		w.Header().Set("WWW-Authenticate", `Basic realm="vendor"`)
+		w.Header().Set("Proxy-Authenticate", `Basic realm="vendor"`)
+		w.Header().Set("Access-Control-Allow-Origin", "https://app.example.com")
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("X-Vendor-Extra", "keep-me")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	res, err := http.Get(base + "/__gofastr/t/e/x")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	res.Body.Close()
+
+	for _, name := range []string{
+		"Set-Cookie", "Www-Authenticate", "Proxy-Authenticate",
+		"Access-Control-Allow-Origin", "Access-Control-Allow-Credentials",
+	} {
+		if got := res.Header.Get(name); got != "" {
+			t.Errorf("%s leaked to client: %q", name, got)
+		}
+	}
+	if got := res.Header.Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+	if got := res.Header.Get("X-Vendor-Extra"); got != "keep-me" {
+		t.Errorf("X-Vendor-Extra = %q, want passthrough", got)
+	}
+}
+
+func TestNoStoreForcedWhenCacheOKFalse(t *testing.T) {
+	base := startRelay(t, defaultCfg, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "public, max-age=99999")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	res, err := http.Get(base + "/__gofastr/t/e/x")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	res.Body.Close()
+	if got := res.Header.Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+}
+
+func TestCacheOKTruePassesCacheHeaders(t *testing.T) {
+	base := startRelay(t, func(up string) Config {
+		cfg := defaultCfg(up)
+		cfg.Routes[0].CacheOK = true
+		return cfg
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	res, err := http.Get(base + "/__gofastr/t/e/x")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	res.Body.Close()
+	if got := res.Header.Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+		t.Fatalf("Cache-Control = %q, want upstream value", got)
+	}
+}
+
+func TestBodyCapDeclaredLength413(t *testing.T) {
+	base, cap := startRelayCap(t, func(up string) Config {
+		cfg := defaultCfg(up)
+		cfg.Routes[0].MaxBodyBytes = 32
+		return cfg
+	})
+
+	body := bytes.Repeat([]byte("x"), 64)
+	res, err := http.Post(base+"/__gofastr/t/e/ev", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", res.StatusCode)
+	}
+	if cap.count() != 0 {
+		t.Fatalf("oversized declared body reached upstream (%d hits)", cap.count())
+	}
+}
+
+func TestBodyCapChunked413(t *testing.T) {
+	base, cap := startRelayCap(t, func(up string) Config {
+		cfg := defaultCfg(up)
+		cfg.Routes[0].MaxBodyBytes = 32
+		return cfg
+	})
+
+	// unknownLenReader hides the length so the client sends chunked.
+	req, _ := http.NewRequest(http.MethodPost, base+"/__gofastr/t/e/ev",
+		unknownLenReader{r: bytes.NewReader(bytes.Repeat([]byte("x"), 64))})
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", res.StatusCode)
+	}
+	_, _, _, body, _ := cap.snapshot()
+	if len(body) >= 64 {
+		t.Fatalf("full chunked body reached upstream (%d bytes)", len(body))
+	}
+}
+
+type unknownLenReader struct{ r io.Reader }
+
+func (u unknownLenReader) Read(p []byte) (int, error) { return u.r.Read(p) }
+
+func TestUpstreamRedirectRefused502(t *testing.T) {
+	base := startRelay(t, defaultCfg, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "https://vendor.example/elsewhere")
+		w.WriteHeader(http.StatusFound)
+	}))
+
+	res, err := http.Get(base + "/__gofastr/t/e/x")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", res.StatusCode)
+	}
+	if got := res.Header.Get("Location"); got != "" {
+		t.Fatalf("Location leaked: %q", got)
+	}
+}
+
+func TestNotModifiedPassesThrough(t *testing.T) {
+	base := startRelay(t, defaultCfg, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotModified)
+	}))
+
+	res, err := http.Get(base + "/__gofastr/t/e/x")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusNotModified {
+		t.Fatalf("status = %d, want 304", res.StatusCode)
+	}
+}
+
+func TestGzipPassthroughBytesIdentical(t *testing.T) {
+	var gz bytes.Buffer
+	zw := gzip.NewWriter(&gz)
+	zw.Write([]byte("compress me untouched"))
+	zw.Close()
+	want := gz.Bytes()
+
+	base := startRelay(t, defaultCfg, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write(want)
+	}))
+
+	req, _ := http.NewRequest(http.MethodGet, base+"/__gofastr/t/e/blob", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	res, err := http.DefaultTransport.RoundTrip(req) // no transparent gunzip
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer res.Body.Close()
+	got, _ := io.ReadAll(res.Body)
+	if res.Header.Get("Content-Encoding") != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", res.Header.Get("Content-Encoding"))
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("gzip bytes not identical: got %d bytes, want %d", len(got), len(want))
+	}
+}
+
+// TestDeadlineExceededGives504 drives the router directly with a
+// recorder so the relay's own 504 is observable: the client's transport
+// isn't racing to abort first. The relay's per-request deadline is
+// min(inherited ctx, 30s); here the inherited ctx wins.
+func TestDeadlineExceededGives504(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(up.Close)
+
+	app := framework.NewApp(framework.WithoutDefaultMiddleware())
+	app.RegisterPlugin(New(defaultCfg(up.URL + "/cdn")))
+	if err := app.InitPlugins(); err != nil {
+		t.Fatalf("InitPlugins: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	req := httptest.NewRequest(http.MethodGet, "/__gofastr/t/e/x", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	app.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504", rec.Code)
+	}
+}
+
+func TestTransportFailureGives502(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	cfg := defaultCfg(up.URL + "/cdn")
+	up.Close() // connection refused from here on
+
+	app := framework.NewApp(framework.WithoutDefaultMiddleware())
+	app.RegisterPlugin(New(cfg))
+	if err := app.InitPlugins(); err != nil {
+		t.Fatalf("InitPlugins: %v", err)
+	}
+	srv := httptest.NewServer(app.Router())
+	t.Cleanup(srv.Close)
+
+	res, err := http.Get(srv.URL + "/__gofastr/t/e/x")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", res.StatusCode)
+	}
+}
+
+func TestBaseReturnsMountPath(t *testing.T) {
+	if got := New(Config{Routes: []Route{{Prefix: "e/", Upstream: "https://example.com", Methods: []string{"GET"}}}}).Base(); got != "/__gofastr/t" {
+		t.Fatalf("default Base = %q, want /__gofastr/t", got)
+	}
+	if got := New(Config{Path: "/firstparty", Routes: []Route{{Prefix: "e/", Upstream: "https://example.com", Methods: []string{"GET"}}}}).Base(); got != "/firstparty" {
+		t.Fatalf("custom Base = %q, want /firstparty", got)
+	}
+}
+
+func TestRoutesRegisteredOnInit(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(up.Close)
+
+	app := framework.NewApp(framework.WithoutDefaultMiddleware())
+	app.RegisterPlugin(New(Config{
+		Routes: []Route{
+			{Prefix: "e/", Upstream: up.URL, Methods: []string{http.MethodGet}},
+			{Prefix: "ping", Upstream: up.URL, Methods: []string{http.MethodPost}},
+		},
+	}))
+	if err := app.InitPlugins(); err != nil {
+		t.Fatalf("InitPlugins: %v", err)
+	}
+
+	want := map[string]bool{
+		"GET /__gofastr/t/e/{rest...}": false,
+		"POST /__gofastr/t/ping":       false,
+	}
+	for _, rt := range app.Router().Routes() {
+		key := rt.Method + " " + rt.Pattern
+		if _, ok := want[key]; ok {
+			want[key] = true
+		}
+	}
+	for key, seen := range want {
+		if !seen {
+			t.Errorf("route %q not registered", key)
+		}
+	}
+}
+
+func TestShutdownClosesIdleTransportConns(t *testing.T) {
+	var openConns atomic.Int64
+	up := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	up.Config.ConnState = func(c net.Conn, cs http.ConnState) {
+		switch cs {
+		case http.StateNew:
+			openConns.Add(1)
+		case http.StateClosed, http.StateHijacked:
+			openConns.Add(-1)
+		}
+	}
+	up.Start()
+	t.Cleanup(up.Close)
+
+	app := framework.NewApp(framework.WithoutDefaultMiddleware())
+	app.RegisterPlugin(New(defaultCfg(up.URL + "/cdn")))
+	if err := app.InitPlugins(); err != nil {
+		t.Fatalf("InitPlugins: %v", err)
+	}
+	srv := httptest.NewServer(app.Router())
+	t.Cleanup(srv.Close)
+
+	res, err := http.Get(srv.URL + "/__gofastr/t/e/x")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	res.Body.Close()
+
+	// One keep-alive conn to the upstream should now be idle on the
+	// relay's shared transport.
+	deadline := time.Now().Add(2 * time.Second)
+	for openConns.Load() != 1 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := openConns.Load(); got != 1 {
+		t.Fatalf("idle upstream conns = %d, want 1 before shutdown", got)
+	}
+
+	if err := app.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	deadline = time.Now().Add(2 * time.Second)
+	for openConns.Load() != 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := openConns.Load(); got != 0 {
+		t.Fatalf("open upstream conns after Shutdown = %d, want 0 (CloseIdleConnections via OnStop)", got)
+	}
+}

--- a/battery/relay/relay_test.go
+++ b/battery/relay/relay_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"crypto/tls"
 	"io"
 	"net"
 	"net/http"
@@ -233,9 +232,7 @@ func TestForwardedProtoHTTPSOnTLSLeg(t *testing.T) {
 	}
 	srv := httptest.NewTLSServer(app.Router())
 	t.Cleanup(srv.Close)
-	client := &http.Client{Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}}
+	client := srv.Client()
 
 	res, err := client.Get(srv.URL + "/__gofastr/t/e/x")
 	if err != nil {
@@ -617,5 +614,31 @@ func TestShutdownClosesIdleTransportConns(t *testing.T) {
 	}
 	if got := openConns.Load(); got != 0 {
 		t.Fatalf("open upstream conns after Shutdown = %d, want 0 (CloseIdleConnections via OnStop)", got)
+	}
+}
+
+// closeRecorder records whether the wrapped body was closed.
+type closeRecorder struct {
+	io.Reader
+	closed bool
+}
+
+func (c *closeRecorder) Close() error { c.closed = true; return nil }
+
+func TestRefusedRedirectClosesUpstreamBody(t *testing.T) {
+	r := New(defaultCfg("http://127.0.0.1:1/base"))
+	rt := r.routes[0]
+	body := &closeRecorder{Reader: strings.NewReader("moved")}
+	resp := &http.Response{
+		StatusCode: http.StatusFound,
+		Header:     http.Header{"Location": []string{"https://vendor.example/next"}},
+		Body:       body,
+	}
+	r.modifyResponse(rt, resp)
+	if !body.closed {
+		t.Fatal("refused redirect left the upstream body open")
+	}
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
 	}
 }

--- a/battery/relay/security_test.go
+++ b/battery/relay/security_test.go
@@ -1,0 +1,317 @@
+package relay
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/framework"
+)
+
+func TestValidateTailRejectsHostileForms(t *testing.T) {
+	bad := []string{
+		"../x",           // literal traversal (mux usually cleans it; sink still rejects)
+		"a/../../x",      // mid-path traversal
+		"e/..",           // trailing dot-dot
+		"a\\b",           // backslash (alternate path separator on win32 upstreams)
+		"a\x00b",         // NUL
+		"a\x01b",         // control
+		"a\x1fb",         // control
+		"a\x7fb",         // DEL
+		"a#b",            // fragment smuggled into the path
+		"a//b",           // empty segment (raw-encoded form reaches the sink)
+		"/abs",           // leading slash would double-join
+		"a/b/../../../c", // deep traversal
+	}
+	for _, tail := range bad {
+		if err := validateTail(tail, false); err == nil {
+			t.Errorf("validateTail(%q) accepted a hostile form", tail)
+		}
+	}
+	// Non-canonical percent-encoding anywhere in the URL (RawPath set)
+	// is refused regardless of the decoded value: %2F smuggling is
+	// invisible in the decoded tail.
+	for _, tail := range []string{"a/b.js", "lib/app.js", "x"} {
+		if err := validateTail(tail, true); err == nil {
+			t.Errorf("validateTail(%q, rawEncoded=true) accepted an encoded-smuggle form", tail)
+		}
+	}
+	good := []string{"", "a.js", "lib/app.js", "v1/x.y-z_1.js"}
+	for _, tail := range good {
+		if err := validateTail(tail, false); err != nil {
+			t.Errorf("validateTail(%q) = %v, want accepted", tail, err)
+		}
+	}
+}
+
+func TestHostileTailsRejectedOrStayOnHost(t *testing.T) {
+	base, cap := startRelayCap(t, defaultCfg)
+
+	// One legit request first so the capture holds the real upstream
+	// host for comparison.
+	res, err := http.Get(base + "/__gofastr/t/e/x")
+	if err != nil {
+		t.Fatalf("legit get: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("legit get status = %d", res.StatusCode)
+	}
+	_, _, upstreamHost, _, _ := cap.snapshot()
+	if upstreamHost == "" {
+		t.Fatal("no upstream host captured")
+	}
+
+	// Smuggled-encoding, traversal, and control forms must be refused
+	// outright: no 200 from anywhere.
+	mustRefuse := []string{
+		"..%2F..%2Fkeys",
+		"%2e%2e/admin",
+		"a%2Fb",
+		"%2f%2fevil.example",
+		"a%5Cb",
+		"a%00b",
+		"a%01b",
+		"a%1fb",
+		"a%23b",
+		"../../../etc/passwd",
+	}
+	for _, tail := range mustRefuse {
+		req, _ := http.NewRequest(http.MethodGet, base+"/__gofastr/t/e/"+tail, nil)
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("tail %q: request error: %v", tail, err)
+		}
+		res.Body.Close()
+		if res.StatusCode == http.StatusOK {
+			t.Fatalf("tail %q: answered 200; smuggling must be refused, got uri from upstream", tail)
+		}
+	}
+
+	// Origin-looking tails are either cleaned by the mux or forwarded
+	// as ordinary path segments — either way they land on the FIXED
+	// upstream, inside its base path. Request data can never select
+	// scheme, host, or port.
+	mustStayOnHost := []string{
+		"https://evil.example",
+		"http://evil.example",
+		"//evil.example",
+		"https:////evil.example",
+		"@evil.example/x",
+		"evil.example:8443/x",
+	}
+	for _, tail := range mustStayOnHost {
+		req, _ := http.NewRequest(http.MethodGet, base+"/__gofastr/t/e/"+tail, nil)
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("tail %q: request error: %v", tail, err)
+		}
+		res.Body.Close()
+		if res.StatusCode == http.StatusOK {
+			_, uri, host, _, _ := cap.snapshot()
+			if host != upstreamHost {
+				t.Fatalf("tail %q: 200 from host %q (upstream host %q) — request data selected the origin", tail, host, upstreamHost)
+			}
+			if !strings.HasPrefix(uri, "/cdn/") {
+				t.Fatalf("tail %q: escaped the upstream base path: %q", tail, uri)
+			}
+		}
+	}
+}
+
+// TestRawFragmentTailRefused: a literal "#" in the request-target
+// (only sendable by a raw client — Go's http.Client strips fragments
+// and escapes any "#" it finds in a URL) reaches the handler decoded
+// into the tail. The sink validator must refuse it: forwarded verbatim
+// it would be re-escaped upstream, but a relay that accepts fragment
+// markers into tails is one refactor away from accepting them
+// anywhere.
+func TestRawFragmentTailRefused(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(up.Close)
+
+	app := framework.NewApp(framework.WithoutDefaultMiddleware())
+	app.RegisterPlugin(New(defaultCfg(up.URL + "/cdn")))
+	if err := app.InitPlugins(); err != nil {
+		t.Fatalf("InitPlugins: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/__gofastr/t/e/lib.js#frag", nil)
+	rec := httptest.NewRecorder()
+	app.Router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for a fragment in the tail", rec.Code)
+	}
+}
+
+func TestNewPanicsOnBadUpstream(t *testing.T) {
+	bad := []string{
+		"",
+		"notaurl",
+		"ftp://example.com/x",
+		"https://user:pw@example.com", // embedded credentials
+		"https://example.com?q=1",     // query in upstream base
+		"https://example.com#frag",    // fragment in upstream base
+		"http://example.com",          // http to a non-loopback host
+		"http://192.168.1.4",          // http + private
+		"https://10.0.0.5",            // RFC1918 literal
+		"https://192.168.1.4",         // RFC1918 literal
+		"https://172.16.3.3",          // RFC1918 literal
+		"https://169.254.169.254",     // cloud metadata
+		"https://100.64.0.1",          // CGNAT
+		"https://host.internal",       // internal-suffixed name
+		"https://metadata.google.internal",
+		"https://[fd00::1]", // IPv6 unique-local
+	}
+	for _, up := range bad {
+		cfg := Config{Routes: []Route{{Prefix: "e/", Upstream: up, Methods: []string{"GET"}}}}
+		got := func() (msg string) {
+			defer func() { msg, _ = recover().(string) }()
+			New(cfg)
+			return ""
+		}()
+		if got == "" {
+			t.Errorf("New(upstream=%q) did not panic", up)
+			continue
+		}
+		if !strings.Contains(got, "relay:") {
+			t.Errorf("New(upstream=%q) panic = %q, want a relay: message", up, got)
+		}
+	}
+}
+
+func TestNewAcceptsLoopbackAndHTTPS(t *testing.T) {
+	good := []string{
+		"http://127.0.0.1:9999",   // loopback literal, http allowed
+		"http://localhost:9999",   // loopback name
+		"http://[::1]:9999",       // IPv6 loopback
+		"https://example.com",     // plain https
+		"https://example.com/cdn", // base path
+		"https://203.0.113.7",     // public literal
+	}
+	for _, up := range good {
+		cfg := Config{Routes: []Route{{Prefix: "e/", Upstream: up, Methods: []string{"GET"}}}}
+		r := New(cfg)
+		if r == nil || r.Name() != "relay" {
+			t.Errorf("New(upstream=%q) returned %v", up, r)
+		}
+	}
+}
+
+func TestResolvedPrivateUpstreamRefused(t *testing.T) {
+	lookupPrivate := func(host string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("203.0.113.7"), net.ParseIP("10.0.0.7")}, nil
+	}
+	if err := validateUpstreamURL("https://acme.dev", lookupPrivate); err == nil {
+		t.Fatal("hostname resolving onto an RFC1918 IP was accepted")
+	}
+	lookupPublic := func(host string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("203.0.113.7")}, nil
+	}
+	if err := validateUpstreamURL("https://acme.dev", lookupPublic); err != nil {
+		t.Fatalf("public resolution refused: %v", err)
+	}
+	lookupFail := func(host string) ([]net.IP, error) {
+		return nil, net.UnknownNetworkError("dns")
+	}
+	if err := validateUpstreamURL("https://acme.dev", lookupFail); err != nil {
+		t.Fatalf("DNS failure at construction should defer to request time, got %v", err)
+	}
+}
+
+func TestNewPanicsOnBadRouteConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		r    Route
+	}{
+		{"empty prefix", Route{Upstream: "https://example.com", Methods: []string{"GET"}}},
+		{"traversal prefix", Route{Prefix: "../x", Upstream: "https://example.com", Methods: []string{"GET"}}},
+		{"dot-dot segment", Route{Prefix: "e/..", Upstream: "https://example.com", Methods: []string{"GET"}}},
+		{"empty segment", Route{Prefix: "a//b", Upstream: "https://example.com", Methods: []string{"GET"}}},
+		{"absolute prefix", Route{Prefix: "/abs", Upstream: "https://example.com", Methods: []string{"GET"}}},
+		{"encoded prefix", Route{Prefix: "a%2fb", Upstream: "https://example.com", Methods: []string{"GET"}}},
+		{"control char prefix", Route{Prefix: "a\x01b", Upstream: "https://example.com", Methods: []string{"GET"}}},
+		{"backslash prefix", Route{Prefix: `a\b`, Upstream: "https://example.com", Methods: []string{"GET"}}},
+		{"empty methods", Route{Prefix: "e/", Upstream: "https://example.com"}},
+		{"lowercase method", Route{Prefix: "e/", Upstream: "https://example.com", Methods: []string{"get"}}},
+		{"method with space", Route{Prefix: "e/", Upstream: "https://example.com", Methods: []string{"POS T"}}},
+		{"negative body cap", Route{Prefix: "e/", Upstream: "https://example.com", Methods: []string{"GET"}, MaxBodyBytes: -1}},
+	}
+	for _, tc := range cases {
+		cfg := Config{Routes: []Route{tc.r}}
+		got := func() (msg string) {
+			defer func() { msg, _ = recover().(string) }()
+			New(cfg)
+			return ""
+		}()
+		if got == "" {
+			t.Errorf("New(%s) did not panic", tc.name)
+			continue
+		}
+		if !strings.Contains(got, "relay:") {
+			t.Errorf("New(%s) panic = %q, want a relay: message", tc.name, got)
+		}
+	}
+
+	// Duplicate prefixes across routes.
+	dup := func() (msg string) {
+		defer func() { msg, _ = recover().(string) }()
+		New(Config{Routes: []Route{
+			{Prefix: "e/", Upstream: "https://example.com", Methods: []string{"GET"}},
+			{Prefix: "e/", Upstream: "https://other.example.com", Methods: []string{"POST"}},
+		}})
+		return ""
+	}()
+	if dup == "" {
+		t.Error("duplicate route prefix did not panic")
+	}
+}
+
+func TestNewPanicsOnBadPath(t *testing.T) {
+	bad := []string{
+		"", // handled by default, not panic — see below; keep list explicit
+		"/__gofastr",
+		"/__gofastr/",
+		"/__gofastr/sse",
+		"/__gofastr/runtime.js/x",
+		"t/e",
+		"/t/",
+		"/a//b",
+		"/a/../b",
+		"/a%2Fb",
+		"/a b",
+	}
+	for _, p := range bad {
+		if p == "" {
+			continue
+		}
+		cfg := Config{Path: p, Routes: []Route{{Prefix: "e/", Upstream: "https://example.com", Methods: []string{"GET"}}}}
+		got := func() (msg string) {
+			defer func() { msg, _ = recover().(string) }()
+			New(cfg)
+			return ""
+		}()
+		if got == "" {
+			t.Errorf("New(path=%q) did not panic", p)
+			continue
+		}
+		if !strings.Contains(got, "relay:") {
+			t.Errorf("New(path=%q) panic = %q, want a relay: message", p, got)
+		}
+	}
+}
+
+func TestNoRoutesPanics(t *testing.T) {
+	got := func() (msg string) {
+		defer func() { msg, _ = recover().(string) }()
+		New(Config{Path: "/t"})
+		return ""
+	}()
+	if got == "" {
+		t.Fatal("New with zero routes did not panic")
+	}
+}

--- a/battery/relay/tail.go
+++ b/battery/relay/tail.go
@@ -1,0 +1,68 @@
+package relay
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// validateTail is the sink-side guard on the only attacker-influenced
+// part of a relay request: the subtree remainder under a route prefix.
+//
+// The framework's router already bounds path params (core/router.Param
+// truncates at CR/LF/NUL, single-segment slashes, and dot-dot
+// segments), and Go's ServeMux cleans literal traversal and duplicate
+// slashes out of the request path before matching. Neither replaces
+// validation at the sink: encoded forms ("%2e%2e", "%2f", "%23", "%5c")
+// survive both layers decoded into the tail, and PathValue-based
+// truncation would silently proxy a DIFFERENT path than the one the
+// client asked for. This validator rejects instead of truncating.
+//
+// rawEncoded reports whether r.URL.RawPath is non-empty, i.e. some
+// part of the request URL was percent-encoded in a way that does not
+// round-trip as the canonical encoding of the decoded value (how
+// "%2F" and "%2e" smuggling present). Any such encoding in the tail
+// region is refused outright: legit vendor asset paths are plain, and
+// the canonical encodings that DO round-trip (UTF-8, "%20") leave
+// RawPath empty and pass.
+func validateTail(tail string, rawEncoded bool) error {
+	if rawEncoded {
+		return fmt.Errorf("path tail uses non-canonical percent-encoding (possible %%2F/%%2e smuggling)")
+	}
+	if tail == "" {
+		return nil
+	}
+	for i := range len(tail) {
+		c := tail[i]
+		if c < 0x20 || c == 0x7f {
+			return fmt.Errorf("path tail contains a control character")
+		}
+	}
+	if strings.Contains(tail, "\\") {
+		return fmt.Errorf(`path tail contains a backslash`)
+	}
+	if strings.Contains(tail, "#") {
+		return fmt.Errorf("path tail contains a fragment marker")
+	}
+	for _, seg := range strings.Split(tail, "/") {
+		if seg == "" {
+			return fmt.Errorf("path tail contains an empty segment")
+		}
+		if seg == "." || seg == ".." {
+			return fmt.Errorf("path tail contains a traversal segment")
+		}
+	}
+	return nil
+}
+
+// joinUpstreamPath maps a validated tail onto the upstream's base
+// path. path.Join also lexically cleans the result: with the tail
+// validator in front it is a no-op, but it guarantees that even a
+// smuggled dot-segment could only resolve INSIDE the upstream's base
+// path, never into another origin.
+func joinUpstreamPath(base, tail string) string {
+	if base == "" {
+		base = "/"
+	}
+	return path.Join(base, tail)
+}

--- a/cmd/gofastr/agents.go
+++ b/cmd/gofastr/agents.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/DonaldMurillo/gofastr/battery/notify"
 	_ "github.com/DonaldMurillo/gofastr/battery/print"
 	_ "github.com/DonaldMurillo/gofastr/battery/queue"
+	_ "github.com/DonaldMurillo/gofastr/battery/relay"
 	_ "github.com/DonaldMurillo/gofastr/battery/search"
 	_ "github.com/DonaldMurillo/gofastr/battery/setup"
 	_ "github.com/DonaldMurillo/gofastr/battery/storage"

--- a/cmd/gofastr/embedded/gofastr-host-skill.md
+++ b/cmd/gofastr/embedded/gofastr-host-skill.md
@@ -1,6 +1,6 @@
 ---
 name: gofastr-host
-description: Auto-loads when working on a *host application* that imports the GoFastr framework (not the framework itself). Encodes the "don't reinvent: reach for the battery first" rule and the import paths an agent needs. Triggers on edits to Go files in repos that import `github.com/DonaldMurillo/gofastr/...`, on `main.go` files calling `framework.NewApp`, and on phrases like "login", "signup", "session", "user table", "log out", "magic link", "forgot password", "reset password", "add admin page", "back office", "audit log", "audit trail", "compliance log", "send email", "transactional email", "welcome email", "send a notification", "notify the user", "background job", "async task", "schedule", "cron", "run every hour", "retry on failure", "upload", "store images", "store files", "S3", "MinIO", "attachments", "avatar", "full-text search", "find records containing", "outbound webhook", "signed callback", "POST to a customer URL", "cache", "memoize", "remember for N seconds", "CSRF", "RBAC", "require admin", "roles", "rate limit", "throttle", "request log", "access log", "panic recovery", "structured logging", "live debug", "per-test isolated DB", "test fixture", "favicon", "app icon", "SEO", "meta tags", "Open Graph", "JSON-LD", "structured data", "sitemap", "robots.txt", "accessibility", "a11y", "WCAG", "aria-label", "upgrade gofastr", "bump the framework version", "migrate to the new version", "live updates", "auto-refresh", "real-time", "websocket", "polling", "multiple replicas", "horizontal scaling".
+description: Auto-loads when working on a *host application* that imports the GoFastr framework (not the framework itself). Encodes the "don't reinvent: reach for the battery first" rule and the import paths an agent needs. Triggers on edits to Go files in repos that import `github.com/DonaldMurillo/gofastr/...`, on `main.go` files calling `framework.NewApp`, and on phrases like "login", "signup", "session", "user table", "log out", "magic link", "forgot password", "reset password", "add admin page", "back office", "audit log", "audit trail", "compliance log", "send email", "transactional email", "welcome email", "send a notification", "notify the user", "background job", "async task", "schedule", "cron", "run every hour", "retry on failure", "upload", "store images", "store files", "S3", "MinIO", "attachments", "avatar", "full-text search", "find records containing", "outbound webhook", "signed callback", "POST to a customer URL", "cache", "memoize", "remember for N seconds", "CSRF", "RBAC", "require admin", "roles", "rate limit", "throttle", "request log", "access log", "panic recovery", "structured logging", "live debug", "per-test isolated DB", "test fixture", "favicon", "app icon", "SEO", "meta tags", "Open Graph", "JSON-LD", "structured data", "sitemap", "robots.txt", "accessibility", "a11y", "WCAG", "aria-label", "upgrade gofastr", "bump the framework version", "migrate to the new version", "live updates", "auto-refresh", "real-time", "websocket", "polling", "multiple replicas", "horizontal scaling", "PostHog", "Statsig", "Plausible", "analytics", "product analytics", "A/B test", "experiment", "feature flag vendor", "ad blocker", "first-party proxy", "reverse proxy a vendor".
 ---
 
 # GoFastr host-app: load this before writing app code
@@ -70,6 +70,7 @@ generated guidance.
 | image upload wanting thumbnails, srcset, blur placeholder | `framework.WithImagePipeline(imagefield.MustNew(...))`: every `schema.Image` upload gets renditions + a BlurHash, written to `<field>_blurhash` / `<field>_variants` / `<field>_placeholder` sibling columns you declare. Render with `image.BlurHashDataURL` + `ui.PipelineImage`. Per-field variation via `WithImagePipelineFor`. Never hand-roll resize/encode in an upload handler |
 | full-text search | `battery/search` |
 | outbound signed webhooks with retry | `battery/webhook` |
+| PostHog, Statsig, Plausible, product analytics, A/B test, experiment behind a vendor, ad blocker eating the vendor script, first-party proxy | `battery/relay` + a host-authored bootstrap: `gofastr docs analytics-recipes` (relay routes, `uihost.ScriptHandler` + `RegisterExternalScript(uihost.ScriptURL(...))`, one pageview per `gofastr:navigate`, `{"id":...}` endpoint over `handler.GetUser`) |
 | cache key/value, memoize, "remember for N seconds" | `battery/cache` |
 | UI components, page layout, forms, tables, theming, dark mode | `framework/ui` (~100 components): `gofastr docs ui-composition-recipes` for page grammar, `gofastr docs ui-new-components` for the catalog, live demos at `/components/<slug>` on the docs site (`examples/site`) |
 | live/auto-refreshing dashboard, counter, status ("websockets"?) | the reactivity ladder (`gofastr docs reactivity`): passive freshness = `data-fui-poll` / widget `Builder.Poll` (no connection, no infra); SSE bus ONLY for presence/collab/sub-second; never WebSockets, never a bespoke `EventSource` |
@@ -88,6 +89,22 @@ generated guidance.
 | upgrading the framework version, migration notes between releases | install the target CLI first, then `gofastr upgrade [--to vX.Y.Z] [--apply]`. It shows every migration-relevant change in range with file:line hits in your app; `gofastr docs upgrading`; finish with `gofastr agents sync` |
 | customer-facing CLI, "ship a terminal client", stripe/gh-style CLI for my API | `gofastr generate cli`: standalone stdlib binary, scoped `gfsk_` token auth, `custom.go` extension seam; `gofastr docs app-cli` |
 | client SDKs, "publish an SDK", downloadable Go/JS/TS client, API docs site for customers | `gofastr generate sdk` (Go module zip + client.js/client.d.ts under `gen/sdk/`) + `sdkdocs.Mount(site, app.Router(), sdkdocs.Config{Registry: app.Registry, Artifacts: os.DirFS("gen/sdk/dist")})` for the hosted docs site + downloads; `gofastr docs sdk` |
+
+## First-party analytics and experiments
+
+When the task is wiring a hosted analytics or experimentation vendor
+(PostHog, Statsig, Plausible), do not link their CDN and do not punch
+`script-src`/`connect-src` holes into the CSP. The shipped pattern:
+`battery/relay` mounts the vendor's SDK and endpoints under one
+same-origin path with fixed upstreams; your own bootstrap JS is served
+via `uihost.ScriptHandler` and registered with
+`RegisterExternalScript(uihost.ScriptURL(...))`, so it ships on every
+full-page render and survives client-side navigation; pageviews ride the
+runtime's `gofastr:navigate` event (fire the initial one yourself; never
+count on `gofastr:beforenavigate`, it is cancelable and pre-commit);
+identity comes from a same-origin endpoint over `handler.GetUser`.
+`gofastr docs analytics-recipes` has both vendors wired end to end, plus
+a `featureflag.Store` adapter for server-side boolean gates.
 
 ## Hard rules
 

--- a/core-ui/ARCHITECTURE.md
+++ b/core-ui/ARCHITECTURE.md
@@ -595,6 +595,31 @@ client-side with no per-consumer round-trip.
 
 See `framework/docs/content/signal-store.md` for the full guide.
 
+### Extra scripts (the body-close script rail)
+
+`uihost.WithExtraScripts` adds external `<script src="…">` tags just
+before `</body>`, after `runtime.js` and the per-screen action scripts.
+They are same-origin resources under the default CSP (`default-src
+'self'`), so every URL on the rail must be a path the app itself serves;
+the dev livereload client is the canonical example. The tags ship only on
+full shell renders — SPA partial responses never carry them.
+
+Options freeze at `New`, but plugins and batteries wire themselves in
+`Init`, which runs after `Mount`. `(*uihost.UIHost).RegisterExternalScript`
+exists for that window: it appends to the same rail, in
+first-registration order, and is idempotent. `src` must be a same-origin
+absolute path (`/x.js`), optionally with a query (`/x.js?v=abc`);
+schemes, protocol-relative URLs, backslashes, control characters, and
+`.`/`..` segments (raw or percent-encoded) are rejected. Registration
+returns an error once the host has rendered its first full shell: a late
+registration would ship on some pages and not others.
+
+`uihost.ScriptHandler(js)` and `uihost.ScriptURL(path, js)` are the
+serving half for host apps: mount the handler at `path`, register the
+returned `path?v=<hash>` URL, and the response follows the same
+strong-ETag + immutable-on-match policy as every `/__gofastr` script,
+with the hash changing whenever the bytes do.
+
 ### Background compute (`core-ui/compute`)
 
 Applications register self-contained worker JavaScript and WebAssembly bytes

--- a/examples/site/analytics_demo.go
+++ b/examples/site/analytics_demo.go
@@ -1,0 +1,148 @@
+package main
+
+// Fake first-party analytics wiring — TEST/DEMO ONLY.
+//
+// This file exists so the e2e suite (e2e_analytics_test.go) can prove the
+// shipped first-party analytics mechanisms end to end against a
+// PostHog-shaped fake vendor, with zero vendor accounts:
+//
+//   - battery/relay mounts the vendor's SDK and event endpoint on THIS
+//     origin (default mount /__gofastr/t), so the strict default CSP
+//     (default-src 'self') needs no script-src/connect-src exceptions and
+//     the page never contacts a third-party origin.
+//   - uihost.ScriptHandler + uihost.ScriptURL + RegisterExternalScript
+//     serve the host-authored bootstrap as an external, hash-versioned
+//     script — zero inline JS anywhere.
+//   - handler.GetUser backs a whoami endpoint so the bootstrap can
+//     identify the visitor when an auth chain is present.
+//
+// Inert unless BOTH env vars are set (the e2e suite sets them via
+// t.Setenv before booting the app):
+//
+//	SITE_ANALYTICS_FAKE=1
+//	SITE_ANALYTICS_FAKE_UPSTREAM=http://127.0.0.1:<port>
+//
+// The default site build never sets them, so its behavior is byte-for-byte
+// identical with this file present: wireFakeAnalytics returns before
+// touching the app. relay.New itself enforces that the upstream is a
+// loopback http:// origin — exactly what a test httptest server is.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/DonaldMurillo/gofastr/battery/relay"
+	"github.com/DonaldMurillo/gofastr/core/handler"
+	"github.com/DonaldMurillo/gofastr/framework"
+	"github.com/DonaldMurillo/gofastr/framework/uihost"
+)
+
+// fakeAnalyticsBootstrapJS is the host-authored page bootstrap, the recipe
+// a real integration would ship: configure the SDK, load it through the
+// relay, resolve identity, fire the initial pageview, and translate the
+// runtime's SPA navigation event into one pageview per destination.
+//
+// Served by uihost.ScriptHandler as an EXTERNAL script (CSP: no inline JS)
+// and registered with RegisterExternalScript so every full-page render
+// emits it after runtime.js. SPA partial responses never carry it, so the
+// listener survives client-side navigation exactly once.
+const fakeAnalyticsBootstrapJS = `(function () {
+  'use strict';
+  // The relayed mount points (fixed at wiring time; both same-origin).
+  // The events URL carries a tail segment ("batch") the way real vendor
+  // SDKs do: the relay maps the sanitized tail verbatim onto the upstream
+  // base path, and an empty tail would join as "/e" (path.Join drops the
+  // trailing slash).
+  var SDK_URL = '/__gofastr/t/js/sdk.js';
+  var EVENTS_URL = '/__gofastr/t/e/batch';
+
+  // Configure the vendor SDK before it loads: it reads this on execution.
+  window.__fakeVendorCfg = { eventsURL: EVENTS_URL };
+
+  function vendor() { return window.__fakeVendor; }
+  function pageview(path) {
+    var v = vendor();
+    if (v && v.capture) v.capture('$pageview', { path: path });
+  }
+
+  // SPA navigation: the runtime swaps <main> without a reload and fires
+  // gofastr:navigate carrying the destination path.
+  window.addEventListener('gofastr:navigate', function (e) {
+    pageview((e.detail && e.detail.path) || location.pathname);
+  });
+
+  var s = document.createElement('script');
+  s.src = SDK_URL;
+  s.async = true;
+  s.onload = function () {
+    // Who is the current visitor? Anonymous until the app says otherwise.
+    fetch('/__site/analytics/whoami', { headers: { 'Accept': 'application/json' } })
+      .then(function (r) { return r.json(); })
+      .then(function (me) {
+        var v = vendor();
+        if (v && v.identify && me && me.id) v.identify(me.id);
+        pageview(location.pathname);
+      })
+      .catch(function () { /* analytics must never break the page */ });
+  };
+  document.head.appendChild(s);
+})();
+`
+
+// wireFakeAnalytics wires the fake analytics integration into the site app
+// when the test env gate is on. host is the site's uihost, app the
+// wrapping framework.App. See the file comment for the full contract.
+func wireFakeAnalytics(host *uihost.UIHost, app *framework.App) {
+	if os.Getenv("SITE_ANALYTICS_FAKE") != "1" {
+		return // default build: nothing below runs
+	}
+	upstream := os.Getenv("SITE_ANALYTICS_FAKE_UPSTREAM")
+	if upstream == "" {
+		panic("analytics_demo: SITE_ANALYTICS_FAKE=1 requires SITE_ANALYTICS_FAKE_UPSTREAM (a loopback http:// origin)")
+	}
+
+	// 1. The relay: vendor SDK + event beacons become same-origin. The
+	// assets route is CacheOK (an immutable, versioned script); the
+	// events route is a POST-only beacon endpoint.
+	app.RegisterPlugin(relay.New(relay.Config{
+		Routes: []relay.Route{
+			{Prefix: "js/", Upstream: upstream + "/js", Methods: []string{http.MethodGet}, CacheOK: true},
+			{Prefix: "e/", Upstream: upstream + "/e", Methods: []string{http.MethodPost}},
+		},
+	}))
+
+	// 2. The bootstrap: host-authored external script, served with the
+	// framework's versioned-script caching policy (strong ETag, immutable
+	// on matching ?v=) and registered onto every full-page render.
+	js := []byte(fakeAnalyticsBootstrapJS)
+	app.Router().Get("/__site/analytics/bootstrap.js", uihost.ScriptHandler(js))
+	if err := host.RegisterExternalScript(uihost.ScriptURL("/__site/analytics/bootstrap.js", js)); err != nil {
+		panic("analytics_demo: RegisterExternalScript: " + err.Error())
+	}
+
+	// 3. Identity endpoint: who is the current visitor? Anonymous (id
+	// null) unless an auth chain put a user in the request context.
+	app.Router().Get("/__site/analytics/whoami", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		var id any // nil marshals to JSON null
+		if u, ok := handler.GetUser(r.Context()); ok && u != nil {
+			switch v := u.(type) {
+			case string:
+				id = v
+			case fmt.Stringer:
+				id = v.String()
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
+	}))
+
+	// The e2e harness drives app.Router() directly (no App.Start), so run
+	// the plugin Inits explicitly — the same call Start makes; it is
+	// idempotent and documents the production flow.
+	if err := app.InitPlugins(); err != nil {
+		panic("analytics_demo: InitPlugins: " + err.Error())
+	}
+}

--- a/examples/site/docs_catalog.go
+++ b/examples/site/docs_catalog.go
@@ -181,6 +181,8 @@ var docIntents = []docIntent{
 			{"scaling", "Horizontal scaling", "What's process-local by default and the replica-safe alternative for each."},
 			{"queue", "Job queue", "Durable background jobs via battery/queue."},
 			{"feature-flags", "Feature flags", "Rollout percentage, allow lists, env evaluator."},
+			{"relay", "First-party relay", "Same-origin reverse proxy for third-party services: fixed upstreams, method allow-lists, credentials stripped both ways."},
+			{"analytics-recipes", "Analytics recipes", "PostHog and Statsig first-party through battery/relay: bootstrap script, SPA pageviews, identity, server-side flag gates."},
 			{"i18n", "i18n", "JSON catalogs, plurals, Accept-Language negotiation."},
 			{"cron", "Cron", "Scheduled jobs with retry + jitter."},
 			{"events", "Events", "In-process pub/sub for decoupled side effects."},

--- a/examples/site/e2e_analytics_test.go
+++ b/examples/site/e2e_analytics_test.go
@@ -262,7 +262,12 @@ func (n *netRecorder) requestsMatching(prefix string) []netRecorded {
 	var out []netRecorded
 	for _, r := range n.reqs {
 		if strings.HasPrefix(r.URL, prefix) {
-			out = append(out, r)
+			// Deep-copy the header map: the CDP listener keeps writing
+			// into the recorded entry (ExtraInfo events) under the lock,
+			// and callers read the result after the lock is released.
+			cp := r
+			cp.Header = r.Header.Clone()
+			out = append(out, cp)
 		}
 	}
 	return out
@@ -273,7 +278,11 @@ func (n *netRecorder) responseMatching(prefix string) *netRecorded {
 	defer n.mu.Unlock()
 	for i := range n.resps {
 		if strings.HasPrefix(n.resps[i].URL, prefix) {
-			return &n.resps[i]
+			// Copy out (headers included): the listener keeps mutating
+			// the slice entry under the lock after we return.
+			cp := n.resps[i]
+			cp.Header = cp.Header.Clone()
+			return &cp
 		}
 	}
 	return nil

--- a/examples/site/e2e_analytics_test.go
+++ b/examples/site/e2e_analytics_test.go
@@ -1,0 +1,653 @@
+package main
+
+// Browser-level (chromedp) e2e for the first-party analytics pattern:
+// battery/relay + uihost.ScriptHandler/ScriptURL/RegisterExternalScript +
+// the handler.GetUser identity endpoint, all wired through the env-gated
+// analytics_demo.go seam. The "vendor" is an httptest server speaking a
+// PostHog-shaped protocol — zero vendor accounts, zero network egress
+// beyond loopback.
+//
+// What each test pins:
+//
+//   - InitialLoad: the SDK and the initial $pageview both arrive at the
+//     vendor THROUGH the relay (server-side recorded requests) while the
+//     browser's own network log never leaves the app origin, under the
+//     strict default CSP (pinned byte-for-byte), with zero console errors
+//     or CSP violations.
+//   - SPANav: one real client-side navigation (data-fui router) produces
+//     exactly one more $pageview carrying the destination path, and the
+//     SDK is NOT re-fetched (SPA partial responses carry no script tags).
+//   - CancelledNav: a listener that preventDefault()s gofastr:beforenavigate
+//     claims the click; no pageview fires and the URL stays put.
+//   - CredentialStripping: with a cookie held on the app origin, the
+//     browser demonstrably sends it on the same-origin relay beacon while
+//     the vendor never sees Cookie/Authorization (inbound stripping) and
+//     the vendor's Set-Cookie never reaches the browser (outbound).
+//   - IdentityEndpoint: plain HTTP shape of whoami — application/json,
+//     no-store, {"id":null} anonymous.
+//
+// Gated by -short like every chromedp e2e in this package; run serialized
+// (the shared browser is single-tenant).
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	cdplog "github.com/chromedp/cdproto/log"
+	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/cdproto/runtime"
+	"github.com/chromedp/chromedp"
+)
+
+// wantDefaultCSP is the framework's strict default Content-Security-Policy
+// (core/middleware security.go), the one the analytics integration must
+// live under without any widening.
+const wantDefaultCSP = "default-src 'self'; img-src 'self' data:; object-src 'none'; " +
+	"form-action 'self'; frame-ancestors 'none'; base-uri 'self'"
+
+// fakeVendorSDKJS is the tiny "vendor SDK" served by the fake upstream
+// THROUGH the relay. PostHog-shaped surface: window.__fakeVendor with
+// capture(name, props) POSTing JSON to the configured events URL, plus
+// identify/reset recording their calls. It deliberately uses default
+// fetch() credentials ("same-origin"), so the app-origin cookie jar rides
+// the beacon — exactly what the relay must strip.
+const fakeVendorSDKJS = `(function () {
+  'use strict';
+  var cfg = window.__fakeVendorCfg || {};
+  var eventsURL = cfg.eventsURL || '/__gofastr/t/e/';
+  var calls = [];
+  window.__fakeVendor = {
+    capture: function (name, props) {
+      calls.push({ op: 'capture', name: name, props: props || {} });
+      fetch(eventsURL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          event: name, props: props || {}, url: location.href, ts: Date.now()
+        }),
+      }).catch(function () {});
+    },
+    identify: function (id) { calls.push({ op: 'identify', id: id }); },
+    reset: function () { calls.push({ op: 'reset' }); },
+    _calls: calls,
+  };
+})();
+`
+
+// fakeVendorReq is one request the fake vendor upstream received.
+type fakeVendorReq struct {
+	Method string
+	URI    string // path?query as the upstream saw it
+	Header http.Header
+	Body   string
+}
+
+// fakeVendor is the fake vendor upstream: records every request and serves
+// the SDK + event endpoints the relay points at.
+type fakeVendor struct {
+	mu   sync.Mutex
+	reqs []fakeVendorReq
+	srv  *httptest.Server
+}
+
+func newFakeVendor(t *testing.T) *fakeVendor {
+	t.Helper()
+	f := &fakeVendor{}
+	mux := http.NewServeMux()
+	// SDK: any /js/... path serves the fake SDK (the relay maps the tail
+	// verbatim; the bootstrap requests /js/sdk.js).
+	mux.HandleFunc("/js/", func(w http.ResponseWriter, r *http.Request) {
+		f.record(r, "")
+		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+		// CacheOK route: the relay passes upstream cache headers through.
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		fmt.Fprint(w, fakeVendorSDKJS)
+	})
+	// Events beacon endpoint: PostHog-style 200 {"status":1}. It also
+	// sets a cookie the relay must strip on the way back out.
+	mux.HandleFunc("/e/", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(io.LimitReader(r.Body, 64<<10))
+		f.record(r, string(body))
+		http.SetCookie(w, &http.Cookie{Name: "vendor_sid", Value: "leak-attempt"})
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"status":1}`)
+	})
+	f.srv = httptest.NewServer(mux)
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func (f *fakeVendor) record(r *http.Request, body string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reqs = append(f.reqs, fakeVendorReq{
+		Method: r.Method,
+		URI:    r.URL.RequestURI(),
+		Header: r.Header.Clone(),
+		Body:   body,
+	})
+}
+
+func (f *fakeVendor) requests() []fakeVendorReq {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]fakeVendorReq(nil), f.reqs...)
+}
+
+// pageviews returns the paths of every $pageview event received, in order.
+func (f *fakeVendor) pageviews() []string {
+	var paths []string
+	for _, q := range f.requests() {
+		if q.Method != http.MethodPost || !strings.HasPrefix(q.URI, "/e/") {
+			continue
+		}
+		var ev struct {
+			Event string `json:"event"`
+			Props struct {
+				Path string `json:"path"`
+			} `json:"props"`
+		}
+		if err := json.Unmarshal([]byte(q.Body), &ev); err != nil || ev.Event != "$pageview" {
+			continue
+		}
+		paths = append(paths, ev.Props.Path)
+	}
+	return paths
+}
+
+// analyticsE2EServer boots the site with the fake analytics wiring enabled
+// (analytics_demo.go) pointed at a fresh fake vendor, and returns the
+// vendor plus the app's base URL. Each call is its own app + upstream, so
+// tests never share recorded-request state.
+func analyticsE2EServer(t *testing.T) (*fakeVendor, string) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("e2e: -short")
+	}
+	upstream := newFakeVendor(t)
+	t.Setenv("SITE_ANALYTICS_FAKE", "1")
+	t.Setenv("SITE_ANALYTICS_FAKE_UPSTREAM", upstream.srv.URL)
+	base := siteE2EServer(t)
+	return upstream, base
+}
+
+// waitForAnalytics polls cond until true or the deadline passes, then
+// fatals with desc.
+func waitForAnalytics(t *testing.T, desc string, deadline time.Duration, cond func() bool) {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if cond() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", desc)
+}
+
+// netRecorded is one browser-side request (or response) captured from CDP
+// network events, with ExtraInfo headers merged over the base set (that is
+// where the network layer reports the attached Cookie header).
+type netRecorded struct {
+	URL    string
+	Method string
+	Header http.Header
+}
+
+// netRecorder captures every request the browser makes, to prove the page
+// never leaves the app origin and to inspect what the browser really sent
+// on the relay beacon.
+type netRecorder struct {
+	origin string
+	mu     sync.Mutex
+	reqs   []netRecorded
+	resps  []netRecorded
+	// requestID → index into reqs, for merging ExtraInfo headers.
+	byID map[network.RequestID]int
+}
+
+func (n *netRecorder) listen(ctx context.Context) {
+	chromedp.ListenTarget(ctx, func(ev any) {
+		switch e := ev.(type) {
+		case *network.EventRequestWillBeSent:
+			n.mu.Lock()
+			if n.byID == nil {
+				n.byID = map[network.RequestID]int{}
+			}
+			n.byID[e.RequestID] = len(n.reqs)
+			n.reqs = append(n.reqs, netRecorded{
+				URL:    e.Request.URL,
+				Method: e.Request.Method,
+				Header: headerFromCDP(e.Request.Headers),
+			})
+			n.mu.Unlock()
+		case *network.EventRequestWillBeSentExtraInfo:
+			n.mu.Lock()
+			if i, ok := n.byID[e.RequestID]; ok {
+				for k, v := range headerFromCDP(e.Headers) {
+					n.reqs[i].Header[k] = v
+				}
+			}
+			n.mu.Unlock()
+		case *network.EventResponseReceived:
+			n.mu.Lock()
+			n.resps = append(n.resps, netRecorded{
+				URL:    e.Response.URL,
+				Header: headerFromCDP(e.Response.Headers),
+			})
+			n.mu.Unlock()
+		}
+	})
+}
+
+func headerFromCDP(h network.Headers) http.Header {
+	out := http.Header{}
+	for k, v := range h {
+		out.Set(k, fmt.Sprint(v))
+	}
+	return out
+}
+
+func (n *netRecorder) requestsMatching(prefix string) []netRecorded {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	var out []netRecorded
+	for _, r := range n.reqs {
+		if strings.HasPrefix(r.URL, prefix) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (n *netRecorder) responseMatching(prefix string) *netRecorded {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for i := range n.resps {
+		if strings.HasPrefix(n.resps[i].URL, prefix) {
+			return &n.resps[i]
+		}
+	}
+	return nil
+}
+
+// offOrigin returns every http(s) request URL that left the app origin.
+func (n *netRecorder) offOrigin() []string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	var out []string
+	for _, r := range n.reqs {
+		if strings.HasPrefix(r.URL, "http") && !strings.HasPrefix(r.URL, n.origin) {
+			out = append(out, r.URL)
+		}
+	}
+	return out
+}
+
+// assertDefaultCSP fetches url over plain HTTP and asserts the response
+// carries the framework's strict default Content-Security-Policy.
+func assertDefaultCSP(t *testing.T, url string) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if got := resp.Header.Get("Content-Security-Policy"); got != wantDefaultCSP {
+		t.Errorf("Content-Security-Policy = %q, want the framework default %q", got, wantDefaultCSP)
+	}
+}
+
+// TestE2E_Analytics_InitialLoad: full first paint under the strict default
+// CSP — the SDK loads and the initial pageview fires, both through the
+// relay (the vendor's own log proves it) while the browser never leaves
+// the app origin, and the console/CSP error sink stays empty.
+func TestE2E_Analytics_InitialLoad(t *testing.T) {
+	upstream, base := analyticsE2EServer(t)
+	ctx := siteBrowserCtx(t)
+	sink := &consoleErrSink{}
+	sink.listen(ctx)
+	net := &netRecorder{origin: base}
+	net.listen(ctx)
+
+	// Keystone precondition: the strict default CSP is active on the page.
+	assertDefaultCSP(t, base+"/")
+
+	if err := chromedp.Run(ctx,
+		runtime.Enable(),
+		cdplog.Enable(),
+		chromedp.Navigate(base+"/"),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+
+	// SDK load → whoami → initial pageview, in that order.
+	waitForAnalytics(t, "initial $pageview", 10*time.Second, func() bool {
+		return len(upstream.pageviews()) >= 1
+	})
+
+	if got := upstream.pageviews(); len(got) != 1 || got[0] != "/" {
+		t.Errorf("initial pageviews = %v, want exactly one for \"/\"", got)
+	}
+
+	// The vendor received the SDK fetch through the relay.
+	sdkFetches := 0
+	for _, q := range upstream.requests() {
+		if q.Method == http.MethodGet && q.URI == "/js/sdk.js" {
+			sdkFetches++
+		}
+	}
+	if sdkFetches < 1 {
+		t.Errorf("vendor never saw the SDK fetch through the relay (got %d GET /js/sdk.js)", sdkFetches)
+	}
+
+	// Browser-side: the SDK was requested from the app's own mount.
+	if n := len(net.requestsMatching(base + "/__gofastr/t/js/sdk.js")); n != 1 {
+		t.Errorf("browser made %d requests to the relayed SDK URL, want 1", n)
+	}
+
+	// Browser-side: nothing ever left the app origin.
+	if off := net.offOrigin(); len(off) > 0 {
+		t.Errorf("page contacted off-origin URLs (relay contract broken): %v", off)
+	}
+
+	// Keystone: zero console errors and zero CSP violations.
+	if errs := sink.errors(); len(errs) > 0 {
+		t.Errorf("initial load produced %d console/CSP error(s):\n  %s", len(errs), strings.Join(errs, "\n  "))
+	}
+
+	t.Logf("vendor recorded %d request(s); pageviews so far: %v", len(upstream.requests()), upstream.pageviews())
+}
+
+// TestE2E_Analytics_SPANav: a real client-side navigation (click a header
+// nav link, runtime swaps <main> and fires gofastr:navigate) produces
+// exactly one more $pageview carrying the destination path, and does NOT
+// re-fetch the SDK (SPA partial responses carry no script tags).
+func TestE2E_Analytics_SPANav(t *testing.T) {
+	upstream, base := analyticsE2EServer(t)
+	ctx := siteBrowserCtx(t)
+	sink := &consoleErrSink{}
+	sink.listen(ctx)
+
+	if err := chromedp.Run(ctx,
+		runtime.Enable(),
+		cdplog.Enable(),
+		chromedp.Navigate(base+"/"),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+	waitForAnalytics(t, "initial $pageview", 10*time.Second, func() bool {
+		return len(upstream.pageviews()) >= 1
+	})
+	baseline := len(upstream.pageviews())
+
+	// Click a real site link in the desktop header nav. The data-fui
+	// router intercepts it, swaps the page content client-side, and fires
+	// gofastr:navigate; the destination hub hero is the "DOM appeared"
+	// marker.
+	if err := chromedp.Run(ctx,
+		chromedp.Evaluate(`document.querySelector('nav.ui-site-header__links a[href="/primitives"]').click()`, nil),
+		chromedp.WaitVisible(`section.ex-hero[aria-label="Primitives"]`, chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("SPA nav to /primitives: %v", err)
+	}
+
+	var pathname string
+	if err := chromedp.Run(ctx, chromedp.Evaluate(`location.pathname`, &pathname)); err != nil {
+		t.Fatal(err)
+	}
+	if pathname != "/primitives" {
+		t.Fatalf("after nav, pathname = %q, want /primitives", pathname)
+	}
+
+	waitForAnalytics(t, "$pageview for /primitives", 10*time.Second, func() bool {
+		return len(upstream.pageviews()) >= baseline+1
+	})
+	// Bounded stray window: a double-fire (navigate listener + something
+	// else) would land here and fail the exact-count check below.
+	if err := chromedp.Run(ctx, chromedp.Sleep(800*time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+
+	got := upstream.pageviews()
+	if len(got) != baseline+1 {
+		t.Errorf("pageviews after nav = %v, want exactly one more than baseline %d", got, baseline)
+	}
+	if len(got) > 0 && got[len(got)-1] != "/primitives" {
+		t.Errorf("nav pageview path = %q, want /primitives", got[len(got)-1])
+	}
+	sdkFetches := 0
+	for _, q := range upstream.requests() {
+		if q.Method == http.MethodGet && q.URI == "/js/sdk.js" {
+			sdkFetches++
+		}
+	}
+	if sdkFetches != 1 {
+		t.Errorf("SDK fetched %d time(s) across initial load + SPA nav, want 1 (partials must not re-emit script tags)", sdkFetches)
+	}
+
+	if errs := sink.errors(); len(errs) > 0 {
+		t.Errorf("SPA nav produced %d console/CSP error(s):\n  %s", len(errs), strings.Join(errs, "\n  "))
+	}
+	t.Logf("pageviews: %v (baseline %d)", upstream.pageviews(), baseline)
+}
+
+// TestE2E_Analytics_CancelledNav: a page-injected listener that
+// preventDefault()s gofastr:beforenavigate for one link claims the click —
+// no navigation, no SPA fetch, and NO new pageview.
+func TestE2E_Analytics_CancelledNav(t *testing.T) {
+	upstream, base := analyticsE2EServer(t)
+	ctx := siteBrowserCtx(t)
+	sink := &consoleErrSink{}
+	sink.listen(ctx)
+
+	if err := chromedp.Run(ctx,
+		runtime.Enable(),
+		cdplog.Enable(),
+		chromedp.Navigate(base+"/"),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+		// Cancel exactly one link's navigation. __bnCancelled is the
+		// non-vacuity probe: the router only fires beforenavigate for
+		// clicks it is about to intercept.
+		chromedp.Evaluate(`window.__bnCancelled = false;
+			document.addEventListener('gofastr:beforenavigate', function (e) {
+				var a = e.target && e.target.closest ? e.target.closest('a') : null;
+				if (a && a.getAttribute('href') === '/framework') {
+					e.preventDefault();
+					window.__bnCancelled = true;
+				}
+			});`, nil),
+	); err != nil {
+		t.Fatalf("navigate + inject cancel listener: %v", err)
+	}
+	waitForAnalytics(t, "initial $pageview", 10*time.Second, func() bool {
+		return len(upstream.pageviews()) >= 1
+	})
+	before := len(upstream.pageviews())
+
+	if err := chromedp.Run(ctx,
+		chromedp.Evaluate(`document.querySelector('nav.ui-site-header__links a[href="/framework"]').click()`, nil),
+		// Bounded settle: a pageview that should not exist cannot be
+		// waited for, so give the (suppressed) nav room to misfire.
+		chromedp.Sleep(1200*time.Millisecond),
+	); err != nil {
+		t.Fatalf("click cancelled link: %v", err)
+	}
+
+	var pathname, cancelled string
+	if err := chromedp.Run(ctx,
+		chromedp.Evaluate(`location.pathname`, &pathname),
+		chromedp.Evaluate(`String(window.__bnCancelled)`, &cancelled),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if cancelled != "true" {
+		t.Fatal("gofastr:beforenavigate never fired for the click — the cancellation probe is vacuous")
+	}
+	if pathname != "/" {
+		t.Errorf("cancelled navigation must leave the URL alone, at %q", pathname)
+	}
+	if got := upstream.pageviews(); len(got) != before {
+		t.Errorf("cancelled navigation fired pageviews %v, want none (baseline %d)", got, before)
+	}
+
+	if errs := sink.errors(); len(errs) > 0 {
+		t.Errorf("cancelled nav produced %d console/CSP error(s):\n  %s", len(errs), strings.Join(errs, "\n  "))
+	}
+}
+
+// TestE2E_Analytics_CredentialStripping: with a cookie held on the app
+// origin before the beacon fires, the browser demonstrably attaches it to
+// the same-origin relay beacon (non-vacuity), while the vendor upstream
+// never sees a Cookie or Authorization header on ANY request, and the
+// vendor's own Set-Cookie never reaches the browser.
+func TestE2E_Analytics_CredentialStripping(t *testing.T) {
+	upstream, base := analyticsE2EServer(t)
+	ctx := siteBrowserCtx(t)
+	sink := &consoleErrSink{}
+	sink.listen(ctx)
+	net := &netRecorder{origin: base}
+	net.listen(ctx)
+
+	if err := chromedp.Run(ctx,
+		runtime.Enable(),
+		cdplog.Enable(),
+		// Hold a credential on the app origin BEFORE any beacon fires.
+		// Plain cookie (no __Host- prefix / Secure flag): the e2e origin
+		// is plain http, which Chrome rejects Secure-marked cookies on.
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			return network.SetCookie("e2e_cred", "secret-token").WithURL(base).WithPath("/").Do(ctx)
+		}),
+		chromedp.Navigate(base+"/"),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("set cookie + navigate: %v", err)
+	}
+	waitForAnalytics(t, "initial $pageview", 10*time.Second, func() bool {
+		return len(upstream.pageviews()) >= 1
+	})
+
+	// Non-vacuity: the browser really sent the cookie on the relay beacon.
+	beacons := net.requestsMatching(base + "/__gofastr/t/e/")
+	if len(beacons) == 0 {
+		t.Fatal("browser never POSTed a beacon to the relay mount — cannot prove stripping")
+	}
+	sent := false
+	for _, b := range beacons {
+		if strings.Contains(b.Header.Get("Cookie"), "e2e_cred") {
+			sent = true
+		}
+	}
+	if !sent {
+		t.Errorf("browser did not attach the app-origin cookie to the relay beacon(s): %v", beacons)
+	}
+
+	// The vendor never saw ANY credential, on any request, either direction.
+	for _, q := range upstream.requests() {
+		if c := q.Header.Get("Cookie"); c != "" {
+			t.Errorf("vendor saw Cookie %q on %s %s (relay must strip inbound credentials)", c, q.Method, q.URI)
+		}
+		if a := q.Header.Get("Authorization"); a != "" {
+			t.Errorf("vendor saw Authorization %q on %s %s", a, q.Method, q.URI)
+		}
+	}
+
+	// Outbound direction: the vendor's Set-Cookie never reached the browser.
+	if resp := net.responseMatching(base + "/__gofastr/t/e/"); resp != nil && resp.Header.Get("Set-Cookie") != "" {
+		t.Errorf("relayed beacon response carried Set-Cookie %q to the browser", resp.Header.Get("Set-Cookie"))
+	}
+	var docCookie string
+	if err := chromedp.Run(ctx, chromedp.Evaluate(`document.cookie`, &docCookie)); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(docCookie, "vendor_sid") {
+		t.Errorf("vendor cookie leaked into document.cookie: %q", docCookie)
+	}
+
+	if errs := sink.errors(); len(errs) > 0 {
+		t.Errorf("credential test produced %d console/CSP error(s):\n  %s", len(errs), strings.Join(errs, "\n  "))
+	}
+	t.Logf("vendor saw %d request(s), none carrying credentials", len(upstream.requests()))
+}
+
+// TestE2E_Analytics_IdentityEndpoint: the whoami endpoint's plain-HTTP
+// contract — application/json, no-store, {"id":null} for an anonymous
+// visitor.
+func TestE2E_Analytics_IdentityEndpoint(t *testing.T) {
+	_, base := analyticsE2EServer(t)
+
+	resp, err := http.Get(base + "/__site/analytics/whoami")
+	if err != nil {
+		t.Fatalf("GET whoami: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET whoami: status %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", cc)
+	}
+	var got struct {
+		ID any `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode whoami body: %v", err)
+	}
+	if got.ID != nil {
+		t.Errorf("whoami id = %v, want null (no auth chain wired on the site)", got.ID)
+	}
+
+	// Authed shape: the site app wires no auth battery and the harness has
+	// no session helper, so the logged-in {"id":"..."} variant is noted as
+	// skipped in the task report rather than built here.
+	t.Log("authed whoami variant skipped: no auth chain on the site app, producing a logged-in session would mean building a login flow")
+}
+
+// TestE2E_Analytics_InertByDefault pins the isolation contract: with the
+// env gate unset (the default site build), no analytics artifact exists —
+// no bootstrap tag on the page, and none of the demo routes serve. The
+// wiring is unobservable when off.
+func TestE2E_Analytics_InertByDefault(t *testing.T) {
+	// No t.Setenv here: the gate must stay OFF. t.Setenv from the tests
+	// above has been restored, so setupServer sees a clean environment.
+	base := siteE2EServer(t)
+
+	resp, err := http.Get(base + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+	pageBytes, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(pageBytes), "/__site/analytics/") {
+		t.Error("default build emitted the analytics bootstrap; the env gate leaked")
+	}
+
+	for _, p := range []string{
+		"/__site/analytics/bootstrap.js",
+		"/__site/analytics/whoami",
+		"/__gofastr/t/js/sdk.js",
+		"/__gofastr/t/e/batch",
+	} {
+		r, err := http.Get(base + p)
+		if err != nil {
+			t.Fatalf("GET %s: %v", p, err)
+		}
+		r.Body.Close()
+		if r.StatusCode != http.StatusNotFound {
+			t.Errorf("default build must not serve %s, got %d", p, r.StatusCode)
+		}
+	}
+}

--- a/examples/site/main.go
+++ b/examples/site/main.go
@@ -730,6 +730,9 @@ func setupServer() *framework.App {
 		stopLiveDash()
 		return nil
 	})
+	// Fake first-party analytics wiring (test/demo only; inert unless
+	// SITE_ANALYTICS_FAKE=1). See analytics_demo.go.
+	wireFakeAnalytics(host, fwApp)
 
 	return fwApp
 }

--- a/framework/docs/content/README.md
+++ b/framework/docs/content/README.md
@@ -153,6 +153,10 @@ results, the harness contract) are exempt. The exemption list lives in
   proxy for third-party services (analytics, widgets, trackers) with
   fixed upstreams, stripped credentials both ways, and the strict CSP
   kept intact.
+- [Analytics recipes](analytics-recipes.md): PostHog and Statsig
+  first-party through `battery/relay`: bootstrap script, pageviews on
+  `gofastr:navigate`, same-origin identity, and a `featureflag.Store`
+  adapter for server-side gates.
 - [Internationalization](i18n.md): `core/i18n` translator,
   JSON catalogs, plurals, `Accept-Language` negotiation.
 - [Unified notifications](notifications.md): `battery/notify` sends

--- a/framework/docs/content/README.md
+++ b/framework/docs/content/README.md
@@ -149,6 +149,10 @@ results, the harness contract) are exempt. The exemption list lives in
   rollout percentage, user/tenant/environment allow lists.
 - [Outbound webhooks](webhooks.md): `battery/webhook`: signed
   delivery, retry-with-backoff, dead-letter, glob event filters.
+- [First-party relay](relay.md): `battery/relay`: same-origin reverse
+  proxy for third-party services (analytics, widgets, trackers) with
+  fixed upstreams, stripped credentials both ways, and the strict CSP
+  kept intact.
 - [Internationalization](i18n.md): `core/i18n` translator,
   JSON catalogs, plurals, `Accept-Language` negotiation.
 - [Unified notifications](notifications.md): `battery/notify` sends

--- a/framework/docs/content/analytics-recipes.md
+++ b/framework/docs/content/analytics-recipes.md
@@ -1,0 +1,486 @@
+# Analytics recipes
+
+How to run a hosted product-analytics or experimentation vendor (PostHog,
+Statsig, Plausible-class tools) through your app first-party: the vendor's
+script and beacons served from your origin, pageviews tracking client-side
+navigation, visitors identified from your session, and boolean experiment
+gates surfaced through `core/featureflag`. Everything here composes five
+shipped mechanisms: [`battery/relay`](relay.md), a host-authored bootstrap
+served with `uihost.ScriptHandler` and registered with
+`RegisterExternalScript`, the runtime's `gofastr:navigate` event,
+`handler.GetUser`, and the `featureflag.Store` seam. The default CSP
+(`default-src 'self'`) stays intact, no `connect-src`/`script-src`
+exceptions, no third-party cookies on your origin, and no inline JS
+anywhere.
+
+## The pattern
+
+One relay mount, one external bootstrap script, one identity endpoint:
+
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/battery/relay"
+import "github.com/DonaldMurillo/gofastr/framework"
+import "github.com/DonaldMurillo/gofastr/framework/uihost"
+var host *uihost.UIHost
+-->
+```go
+app := framework.NewApp(framework.WithConfig(framework.AppConfig{Name: "myapp"}))
+
+// 1. The relay: the vendor's script and its endpoints become same-origin.
+//    Upstreams are fixed at construction; request data never picks a host.
+app.RegisterPlugin(relay.New(relay.Config{
+	Routes: []relay.Route{
+		{Prefix: "v-assets/", Upstream: "https://cdn.vendor.example",
+			Methods: []string{"GET"}, CacheOK: true},
+		{Prefix: "v/", Upstream: "https://ingest.vendor.example",
+			Methods: []string{"GET", "POST"}},
+	},
+}))
+
+// 2. The bootstrap: host-authored JS, served as a versioned external
+//    script and emitted on every full-page render, after runtime.js.
+js := []byte("/* configure the SDK, load it through the relay, wire pageviews + identity */")
+app.Router().Get("/fp/analytics.js", uihost.ScriptHandler(js))
+if err := host.RegisterExternalScript(uihost.ScriptURL("/fp/analytics.js", js)); err != nil {
+	panic(err) // refused only once serving has begun; wire in main or plugin Init
+}
+```
+
+What each piece buys you:
+
+- `uihost.ScriptHandler` serves the bytes with the framework's
+  versioned-script policy: a strong ETag, and immutable caching when the
+  request's `?v=` matches the content hash. `ScriptURL` produces exactly
+  that URL, so editing the bootstrap cache-busts it automatically.
+- `RegisterExternalScript` puts the tag on every full-page render, after
+  runtime.js. SPA partial responses carry no script tags, so the listener
+  your bootstrap installs is installed once per real page load and
+  survives every client-side navigation without double-firing. It refuses
+  registration once a page has been served: a script that appears on some
+  pages and not others is a wiring bug, so wire it in `main.go` or a
+  plugin's `Init`. (`uihost.WithExtraScripts` is the construction-time
+  equivalent.)
+- Use `relay.Base()` when composing URLs server-side instead of
+  hard-coding the mount prefix.
+
+The recipes below only differ in the route table, the SDK configuration,
+and the identity calls.
+
+## Pageviews on a client-side-navigation app
+
+GoFastr swaps page content client-side; there is no reload between `/a`
+and `/b`, so a vendor's default "fire on script load" pageview counts one
+visit, ever. The runtime fires `gofastr:navigate` on `window` when a
+navigation completes. Its `detail` carries `path` (the destination),
+`prevPath`, `cached` (true when the screen replayed from the client
+cache), and `root` (the swapped element).
+
+```js
+window.addEventListener('gofastr:navigate', function (e) {
+  var path = (e.detail && e.detail.path) || location.pathname;
+  // fire your SDK's pageview here, e.g. posthog.capture('$pageview', ...)
+});
+```
+
+Two rules the event's shape imposes:
+
+- **The initial pageview is yours to fire.** `gofastr:navigate` fires on
+  completed client-side navigations; first load is not one. Fire it once
+  from the bootstrap, after the SDK has loaded and identity resolved.
+- **Do not hook `gofastr:beforenavigate`.** That event is cancelable and
+  fires before the router commits; a listener calling `preventDefault()`
+  claims the click and no navigation happens at all. Counting there
+  records pageviews for visits that never occurred. (The site's e2e
+  analytics suite pins both rules: one pageview per `gofastr:navigate`,
+  zero for a cancelled `beforenavigate`.)
+
+## Identity
+
+A 10-line same-origin endpoint over `handler.GetUser`:
+
+<!-- gofastr:compile
+import "encoding/json"
+import "fmt"
+import "github.com/DonaldMurillo/gofastr/core/handler"
+import "github.com/DonaldMurillo/gofastr/framework"
+import "net/http"
+var app = framework.NewApp()
+-->
+```go
+app.Router().Get("/fp/whoami", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store") // identity changes any moment
+	var id any // nil marshals to JSON null
+	if u, ok := handler.GetUser(r.Context()); ok && u != nil {
+		switch v := u.(type) {
+		case string:
+			id = v
+		case fmt.Stringer:
+			id = v.String()
+		}
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
+}))
+```
+
+It answers `{"id":"..."}` or `{"id":null}`, never a guess, and
+`no-store` so a login or logout is never served a cached identity. It
+only knows a user when `auth.SessionMiddleware` (or your equivalent) put
+one in the request context for that route chain.
+
+The client side fetches it with a generation counter, so a stale response
+can never overwrite a newer refresh's identity:
+
+```js
+var idGen = 0;
+function refreshIdentity(apply) {
+  var my = ++idGen;
+  fetch('/fp/whoami', {
+    credentials: 'same-origin',
+    headers: { Accept: 'application/json' },
+  })
+    .then(function (r) { return r.json(); })
+    .then(function (me) {
+      if (my !== idGen) return; // superseded by a newer refresh
+      apply(me && me.id ? me.id : null);
+    })
+    .catch(function () { /* analytics must never break the page */ });
+}
+```
+
+Call it once after the SDK loads and again after any navigation that can
+change identity (your login/logout destinations).
+
+Sequencing the transitions matters as much as fetching them:
+
+| Transition         | PostHog                    | Statsig                          |
+|--------------------|----------------------------|----------------------------------|
+| anonymous → A      | `identify(A)`              | `updateUserAsync({userID: A})`   |
+| A → anonymous      | `reset()`                  | `updateUserAsync({})`            |
+| A → B (switch)     | `reset()`, then `identify(B)` | `updateUserAsync({userID: B})` |
+
+PostHog's `identify` links the current anonymous id into the named
+user's chain; calling it while A is active merges A's history into B's.
+`reset()` severs the chain first, which is why A→B is reset-then-identify
+and never a bare identify. Statsig has no such chain; a plain user swap
+is correct.
+
+## PostHog
+
+PostHog's proxy layout is two rules: `/static/*` and `/array/*` live on
+the region's assets host, everything else (`/e`, `/s`, `/i/v0/e`,
+`/flags`, `/decide`, `/batch`) on the ingestion host. `/decide` is legacy
+but still called by current SDKs; the subtree route covers it for free.
+PostHog's docs say to allow GET and POST on all proxied paths:
+
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/battery/relay"
+import "github.com/DonaldMurillo/gofastr/framework"
+-->
+```go
+app := framework.NewApp(framework.WithConfig(framework.AppConfig{Name: "myapp"}))
+app.RegisterPlugin(relay.New(relay.Config{
+	Routes: []relay.Route{
+		// /static/* and /array/*: the SDK and its array of loader assets.
+		{Prefix: "ph-assets/", Upstream: "https://us-assets.i.posthog.com",
+			Methods: []string{"GET", "POST"}, CacheOK: true},
+		// Everything else: /e, /s, /i/v0/e, /flags, /decide, /batch.
+		{Prefix: "ph/", Upstream: "https://us.i.posthog.com",
+			Methods: []string{"GET", "POST"}},
+	},
+}))
+```
+
+EU projects swap in `https://eu-assets.i.posthog.com` and
+`https://eu.i.posthog.com`.
+
+Two headers are load-bearing for PostHog, and the relay already does
+both: the outbound request carries the upstream's own `Host` (PostHog
+answers requests with the wrong `Host` 401), and `X-Forwarded-For` is
+built from the connection's real peer, never from inbound headers, which
+is what PostHog resolves geo from. Nothing to configure. Do not override
+`relay.Config.ClientIP` with anything that reads inbound headers.
+
+The bootstrap, whole:
+
+```js
+(function () {
+  'use strict';
+  var API = '/__gofastr/t/ph';
+  var ASSETS = '/__gofastr/t/ph-assets';
+
+  var s = document.createElement('script');
+  s.src = ASSETS + '/array.js';
+  s.async = true;
+  s.onload = function () {
+    var ph = window.posthog;
+    if (!ph) return;
+    ph.init('<phc_project_api_key>', {
+      api_host: location.origin + API,     // the relay's ingestion route
+      asset_host: location.origin + ASSETS, // the relay's assets route
+      ui_host: 'https://us.posthog.com',   // the real region UI (EU: eu.posthog.com)
+      capture_pageview: false,             // pageviews are ours (see below)
+    });
+
+    var known = null;
+    function applyIdentity(id) {
+      if (id === known) return;
+      if (known) ph.reset(); // A→anon and A→B: sever the old chain first
+      known = id;
+      if (id) ph.identify(id);
+    }
+    refreshIdentity(applyIdentity);
+
+    // The initial pageview: gofastr:navigate does not fire on first load.
+    ph.capture('$pageview', { $current_url: location.href });
+
+    window.addEventListener('gofastr:navigate', function (e) {
+      var path = (e.detail && e.detail.path) || location.pathname;
+      ph.capture('$pageview', { $current_url: location.origin + path });
+    });
+  };
+  document.head.appendChild(s);
+})();
+```
+
+On the init options:
+
+- `ui_host` must stay the real region UI (`https://us.posthog.com` /
+  `https://eu.posthog.com`). Point it at the relay and the toolbar and
+  the session-replay player break: they load UI assets from that host.
+  It is configuration for PostHog tools, not a script your page loads.
+- `capture_pageview: false` plus the manual `$pageview` calls above is
+  the primary recipe: one pageview per completed client-side navigation,
+  same timing as the content it names. The zero-code alternative,
+  `capture_pageview: 'history_change'`, makes the SDK watch the History
+  API itself; it fires when history changes, not when GoFastr's swap
+  completes, so the pageview can precede the content it names.
+- PostHog's own docs advise against proxy path names like `/analytics`,
+  `/tracking`, or `/posthog`: path-based block lists carry generic rules
+  for exactly those. The relay's neutral default mount (`/__gofastr/t`)
+  already conforms, and the prefixes above describe the integration, not
+  the vendor.
+
+**Session replay.** Replay uploads can reach 64 MB request bodies. The
+relay's default 8 MiB cap 413s them, which is the correct posture unless
+you actually enable replay. If you do, raise the cap on the ingestion
+route only, and read it as an egress number: every accepted byte is
+billed to your bandwidth.
+
+```go
+{Prefix: "ph/", Upstream: "https://us.i.posthog.com",
+	Methods: []string{"GET", "POST"}, MaxBodyBytes: 64 << 20},
+```
+
+## Statsig
+
+Statsig's browser client talks to two endpoints on two different hosts:
+`https://featureassets.org/v1/initialize` and
+`https://prodregistryv2.org/v1/rgstr`. Both are POST beacons, and each is
+a single fixed URL, so exact routes (no subtree prefix) fit:
+
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/battery/relay"
+import "github.com/DonaldMurillo/gofastr/framework"
+-->
+```go
+app := framework.NewApp(framework.WithConfig(framework.AppConfig{Name: "myapp"}))
+app.RegisterPlugin(relay.New(relay.Config{
+	Routes: []relay.Route{
+		{Prefix: "sg-init", Upstream: "https://featureassets.org/v1/initialize",
+			Methods: []string{"POST"}},
+		{Prefix: "sg-events", Upstream: "https://prodregistryv2.org/v1/rgstr",
+			Methods: []string{"POST"}},
+	},
+}))
+```
+
+Point the client at them with the per-endpoint overrides, not
+`networkConfig.api`: `api` is one host override, and these two endpoints
+live on two different hosts.
+
+```js
+statsig.initialize({
+  clientSDKKey: 'client-your-key',
+  networkConfig: {
+    initializeUrl: location.origin + '/__gofastr/t/sg-init',
+    logEventUrl: location.origin + '/__gofastr/t/sg-events',
+  },
+});
+```
+
+`initializeFallbackUrls` and `logEventFallbackUrls` also exist, for
+multi-proxy failover; a single relay has none to offer.
+
+The vendor HTML snippet loads a major-version pinned bundle
+(`/@statsig/js-client@3/...` tracks every 3.x release; it is not a
+frozen version). Two ways to serve it without a CSP exception:
+
+```go
+// Option A: relay jsdelivr and load the bundle through the mount.
+{Prefix: "sg-js/", Upstream: "https://cdn.jsdelivr.net/npm",
+	Methods: []string{"GET"}, CacheOK: true},
+```
+
+```html
+<script src="/__gofastr/t/sg-js/@statsig/js-client@3/build/statsig-js-client+session-replay+web-analytics.min.js" defer></script>
+```
+
+Option B is to npm-bundle the SDK into your own asset build, in which
+case only the two endpoints above go through the relay. Either way the
+bootstrap follows the same shape as PostHog's: initialize, then identity
+transitions, then the initial pageview and one `gofastr:navigate`
+listener firing your page-view event (`statsig.logEvent` with your
+schema).
+
+Statsig's identity calls map straight onto the transition table:
+
+```js
+var known = null;
+function applyIdentity(id) {
+  if (id === known) return;
+  known = id;
+  statsig.updateUserAsync(id ? { userID: id } : {});
+}
+```
+
+One vendor constraint the relay satisfies by construction: Statsig's
+proxy guidance says never deserialize or inspect payload bodies. The
+relay streams request and response bytes through untouched, capping
+without parsing; there is no code path that could read them.
+
+## Server-side feature flags
+
+The same vendor can gate server code through `core/featureflag`: implement
+`featureflag.Store` with an adapter that asks the vendor's server SDK
+(posthog-go, the Statsig server SDK, whatever your app imports; the SDK
+is a host-app dependency, never the framework's) and returns a `Flag`
+that reproduces the vendor's decision.
+
+<!-- gofastr:compile
+import "context"
+import "github.com/DonaldMurillo/gofastr/core/featureflag"
+import "github.com/DonaldMurillo/gofastr/framework"
+
+type vendorClient struct{}
+
+func (vendorClient) BoolGate(ctx context.Context, key, userID string) (bool, bool, error) {
+	return false, false, nil // stand-in for posthog-go / the Statsig server SDK
+}
+
+var app = framework.NewApp()
+stmt: app.SetFlagStore(vendorFlagStore{client: vendorClient{}})
+-->
+```go
+type vendorFlagStore struct{ client vendorClient }
+
+// Get implements featureflag.Store. The request ctx arrives here, so
+// FromContext yields the caller the middleware attached.
+func (s vendorFlagStore) Get(ctx context.Context, key string) (*featureflag.Flag, error) {
+	ec := featureflag.FromContext(ctx)
+	on, exists, err := s.client.BoolGate(ctx, key, ec.UserID)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
+	}
+	return &featureflag.Flag{Key: key, Enabled: on, Rollout: 100}, nil
+}
+```
+
+Each return is load-bearing:
+
+- **`Rollout: 100` is required.** The vendor already decided per user;
+  any rollout under 100 would re-bucket subjects from a stable hash and
+  split that decision. `Enabled` alone carries the answer: `true` turns
+  the flag on for every caller, `false` is the kill switch and returns
+  false for everyone.
+- **`(nil, nil)` only when the vendor proves the key unknown.** That is
+  the "genuinely absent" answer `BoolDefault` needs to honor its
+  fallback, so a typo'd kill-switch key still fails safe to the default
+  you chose.
+- **Any other outcome returns the error.** The evaluator fails closed:
+  `Bool` and `BoolDefault` both answer false on storage errors, so a
+  vendor outage disables gated code instead of opening it.
+
+Wire it before the first flag check, and attach the caller once per
+request:
+
+<!-- gofastr:compile
+import "context"
+import "github.com/DonaldMurillo/gofastr/core/handler"
+import "github.com/DonaldMurillo/gofastr/core/featureflag"
+import "github.com/DonaldMurillo/gofastr/framework"
+import "net/http"
+
+type vendorFlagStore struct{ client vendorClient }
+type vendorClient struct{}
+
+// stub for the block above; the real adapter implements Get
+func (vendorFlagStore) Get(ctx context.Context, key string) (*featureflag.Flag, error) {
+	return nil, nil
+}
+
+var app = framework.NewApp()
+-->
+```go
+// Before any handler calls Flags()/IsEnabled: SetFlagStore panics once
+// the lazy default evaluator has been used, by design.
+app.SetFlagStore(vendorFlagStore{client: vendorClient{}})
+
+app.Use(func(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ec featureflag.EvalContext
+		if u, ok := handler.GetUser(r.Context()); ok && u != nil {
+			if id, ok := u.(string); ok {
+				ec.UserID = id
+			}
+		}
+		next.ServeHTTP(w, r.WithContext(featureflag.WithContext(r.Context(), ec)))
+	})
+})
+```
+
+Boolean gates only. Multi-variant experiments (variants, payloads,
+holdouts) do not fit `Flag`'s on/off model; gate those handlers on the
+vendor SDK directly. See [Feature flags](feature-flags.md) for the
+evaluator itself.
+
+## Common mistakes
+
+- **Beacon URLs need a tail segment.** A subtree route's empty tail
+  joins onto the upstream base without a trailing slash (`/e/` becomes
+  `/e`), and a vendor that answers the bare path with a redirect gets
+  that redirect refused by the relay — the beacon dies as a 502 the
+  SDK's `.catch` swallows. Point event URLs at a tailed path
+  (`.../e/batch`), the shape vendor SDKs use anyway.
+- **No auth middleware on the identity chain.** The endpoint reads
+  `handler.GetUser`, which carries a value only when
+  `auth.SessionMiddleware` (or your equivalent) ran. Without it every
+  response is `{"id":null}` and you shipped an anonymous-only funnel.
+- **A global `auth.CSRF()` 403s the beacon POSTs.** Vendor beacons are
+  form-less POSTs with no token. Exempt the mount:
+  `app.Use(auth.CSRF(auth.WithCSRFSkipPaths("/__gofastr/t/")))`. This is
+  safe because the relay strips cookies both directions: there is no
+  credential in play to forge with.
+- **`auth.RequireSession` app-wide gates the relay.** Beacons fire from
+  logged-out pages and before login; a session gate turns your
+  first-party numbers into "only logged-in users". Gate per-route if you
+  must, never the app. (Same callout as [relay](relay.md); it bears
+  repeating because analytics is where app-wide auth defaults bite.)
+- **Expecting this to work from a static export.** `app.ExportStatic`
+  renders HTML files; a reverse proxy is a live server. The relay mount,
+  the bootstrap's identity fetch, and the beacons all need your Go
+  process running. Static-export deployments get no first-party
+  analytics; serve the app or skip the integration.
+- **Ad-block optimism.** First-party serving defeats domain-based block
+  lists only. Path-based rules still match `/analytics`-style paths under
+  your mount, and visitors who block on behavior rather than origin still
+  block. Keep the neutral default mount and prefixes that describe your
+  integration, and accept the remainder. See "Ad-block honesty" in
+  [relay](relay.md).
+- **Raising the body cap without reading it as egress.** The 8 MiB
+  default is a brake: every accepted byte leaves from your servers and is
+  billed to your bandwidth. The 64 MB replay exception above is for a
+  named, enabled feature on one route, not a posture.

--- a/framework/docs/content/analytics-recipes.md
+++ b/framework/docs/content/analytics-recipes.md
@@ -229,6 +229,8 @@ The bootstrap, whole:
       known = id;
       if (id) ph.identify(id);
     }
+    // refreshIdentity is the helper from the Identity section above;
+    // this bootstrap needs it in the same file.
     refreshIdentity(applyIdentity);
 
     // The initial pageview: gofastr:navigate does not fire on first load.
@@ -409,6 +411,7 @@ request:
 
 <!-- gofastr:compile
 import "context"
+import "fmt"
 import "github.com/DonaldMurillo/gofastr/core/handler"
 import "github.com/DonaldMurillo/gofastr/core/featureflag"
 import "github.com/DonaldMurillo/gofastr/framework"
@@ -433,8 +436,14 @@ app.Use(func(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var ec featureflag.EvalContext
 		if u, ok := handler.GetUser(r.Context()); ok && u != nil {
-			if id, ok := u.(string); ok {
-				ec.UserID = id
+			// Same normalization as the identity endpoint: a mismatch
+			// here means flags evaluate anonymous for users the
+			// endpoint identifies.
+			switch v := u.(type) {
+			case string:
+				ec.UserID = v
+			case fmt.Stringer:
+				ec.UserID = v.String()
 			}
 		}
 		next.ServeHTTP(w, r.WithContext(featureflag.WithContext(r.Context(), ec)))
@@ -460,8 +469,9 @@ evaluator itself.
   `auth.SessionMiddleware` (or your equivalent) ran. Without it every
   response is `{"id":null}` and you shipped an anonymous-only funnel.
 - **A global `auth.CSRF()` 403s the beacon POSTs.** Vendor beacons are
-  form-less POSTs with no token. Exempt the mount:
-  `app.Use(auth.CSRF(auth.WithCSRFSkipPaths("/__gofastr/t/")))`. This is
+  form-less POSTs with no token. Exempt the mount, deriving the prefix
+  from the relay so a custom `Path` stays covered:
+  `app.Use(auth.CSRF(auth.WithCSRFSkipPaths(r.Base() + "/")))`. This is
   safe because the relay strips cookies both directions: there is no
   credential in play to forge with.
 - **`auth.RequireSession` app-wide gates the relay.** Beacons fire from

--- a/framework/docs/content/relay.md
+++ b/framework/docs/content/relay.md
@@ -1,0 +1,142 @@
+# First-party relay
+
+`battery/relay` is a declarative reverse proxy that serves third-party
+services — analytics vendors, chat widgets, error trackers — from your
+own origin. You declare one mount path and, under it, a fixed list of
+routes: prefix, upstream, allowed methods. Visitors' browsers then talk
+to `https://your-app.example.com/__gofastr/t/...` instead of the
+vendor's domain, and your strict default Content-Security-Policy
+(`default-src 'self'`) stays untouched: no `script-src` or
+`connect-src` exceptions, no third-party cookies on your origin, no
+vendor DNS on your pages. It is a `framework.Plugin`, not a Battery:
+no dependencies, no workers, one shared HTTP transport whose idle
+connections close on app shutdown.
+
+## Wiring
+
+<!-- gofastr:compile
+stmt: _ = app
+-->
+```go
+import (
+	"github.com/DonaldMurillo/gofastr/battery/relay"
+	"github.com/DonaldMurillo/gofastr/framework"
+)
+
+app := framework.NewApp(
+	framework.WithConfig(framework.AppConfig{Name: "myapp"}),
+)
+app.RegisterPlugin(relay.New(relay.Config{
+	// Path defaults to "/__gofastr/t"; any absolute path works.
+	Routes: []relay.Route{
+		{
+			Prefix:   "e/",   // subtree: POST /t/e/{rest} → plausible.io/api/event/{rest}
+			Upstream: "https://plausible.io/api/event",
+			Methods:  []string{"POST"},
+		},
+		{
+			Prefix:   "js/",   // GET /t/js/{rest} → plausible.io/js/{rest}
+			Upstream: "https://plausible.io/js",
+			Methods:  []string{"GET"},
+			CacheOK:  true,   // immutable, versioned scripts may cache
+		},
+	},
+}))
+```
+
+Point the vendor's client SDK at the mount with `Base()` instead of
+hard-coding the prefix:
+
+```go
+plausibleBase := r.Base() + "/e"
+```
+
+`New` panics on invalid config (unknown scheme, `http://` to a
+non-loopback host, an internal/private upstream, empty `Methods`,
+traversal in a prefix, a mount colliding with a reserved
+`/__gofastr/...` route). A misdeclared relay is a programmer error you
+want at startup, not a runtime surprise.
+
+## Route table semantics
+
+| Prefix shape    | Matches                          | Upstream mapping                          |
+|-----------------|----------------------------------|-------------------------------------------|
+| `e/` (subtree)  | `/t/e/` and everything below it  | base path + the sanitized tail            |
+| `ping` (exact)  | `/t/ping` only                   | base path as-is                           |
+
+- The request's **query string passes through** verbatim
+  (`/t/e/x?v=2` → upstream `…/x?v=2`); analytics SDKs need it.
+- **Methods are an allow-list.** Empty is invalid — be explicit.
+  Anything undeclared gets `405` with an `Allow` header; tails under
+  no declared prefix get `404`.
+- **Bodies** are capped per route at `MaxBodyBytes` (default 8 MiB),
+  covering both declared `Content-Length` and chunked bodies → `413`.
+- **Caching**: `CacheOK: false` (default) forces
+  `Cache-Control: no-store` on every response. `CacheOK: true` passes
+  upstream cache headers through, for immutable versioned assets.
+  `304 Not Modified` always passes through.
+
+## The hardening contract
+
+None of this is configurable. The relay is on your public edge, so its
+posture is fixed:
+
+| Guard | Behavior |
+|---|---|
+| Fixed origins | Scheme, host, and port come ONLY from `Route.Upstream`. The path tail and query are the only attacker-influenced parts of the outbound request. |
+| Tail validation | Traversal (`..`, `%2e%2e`), backslashes, NUL/control bytes, empty segments (`//`), encoded slashes (`%2F`, caught via `RawPath`), and fragment markers are refused with `400`. The router bounds path params; the relay still validates at the sink. |
+| Credentials stripped (inbound) | `Cookie`, `Authorization`, `Proxy-Authorization`, `X-CSRF-Token`, `X-API-Key`, and every `X-Forwarded-*` never reach the vendor. |
+| Forwarded metadata | `X-Forwarded-For` is the connection's peer (or your `Config.ClientIP`), `X-Forwarded-Proto` comes from the actual TLS state. Inbound forwarding headers are never trusted — they are one `curl -H` away from arbitrary values. |
+| Auth stripped (outbound) | `Set-Cookie`, `WWW-Authenticate`, `Proxy-Authenticate`, and `Access-Control-*` never reach the browser. `X-Content-Type-Options: nosniff` is always added. |
+| No redirects | Any `3xx` carrying a `Location` header is replaced with a plain `502` and logged: forwarding it would leak the vendor origin (absolute) or point outside the mount (relative). `304` passes. |
+| Compression | Proxied bytes are never decompressed or re-encoded: a gzip body arrives byte-identical. |
+| Timeouts | Dial 5s, TLS handshake 5s, response headers 10s, whole request min(inherited context, 30s). Deadlines/timeouts → `504`; other transport failures → `502`. Error bodies are plain text; upstream error detail goes to the log only. |
+| Upstream restrictions | `https://` only, except `http://` for loopback (tests/dev). RFC1918, link-local (incl. cloud metadata), CGNAT, IPv6 unique-local, `*.internal`, and `*.localhost` upstreams are refused at `New` regardless of scheme. |
+
+## Threat model
+
+**This is not an open proxy.** An open proxy takes a URL from the
+request and fetches it; the relay takes nothing. Every route names its
+upstream at construction, request data cannot select scheme, host, or
+port (verified by hostile-tail tests in `battery/relay`), credentials
+flow neither direction, and the outbound surface per route is bounded
+by the method list and the body cap.
+
+**Egress is your cost now.** Every relayed byte leaves from your
+servers, and every request your page makes to the vendor is a request
+an attacker can also make to your wallet: the mount is public unless
+you gate it (see below). The 8 MiB default body cap is a brake, not a
+budget — think before raising it.
+
+**Ad-block honesty.** Serving the vendor first-party defeats
+*domain-based* block lists (the request no longer goes to
+`plausible.io`, it goes to you). It does NOT defeat *path-based* lists:
+ad-blockers that ship generic rules for `/api/event`,
+`/collect`, `/analytics` style paths will match those same paths under
+your mount. That is why the default `Path` is the neutral
+`/__gofastr/t` and prefixes are yours to choose: pick names that
+describe YOUR integration (`t/e`, `t/js`), not the vendor's
+vocabulary, and don't expect immunity — visitors who block trackers on
+behavior rather than origin will still block.
+
+## Common mistakes
+
+- **Forgetting `auth.CSRF()` when you add `app.Use(auth.CSRF(...))`
+  app-wide.** The relay's POST routes are form-less beacons; a global
+  CSRF middleware 403s them because they carry no token. Exempt the
+  mount: `app.Use(auth.CSRF(auth.WithCSRFSkipPaths("/__gofastr/t/")))`
+  — the credential-stripping contract above is what makes this safe:
+  no cookies reach the vendor, so there is nothing to forge with.
+- **Gating the relay behind `auth.RequireSession`.** Analytics and
+  error-tracking beacons fire before login and from logged-out pages;
+  a session gate turns your first-party numbers into
+  "only logged-in users". Gate per-route with your own middleware if
+  you must, not app-wide.
+- **Assuming ad-block immunity.** First-party origin defeats
+  domain-based lists only. Path-based lists still match; see
+  "Ad-block honesty" above.
+- **Raising `MaxBodyBytes` without thinking.** The cap is an egress
+  brake: every accepted byte is billed to your upstream bandwidth.
+  Beacon endpoints need kilobytes; if a vendor wants 100 MiB uploads
+  through your relay, that traffic belongs on the vendor's own origin,
+  not yours.

--- a/framework/docs/content/relay.md
+++ b/framework/docs/content/relay.md
@@ -26,7 +26,7 @@ import (
 app := framework.NewApp(
 	framework.WithConfig(framework.AppConfig{Name: "myapp"}),
 )
-app.RegisterPlugin(relay.New(relay.Config{
+r := relay.New(relay.Config{
 	// Path defaults to "/__gofastr/t"; any absolute path works.
 	Routes: []relay.Route{
 		{
@@ -41,7 +41,8 @@ app.RegisterPlugin(relay.New(relay.Config{
 			CacheOK:  true,   // immutable, versioned scripts may cache
 		},
 	},
-}))
+})
+app.RegisterPlugin(r)
 ```
 
 Point the vendor's client SDK at the mount with `Base()` instead of

--- a/framework/uihost/assetserve.go
+++ b/framework/uihost/assetserve.go
@@ -49,3 +49,25 @@ func serveVersionedText(w http.ResponseWriter, r *http.Request, contentType, bod
 	}
 	_, _ = w.Write([]byte(body))
 }
+
+// ScriptHandler serves js as "application/javascript; charset=utf-8" with
+// nosniff, a strong ETag, and immutable caching when the request's ?v=
+// matches the content hash — the same serveVersionedText policy every
+// /__gofastr script follows. The hash is computed once, at construction.
+//
+// It is the serving half for host-app page scripts registered via
+// (*UIHost).RegisterExternalScript; see ScriptURL for the URL to register.
+func ScriptHandler(js []byte) http.Handler {
+	body := string(js)
+	hash := hashStrings(body)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serveVersionedText(w, r, "application/javascript; charset=utf-8", body, hash, false)
+	})
+}
+
+// ScriptURL returns path plus "?v=" + the content hash of js: the URL to
+// pass to RegisterExternalScript so the bytes ScriptHandler serves cache
+// immutably and cache-bust automatically whenever js changes.
+func ScriptURL(path string, js []byte) string {
+	return path + "?v=" + hashStrings(string(js))
+}

--- a/framework/uihost/assetserve_test.go
+++ b/framework/uihost/assetserve_test.go
@@ -1,6 +1,8 @@
 package uihost
 
 import (
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -83,5 +85,94 @@ func TestChromeReferencesVersionedAssets(t *testing.T) {
 		if !strings.Contains(page, want) {
 			t.Errorf("rendered chrome missing versioned reference %q", want)
 		}
+	}
+}
+
+// ScriptHandler is the exported serving half for host-app bootstrap
+// scripts: same versioned-text policy as every /__gofastr script.
+func TestScriptHandlerHeadersAndETag(t *testing.T) {
+	js := []byte("window.plug = 1;\n")
+	w := httptest.NewRecorder()
+	ScriptHandler(js).ServeHTTP(w, httptest.NewRequest("GET", "/plug.js", nil))
+
+	if ct := w.Header().Get("Content-Type"); ct != "application/javascript; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want application/javascript; charset=utf-8", ct)
+	}
+	if xo := w.Header().Get("X-Content-Type-Options"); xo != "nosniff" {
+		t.Errorf("X-Content-Type-Options = %q, want nosniff", xo)
+	}
+	if etag := w.Header().Get("ETag"); etag != `"`+hashStrings(string(js))+`"` {
+		t.Errorf("ETag = %q, want quoted hashStrings hash", etag)
+	}
+	if w.Body.String() != string(js) {
+		t.Errorf("body = %q, want %q", w.Body.String(), js)
+	}
+}
+
+func TestScriptHandlerImmutableOnlyWithV(t *testing.T) {
+	h := ScriptHandler([]byte("x"))
+	get := func(url string) string {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequest("GET", url, nil))
+		return w.Header().Get("Cache-Control")
+	}
+	if cc := get("/plug.js?v=" + hashStrings("x")); cc != "public, max-age=31536000, immutable" {
+		t.Errorf("matching ?v= Cache-Control = %q, want immutable", cc)
+	}
+	if cc := get("/plug.js?v=stale-deploy"); cc != "no-cache" {
+		t.Errorf("stale ?v= Cache-Control = %q, want no-cache", cc)
+	}
+	if cc := get("/plug.js"); cc != "no-cache" {
+		t.Errorf("bare Cache-Control = %q, want no-cache", cc)
+	}
+}
+
+func TestScriptHandler304Revalidation(t *testing.T) {
+	h := ScriptHandler([]byte("x"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("GET", "/plug.js", nil))
+	etag := w.Header().Get("ETag")
+
+	req := httptest.NewRequest("GET", "/plug.js", nil)
+	req.Header.Set("If-None-Match", etag)
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, req)
+	if w2.Code != 304 {
+		t.Fatalf("If-None-Match revalidation: status %d, want 304", w2.Code)
+	}
+	if w2.Body.Len() != 0 {
+		t.Errorf("304 must have an empty body, got %d bytes", w2.Body.Len())
+	}
+}
+
+// ScriptURL and ScriptHandler must share the hash primitive: the URL the
+// app hands to RegisterExternalScript must hit the handler's immutable
+// branch, and the hash must change when the bytes do.
+func TestScriptURLRoundTripImmutable(t *testing.T) {
+	js := []byte("console.log('plug')\n")
+	mux := http.NewServeMux()
+	mux.Handle("/plug.js", ScriptHandler(js))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	url := ScriptURL("/plug.js", js)
+	if !strings.HasPrefix(url, "/plug.js?v=") {
+		t.Fatalf("ScriptURL = %q, want /plug.js?v=<hash>", url)
+	}
+	if ScriptURL("/plug.js", []byte("other")) == url {
+		t.Error("ScriptURL must change when the script bytes change")
+	}
+
+	resp, err := http.Get(srv.URL + url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if cc := resp.Header.Get("Cache-Control"); cc != "public, max-age=31536000, immutable" {
+		t.Errorf("round-trip Cache-Control = %q, want immutable (ScriptURL/ScriptHandler hash mismatch?)", cc)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != string(js) {
+		t.Errorf("round-trip body = %q, want %q", body, js)
 	}
 }

--- a/framework/uihost/register_script.go
+++ b/framework/uihost/register_script.go
@@ -1,0 +1,112 @@
+package uihost
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"unicode"
+)
+
+// RegisterExternalScript adds an external same-origin <script src> URL to
+// every full-page render, emitted just before </body> after runtime.js and
+// the per-screen action scripts. It exists for plugins and batteries that
+// wire themselves in Init, which runs after Mount — when the
+// construction-time options (WithExtraScripts) are already frozen.
+//
+// src must be a same-origin absolute path ("/x.js"), optionally carrying a
+// query string ("/x.js?v=abc" for hash-versioned URLs). Schemes, hosts,
+// protocol-relative URLs, backslashes, control characters, fragments, and
+// "." / ".." path segments (raw or percent-encoded) are rejected: the tag
+// loads under the default CSP's script-src 'self', so every accepted form
+// must resolve to a same-origin path.
+//
+// Registration is idempotent: a src already on the rail returns nil, and
+// first-registration order is preserved. It returns an error once the host
+// has rendered a page: a script registered after serving began would ship
+// on some pages and not others.
+//
+// Pair with ScriptHandler and ScriptURL to serve the bytes with correct
+// caching:
+//
+//	js := []byte("…")
+//	r.Get("/plug.js", uihost.ScriptHandler(js))
+//	ds.RegisterExternalScript(uihost.ScriptURL("/plug.js", js))
+func (ds *UIHost) RegisterExternalScript(src string) error {
+	if !validExternalScriptSrc(src) {
+		return fmt.Errorf("uihost: RegisterExternalScript: invalid src %q: must be a same-origin absolute path (\"/x.js\"), optionally with a query (\"/x.js?v=abc\")", src)
+	}
+	ds.scriptMu.Lock()
+	defer ds.scriptMu.Unlock()
+	if ds.servingStarted.Load() {
+		return fmt.Errorf("uihost: RegisterExternalScript(%q) refused: serving has already begun; register during plugin Init, before the first page render", src)
+	}
+	for _, s := range ds.extraScripts {
+		if s == src {
+			return nil // already on the rail; idempotent
+		}
+	}
+	ds.extraScripts = append(ds.extraScripts, src)
+	return nil
+}
+
+// markServingBegun latches on the first full-shell render. It takes
+// scriptMu so the latch serializes with RegisterExternalScript's
+// check+append: any registration that observes servingStarted==false
+// completes its append before the calling render reads extraScripts, and
+// once the flag is set no append can follow. The emission loop in
+// injectChromeModeFor therefore needs no lock.
+func (ds *UIHost) markServingBegun() {
+	ds.scriptMu.Lock()
+	ds.servingStarted.Store(true)
+	ds.scriptMu.Unlock()
+}
+
+// validExternalScriptSrc reports whether src is safe to emit as
+// <script src="src"> on every page. Same grammar as isSafePartialRedirect
+// (single leading "/", no scheme, no host, no backslash, no control bytes,
+// checked on both the raw input AND the percent-decoded path) plus
+// script-rail specifics: no "." / ".." segments (traversal), no fragments,
+// and query strings allowed (hash-versioned URLs like /x.js?v=abc need
+// them).
+func validExternalScriptSrc(src string) bool {
+	if src == "" {
+		return false
+	}
+	if !strings.HasPrefix(src, "/") || strings.HasPrefix(src, "//") {
+		return false
+	}
+	// A ":" before the first "/" is a scheme (https:, javascript:, data:).
+	// Unreachable after the leading-"/" rule above, but it keeps the
+	// grammar explicit and holds if the checks are ever reordered.
+	if i, j := strings.IndexByte(src, ':'), strings.IndexByte(src, '/'); i >= 0 && (j < 0 || i < j) {
+		return false
+	}
+	u, err := url.Parse(src)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "" || u.Opaque != "" || u.Host != "" {
+		return false
+	}
+	if strings.Contains(src, "#") || u.Fragment != "" {
+		return false
+	}
+	// Raw input AND decoded path: "/a%5Cb.js" passes the raw checks but
+	// decodes to a backslash the browser then normalizes.
+	if hasControlOrBackslash(src) || hasControlOrBackslash(u.Path) {
+		return false
+	}
+	if !strings.HasPrefix(u.Path, "/") || strings.HasPrefix(u.Path, "//") {
+		return false
+	}
+	for _, seg := range strings.Split(u.Path, "/") {
+		if seg == "." || seg == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func hasControlOrBackslash(s string) bool {
+	return strings.ContainsRune(s, '\\') || strings.IndexFunc(s, unicode.IsControl) >= 0
+}

--- a/framework/uihost/register_script_test.go
+++ b/framework/uihost/register_script_test.go
@@ -1,0 +1,149 @@
+package uihost
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// RegisterExternalScript exists for plugins/batteries wiring in Init, which
+// runs after Mount froze the construction-time options. This file pins the
+// rail's contract: validation, dedupe/order, full-shell-only emission, and
+// the refuse-once-serving guard.
+
+func TestRegisterExternalScriptRejectsUnsafe(t *testing.T) {
+	ds := newTestUIHost()
+	for _, src := range []string{
+		"https://evil.com/x.js", // cross-origin scheme
+		"//evil.com/x.js",       // protocol-relative
+		"javascript:x",          // dangerous scheme, no path
+		"..%2F",                 // traversal, no leading /
+		"/a/../b.js",            // traversal segment
+		"/a/./b.js",             // dot segment
+		"/%2e%2e/b.js",          // encoded traversal segment
+		`/a\b.js`,               // backslash
+		"/a%5Cb.js",             // encoded backslash
+		"",                      // empty
+		"?v=1",                  // query only, no path
+		"#f",                    // fragment only
+		"/x.js#f",               // fragment on a path
+		"/x\x00.js",             // NUL
+		"/x\n.js",               // control chars (attribute injection)
+		"/x\r.js",
+		"/x\t.js",
+		"x.js", // relative, not an absolute path
+	} {
+		if err := ds.RegisterExternalScript(src); err == nil {
+			t.Errorf("RegisterExternalScript(%q) = nil, want error", src)
+		}
+	}
+}
+
+func TestRegisterExternalScriptAcceptsValid(t *testing.T) {
+	ds := newTestUIHost()
+	for _, src := range []string{"/x.js", "/x.js?v=abc", "/a/b/c.js", "/x.js?"} {
+		if err := ds.RegisterExternalScript(src); err != nil {
+			t.Errorf("RegisterExternalScript(%q) = %v, want nil", src, err)
+		}
+	}
+}
+
+func TestRegisterExternalScriptDedupesInOrder(t *testing.T) {
+	ds := newTestUIHost()
+	for _, src := range []string{"/b.js", "/a.js", "/b.js"} {
+		if err := ds.RegisterExternalScript(src); err != nil {
+			t.Fatalf("RegisterExternalScript(%q) = %v, want nil (duplicate must be idempotent)", src, err)
+		}
+	}
+	w := httptest.NewRecorder()
+	ds.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	page := w.Body.String()
+	bTag := `<script src="/b.js"></script>`
+	aTag := `<script src="/a.js"></script>`
+	if n := strings.Count(page, bTag); n != 1 {
+		t.Errorf("duplicate /b.js emitted %d times, want exactly 1", n)
+	}
+	if n := strings.Count(page, aTag); n != 1 {
+		t.Errorf("/a.js emitted %d times, want exactly 1", n)
+	}
+	if strings.Index(page, bTag) > strings.Index(page, aTag) {
+		t.Error("first-registered /b.js must precede /a.js in the rail")
+	}
+}
+
+func TestRegisterScriptRefusedAfterServing(t *testing.T) {
+	ds := newTestUIHost()
+	w := httptest.NewRecorder()
+	ds.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	if w.Code != 200 {
+		t.Fatalf("first page render: status %d", w.Code)
+	}
+	err := ds.RegisterExternalScript("/x.js")
+	if err == nil {
+		t.Fatal("RegisterExternalScript after a page was served = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "serving") {
+		t.Errorf("error should name serving, got %q", err.Error())
+	}
+}
+
+func TestExtraScriptEmittedFullPageOnly(t *testing.T) {
+	ds := newTestUIHost()
+	if err := ds.RegisterExternalScript("/plug.js?v=abc"); err != nil {
+		t.Fatalf("RegisterExternalScript: %v", err)
+	}
+	tag := `<script src="/plug.js?v=abc"></script>`
+
+	// Full shell render: exactly once, after runtime.js.
+	w := httptest.NewRecorder()
+	ds.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	page := w.Body.String()
+	if n := strings.Count(page, tag); n != 1 {
+		t.Errorf("full page emits the tag %d times, want 1", n)
+	}
+	rt, tagAt := strings.Index(page, "/__gofastr/runtime.js"), strings.Index(page, tag)
+	if rt == -1 || tagAt == -1 || tagAt < rt {
+		t.Errorf("extra script must load after runtime.js (runtime@%d, tag@%d)", rt, tagAt)
+	}
+
+	// SPA partial navigation response: content cell only, no script rail.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Gofastr-Navigate", "1")
+	pw := httptest.NewRecorder()
+	ds.ServeHTTP(pw, req)
+	if strings.Contains(pw.Body.String(), tag) {
+		t.Error("partial response must not carry the extra script rail")
+	}
+}
+
+// A registered same-origin script needs no CSP widening: default-src 'self'
+// already covers it, and the header must stay byte-identical (the exact
+// framework default) across registration.
+func TestRegisterScriptKeepsDefaultCSP(t *testing.T) {
+	const defaultCSP = "default-src 'self'; img-src 'self' data:; object-src 'none'; " +
+		"form-action 'self'; frame-ancestors 'none'; base-uri 'self'"
+
+	get := func(ds *UIHost) string {
+		t.Helper()
+		w := httptest.NewRecorder()
+		ds.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+		csp := w.Header().Get("Content-Security-Policy")
+		if csp == "" {
+			t.Fatal("page response carries no Content-Security-Policy")
+		}
+		return csp
+	}
+
+	before := get(newTestUIHost())
+
+	withScript := newTestUIHost()
+	if err := withScript.RegisterExternalScript("/plug.js?v=abc"); err != nil {
+		t.Fatalf("RegisterExternalScript: %v", err)
+	}
+	after := get(withScript)
+
+	if before != defaultCSP || after != defaultCSP || before != after {
+		t.Errorf("CSP changed across script registration:\nbefore: %q\nafter:  %q", before, after)
+	}
+}

--- a/framework/uihost/uihost.go
+++ b/framework/uihost/uihost.go
@@ -100,6 +100,8 @@ type UIHost struct {
 	actionComps         map[string]component.Component       // componentID → the component the registry was compiled FROM (embed_actions.go walks it)
 	customCSS           string                               // extra CSS to inject (e.g. demo.css)
 	extraScripts        []string                             // extra <script src="…"> URLs to inject before </body>
+	scriptMu            sync.Mutex                           // guards post-construction extraScripts appends + the servingStarted latch (see register_script.go)
+	servingStarted      atomic.Bool                          // latched on the first full-shell render; RegisterExternalScript refuses after it
 	staticDir           string                               // directory to serve static files from
 	staticFS            fs.FS                                // embedded filesystem for static files
 	llmMDPublic         bool                                 // when true, mount per-screen /llm.md + /llm-pages.md; default disabled (schema disclosure)
@@ -1518,6 +1520,9 @@ func (ds *UIHost) injectChromeMode(page, pagePath, sessionID, presenceTopic stri
 }
 
 func (ds *UIHost) injectChromeModeFor(page, pagePath, sessionID, presenceTopic string, bundle bool, comp component.Component) string {
+	// First full-shell render freezes the extra-script rail: registering
+	// after this point would ship a script on some pages and not others.
+	ds.markServingBegun()
 	headClose := borrowBuilder()
 	defer returnBuilder(headClose)
 	bodyClose := borrowBuilder()


### PR DESCRIPTION
## What this adds

Four vendor-neutral mechanisms so a GoFastr app can run a hosted
analytics/experimentation vendor (PostHog, Statsig, Plausible-class)
first-party — strict default CSP untouched, no vendor-named code in the
framework:

1. **uihost: pre-serve script registration** — `RegisterExternalScript`
   lets plugins/batteries add a same-origin external script to every
   full-page render during Init (construction-time options are frozen by
   then). Refuses registration after the first render so a script can't
   ship on some pages and not others. `ScriptHandler`/`ScriptURL` export
   the versioned-script serving policy (strong ETag, immutable on
   matching `?v=`).
2. **battery/relay** — a declarative, hardened same-origin reverse proxy:
   one mount path, fixed route table (prefix → upstream), per-route
   method allow-lists and body caps. Vendor scripts and beacons become
   same-origin, so the CSP needs no script-src/connect-src exceptions and
   domain-based ad blocking no longer severs pages from analytics. Not an
   open proxy: upstreams compile at `New` (https-only, loopback-http for
   dev, private/internal hosts refused), request data never selects
   scheme/host/port, credentials strip both directions, inbound
   `X-Forwarded-*` is never trusted, upstream redirects are refused.
   Every guard is mutation-proven by a named test.
3. **Analytics recipes doc** (`framework/docs/content/analytics-recipes.md`) —
   the full pattern plus worked PostHog and Statsig recipes with
   endpoint tables verified against current vendor docs, pageviews on
   `gofastr:navigate`, a same-origin identity endpoint, and a
   `featureflag.Store` adapter surfacing vendor boolean gates
   server-side (`Rollout: 100` so the evaluator can't re-bucket).
4. **examples/site e2e** — six chromedp tests prove the pattern against a
   fake vendor with zero accounts: SDK + pageviews arrive through the
   relay with zero off-origin requests, CSP byte-identical to the
   default, one pageview per SPA nav, none for a cancelled nav, cookies
   never reach the vendor, all inert unless `SITE_ANALYTICS_FAKE=1`.

Vendor endpoint churn stays out of the framework release cycle by design:
route tables live in host apps; the doc records the current tables.

## Verification

- Full `./scripts/test-all.sh` run green (chromedp site suite included);
  the 13 `TEST_POSTGRES_DSN` packages green against the pg-5433 container.
- Coverage floors, contracts, and the deterministic sweep ran on every
  commit via hooks.
- Relay hardening and the uihost registration guards each have a
  break-the-guard-watch-it-fail proof (16 mutations logged for relay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX4wtfjUH8A8yarHTYLzSc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hardened same-origin relay for securely proxying approved third-party services.
  * Added external script registration for full-page renders, with validation, deduplication, versioned URLs, and strong caching.
  * Added analytics and experimentation integration patterns, including navigation pageviews, identity lookup, and feature-flag support.
  * Added a first-party analytics demonstration with vendor requests routed through the site origin.

* **Documentation**
  * Added setup, security, configuration, and analytics guidance for the relay and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->