### PR TITLE
Release v0.71.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.71.0] - 2026-08-25
+
 ### Added
 
 - **uihost: host-page scripts registered before serving.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ Honest expectations:
 
 ## Supported versions
 
-GoFastr is pre-1.0. Only the **latest minor release** (currently `0.70.x`)
+GoFastr is pre-1.0. Only the **latest minor release** (currently `0.71.x`)
 receives security fixes. Older `0.x` lines are not patched. Upgrade to
 the latest release to stay supported.
 

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.70.0
+through: v0.71.0
 
 releases:
   - version: v0.3.0
@@ -804,3 +804,12 @@ releases:
       - change: "`go fix`'s embedlit analyzer corrupts source in Go 1.27.0"
         breaking: false
         guidance: "Not a framework change, a warning for your own tree. Rewriting a composite literal with an embedded struct field, embedlit deleted the field name and its closing brace and left unparseable Go: one file in 571 here, which makes its other edits untrustworthy by the same token. Run the modernizers with -embedlit=false and check that every changed file still parses, which is how it was found."
+  - version: v0.71.0
+    title: First-party analytics mechanisms
+    notes:
+      - change: battery/relay serves fixed third-party routes same-origin
+        breaking: false
+        guidance: "New battery; nothing changes until you mount it. The route table is fixed at New with per-route method allow-lists and body caps, credentials are stripped in both directions, inbound X-Forwarded-* is never trusted, and upstream redirects are refused rather than followed or leaked — so an upstream that answers with a redirect needs its final host in the route table."
+      - change: uihost registers external host-page scripts before serving
+        breaking: false
+        guidance: "New surface for plugins and batteries wiring in Init, after construction-time options froze. RegisterExternalScript adds a same-origin <script src> to every full-page render and refuses registration once a page has been served, so register during Init, never lazily. ScriptHandler serves the bytes under the versioned-script policy (strong ETag, immutable on a matching ?v=) and ScriptURL produces that URL."

--- a/framework/uihost/embed_test.go
+++ b/framework/uihost/embed_test.go
@@ -857,6 +857,12 @@ func TestEmbedThemeCapBoundsTheVariantRegistry(t *testing.T) {
 // microseconds, so the goroutines serialise and the test passes with the bug
 // present. Making the window explicit is the difference between testing the
 // invariant and hoping for a schedule.
+//
+// The gap is a barrier, not a sleep: every racer finishes its reserve before
+// any admitted racer records. A sleep stood here once and flaked on a loaded
+// CI runner, because a goroutine scheduled after the first record is not part
+// of the burst any more — it finds a resolved entry and legitimately takes it
+// over by LRU eviction, which the admission count then misread as a cap breach.
 func TestEmbedThemeCapHoldsUnderConcurrency(t *testing.T) {
 	const (
 		racers = 40
@@ -864,8 +870,9 @@ func TestEmbedThemeCapHoldsUnderConcurrency(t *testing.T) {
 	)
 	var state embedThemeState
 	var admitted atomic.Int32
-	var wg sync.WaitGroup
+	var wg, reserved sync.WaitGroup
 	start := make(chan struct{})
+	reserved.Add(racers)
 
 	for i := range racers {
 		wg.Add(1)
@@ -874,13 +881,15 @@ func TestEmbedThemeCapHoldsUnderConcurrency(t *testing.T) {
 			param := fmt.Sprintf("theme-%d", i)
 			<-start
 			ok, _, _ := state.reserve("reports", param, max)
+			reserved.Done()
 			if !ok {
 				return
 			}
 			admitted.Add(1)
 			// Stand in for the CSS render that happens between reserving a slot
-			// and knowing the variant key.
-			time.Sleep(2 * time.Millisecond)
+			// and knowing the variant key. Recording only after every racer has
+			// been through reserve keeps the whole burst inside the window.
+			reserved.Wait()
 			state.record("reports", param, "key-"+param)
 		}(i)
 	}


### PR DESCRIPTION
Rolls the Unreleased changelog to 0.71.0 (2026-08-25), moves SECURITY.md's supported line to 0.71.x for the release gate, and bumps the upgrade registry's `through` marker with an entry beside it.

The wave is everything merged since v0.70.0:

- **battery/relay** — first-party relay for third-party services (PR #225)
- **uihost** — pre-serve script registration + versioned script serving (PR #225)
- **Analytics recipes** doc for PostHog and Statsig (PR #225)
- Entity exposure-defaults docs + pinned route surface, no behavior change (PR #224)

Nothing breaking; the registry entry carries two non-breaking notes (relay's refused-redirect posture, register-during-Init for host-page scripts).

After merge: tag the merge commit `v0.71.0` and push; the tag push runs the gated release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ER8DmsvusFXpfrMgDcUjkQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added first-party analytics support through a secure same-origin relay.
  - Added support for registering versioned external host-page scripts before pages are served.
  - Analytics requests now follow controlled routing and security restrictions.

- **Documentation**
  - Added the 0.71.0 release entry, dated August 25, 2026.
  - Updated supported versions to include the 0.71.x release line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->