### PR TITLE
fix(site): analytics demo whoami handles GetID principals

### DIFF
--- a/examples/site/analytics_demo.go
+++ b/examples/site/analytics_demo.go
@@ -132,6 +132,10 @@ func wireFakeAnalytics(host *uihost.UIHost, app *framework.App) {
 			switch v := u.(type) {
 			case string:
 				id = v
+			case interface{ GetID() string }:
+				// battery/auth principals (*auth.BasicUser) carry
+				// their identity here; they don't implement Stringer.
+				id = v.GetID()
 			case fmt.Stringer:
 				id = v.String()
 			}


### PR DESCRIPTION
Sibling of #229 flagged by its review: the examples/site demo's identity endpoint matched `string`/`fmt.Stringer` only, serializing `{"id":null}` for `battery/auth` principals. The invariant sweep (any identity extraction lacking a `GetID() string` arm) now comes up empty in both repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX4wtfjUH8A8yarHTYLzSc