### PR TITLE
test(site): poll for the recorded cookie instead of one-shot reading

### DIFF
--- a/examples/site/e2e_analytics_test.go
+++ b/examples/site/e2e_analytics_test.go
@@ -563,19 +563,20 @@ func TestE2E_Analytics_CredentialStripping(t *testing.T) {
 	})
 
 	// Non-vacuity: the browser really sent the cookie on the relay beacon.
-	beacons := net.requestsMatching(base + "/__gofastr/t/e/")
-	if len(beacons) == 0 {
-		t.Fatal("browser never POSTed a beacon to the relay mount — cannot prove stripping")
-	}
-	sent := false
-	for _, b := range beacons {
-		if strings.Contains(b.Header.Get("Cookie"), "e2e_cred") {
-			sent = true
+	// Poll rather than read once: the wait above gates on the SERVER
+	// receiving the beacon, but the Cookie header rides the CDP
+	// ExtraInfo event, and chromedp can deliver that to the recorder
+	// AFTER the upstream already answered — a one-shot read here lost
+	// the race twice in CI even with the recorder's out-of-order
+	// buffering in place.
+	waitForAnalytics(t, "beacon with app-origin cookie recorded", 10*time.Second, func() bool {
+		for _, b := range net.requestsMatching(base + "/__gofastr/t/e/") {
+			if strings.Contains(b.Header.Get("Cookie"), "e2e_cred") {
+				return true
+			}
 		}
-	}
-	if !sent {
-		t.Errorf("browser did not attach the app-origin cookie to the relay beacon(s): %v", beacons)
-	}
+		return false
+	})
 
 	// The vendor never saw ANY credential, on any request, either direction.
 	for _, q := range upstream.requests() {


### PR DESCRIPTION
Second CI failure of `TestE2E_Analytics_CredentialStripping` with the identical signature (beacon recorded with every JS-visible header but no Cookie) — on a commit that already carries the recorder's ExtraInfo out-of-order buffering. Root cause this time: the test waits for the **server** to receive the beacon, then reads the recorder once; the Cookie header arrives via the CDP ExtraInfo event, which chromedp can deliver **after** the upstream answers. Merge-time ordering was fixed in v0.71.2; this fixes assertion-time ordering by polling the recorder (same `waitForAnalytics` helper the rest of the suite uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX4wtfjUH8A8yarHTYLzSc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved analytics end-to-end test reliability by waiting for browser beacon requests to be recorded.
  * Reduced intermittent failures caused by delayed browser event reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->