### PR TITLE
Release v0.71.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.71.1] - 2026-08-25
+
+### Fixed
+
+- **battery/relay: trailing-slash tails are forwarded, not rejected.**
+  The tail validator treated any empty path segment as the `//`
+  smuggling shape, which 400'd the trailing-slash paths vendor SDKs
+  post to (posthog-js sends `/i/v0/e/` and `/e/`). One final empty
+  segment is now allowed (mid-path empties still refuse) and the
+  validated trailing slash survives the upstream join, so upstreams
+  that distinguish `/e` from `/e/` see the path verbatim.
+
 ## [0.71.0] - 2026-08-25
 
 ### Added

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.71.0
+through: v0.71.1
 
 releases:
   - version: v0.3.0
@@ -813,3 +813,9 @@ releases:
       - change: uihost registers external host-page scripts before serving
         breaking: false
         guidance: "New surface for plugins and batteries wiring in Init, after construction-time options froze. RegisterExternalScript adds a same-origin <script src> to every full-page render and refuses registration once a page has been served, so register during Init, never lazily. ScriptHandler serves the bytes under the versioned-script policy (strong ETag, immutable on a matching ?v=) and ScriptURL produces that URL."
+  - version: v0.71.1
+    title: Relay forwards trailing-slash tails
+    notes:
+      - change: battery/relay forwards trailing-slash subtree tails
+        breaking: false
+        guidance: "Fix only. Vendor SDK paths like /i/v0/e/ previously died as the relay's own 400; they now reach the upstream with the slash intact. Mid-path empty segments are still refused. No configuration changes."


### PR DESCRIPTION
Patch release: the relay trailing-slash fix (merged in #227, found by
the live self-hosted-PostHog dogfood) rolled into the changelog and
upgrades.yml. Tag v0.71.1 on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX4wtfjUH8A8yarHTYLzSc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for v0.71.1.
  - Documented improved battery/relay path handling: trailing-slash paths are accepted and forwarded unchanged.
  - Clarified that empty segments in the middle of paths continue to be rejected.
- **Migration**
  - Updated release migration guidance to include v0.71.1 and the revised path-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->