### PR TITLE
docs(analytics): identity recipes must handle GetID principals

### DIFF
--- a/framework/docs/content/analytics-recipes.md
+++ b/framework/docs/content/analytics-recipes.md
@@ -115,6 +115,10 @@ app.Router().Get("/fp/whoami", http.HandlerFunc(func(w http.ResponseWriter, r *h
 		switch v := u.(type) {
 		case string:
 			id = v
+		case interface{ GetID() string }:
+			// battery/auth principals (*auth.BasicUser) carry their
+			// identity here; they do NOT implement fmt.Stringer.
+			id = v.GetID()
 		case fmt.Stringer:
 			id = v.String()
 		}
@@ -442,6 +446,8 @@ app.Use(func(next http.Handler) http.Handler {
 			switch v := u.(type) {
 			case string:
 				ec.UserID = v
+			case interface{ GetID() string }:
+				ec.UserID = v.GetID()
 			case fmt.Stringer:
 				ec.UserID = v.String()
 			}

--- a/framework/seed_test.go
+++ b/framework/seed_test.go
@@ -7,7 +7,9 @@ import (
 	"embed"
 	"encoding/json"
 	"log/slog"
+	"os"
 	"path/filepath"
+	"runtime/pprof"
 	"strings"
 	"testing"
 	"time"
@@ -541,7 +543,15 @@ func TestAppStart_WiresRunSeeds(t *testing.T) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	_ = app.Shutdown(context.Background())
+	// A deadline is load-bearing: Server.Shutdown waits forever for a
+	// connection that never goes idle (Go 1.27 pools conns that can park
+	// in StateNew — the class documented in the go1.27 adoption notes),
+	// and App.Shutdown's bounded-drain srv.Close() fallback only runs
+	// when this ctx expires. Background gave CI a 30s hang with the
+	// force-close path unreachable.
+	sdCtx, sdCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer sdCancel()
+	_ = app.Shutdown(sdCtx)
 	select {
 	case err := <-startErr:
 		// Start's error IS the diagnosis when the row does not land: a failing
@@ -553,10 +563,11 @@ func TestAppStart_WiresRunSeeds(t *testing.T) {
 			t.Fatalf("App.Start: %v", err)
 		}
 	case <-time.After(30 * time.Second):
-		// Same budget rationale as the poll above: only ever spent on
-		// failure. 10s was a real flake on race-detector runners under
-		// full parallel-job load (twice on 2026-08-25 alone); a graceful
-		// drain on a starved box can exceed it without anything hanging.
+		// Shutdown now carries a 5s deadline that triggers the bounded
+		// drain, so reaching this line means Start is genuinely stuck
+		// somewhere new — dump every goroutine so the CI log carries
+		// the diagnosis instead of a bare timeout.
+		_ = pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
 		t.Fatal("App.Start did not return within 30s of Shutdown")
 	}
 


### PR DESCRIPTION
The whoami and EvalContext recipes only matched `string`/`fmt.Stringer`, but `battery/auth` installs `*auth.BasicUser` (`GetID() string`, no Stringer) — a host following the recipes verbatim with the framework's own auth battery got permanent anonymity. Found by a live signup flow against self-hosted PostHog. Same fix already applied to the packaged plugin (gofastr-plugins #12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX4wtfjUH8A8yarHTYLzSc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identity handling for integrations that provide user objects with a `GetID()` method.
  * Ensured consistent identity resolution across identity endpoints and feature-flag evaluations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->