### PR TITLE
fix(framework): a Shutdown during a pre-listen phase is a graceful nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Fixed
+
+- **framework: a Shutdown during a pre-listen phase is a graceful nil.**
+  The v0.71.2 startup-race fix covered a Shutdown landing after the
+  phases but before the server; a Shutdown landing DURING a phase still
+  surfaced as a Start error, because cancelling the lifecycle context
+  made the running phase fail with `context canceled` (seen on main CI
+  as `run seeds: … record ledger: context canceled`; a SIGTERM
+  mid-migration would report the same way). Start's abort funnel now
+  returns nil when the phase error is the app's own shutdown
+  cancellation, pinned by a deterministic mid-seed regression test.
+
 ## [0.71.2] - 2026-08-26
 
 ### Fixed

--- a/framework/app.go
+++ b/framework/app.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -2761,9 +2762,24 @@ func (a *App) Start(addr string) error {
 	a.guardDevMCPBind(addr)
 
 	abort := func(err error) error {
+		// Read the shutdown state BEFORE draining: the drain below calls
+		// Shutdown itself, which always cancels the lifecycle context, so
+		// checking afterwards could not tell an external Shutdown from
+		// abort's own. appCancel nil + appCtx cancelled together mean a
+		// concurrent Shutdown already ran.
+		a.serverMu.Lock()
+		wasShutDown := a.appCancel == nil && a.appCtx != nil && a.appCtx.Err() != nil
+		a.serverMu.Unlock()
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()
 		_ = a.Shutdown(shutdownCtx)
+		// A phase failing with context.Canceled because the app's own
+		// Shutdown cancelled the lifecycle context is a graceful stop,
+		// not a failure: Start returns nil for a shutdown at any later
+		// point, and a SIGTERM mid-migration deserves the same answer.
+		if err != nil && wasShutDown && errors.Is(err, context.Canceled) {
+			return nil
+		}
 		return err
 	}
 

--- a/framework/seed_test.go
+++ b/framework/seed_test.go
@@ -621,3 +621,47 @@ func TestShutdownDuringStartupStopsStart(t *testing.T) {
 		t.Fatal("Start kept serving after a mid-startup Shutdown")
 	}
 }
+
+// The sibling of TestShutdownDuringStartupStopsStart, one phase earlier:
+// a Shutdown DURING a pre-listen phase cancels the lifecycle context,
+// and the phase then fails with context.Canceled (here the seed ledger
+// write, exactly CI's "record ledger: context canceled"). That is a
+// graceful stop, not a failure — Start must return nil, the way it does
+// for a shutdown at any later point. The seed pins the interleaving by
+// shutting the app down between its own row insert and the ledger write
+// that follows every seed.
+func TestShutdownDuringSeedIsGraceful(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+
+	app := NewApp(WithDB(db))
+	app.Entity("seed_shutdown_race", entity.EntityConfig{
+		Fields: []schema.Field{{Name: "name", Type: schema.String, Required: true}},
+		Seed: func(ctx context.Context, db *sql.DB) error {
+			if _, err := db.ExecContext(ctx, "INSERT INTO seed_shutdown_race (id, name) VALUES ('1','x')"); err != nil {
+				return err
+			}
+			sdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = app.Shutdown(sdCtx)
+			return nil
+		},
+	})
+
+	startErr := make(chan error, 1)
+	go func() { startErr <- app.Start(":0") }()
+
+	select {
+	case err := <-startErr:
+		if err != nil {
+			t.Fatalf("Start after a mid-seed Shutdown must be a graceful nil, got: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		_ = pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
+		t.Fatal("Start did not return after a mid-seed Shutdown")
+	}
+}


### PR DESCRIPTION
Main CI failed on `TestAppStart_WiresRunSeeds` with `run seeds: seed startup_seeded: record ledger: context canceled` — a new failure mode, not the adoption race fixed in v0.71.2. The test's Shutdown fired between the seed's row insert (which it polls for) and the ledger write that follows; Shutdown cancels the lifecycle context, the ledger write fails with `context.Canceled`, and Start surfaces a graceful stop as an error. A SIGTERM mid-migration gives a real host the same wrong answer.

**Fix**: Start's `abort` funnel snapshots the shutdown state before its own drain (which also cancels the context — checking after could not tell an external Shutdown from abort's own), and returns nil when the phase error is the app's own shutdown cancellation.

**TDD**: `TestShutdownDuringSeedIsGraceful` pins the interleaving deterministically by shutting down from inside the seed — red with CI's exact message, green after, 5× under `-race` alongside its sibling tests. Full framework suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX4wtfjUH8A8yarHTYLzSc