### PR TITLE
fix(relay): forward trailing-slash tails instead of rejecting them

### DIFF
--- a/battery/relay/relay_test.go
+++ b/battery/relay/relay_test.go
@@ -642,3 +642,24 @@ func TestRefusedRedirectClosesUpstreamBody(t *testing.T) {
 		t.Fatalf("status = %d, want 502", resp.StatusCode)
 	}
 }
+
+func TestTrailingSlashTailForwarded(t *testing.T) {
+	// Vendor SDKs post to trailing-slash paths (posthog-js: /i/v0/e/).
+	base, cap := startRelayCap(t, func(up string) Config {
+		return Config{Routes: []Route{{
+			Prefix: "ph/", Upstream: up, Methods: []string{"POST"},
+		}}}
+	})
+	res, err := http.Post(base+DefaultPath+"/ph/i/v0/e/", "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("trailing-slash tail: got %d, want 200", res.StatusCode)
+	}
+	_, uri, _, _, _ := cap.snapshot()
+	if uri != "/cdn/i/v0/e/" {
+		t.Fatalf("upstream saw %q, want /cdn/i/v0/e/ (slash preserved)", uri)
+	}
+}

--- a/battery/relay/tail.go
+++ b/battery/relay/tail.go
@@ -44,8 +44,15 @@ func validateTail(tail string, rawEncoded bool) error {
 	if strings.Contains(tail, "#") {
 		return fmt.Errorf("path tail contains a fragment marker")
 	}
-	for _, seg := range strings.Split(tail, "/") {
+	segs := strings.Split(tail, "/")
+	for i, seg := range segs {
 		if seg == "" {
+			// A single trailing empty segment is a trailing slash, which
+			// vendor SDKs legitimately use (posthog-js posts /i/v0/e/).
+			// Empty segments anywhere else are the "//" smuggling shape.
+			if i == len(segs)-1 && i > 0 {
+				continue
+			}
 			return fmt.Errorf("path tail contains an empty segment")
 		}
 		if seg == "." || seg == ".." {
@@ -64,5 +71,12 @@ func joinUpstreamPath(base, tail string) string {
 	if base == "" {
 		base = "/"
 	}
-	return path.Join(base, tail)
+	joined := path.Join(base, tail)
+	// path.Join drops a trailing slash; the upstream may distinguish
+	// /e from /e/ (or redirect one to the other, which the relay
+	// refuses), so a validated trailing slash is preserved verbatim.
+	if strings.HasSuffix(tail, "/") && !strings.HasSuffix(joined, "/") {
+		joined += "/"
+	}
+	return joined
 }

--- a/framework/docs/content/analytics-recipes.md
+++ b/framework/docs/content/analytics-recipes.md
@@ -458,12 +458,13 @@ evaluator itself.
 
 ## Common mistakes
 
-- **Beacon URLs need a tail segment.** A subtree route's empty tail
-  joins onto the upstream base without a trailing slash (`/e/` becomes
-  `/e`), and a vendor that answers the bare path with a redirect gets
-  that redirect refused by the relay — the beacon dies as a 502 the
-  SDK's `.catch` swallows. Point event URLs at a tailed path
-  (`.../e/batch`), the shape vendor SDKs use anyway.
+- **A bare mount is not a beacon URL.** A subtree route's fully empty
+  tail joins onto the upstream base without a trailing slash (`.../ph/`
+  becomes the base path itself), and a vendor that answers that bare
+  path with a redirect gets the redirect refused by the relay — a 502
+  the SDK's `.catch` swallows. Tailed paths are fine, including
+  trailing-slash ones (`/i/v0/e/` is forwarded verbatim); it is only
+  the empty tail that has nothing to forward.
 - **No auth middleware on the identity chain.** The endpoint reads
   `handler.GetUser`, which carries a value only when
   `auth.SessionMiddleware` (or your equivalent) ran. Without it every

--- a/framework/seed_test.go
+++ b/framework/seed_test.go
@@ -552,8 +552,12 @@ func TestAppStart_WiresRunSeeds(t *testing.T) {
 		if err != nil {
 			t.Fatalf("App.Start: %v", err)
 		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("App.Start did not return within 10s of Shutdown")
+	case <-time.After(30 * time.Second):
+		// Same budget rationale as the poll above: only ever spent on
+		// failure. 10s was a real flake on race-detector runners under
+		// full parallel-job load (twice on 2026-08-25 alone); a graceful
+		// drain on a starved box can exceed it without anything hanging.
+		t.Fatal("App.Start did not return within 30s of Shutdown")
 	}
 
 	// Read only AFTER receiving from startErr, which orders this against the


### PR DESCRIPTION
## What

The relay's tail validator treated any empty path segment as the `//`
smuggling shape — but a single trailing empty segment is just a
trailing slash, and vendor SDKs post to exactly that (posthog-js sends
`/i/v0/e/` and `/e/`). Every beacon died as the relay's own 400 while
the identical POST straight to the vendor returned 200.

The validator now allows one final empty segment (mid-path empties
still refuse), and `joinUpstreamPath` preserves the validated trailing
slash that `path.Join` drops, so upstreams that distinguish `/e` from
`/e/` — or redirect between them, which the relay refuses — see the
path verbatim. The analytics-recipes Common-mistakes bullet is
updated: only the fully empty tail remains a footgun.

## How it was found

Live dogfood of the full first-party pattern against a real
self-hosted PostHog (docker hobby stack): real posthog-js loaded
through the relay, fired beacons, and the relay 400'd them. With this
fix the same run lands `$pageview` (initial + SPA navigation via
`gofastr:navigate`) and `$autocapture` in PostHog's events API, lib
`web 1.418.17`, one stable distinct id, strict default CSP untouched.

## Verification

- `TestTrailingSlashTailForwarded` — red before the fix (400), green
  after; both halves (validator allowance, slash preservation)
  mutation-proven.
- Full relay suite + the pre-commit deterministic sweep, coverage
  floors, and contracts all green.
- End-to-end: events visible in a real PostHog instance as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX4wtfjUH8A8yarHTYLzSc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved trailing slashes when forwarding valid beacon and relay requests.
  * Continued rejecting invalid internal empty path segments while allowing legitimate trailing-slash paths.
  * Improved handling of requests under prefixed paths.

* **Documentation**
  * Clarified analytics guidance for trailing-slash and tailed beacon URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->