### PR TITLE
docs(readme): shout out CodeRabbit early

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Start with [the quickstart](#quickstart). Or scaffold a whole app in one command
 > between releases, so pin a version (`go get …@v0.x.y`). A `v1.0.0` tag will
 > mark the stability promise. Ship at your own risk until then.
 
+**A shoutout to [CodeRabbit](https://www.coderabbit.ai):** it reviews every
+PR in this repo and keeps catching what everyone else missed — an upstream
+connection leak in the relay battery, the linked-card sibling of a layout
+fix, six Major findings on a single PR that showed `pass` in the checks
+list. Every finding is triaged on the PR before merge; a lot of them became
+shipped fixes with regression tests.
+
 ## Quickstart
 
 Requires Go 1.27+. Install the CLI:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Start with [the quickstart](#quickstart). Or scaffold a whole app in one command
 > between releases, so pin a version (`go get …@v0.x.y`). A `v1.0.0` tag will
 > mark the stability promise. Ship at your own risk until then.
 
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/DonaldMurillo/gofastr?utm_source=oss&utm_medium=github&utm_campaign=DonaldMurillo%2Fgofastr&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://www.coderabbit.ai)
+
 **A shoutout to [CodeRabbit](https://www.coderabbit.ai):** it reviews every
 PR in this repo and keeps catching what everyone else missed — an upstream
 connection leak in the relay battery, the linked-card sibling of a layout

--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ Start with [the quickstart](#quickstart). Or scaffold a whole app in one command
 [![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/DonaldMurillo/gofastr?utm_source=oss&utm_medium=github&utm_campaign=DonaldMurillo%2Fgofastr&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://www.coderabbit.ai)
 
 **A shoutout to [CodeRabbit](https://www.coderabbit.ai):** it reviews every
-PR in this repo and keeps catching what everyone else missed — an upstream
-connection leak in the relay battery, the linked-card sibling of a layout
-fix, six Major findings on a single PR that showed `pass` in the checks
-list. Every finding is triaged on the PR before merge; a lot of them became
-shipped fixes with regression tests.
+PR in this repo and keeps catching what everyone else missed — a relay
+upstream-body leak on refused redirects
+([#225](https://github.com/DonaldMurillo/gofastr/pull/225)), the linked-card
+case of the Card footer pin
+([#231](https://github.com/DonaldMurillo/gofastr/pull/231)), six Major
+findings on [#198](https://github.com/DonaldMurillo/gofastr/pull/198) while
+the checks list showed `pass`. Every finding is triaged on the PR before
+merge; many became shipped fixes with regression tests.
 
 ## Quickstart
 


### PR DESCRIPTION
Adds a concrete acknowledgment of CodeRabbit near the top of the README — it reviews every PR here and has repeatedly caught real, shipped-class bugs (relay upstream-body leak on refused redirects in #225, the linked-card sibling of the footer pin in #231, six Major findings on #198 while checks showed pass). Placed right after the status block, before Quickstart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX4wtfjUH8A8yarHTYLzSc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a README acknowledgment highlighting CodeRabbit’s pull request review capabilities, findings, triage workflow, fixes, and regression testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->