### PR TITLE
chore: roll the changelog to v0.72.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.72.0] - 2026-08-27
+
 ### Added
 
 - **Agent-readiness wave for the is-agentic class of scanners** (the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ Honest expectations:
 
 ## Supported versions
 
-GoFastr is pre-1.0. Only the **latest minor release** (currently `0.71.x`)
+GoFastr is pre-1.0. Only the **latest minor release** (currently `0.72.x`)
 receives security fixes. Older `0.x` lines are not patched. Upgrade to
 the latest release to stay supported.
 

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.71.2
+through: v0.72.0
 
 releases:
   - version: v0.3.0
@@ -826,3 +826,16 @@ releases:
       - change: ui.Card footers carry margin-top auto and the linked variant's inner wrapper grows to fill the anchor
         breaking: false
         guidance: "Fix only. Config-only cards (Heading/Description/Footer with no body children) in a stretch context — a ui.Grid row, an align-stretch flex parent — previously floated the footer mid-card; it now pins to the bottom edge, for plain and linked (Href) cards alike. No configuration changes."
+
+  - version: v0.72.0
+    title: Agent-readiness surfaces and negotiated errors
+    notes:
+      - change: 404s content-negotiate (problem+json under JSON Accepts, markdown when negotiation is on) and API-namespace misses always answer problem+json
+        breaking: false
+        guidance: "Additive. Machine clients now get RFC 9457 documents where they previously got the HTML 404; HTML behavior for browsers is unchanged. If a client scraped the HTML 404 while sending Accept: application/json, read the problem document instead."
+      - change: Accept-negotiated responses carry Vary Accept
+        breaking: false
+        guidance: "Fix only. CDNs keyed without Vary could cache the wrong representation; purge cached HTML/markdown variants after upgrading."
+      - change: new opt-in surfaces — WithOrganization JSON-LD, llms.txt WhenToUse/CLI sections, /.well-known/mcp.json when MCP is mounted
+        breaking: false
+        guidance: "Opt-in via config; nothing renders unless configured (the MCP manifest follows the existing WithMCP mount)."


### PR DESCRIPTION
Rolls [Unreleased] → v0.72.0 (the agent-readiness wave from #236 plus the graceful mid-phase shutdown fix from #235) and bumps the upgrade registry through v0.72.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX4wtfjUH8A8yarHTYLzSc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added content-negotiated 404 responses, including RFC 9457 `problem+json` for JSON requests and markdown when enabled.
  - API routes now return `problem+json` for missing resources.
  - Added `Vary: Accept` to content-negotiated responses.
  - Added opt-in JSON-LD support, expanded `llms.txt` sections, and `/.well-known/mcp.json` when MCP is enabled.

- **Documentation**
  - Added the version 0.72.0 release entry, dated August 27, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->