### PR TITLE
fix(ui): pin Card footers to the card's bottom edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.71.2] - 2026-08-26
+
 ### Fixed
 
 - **framework/ui: Card footers pin to the card's bottom edge.** A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   no flex-stretch element inside, so in a stretch context — a `ui.Grid`
   row, an align-stretch flex parent — the footer floated mid-card with
   dead space beneath it and sibling cards' footer rows misaligned. The
-  footer now carries `margin-top: auto`; a chromium-tagged layout test
-  measures the pinned edge in a real Grid.
+  footer now carries `margin-top: auto`, and the linked variant's
+  `.ui-card__inner` wrapper grows to fill the stretched anchor so the
+  pin reaches the card edge there too (CodeRabbit caught the linked
+  sibling). A chromium-tagged layout test measures all three shapes'
+  pinned edges in a real Grid.
 
 ## [0.71.1] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Fixed
 
+- **framework: a Shutdown during startup stops Start.** `App.Shutdown`
+  racing `App.Start`'s pre-listen phases (migrations, seeds, plugin
+  init) found no server to stop, drained the batteries, and returned —
+  and Start then adopted the listener and served forever with nobody
+  left to stop it. Start now checks the cancelled lifecycle context
+  under the adoption lock, re-drains, and returns nil like any graceful
+  shutdown. This was the intermittent 30s race-job hang in
+  `TestAppStart_WiresRunSeeds`; the window is now pinned by a
+  deterministic regression test.
+
 - **framework/ui: Card footers pin to the card's bottom edge.** A
   config-only card (Heading/Description/Footer, no body children) has
   no flex-stretch element inside, so in a stretch context — a `ui.Grid`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Fixed
+
+- **framework/ui: Card footers pin to the card's bottom edge.** A
+  config-only card (Heading/Description/Footer, no body children) has
+  no flex-stretch element inside, so in a stretch context — a `ui.Grid`
+  row, an align-stretch flex parent — the footer floated mid-card with
+  dead space beneath it and sibling cards' footer rows misaligned. The
+  footer now carries `margin-top: auto`; a chromium-tagged layout test
+  measures the pinned edge in a real Grid.
+
 ## [0.71.1] - 2026-08-25
 
 ### Fixed

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.71.1
+through: v0.71.2
 
 releases:
   - version: v0.3.0
@@ -819,3 +819,10 @@ releases:
       - change: battery/relay forwards trailing-slash subtree tails
         breaking: false
         guidance: "Fix only. Vendor SDK paths like /i/v0/e/ previously died as the relay's own 400; they now reach the upstream with the slash intact. Mid-path empty segments are still refused. No configuration changes."
+
+  - version: v0.71.2
+    title: Card footers pin to the card edge
+    notes:
+      - change: ui.Card footers carry margin-top auto and the linked variant's inner wrapper grows to fill the anchor
+        breaking: false
+        guidance: "Fix only. Config-only cards (Heading/Description/Footer with no body children) in a stretch context — a ui.Grid row, an align-stretch flex parent — previously floated the footer mid-card; it now pins to the bottom edge, for plain and linked (Href) cards alike. No configuration changes."

--- a/examples/site/e2e_analytics_test.go
+++ b/examples/site/e2e_analytics_test.go
@@ -212,6 +212,10 @@ type netRecorder struct {
 	resps  []netRecorded
 	// requestID → index into reqs, for merging ExtraInfo headers.
 	byID map[network.RequestID]int
+	// ExtraInfo events CDP delivered BEFORE their base event — the
+	// ordering is not guaranteed, and dropping an early ExtraInfo
+	// silently loses the Cookie header the credential test asserts on.
+	pendingExtra map[network.RequestID]http.Header
 }
 
 func (n *netRecorder) listen(ctx context.Context) {
@@ -223,11 +227,18 @@ func (n *netRecorder) listen(ctx context.Context) {
 				n.byID = map[network.RequestID]int{}
 			}
 			n.byID[e.RequestID] = len(n.reqs)
-			n.reqs = append(n.reqs, netRecorded{
+			rec := netRecorded{
 				URL:    e.Request.URL,
 				Method: e.Request.Method,
 				Header: headerFromCDP(e.Request.Headers),
-			})
+			}
+			if extra, ok := n.pendingExtra[e.RequestID]; ok {
+				for k, v := range extra {
+					rec.Header[k] = v
+				}
+				delete(n.pendingExtra, e.RequestID)
+			}
+			n.reqs = append(n.reqs, rec)
 			n.mu.Unlock()
 		case *network.EventRequestWillBeSentExtraInfo:
 			n.mu.Lock()
@@ -235,6 +246,11 @@ func (n *netRecorder) listen(ctx context.Context) {
 				for k, v := range headerFromCDP(e.Headers) {
 					n.reqs[i].Header[k] = v
 				}
+			} else {
+				if n.pendingExtra == nil {
+					n.pendingExtra = map[network.RequestID]http.Header{}
+				}
+				n.pendingExtra[e.RequestID] = headerFromCDP(e.Headers)
 			}
 			n.mu.Unlock()
 		case *network.EventResponseReceived:

--- a/framework/app.go
+++ b/framework/app.go
@@ -3112,6 +3112,20 @@ func (a *App) Start(addr string) error {
 			srv.WriteTimeout = 0
 		}
 	}
+	// A concurrent Shutdown may have run while the pre-listen phases
+	// were still executing (a host tearing down mid-boot, or a test that
+	// observed a seeded row before the server existed). It found no
+	// server to stop and drained what was started; adopting a server NOW
+	// would serve forever with nobody left to stop it. The cancelled
+	// lifecycle context is the durable record of that Shutdown — checked
+	// under the same lock Shutdown holds, so the window is closed, not
+	// narrowed. abort re-drains whatever started after that Shutdown's
+	// sweep (Shutdown is idempotent) and nil keeps the graceful-shutdown
+	// contract: Start reports no error when told to stop.
+	if a.appCtx != nil && a.appCtx.Err() != nil {
+		a.serverMu.Unlock()
+		return abort(nil)
+	}
 	a.server = srv
 	a.serverMu.Unlock()
 	// Bind first, then Serve, split from ListenAndServe so OnReady hooks

--- a/framework/seed_test.go
+++ b/framework/seed_test.go
@@ -582,3 +582,42 @@ func TestAppStart_WiresRunSeeds(t *testing.T) {
 		t.Errorf("seeded row not present after App.Start; got %d rows", rows)
 	}
 }
+
+// A Shutdown that lands in the window between the last pre-listen start
+// phase and the server adoption used to be swallowed: Shutdown found no
+// server to stop, drained the batteries, and returned — then Start
+// adopted the listener and served forever with nobody left to stop it
+// (caught as a 30s race-job hang in TestAppStart_WiresRunSeeds, where
+// the test's Shutdown raced Start's post-seed phases). The OnStart hook
+// pins Shutdown inside that window deterministically; Start must notice
+// the cancelled lifecycle context at adoption and return instead of
+// serving.
+func TestShutdownDuringStartupStopsStart(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+
+	app := NewApp(WithDB(db))
+	app.OnStart(func(ctx context.Context) error {
+		sdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = app.Shutdown(sdCtx)
+		return nil
+	})
+
+	startErr := make(chan error, 1)
+	go func() { startErr <- app.Start(":0") }()
+
+	select {
+	case err := <-startErr:
+		if err != nil {
+			t.Fatalf("App.Start after mid-startup Shutdown: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		_ = pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
+		t.Fatal("Start kept serving after a mid-startup Shutdown")
+	}
+}

--- a/framework/ui/card_footer_pin_chromium_test.go
+++ b/framework/ui/card_footer_pin_chromium_test.go
@@ -60,25 +60,35 @@ func TestCardFooterPinsToBottomInGrid(t *testing.T) {
 	ctx, cancelTimeout := context.WithTimeout(ctx, 30*time.Second)
 	defer cancelTimeout()
 
-	// For each card: the gap between the card's bottom edge and its
-	// footer's bottom edge. A pinned footer sits on the edge (≈0); the
-	// regression showed up as the short card's footer floating far above.
-	var gaps []float64
+	// For each card: its top edge, and the gap between the card's bottom
+	// edge and its footer's bottom edge. A pinned footer sits on the edge
+	// (≈0); the regression showed up as the short card's footer floating
+	// far above.
+	var cards []map[string]float64
 	if err := chromedp.Run(ctx,
 		chromedp.Navigate(srv.URL),
 		chromedp.Evaluate(`Array.from(document.querySelectorAll('[data-fui-comp="ui-card"]')).map(c => {
 			const f = c.querySelector('.ui-card__footer');
-			return c.getBoundingClientRect().bottom - f.getBoundingClientRect().bottom;
-		})`, &gaps),
+			return {top: c.getBoundingClientRect().top,
+				gap: c.getBoundingClientRect().bottom - f.getBoundingClientRect().bottom};
+		})`, &cards),
 	); err != nil {
 		t.Fatal(err)
 	}
-	if len(gaps) != 3 {
-		t.Fatalf("expected 3 cards, measured %d", len(gaps))
+	if len(cards) != 3 {
+		t.Fatalf("expected 3 cards, measured %d", len(cards))
 	}
-	for i, gap := range gaps {
-		if math.Abs(gap) > 1 {
-			t.Errorf("card %d: footer bottom is %.1fpx above the card bottom; footers must pin to the card edge", i, gap)
+	// Anti-vacuity: the assertion only exercises stretch while all three
+	// cards share one grid row. A wrapped card is alone in its row, never
+	// stretches, and would pass the gap check without testing anything.
+	for i, c := range cards[1:] {
+		if math.Abs(c["top"]-cards[0]["top"]) > 1 {
+			t.Fatalf("card %d wrapped to another row (top %.1f vs %.1f); widen the viewport so stretch is actually exercised", i+1, c["top"], cards[0]["top"])
+		}
+	}
+	for i, c := range cards {
+		if math.Abs(c["gap"]) > 1 {
+			t.Errorf("card %d: footer bottom is %.1fpx above the card bottom; footers must pin to the card edge", i, c["gap"])
 		}
 	}
 }

--- a/framework/ui/card_footer_pin_chromium_test.go
+++ b/framework/ui/card_footer_pin_chromium_test.go
@@ -1,0 +1,76 @@
+//go:build chromium
+
+package ui
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
+	"github.com/DonaldMurillo/gofastr/core/render"
+	"github.com/DonaldMurillo/gofastr/framework/ui/theme"
+	"github.com/chromedp/chromedp"
+)
+
+// Hard rule 9: footer placement is layout, invisible to markup dumps. A
+// config-only card (Heading/Description/Footer, no body children) has no
+// flex-stretch element inside, so in any stretch context — a Grid row, an
+// align-stretch flex parent — its footer used to float mid-card with dead
+// space beneath it (caught screenshotting the relayboard recipe's pricing
+// grid). The footer's margin-top:auto is the guard; this renders a real
+// Grid in Chrome and measures it.
+func TestCardFooterPinsToBottomInGrid(t *testing.T) {
+	page := Grid(GridConfig{Min: "12rem"},
+		Card(CardConfig{Heading: "Tall", Footer: render.Text("footer")},
+			html.Paragraph(html.TextConfig{}, render.Text(
+				"Long body copy that wraps onto several lines so this card sets "+
+					"the grid row height and the sibling card must stretch to match it, "+
+					"padding padding padding padding padding padding padding."))),
+		Card(CardConfig{Heading: "Short", Description: "Config-only card.",
+			Footer: render.Text("footer")}),
+	)
+	css := layoutStyle.Entry().CSSFor(theme.Default()) + cardStyle.Entry().CSSFor(theme.Default())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, `<!doctype html><meta charset=utf-8>
+<style>body{margin:0;width:800px}
+%s</style>%s`, css, string(page))
+	}))
+	defer srv.Close()
+
+	allocCtx, cancelAlloc := chromedp.NewExecAllocator(context.Background(),
+		append(chromedp.DefaultExecAllocatorOptions[:], chromedp.NoSandbox)...)
+	defer cancelAlloc()
+	ctx, cancel := chromedp.NewContext(allocCtx)
+	defer cancel()
+	ctx, cancelTimeout := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelTimeout()
+
+	// For each card: the gap between the card's bottom edge and its
+	// footer's bottom edge. A pinned footer sits on the edge (≈0); the
+	// regression showed up as the short card's footer floating far above.
+	var gaps []float64
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL),
+		chromedp.Evaluate(`Array.from(document.querySelectorAll('[data-fui-comp="ui-card"]')).map(c => {
+			const f = c.querySelector('.ui-card__footer');
+			return c.getBoundingClientRect().bottom - f.getBoundingClientRect().bottom;
+		})`, &gaps),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if len(gaps) != 2 {
+		t.Fatalf("expected 2 cards, measured %d", len(gaps))
+	}
+	for i, gap := range gaps {
+		if math.Abs(gap) > 1 {
+			t.Errorf("card %d: footer bottom is %.1fpx above the card bottom; footers must pin to the card edge", i, gap)
+		}
+	}
+}

--- a/framework/ui/card_footer_pin_chromium_test.go
+++ b/framework/ui/card_footer_pin_chromium_test.go
@@ -29,23 +29,31 @@ func TestCardFooterPinsToBottomInGrid(t *testing.T) {
 		Card(CardConfig{Heading: "Tall", Footer: render.Text("footer")},
 			html.Paragraph(html.TextConfig{}, render.Text(
 				"Long body copy that wraps onto several lines so this card sets "+
-					"the grid row height and the sibling card must stretch to match it, "+
+					"the grid row height and the sibling cards must stretch to match it, "+
 					"padding padding padding padding padding padding padding."))),
 		Card(CardConfig{Heading: "Short", Description: "Config-only card.",
 			Footer: render.Text("footer")}),
+		// The linked variant nests everything in .ui-card__inner; unless
+		// that wrapper grows to fill the stretched <a>, the footer pins
+		// to the inner's edge, not the card's.
+		Card(CardConfig{Heading: "Linked", Description: "Config-only linked card.",
+			Href: "/somewhere", Footer: render.Text("footer")}),
 	)
 	css := layoutStyle.Entry().CSSFor(theme.Default()) + cardStyle.Entry().CSSFor(theme.Default())
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		fmt.Fprintf(w, `<!doctype html><meta charset=utf-8>
-<style>body{margin:0;width:800px}
+<style>body{margin:0}
 %s</style>%s`, css, string(page))
 	}))
 	defer srv.Close()
 
+	// Viewport width is browser setup, not page styling: 800px makes the
+	// 12rem-min grid pack all three cards into one row deterministically.
 	allocCtx, cancelAlloc := chromedp.NewExecAllocator(context.Background(),
-		append(chromedp.DefaultExecAllocatorOptions[:], chromedp.NoSandbox)...)
+		append(chromedp.DefaultExecAllocatorOptions[:],
+			chromedp.NoSandbox, chromedp.WindowSize(800, 600))...)
 	defer cancelAlloc()
 	ctx, cancel := chromedp.NewContext(allocCtx)
 	defer cancel()
@@ -65,8 +73,8 @@ func TestCardFooterPinsToBottomInGrid(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	if len(gaps) != 2 {
-		t.Fatalf("expected 2 cards, measured %d", len(gaps))
+	if len(gaps) != 3 {
+		t.Fatalf("expected 3 cards, measured %d", len(gaps))
 	}
 	for i, gap := range gaps {
 		if math.Abs(gap) > 1 {

--- a/framework/ui/styles_primitives.go
+++ b/framework/ui/styles_primitives.go
@@ -169,6 +169,7 @@ func cardCSS(t style.Theme) string {
   padding-top: 0;
 }
 [data-fui-comp="ui-card"] .ui-card__footer {
+  margin-top: auto;
   padding: var(--spacing-md, 8px) var(--spacing-lg, 16px);
   border-top: 1px solid var(--color-border, #E4E4E7);
   display: flex;

--- a/framework/ui/styles_primitives.go
+++ b/framework/ui/styles_primitives.go
@@ -142,6 +142,7 @@ func cardCSS(t style.Theme) string {
 [data-fui-comp="ui-card"] .ui-card__inner {
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
 }
 [data-fui-comp="ui-card"] .ui-card__header {
   padding: var(--spacing-lg, 16px) var(--spacing-lg, 16px) var(--spacing-md, 8px);


### PR DESCRIPTION
A config-only `ui.Card` (Heading/Description/Footer, no body children) has no flex-stretch element inside — `.ui-card__body` carries `flex:1` but only renders when body children exist. In any stretch context (a `ui.Grid` row, an align-stretch flex parent) the footer floated mid-card with dead space under it, and sibling cards' footer rows misaligned.

Caught screenshotting the relayboard recipe's pricing grid in gofastr-plugins#13: the Team card's buy row hung 93px above the card edge.

**Fix**: `margin-top: auto` on `.ui-card__footer`. Footer-less cards are untouched by the rule, so no existing surface moves — Meridian uses no Card footers (grep-verified) and its home page screenshots unchanged.

**Proof (Hard rule 11)**: the new chromium-tagged test renders a real two-card Grid in Chrome and measures each footer's bottom edge against its card's. Watched failing with the margin removed (93.0px gap on the config-only card), restored to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX4wtfjUH8A8yarHTYLzSc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Card footers now remain pinned to the bottom edge of equally sized cards, including linked cards in Grid layouts.
  * Analytics request tracking now preserves credential headers when browser events arrive out of order.

* **Tests**
  * Added browser coverage verifying footer placement across multiple card shapes and content configurations.

* **Documentation**
  * Updated release and upgrade notes for version 0.71.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->