### PR TITLE
feat(ui): ExtraAttrs pass-through on every component config (#251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+
+- **`ExtraAttrs` on every `framework/ui` component Config** (#251): all
+  93 component configs now forward extra attributes (`data-*` test
+  hooks, analytics markers, ARIA overrides) to the component's root
+  element. Component-owned keys are dropped case-insensitively —
+  `class`/`id` (use `Class`/`ID`), `data-fui-*`, and behavior-critical
+  attributes like `href` and form-control `type`/`name` — via the new
+  `html.SafeExtraAttrs` helper. A source-level completeness gate
+  (`framework/ui/extraattrs_contract_test.go`) fails the suite if a
+  component Config ships without the field.
+
+### Changed
+
+- **`ToggleConfig.ExtraAttrs` (Checkbox / Radio / Switch) now follows
+  the sanitized contract**: extras land on the root `<label>` instead
+  of being copied raw onto the `<input>`, and `class`/`id`/`for`/
+  `data-fui-*` keys are dropped. The previous raw copy was documented
+  for `data-fui-*` RPC wiring but had no callers; RPC wiring belongs on
+  forms and widgets.
+
 ## [0.72.0] - 2026-08-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,20 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Added
 
-- **`ExtraAttrs` on every `framework/ui` component Config** (#251): all
-  93 component configs now forward extra attributes (`data-*` test
-  hooks, analytics markers, ARIA overrides) to the component's root
-  element. Component-owned keys are dropped case-insensitively —
-  `class`/`id` (use `Class`/`ID`), `data-fui-*`, and behavior-critical
-  attributes like `href` and form-control `type`/`name` — via the new
-  `html.SafeExtraAttrs` helper. A source-level completeness gate
-  (`framework/ui/extraattrs_contract_test.go`) fails the suite if a
-  component Config ships without the field.
+- **`ExtraAttrs` on every `framework/ui` component Config** (#251): the
+  94 component configs that lacked the field (Lightbox included) now
+  forward extra attributes (`data-*` test hooks, analytics markers,
+  ARIA overrides) to the component's root element, with
+  component-owned keys dropped case-insensitively — `class`/`id` (use
+  `Class`/`ID`), `data-fui-*`, and behavior-critical attributes like
+  `href` and form-control `type`/`name` — via the new
+  `html.SafeExtraAttrs` helper. Charts forward to the shared zero-data
+  placeholder too. Two source-level gates
+  (`framework/ui/extraattrs_contract_test.go`) fail the suite if a
+  component Config ships without the field or if new code forwards
+  extras unsanitized. The 24 components whose pass-through predates
+  this contract still forward raw and are enumerated on the gate's
+  legacy allow-list (#262 tracks unifying them).
 
 ### Changed
 

--- a/core-ui/html/attrs.go
+++ b/core-ui/html/attrs.go
@@ -39,6 +39,50 @@ func Classes(classes map[string]bool) Attrs {
 	return Attrs{"class": strings.Join(active, " ")}
 }
 
+// SafeExtraAttrs returns a copy of a component config's ExtraAttrs with
+// the keys the component owns removed, ready to forward to the
+// component's root element. Dropped: every case-variant of "class",
+// "id", and the listed protected keys, plus any "data-fui-*" key.
+//
+// Case-variants must go, not just exact matches: HTML attribute names
+// are case-insensitive, so a "Class" or "Type" entry survives a
+// lowercase-only overwrite as a distinct map key, renders as a second
+// attribute, and folds back onto the protected one in the parser.
+// "data-fui-*" is reserved for runtime wiring; a caller-supplied value
+// would collide with the marker WrapHTML injects into the root tag.
+//
+// Returns nil when nothing survives, which every ExtraAttrs consumer
+// treats as "no extra attributes".
+func SafeExtraAttrs(attrs Attrs, protected ...string) Attrs {
+	if len(attrs) == 0 {
+		return nil
+	}
+	out := make(Attrs, len(attrs))
+	for k, v := range attrs {
+		if strings.EqualFold(k, "class") || strings.EqualFold(k, "id") {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(k), "data-fui-") {
+			continue
+		}
+		drop := false
+		for _, p := range protected {
+			if strings.EqualFold(k, p) {
+				drop = true
+				break
+			}
+		}
+		if drop {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // DataAttrs converts a map of key-value pairs into data-* attributes.
 // Keys should not include the "data-" prefix; it is added automatically.
 func DataAttrs(data map[string]string) Attrs {

--- a/core-ui/html/attrs_test.go
+++ b/core-ui/html/attrs_test.go
@@ -1,0 +1,36 @@
+package html
+
+import "testing"
+
+func TestSafeExtraAttrsDropsProtectedKeys(t *testing.T) {
+	got := SafeExtraAttrs(Attrs{
+		"class":       "evil",
+		"Class":       "evil-case-variant",
+		"id":          "evil",
+		"ID":          "evil-case-variant",
+		"Type":        "hidden",
+		"data-test":   "hook",
+		"aria-label":  "override",
+		"data-fui-on": "spoof",
+		"DATA-FUI-X":  "spoof-case-variant",
+	}, "type")
+
+	want := Attrs{"data-test": "hook", "aria-label": "override"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("key %q: got %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestSafeExtraAttrsNilOnEmptyResult(t *testing.T) {
+	if got := SafeExtraAttrs(nil); got != nil {
+		t.Errorf("nil input: got %v, want nil", got)
+	}
+	if got := SafeExtraAttrs(Attrs{"class": "x"}); got != nil {
+		t.Errorf("all-dropped input: got %v, want nil", got)
+	}
+}

--- a/framework/docs/content/ui-getting-started.md
+++ b/framework/docs/content/ui-getting-started.md
@@ -559,10 +559,20 @@ component derives from its config (`href` on linked roots, `type` /
 linked Card renders `<a>` instead of `<section>` — the attributes
 follow whichever root is emitted.
 
+A set of components that predate this contract still forwards extras
+raw, where a caller-supplied key can override component-owned
+attributes (Banner, Select, Carousel, and the other files on the
+`extraAttrsRawLegacy` list in
+`framework/ui/extraattrs_contract_test.go`). Until those migrate,
+treat their pass-through as unprotected. `FormConfig`'s raw
+`data-fui-rpc-*` pass-through is deliberate and documented on the
+field.
+
 Component authors: sanitize with `html.SafeExtraAttrs(cfg.ExtraAttrs,
-protected...)` before forwarding, and add the component to the
-completeness gate's coverage (`framework/ui/extraattrs_contract_test.go`
-fails on any component Config without the field).
+protected...)` before forwarding. Two gates in
+`framework/ui/extraattrs_contract_test.go` enforce the contract: one
+fails on any component Config without the field, the other fails on
+any new raw forwarding outside the legacy list.
 
 ## Common mistakes
 

--- a/framework/docs/content/ui-getting-started.md
+++ b/framework/docs/content/ui-getting-started.md
@@ -537,6 +537,33 @@ The matching widget preset is `preset.Popover`, a click-triggered
 anchored surface without backdrop dim or focus trap. Closes on ESC
 and click-outside.
 
+## Attribute pass-through (`ExtraAttrs`)
+
+Every component `Config` carries an `ExtraAttrs html.Attrs` field that
+forwards additional attributes to the component's root element — the
+one that carries `data-fui-comp`. Use it for `data-*` test hooks,
+analytics markers, and ARIA overrides:
+
+```go
+ui.Card(ui.CardConfig{
+    Heading:    "Revenue",
+    ExtraAttrs: html.Attrs{"data-test": "revenue-card"},
+})
+```
+
+Keys the component owns are dropped, case-insensitively: `class` and
+`id` (use the `Class` / `ID` config fields), every `data-fui-*` key
+(reserved for runtime wiring), and behavior-critical attributes the
+component derives from its config (`href` on linked roots, `type` /
+`name` on form controls). When the root shape varies by config — a
+linked Card renders `<a>` instead of `<section>` — the attributes
+follow whichever root is emitted.
+
+Component authors: sanitize with `html.SafeExtraAttrs(cfg.ExtraAttrs,
+protected...)` before forwarding, and add the component to the
+completeness gate's coverage (`framework/ui/extraattrs_contract_test.go`
+fails on any component Config without the field).
+
 ## Common mistakes
 
 - **Registering a screen at an entity's CRUD path.** An entity named

--- a/framework/docs/content/ui-new-components.md
+++ b/framework/docs/content/ui-new-components.md
@@ -42,6 +42,13 @@ sets with `ui.RegisterButtonVariant` / `RegisterButtonSize` /
 registration covers StatusBadge, Tag, Callout, and Notification). See
 "Custom variants on framework components" in `ui-getting-started`.
 
+Every component Config carries `ExtraAttrs html.Attrs`, forwarded to
+the component's root element for `data-*` test hooks, analytics
+markers, and ARIA overrides. Component-owned keys (`class`, `id`,
+`data-fui-*`, behavior-critical attributes) are dropped. See
+"Attribute pass-through" in `ui-getting-started`; the contract is
+enforced by `framework/ui/extraattrs_contract_test.go`.
+
 ### Primitives & semantic markup
 
 - **kbd**: `core-ui/html.Kbd`, semantic `<kbd>` for keyboard input

--- a/framework/docs/content/ui-new-components.md
+++ b/framework/docs/content/ui-new-components.md
@@ -44,10 +44,11 @@ registration covers StatusBadge, Tag, Callout, and Notification). See
 
 Every component Config carries `ExtraAttrs html.Attrs`, forwarded to
 the component's root element for `data-*` test hooks, analytics
-markers, and ARIA overrides. Component-owned keys (`class`, `id`,
-`data-fui-*`, behavior-critical attributes) are dropped. See
-"Attribute pass-through" in `ui-getting-started`; the contract is
-enforced by `framework/ui/extraattrs_contract_test.go`.
+markers, and ARIA overrides. On components following the sanitized
+contract, component-owned keys (`class`, `id`, `data-fui-*`,
+behavior-critical attributes) are dropped; a legacy set still forwards
+raw (enumerated in `framework/ui/extraattrs_contract_test.go`). See
+"Attribute pass-through" in `ui-getting-started`.
 
 ### Primitives & semantic markup
 

--- a/framework/ui/anchored_rail.go
+++ b/framework/ui/anchored_rail.go
@@ -76,6 +76,12 @@ type AnchoredRailConfig struct {
 
 	// ID optionally tags the <aside>.
 	ID string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the rail's root <aside>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, and aria-label (use Label).
+	ExtraAttrs html.Attrs
 }
 
 // AnchoredRail returns the rail HTML. When ObserveSelector is set, the
@@ -125,10 +131,15 @@ func AnchoredRail(cfg AnchoredRailConfig) render.HTML {
 	if cfg.Class != "" {
 		asideClass += " " + cfg.Class
 	}
-	asideAttrs := map[string]string{
-		"class":      asideClass,
-		"aria-label": cfg.Label,
+	// Extras land on the <aside> (the element carrying data-fui-comp),
+	// not on scrollspy's sticky wrapper: the component's CSS keys on
+	// the aside.
+	asideAttrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "aria-label")
+	if asideAttrs == nil {
+		asideAttrs = map[string]string{}
 	}
+	asideAttrs["class"] = asideClass
+	asideAttrs["aria-label"] = cfg.Label
 	if cfg.ID != "" {
 		asideAttrs["id"] = cfg.ID
 	}

--- a/framework/ui/anchored_rail_test.go
+++ b/framework/ui/anchored_rail_test.go
@@ -36,3 +36,15 @@ func TestAnchoredRailScrollspyWrapperUsesRailStickyCSS(t *testing.T) {
 		}
 	}
 }
+
+func TestAnchoredRailExtraAttrsOnRoot(t *testing.T) {
+	h := AnchoredRail(AnchoredRailConfig{
+		Label:      "Sections",
+		Items:      []RailItem{{Text: "A", Anchor: "a"}},
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("aside root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/auth_card.go
+++ b/framework/ui/auth_card.go
@@ -25,6 +25,12 @@ type AuthCardConfig struct {
 	// account" link.
 	Footer render.HTML
 	Class  string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the card's root element.
+	// Keys the component owns are dropped: class (use Class), id, and
+	// data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // AuthCard renders a centered, constrained auth card.
@@ -47,7 +53,9 @@ func AuthCard(cfg AuthCardConfig) render.HTML {
 		cls = cls + " " + cfg.Class
 	}
 	panel := html.Div(html.DivConfig{Class: "ui-auth-card__panel"}, inner...)
-	return authCardStyle.WrapHTML(html.Div(html.DivConfig{Class: cls}, panel))
+	return authCardStyle.WrapHTML(html.Div(html.DivConfig{
+		Class: cls, ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+	}, panel))
 }
 
 var authCardStyle = registry.RegisterStyle("ui-auth-card", authCardCSS)

--- a/framework/ui/auth_card_test.go
+++ b/framework/ui/auth_card_test.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+func TestAuthCardRendersTitleAndFooter(t *testing.T) {
+	h := AuthCard(AuthCardConfig{
+		Title:  "Sign in",
+		Footer: render.Text("No account?"),
+	})
+	for _, want := range []string{
+		`data-fui-comp="ui-auth-card"`,
+		"ui-auth-card__title",
+		"Sign in",
+		"No account?",
+	} {
+		mustContain(t, h, want)
+	}
+}
+
+func TestAuthCardExtraAttrsOnRoot(t *testing.T) {
+	h := AuthCard(AuthCardConfig{
+		Title:      "Sign in",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/avatargroup.go
+++ b/framework/ui/avatargroup.go
@@ -40,6 +40,12 @@ type AvatarGroupConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the group's root element.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, role, and aria-label (use Label).
+	ExtraAttrs html.Attrs
 }
 
 // AvatarGroup renders an overlapping stack of avatars. When
@@ -111,10 +117,11 @@ func AvatarGroup(cfg AvatarGroupConfig) render.HTML {
 	}
 
 	return avatarGroupStyle.WrapHTML(html.Div(html.DivConfig{
-		Class:     cls,
-		ID:        cfg.ID,
-		Role:      "group",
-		AriaLabel: label,
+		Class:      cls,
+		ID:         cfg.ID,
+		Role:       "group",
+		AriaLabel:  label,
+		ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-label"),
 	}, items...))
 }
 

--- a/framework/ui/avatargroup_test.go
+++ b/framework/ui/avatargroup_test.go
@@ -139,3 +139,14 @@ func TestAvatarPresenceDotIsInsetInsideCorner(t *testing.T) {
 		}
 	}
 }
+
+func TestAvatarGroupExtraAttrsOnRoot(t *testing.T) {
+	h := AvatarGroup(AvatarGroupConfig{
+		Avatars:    []AvatarConfig{{Name: "A"}},
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("group root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/backtotop.go
+++ b/framework/ui/backtotop.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core/render"
 )
 
@@ -106,6 +107,13 @@ type BackToTopConfig struct {
 
 	// Class is an optional extra CSS class.
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the root <button>. Keys
+	// the component owns are dropped: class and id (use Class / ID),
+	// data-fui-*, type, aria-label (use Label), and inert (the
+	// runtime's initial-hidden wiring).
+	ExtraAttrs html.Attrs
 }
 
 // defaultArrowUpSVG is the chevron-up icon shown by default.
@@ -162,14 +170,16 @@ func BackToTop(cfg BackToTopConfig) render.HTML {
 		cls += " " + cfg.Class
 	}
 
-	attrs := map[string]string{
-		"type":                   "button",
-		"data-fui-back-to-top":   "",
-		"data-fui-btt-threshold": fmt.Sprintf("%d", threshold),
-		"aria-label":             label,
-		"inert":                  "",
-		"class":                  cls,
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "type", "aria-label", "inert")
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["type"] = "button"
+	attrs["data-fui-back-to-top"] = ""
+	attrs["data-fui-btt-threshold"] = fmt.Sprintf("%d", threshold)
+	attrs["aria-label"] = label
+	attrs["inert"] = ""
+	attrs["class"] = cls
 	if cfg.Smooth != "" {
 		attrs["data-fui-btt-scroll"] = string(cfg.Smooth)
 	}

--- a/framework/ui/backtotop_test.go
+++ b/framework/ui/backtotop_test.go
@@ -1,0 +1,16 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBackToTopExtraAttrsOnRoot(t *testing.T) {
+	h := BackToTop(BackToTopConfig{
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("button root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/barchart.go
+++ b/framework/ui/barchart.go
@@ -201,9 +201,10 @@ func BarChart(cfg BarChartConfig) render.HTML {
 	} else {
 		sb.WriteString(` aria-hidden="true"`)
 	}
+	sb.WriteString(` data-fui-comp="ui-bar-chart"`)
 	sb.WriteString(serializeExtraAttrs(html.SafeExtraAttrs(cfg.ExtraAttrs,
 		"width", "height", "viewBox", "xmlns", "role", "aria-labelledby", "aria-hidden")))
-	sb.WriteString(` data-fui-comp="ui-bar-chart">`)
+	sb.WriteString(`>`)
 
 	// Value axis: hairline gridlines at clean ticks + left labels.
 	if cfg.ShowAxis {

--- a/framework/ui/barchart.go
+++ b/framework/ui/barchart.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -68,12 +69,20 @@ type BarChartConfig struct {
 	LabelledBy string
 	ID         string
 	Class      string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the root <svg>. Keys the
+	// component owns are dropped: class and id (use Class / ID),
+	// data-fui-*, width, height, viewBox, xmlns, role,
+	// aria-labelledby (use LabelledBy), and aria-hidden. With no Bars
+	// the extras land on the shared zero-data placeholder instead.
+	ExtraAttrs html.Attrs
 }
 
 // BarChart renders a categorical bar chart.
 func BarChart(cfg BarChartConfig) render.HTML {
 	if len(cfg.Bars) == 0 {
-		return chartEmpty(cfg.Height, cfg.LabelledBy, cfg.Class, "No data yet")
+		return chartEmpty(cfg.Height, cfg.LabelledBy, cfg.Class, "No data yet", cfg.ExtraAttrs)
 	}
 	w := cfg.Width
 	if w == 0 {
@@ -192,6 +201,8 @@ func BarChart(cfg BarChartConfig) render.HTML {
 	} else {
 		sb.WriteString(` aria-hidden="true"`)
 	}
+	sb.WriteString(serializeExtraAttrs(html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"width", "height", "viewBox", "xmlns", "role", "aria-labelledby", "aria-hidden")))
 	sb.WriteString(` data-fui-comp="ui-bar-chart">`)
 
 	// Value axis: hairline gridlines at clean ticks + left labels.

--- a/framework/ui/barchart_test.go
+++ b/framework/ui/barchart_test.go
@@ -214,3 +214,30 @@ func TestBarChartStatusVariantColor(t *testing.T) {
 		t.Errorf("registered status variant should resolve to its accent fill:\n%s", h)
 	}
 }
+
+func TestBarChartExtraAttrsOnRoot(t *testing.T) {
+	h := BarChart(BarChartConfig{
+		Bars:       []BarChartBar{{Label: "x", Value: 1}},
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("svg root missing data-test:\n%s", root)
+	}
+}
+
+func TestChartExtraAttrsOnEmptyPlaceholder(t *testing.T) {
+	// Zero-data charts render the shared placeholder; a host's test
+	// hook must still resolve there (chartEmpty is shared by bar,
+	// line, and pie, so one chart covers the branch).
+	h := BarChart(BarChartConfig{
+		ExtraAttrs: map[string]string{"data-test": "hook", "role": "spoofed"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("empty placeholder missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `role="img"`) {
+		t.Errorf("owned role overridden on placeholder:\n%s", root)
+	}
+}

--- a/framework/ui/card.go
+++ b/framework/ui/card.go
@@ -65,6 +65,13 @@ type CardConfig struct {
 	Variant CardVariant
 	ID      string
 	Class   string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the card's root element,
+	// whichever shape it takes (<a>, <section>, or <div>). Keys the
+	// component owns are dropped: class and id (use Class / ID),
+	// data-fui-*, and href.
+	ExtraAttrs html.Attrs
 }
 
 // Card renders a labelled content card with optional header, footer,
@@ -81,6 +88,7 @@ func Card(cfg CardConfig, body ...render.HTML) render.HTML {
 	// Card used to emit ui-card--<anything> silently; that let typos
 	// ship unstyled cards with no signal.
 	checkCardVariant(cfg.Variant)
+	extra := html.SafeExtraAttrs(cfg.ExtraAttrs, "href")
 	cls := "ui-card"
 	if cfg.Variant != CardElevated {
 		cls += " ui-card--" + string(cfg.Variant)
@@ -134,17 +142,18 @@ func Card(cfg CardConfig, body ...render.HTML) render.HTML {
 		}
 		inner := html.Div(html.DivConfig{Class: "ui-card__inner"}, out...)
 		return cardStyle.WrapHTML(html.LinkHTML(html.LinkHTMLConfig{
-			Href:    href,
-			Class:   cls,
-			ID:      cfg.ID,
-			Content: inner,
+			Href:       href,
+			Class:      cls,
+			ID:         cfg.ID,
+			Content:    inner,
+			ExtraAttrs: extra,
 		}))
 	}
 
 	if headingID != "" {
 		return cardStyle.WrapHTML(html.Section(html.SectionConfig{
-			Class: cls, ID: cfg.ID, LabelledBy: headingID,
+			Class: cls, ID: cfg.ID, LabelledBy: headingID, ExtraAttrs: extra,
 		}, out...))
 	}
-	return cardStyle.WrapHTML(html.Div(html.DivConfig{Class: cls, ID: cfg.ID}, out...))
+	return cardStyle.WrapHTML(html.Div(html.DivConfig{Class: cls, ID: cfg.ID, ExtraAttrs: extra}, out...))
 }

--- a/framework/ui/card_test.go
+++ b/framework/ui/card_test.go
@@ -67,3 +67,30 @@ func TestCardWithoutHeadingFallsBackToDiv(t *testing.T) {
 		t.Fatalf("expected ui-card marker:\n%s", h)
 	}
 }
+
+func TestCardExtraAttrsOnEveryRootShape(t *testing.T) {
+	extra := map[string]string{"data-test": "hook"}
+	for name, h := range map[string]render.HTML{
+		"div":     Card(CardConfig{ExtraAttrs: extra}),
+		"section": Card(CardConfig{Heading: "x", ExtraAttrs: extra}),
+		"anchor":  Card(CardConfig{Href: "/a", ExtraAttrs: extra}),
+	} {
+		root := string(h)[:strings.Index(string(h), ">")+1]
+		if !strings.Contains(root, `data-test="hook"`) {
+			t.Errorf("%s root missing data-test:\n%s", name, root)
+		}
+	}
+}
+
+func TestCardExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := Card(CardConfig{Href: "/real", Class: "mine", ExtraAttrs: map[string]string{
+		"Class": "evil", "href": "javascript:alert(1)", "data-fui-comp": "spoof",
+	}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	for _, banned := range []string{"evil", "javascript:", "spoof"} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+	mustContain(t, h, `href="/real"`)
+}

--- a/framework/ui/chart_empty.go
+++ b/framework/ui/chart_empty.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -19,14 +20,18 @@ import (
 // constructors but is intentionally not turned into an inline style: the
 // framework forbids inline styles (everything ships via registered CSS), so the
 // placeholder's min-height is a fixed token in the stylesheet below.
-func chartEmpty(_ int, labelledBy, class, message string) render.HTML {
+// The caller's ExtraAttrs ride along so a host's data-* test hook still
+// resolves when the chart happens to render its zero-data branch.
+func chartEmpty(_ int, labelledBy, class, message string, extra html.Attrs) render.HTML {
 	if message == "" {
 		message = "No data yet"
 	}
-	attrs := map[string]string{
-		"data-fui-comp": "ui-chart-empty",
-		"role":          "img",
+	attrs := html.SafeExtraAttrs(extra, "role", "aria-labelledby", "aria-label")
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["data-fui-comp"] = "ui-chart-empty"
+	attrs["role"] = "img"
 	if class != "" {
 		attrs["class"] = class
 	}

--- a/framework/ui/codetabs.go
+++ b/framework/ui/codetabs.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/patterns/tabs"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
@@ -33,6 +34,13 @@ type CodeTabsConfig struct {
 	LineNumbers bool
 	ID          string
 	Class       string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the tab group's root
+	// element. Keys the component owns are dropped: class (use
+	// Class), id (ID tags the inner tabset, not the root), and
+	// data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // CodeTabs renders the same snippet in several languages behind a tab strip,
@@ -72,8 +80,13 @@ func CodeTabs(cfg CodeTabsConfig, samples ...CodeSample) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
+	rootAttrs := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if rootAttrs == nil {
+		rootAttrs = map[string]string{}
+	}
+	rootAttrs["class"] = cls
 	return codeTabsStyle.WrapHTML(render.Tag("div",
-		map[string]string{"class": cls},
+		rootAttrs,
 		tabs.New(tabs.Config{Name: cfg.Name, Label: cfg.Label, ID: cfg.ID}, items...),
 	))
 }

--- a/framework/ui/codetabs_test.go
+++ b/framework/ui/codetabs_test.go
@@ -52,3 +52,14 @@ func TestCodeTabsPanics(t *testing.T) {
 		}()
 	}
 }
+
+func TestCodeTabsExtraAttrsOnRoot(t *testing.T) {
+	h := CodeTabs(CodeTabsConfig{
+		Name:       "install",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	}, CodeSample{Label: "Go", Code: "x"})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root div missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/collapsible.go
+++ b/framework/ui/collapsible.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -33,6 +34,12 @@ type CollapsibleConfig struct {
 	Open    bool   // optional:  start expanded (default: collapsed)
 	Class   string // optional:  additional CSS classes
 	ID      string // optional:  element id
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the root <details>. Keys
+	// the component owns are dropped: class and id (use Class / ID),
+	// data-fui-*, and open (use Open).
+	ExtraAttrs html.Attrs
 }
 
 // Collapsible renders a <details> element with a clickable summary.
@@ -46,11 +53,13 @@ func Collapsible(cfg CollapsibleConfig, body ...render.HTML) render.HTML {
 		panic("ui: Collapsible requires Summary")
 	}
 
-	attrs := map[string]string{
-		"class":               "fui-collapsible",
-		"data-fui-comp":       "fui-collapsible",
-		"data-fui-disclosure": "",
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "open")
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["class"] = "fui-collapsible"
+	attrs["data-fui-comp"] = "fui-collapsible"
+	attrs["data-fui-disclosure"] = ""
 	if cfg.Open {
 		attrs["open"] = ""
 	}

--- a/framework/ui/collapsible_test.go
+++ b/framework/ui/collapsible_test.go
@@ -126,3 +126,14 @@ func TestCollapsibleCustomClassAndID(t *testing.T) {
 		t.Fatalf("expected custom id in output\ngot: %s", s)
 	}
 }
+
+func TestCollapsibleExtraAttrsOnRoot(t *testing.T) {
+	h := Collapsible(CollapsibleConfig{
+		Summary:    "S",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("details root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/colorfield.go
+++ b/framework/ui/colorfield.go
@@ -53,6 +53,13 @@ type ColorFieldConfig struct {
 	TextAttrs   html.Attrs
 
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the row's root element.
+	// Keys the component owns are dropped: class (use Class), id, and
+	// data-fui-*. Per-input attributes belong in SwatchAttrs /
+	// TextAttrs, which merge verbatim.
+	ExtraAttrs html.Attrs
 }
 
 // ColorField renders the swatch + text-input row.
@@ -94,7 +101,12 @@ func ColorField(cfg ColorFieldConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	return colorFieldStyle.WrapHTML(render.Tag("div", html.Attrs{"class": cls},
+	root := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if root == nil {
+		root = map[string]string{}
+	}
+	root["class"] = cls
+	return colorFieldStyle.WrapHTML(render.Tag("div", root,
 		render.VoidTag("input", swatch),
 		render.VoidTag("input", text),
 	))

--- a/framework/ui/colorfield_test.go
+++ b/framework/ui/colorfield_test.go
@@ -125,3 +125,14 @@ func escapeForAttr(s string) string {
 	r := strings.NewReplacer(`&`, "&amp;", `"`, "&#34;", `<`, "&lt;", `>`, "&gt;", `'`, "&#39;")
 	return r.Replace(s)
 }
+
+func TestColorFieldExtraAttrsOnRoot(t *testing.T) {
+	h := ColorField(ColorFieldConfig{
+		SwatchLabel: "Colour",
+		ExtraAttrs:  map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("row root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/colorpicker.go
+++ b/framework/ui/colorpicker.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -30,6 +31,13 @@ type ColorPickerConfig struct {
 	Disabled bool
 	ID       string
 	Class    string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the picker's root element
+	// (the wrapper div, not the <input>). Keys the component owns
+	// are dropped: class, id (the wrapper id derives from ID / Name),
+	// and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // ColorPicker renders a styled native color input with a label.
@@ -75,8 +83,14 @@ func ColorPicker(cfg ColorPickerConfig) render.HTML {
 		}, render.Text(cfg.Label)),
 	}
 
+	rootAttrs := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if rootAttrs == nil {
+		rootAttrs = map[string]string{}
+	}
+	rootAttrs["class"] = cls
+	rootAttrs["id"] = id + "-wrap"
 	return colorPickerStyle.WrapHTML(render.Tag("div",
-		map[string]string{"class": cls, "id": id + "-wrap"},
+		rootAttrs,
 		render.Tag("div", map[string]string{"class": "ui-color-picker__row"}, row...),
 	))
 }

--- a/framework/ui/colorpicker_test.go
+++ b/framework/ui/colorpicker_test.go
@@ -67,3 +67,15 @@ func TestColorPickerSwatchPrecedesLabel(t *testing.T) {
 		t.Errorf("swatch must precede its label (input at %d, label at %d):\n%s", input, label, h)
 	}
 }
+
+func TestColorPickerExtraAttrsOnRoot(t *testing.T) {
+	h := ColorPicker(ColorPickerConfig{
+		Name:       "fg",
+		Label:      "Bars",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("wrapper root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/commandpalette.go
+++ b/framework/ui/commandpalette.go
@@ -75,6 +75,13 @@ type CommandPaletteConfig struct {
 	// (placeholder, trigger + dialog titles, hint chips). When nil,
 	// English fallbacks apply.
 	Ctx context.Context
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) onto the palette's own root
+	// (the ui-cmd-palette panel inside the modal; the modal chrome is
+	// widget machinery). Keys the component owns are dropped:
+	// class, id, and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // PaletteCommand is one entry in a static command-palette list.
@@ -135,6 +142,7 @@ func CommandPalette(cfg CommandPaletteConfig) (render.HTML, *widget.Builder) {
 		navigateLabel: i18nui.T(ctx, i18nui.KeyCommandPaletteNavigate),
 		selectLabel:   i18nui.T(ctx, i18nui.KeyCommandPaletteSelect),
 		closeLabel:    i18nui.T(ctx, i18nui.KeyCommandPaletteClose),
+		extraAttrs:    html.SafeExtraAttrs(cfg.ExtraAttrs),
 	}
 	b := preset.Modal(name).
 		Hidden().
@@ -168,6 +176,7 @@ type commandPaletteSlot struct {
 	navigateLabel string
 	selectLabel   string
 	closeLabel    string
+	extraAttrs    html.Attrs
 }
 
 func (s *commandPaletteSlot) Render() render.HTML {
@@ -212,7 +221,8 @@ func (s *commandPaletteSlot) Render() render.HTML {
 	)
 
 	return commandPaletteStyle.WrapHTML(html.Div(html.DivConfig{
-		Class: "ui-cmd-palette",
+		Class:      "ui-cmd-palette",
+		ExtraAttrs: s.extraAttrs,
 	}, srTitle, combo, footer))
 }
 

--- a/framework/ui/commandpalette_test.go
+++ b/framework/ui/commandpalette_test.go
@@ -84,3 +84,15 @@ func TestCommandPalettePanicsWithoutRPC(t *testing.T) {
 	}()
 	CommandPalette(CommandPaletteConfig{})
 }
+
+func TestCommandPaletteExtraAttrsOnRoot(t *testing.T) {
+	_, b := CommandPalette(CommandPaletteConfig{
+		RPCPath:    "/search",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	h := b.Definition().Slots[0].Component.Render()
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("palette root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/components.go
+++ b/framework/ui/components.go
@@ -27,6 +27,12 @@ type PageHeaderConfig struct {
 	HeadingLevel int
 	Class        string
 	ID           string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the header's root <header>
+	// element. Keys the component owns are dropped: class and id
+	// (use Class / ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // PageHeader renders a top-of-page header with title, optional subtitle
@@ -67,7 +73,9 @@ func PageHeader(cfg PageHeaderConfig) render.HTML {
 			html.DivConfig{Class: "ui-page-header__actions"}, cfg.Actions))
 	}
 	return pageHeaderStyle.WrapHTML(
-		html.Header(html.HeaderConfig{Class: cls, ID: cfg.ID}, body...),
+		html.Header(html.HeaderConfig{
+			Class: cls, ID: cfg.ID, ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+		}, body...),
 	)
 }
 
@@ -125,6 +133,13 @@ type SectionConfig struct {
 	// Ctx carries the per-request context used to resolve the default
 	// Section aria-label. When nil, English fallback applies.
 	Ctx context.Context
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) to the section's root <section> element.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, and the accessible-name contract (role,
+	// aria-label, aria-labelledby).
+	ExtraAttrs html.Attrs
 }
 
 // Section renders a content section with consistent spacing and an
@@ -184,6 +199,7 @@ func Section(cfg SectionConfig, body ...render.HTML) render.HTML {
 		sectionID = slug(cfg.Heading)
 	}
 	secCfg := html.SectionConfig{Class: cls, ID: sectionID}
+	secCfg.ExtraAttrs = html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-label", "aria-labelledby")
 	if headingID != "" {
 		secCfg.LabelledBy = headingID
 	} else if cfg.Label != "" {
@@ -208,6 +224,12 @@ type FormFieldConfig struct {
 	Required bool   // adds a visible "required" hint and aria-required
 	Input    render.HTML
 	Class    string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) to the field row's root <div>. Keys the
+	// component owns are dropped: class and id (use Class) and
+	// data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // FormField renders a labelled form field with optional help and error
@@ -271,7 +293,9 @@ func FormField(cfg FormFieldConfig) render.HTML {
 			ExtraAttrs: html.Attrs{"role": "alert"},
 		}, render.Text(cfg.Error)))
 	}
-	return formFieldStyle.WrapHTML(html.Div(html.DivConfig{Class: cls}, out...))
+	return formFieldStyle.WrapHTML(html.Div(html.DivConfig{
+		Class: cls, ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+	}, out...))
 }
 
 // injectAriaInvalid splices ` aria-invalid="true" aria-describedby="<id>"`
@@ -415,6 +439,13 @@ type FormSectionConfig struct {
 	Heading     string // optional
 	Description string // optional
 	Class       string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) to the group's root element, whichever shape
+	// it takes (<div> without a Heading, <fieldset> with one). Keys the
+	// component owns are dropped: class and id (use Class) and
+	// data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // FormSection wraps a group of FormFields with a shared heading.
@@ -427,6 +458,7 @@ func FormSection(cfg FormSectionConfig, fields ...render.HTML) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
+	extra := html.SafeExtraAttrs(cfg.ExtraAttrs)
 	if cfg.Heading == "" {
 		// No heading → use a plain div, not <fieldset>, to avoid an
 		// unlabelled grouping landmark.
@@ -438,7 +470,7 @@ func FormSection(cfg FormSectionConfig, fields ...render.HTML) render.HTML {
 		}
 		out = append(out, html.Div(
 			html.DivConfig{Class: "ui-form-section__fields"}, fields...))
-		return formSectionStyle.WrapHTML(html.Div(html.DivConfig{Class: cls}, out...))
+		return formSectionStyle.WrapHTML(html.Div(html.DivConfig{Class: cls, ExtraAttrs: extra}, out...))
 	}
 	out := []render.HTML{}
 	if cfg.Description != "" {
@@ -449,7 +481,7 @@ func FormSection(cfg FormSectionConfig, fields ...render.HTML) render.HTML {
 	out = append(out, html.Div(
 		html.DivConfig{Class: "ui-form-section__fields"}, fields...))
 	return formSectionStyle.WrapHTML(html.FieldSet(
-		html.FieldSetConfig{Legend: cfg.Heading, Class: cls},
+		html.FieldSetConfig{Legend: cfg.Heading, Class: cls, ExtraAttrs: extra},
 		out...))
 }
 
@@ -667,6 +699,12 @@ type StatusBadgeConfig struct {
 	Variant StatusVariant // defaults to Neutral
 	ID      string
 	Class   string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the pill's root <span>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // StatusBadge renders a small inline pill conveying state.
@@ -683,8 +721,9 @@ func StatusBadge(cfg StatusBadgeConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	return statusBadgeStyle.WrapHTML(html.Span(html.TextConfig{Class: cls, ID: cfg.ID},
-		render.Text(cfg.Label)))
+	return statusBadgeStyle.WrapHTML(html.Span(html.TextConfig{
+		Class: cls, ID: cfg.ID, ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+	}, render.Text(cfg.Label)))
 }
 
 // ─── EmptyState ─────────────────────────────────────────────────────
@@ -703,6 +742,12 @@ type EmptyStateConfig struct {
 	// only content under the page <h1> (e.g. an admin list with zero rows)
 	// passes 2 so the outline doesn't skip h1 → h3.
 	HeadingLevel int
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the empty state's root
+	// <div>. Keys the component owns are dropped: class and id (use
+	// Class / ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // EmptyState renders a centered title + description + optional CTA for
@@ -736,7 +781,9 @@ func EmptyState(cfg EmptyStateConfig) render.HTML {
 		out = append(out, html.Div(
 			html.DivConfig{Class: "ui-empty-state__action"}, cfg.Action))
 	}
-	return emptyStateStyle.WrapHTML(html.Div(html.DivConfig{Class: cls, ID: cfg.ID}, out...))
+	return emptyStateStyle.WrapHTML(html.Div(html.DivConfig{
+		Class: cls, ID: cfg.ID, ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+	}, out...))
 }
 
 // ─── Callout ────────────────────────────────────────────────────────
@@ -754,9 +801,15 @@ type CalloutConfig struct {
 	// flow: a nested complementary landmark trips axe's
 	// landmark-complementary-is-top-level rule, and an inline tip is emphasis,
 	// not a tangential region. Same trade-off Sidebar already made (div, not
-	// aside, to avoid nesting complementary). Danger/warning always use
 	// role="alert" regardless of this flag.
 	Landmark *bool
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) to the callout's root element, whichever shape
+	// it takes (<aside> landmark, plain <div>, or role="alert" <div>).
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, and the landmark contract (role, aria-label).
+	ExtraAttrs html.Attrs
 }
 
 // Callout renders a persistent info/warning/error block. Distinct from
@@ -773,6 +826,7 @@ func Callout(cfg CalloutConfig, body ...render.HTML) render.HTML {
 		v = StatusInfo
 	}
 	checkStatusVariant("Callout", v)
+	extra := html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-label")
 	cls := "ui-callout ui-callout--" + string(v)
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
@@ -794,7 +848,7 @@ func Callout(cfg CalloutConfig, body ...render.HTML) render.HTML {
 	role := calloutRole(v)
 	if role == "alert" {
 		return calloutStyle.WrapHTML(html.Div(html.DivConfig{
-			Class: cls, ID: cfg.ID, Role: "alert",
+			Class: cls, ID: cfg.ID, Role: "alert", ExtraAttrs: extra,
 		}, out...))
 	}
 	// Note "info" role: html.Aside requires Label/LabelledBy. Use
@@ -808,7 +862,7 @@ func Callout(cfg CalloutConfig, body ...render.HTML) render.HTML {
 		// can nest inside <main> without tripping landmark-complementary-
 		// is-top-level. Visually identical to the landmark form.
 		return calloutStyle.WrapHTML(html.Div(html.DivConfig{
-			Class: cls, ID: cfg.ID,
+			Class: cls, ID: cfg.ID, ExtraAttrs: extra,
 		}, out...))
 	}
 	label := cfg.Title
@@ -816,7 +870,7 @@ func Callout(cfg CalloutConfig, body ...render.HTML) render.HTML {
 		label = string(v) + " note"
 	}
 	return calloutStyle.WrapHTML(html.Aside(html.AsideConfig{
-		Class: cls, ID: cfg.ID, Label: label,
+		Class: cls, ID: cfg.ID, Label: label, ExtraAttrs: extra,
 	}, out...))
 }
 func calloutRole(v StatusVariant) string {
@@ -850,6 +904,12 @@ type StatCardConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the stat card's root <div>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // StatCard renders a metric card: label, value, optional trend pill.
@@ -877,7 +937,9 @@ func StatCard(cfg StatCardConfig) render.HTML {
 			html.TextConfig{Class: "ui-stat-card__trend ui-stat-card__trend--" + string(dir)},
 			render.Text(cfg.Trend)))
 	}
-	return statCardStyle.WrapHTML(html.Div(html.DivConfig{Class: cls, ID: cfg.ID}, out...))
+	return statCardStyle.WrapHTML(html.Div(html.DivConfig{
+		Class: cls, ID: cfg.ID, ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+	}, out...))
 }
 
 // ─── Avatar ─────────────────────────────────────────────────────────
@@ -927,6 +989,12 @@ type AvatarConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the avatar's root <span>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // Avatar renders a circular avatar with an image fallback to text
@@ -945,7 +1013,8 @@ func Avatar(cfg AvatarConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	spanCfg := html.TextConfig{Class: cls, ID: cfg.ID}
+	spanCfg := html.TextConfig{Class: cls, ID: cfg.ID,
+		ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs)}
 
 	var inner []render.HTML
 	if cfg.Src != "" {
@@ -1036,6 +1105,14 @@ type CodeBlockConfig struct {
 	Scroll bool
 	ID     string
 	Class  string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) to the block's root element, whichever shape
+	// it takes (a bare <pre> or a framed <div>). Keys the component
+	// owns are dropped: class and id (use Class / ID), data-fui-*, and
+	// the scroll contract (tabindex, aria-label) that lives on the
+	// <pre> body.
+	ExtraAttrs html.Attrs
 }
 
 // codeBlockSeq mints a process-unique id for a framed block's body so the
@@ -1055,6 +1132,7 @@ func CodeBlock(cfg CodeBlockConfig) render.HTML {
 	if cfg.Language != "" {
 		label = cfg.Language + " source"
 	}
+	extra := html.SafeExtraAttrs(cfg.ExtraAttrs, "tabindex", "aria-label")
 
 	// Body <pre>. WCAG 2.1.1: tabindex=0 so keyboard users can pan the
 	// horizontal scroll. (role=region is intentionally avoided. It would
@@ -1079,7 +1157,13 @@ func CodeBlock(cfg CodeBlockConfig) render.HTML {
 		if cfg.Class != "" {
 			cls += " " + cfg.Class
 		}
-		preAttrs := map[string]string{"class": cls, "tabindex": "0", "aria-label": label}
+		preAttrs := extra
+		if preAttrs == nil {
+			preAttrs = html.Attrs{}
+		}
+		preAttrs["class"] = cls
+		preAttrs["tabindex"] = "0"
+		preAttrs["aria-label"] = label
 		if bodyID != "" {
 			preAttrs["id"] = bodyID
 		}
@@ -1133,7 +1217,7 @@ func CodeBlock(cfg CodeBlockConfig) render.HTML {
 	}
 	pre := render.Tag("pre", preAttrs, body)
 	return codeBlockStyle.WrapHTML(
-		html.Div(html.DivConfig{Class: cls, ID: cfg.ID}, head, pre))
+		html.Div(html.DivConfig{Class: cls, ID: cfg.ID, ExtraAttrs: extra}, head, pre))
 }
 
 // ─── SkipLink ──────────────────────────────────────────────────────
@@ -1163,6 +1247,12 @@ type SkipLinkConfig struct {
 	Text  string
 	Class string
 	ID    string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) to the link's root <a>. Keys the component
+	// owns are dropped: class and id (use Class / ID), data-fui-*, and
+	// href (use Target).
+	ExtraAttrs html.Attrs
 }
 
 // SkipLink renders a WCAG 2.4.1 skip-navigation link.
@@ -1181,10 +1271,11 @@ func SkipLink(cfg SkipLinkConfig) render.HTML {
 	}
 	return skipLinkStyle.WrapHTML(
 		html.Link(html.LinkConfig{
-			Href:  "#" + target,
-			Text:  text,
-			Class: cls,
-			ID:    cfg.ID,
+			Href:       "#" + target,
+			Text:       text,
+			Class:      cls,
+			ID:         cfg.ID,
+			ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs, "href"),
 		}),
 	)
 }

--- a/framework/ui/components_test.go
+++ b/framework/ui/components_test.go
@@ -551,3 +551,136 @@ func TestInjectAttrsDoesNotSkipDescribedByWhenInvalidPresent(t *testing.T) {
 		t.Errorf("aria-describedby was skipped because aria-invalid already present:\n%s", result)
 	}
 }
+
+// ─── ExtraAttrs pass-through (#251) ───
+
+func TestPageHeaderExtraAttrsOnRoot(t *testing.T) {
+	h := PageHeader(PageHeaderConfig{Title: "x", ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("PageHeader root missing data-test:\n%s", root)
+	}
+}
+
+func TestSectionExtraAttrsOnEveryRootShape(t *testing.T) {
+	extra := map[string]string{"data-test": "hook"}
+	for name, h := range map[string]render.HTML{
+		"heading": Section(SectionConfig{Heading: "x", ExtraAttrs: extra}, render.Text("b")),
+		"label":   Section(SectionConfig{Label: "y", ExtraAttrs: extra}, render.Text("b")),
+	} {
+		root := string(h)[:strings.Index(string(h), ">")+1]
+		if !strings.Contains(root, `data-test="hook"`) {
+			t.Errorf("%s root missing data-test:\n%s", name, root)
+		}
+	}
+}
+
+func TestFormFieldExtraAttrsOnRoot(t *testing.T) {
+	h := FormField(FormFieldConfig{
+		Label: "Name", For: "f",
+		Input:      html.Input(html.InputConfig{Type: "text", Name: "f", ID: "f"}),
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("FormField root missing data-test:\n%s", root)
+	}
+}
+
+func TestFormSectionExtraAttrsOnEveryRootShape(t *testing.T) {
+	extra := map[string]string{"data-test": "hook"}
+	for name, h := range map[string]render.HTML{
+		"div":      FormSection(FormSectionConfig{ExtraAttrs: extra}, render.Text("f")),
+		"fieldset": FormSection(FormSectionConfig{Heading: "h", ExtraAttrs: extra}, render.Text("f")),
+	} {
+		root := string(h)[:strings.Index(string(h), ">")+1]
+		if !strings.Contains(root, `data-test="hook"`) {
+			t.Errorf("%s root missing data-test:\n%s", name, root)
+		}
+	}
+}
+
+func TestStatusBadgeExtraAttrsOnRoot(t *testing.T) {
+	h := StatusBadge(StatusBadgeConfig{Label: "ok", ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("StatusBadge root missing data-test:\n%s", root)
+	}
+}
+
+func TestEmptyStateExtraAttrsOnRoot(t *testing.T) {
+	h := EmptyState(EmptyStateConfig{Title: "No items", ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("EmptyState root missing data-test:\n%s", root)
+	}
+}
+
+func TestCalloutExtraAttrsOnEveryRootShape(t *testing.T) {
+	extra := map[string]string{"data-test": "hook"}
+	inline := false
+	for name, h := range map[string]render.HTML{
+		"aside": Callout(CalloutConfig{Title: "t", ExtraAttrs: extra}, render.Text("b")),
+		"alert": Callout(CalloutConfig{Variant: StatusDanger, ExtraAttrs: extra}, render.Text("b")),
+		"div":   Callout(CalloutConfig{Landmark: &inline, ExtraAttrs: extra}, render.Text("b")),
+	} {
+		root := string(h)[:strings.Index(string(h), ">")+1]
+		if !strings.Contains(root, `data-test="hook"`) {
+			t.Errorf("%s root missing data-test:\n%s", name, root)
+		}
+	}
+}
+
+func TestStatCardExtraAttrsOnRoot(t *testing.T) {
+	h := StatCard(StatCardConfig{Label: "l", Value: "1", ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("StatCard root missing data-test:\n%s", root)
+	}
+}
+
+func TestAvatarExtraAttrsOnRoot(t *testing.T) {
+	h := Avatar(AvatarConfig{Name: "Ada Lovelace", ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("Avatar root missing data-test:\n%s", root)
+	}
+}
+
+func TestCodeBlockExtraAttrsOnEveryRootShape(t *testing.T) {
+	extra := map[string]string{"data-test": "hook"}
+	for name, h := range map[string]render.HTML{
+		"pre":    CodeBlock(CodeBlockConfig{Code: "x = 1", ExtraAttrs: extra}),
+		"framed": CodeBlock(CodeBlockConfig{Code: "x = 1", Filename: "a.go", ExtraAttrs: extra}),
+	} {
+		root := string(h)[:strings.Index(string(h), ">")+1]
+		if !strings.Contains(root, `data-test="hook"`) {
+			t.Errorf("%s root missing data-test:\n%s", name, root)
+		}
+	}
+}
+
+func TestCodeBlockExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := CodeBlock(CodeBlockConfig{
+		Code: "x", Language: "go",
+		ExtraAttrs: map[string]string{
+			"tabindex": "9", "ARIA-LABEL": "evil", "data-fui-comp": "spoof",
+		},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	for _, banned := range []string{`tabindex="9"`, `evil`, `spoof`} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+	mustContain(t, h, `tabindex="0"`)
+	mustContain(t, h, `aria-label="go source"`)
+}
+
+func TestSkipLinkExtraAttrsOnRoot(t *testing.T) {
+	h := SkipLink(SkipLinkConfig{ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("SkipLink root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/conditionalfield.go
+++ b/framework/ui/conditionalfield.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
 )
@@ -29,6 +30,14 @@ type ConditionalFieldConfig struct {
 	Children []render.HTML
 
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the root element. Keys
+	// the component owns are dropped: class (use Class), id,
+	// data-fui-*, data-when-name / data-when-value (use WhenName /
+	// WhenValue), hidden, and aria-hidden (the runtime toggles
+	// visibility).
+	ExtraAttrs html.Attrs
 }
 
 // ConditionalField renders a container that is hidden by default and
@@ -50,14 +59,17 @@ func ConditionalField(cfg ConditionalFieldConfig) render.HTML {
 		cls += " " + cfg.Class
 	}
 
-	attrs := map[string]string{
-		"data-fui-comp":   "ui-conditional-field",
-		"class":           cls,
-		"data-when-name":  cfg.WhenName,
-		"data-when-value": cfg.WhenValue,
-		"hidden":          "",
-		"aria-hidden":     "true",
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"data-when-name", "data-when-value", "hidden", "aria-hidden")
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["data-fui-comp"] = "ui-conditional-field"
+	attrs["class"] = cls
+	attrs["data-when-name"] = cfg.WhenName
+	attrs["data-when-value"] = cfg.WhenValue
+	attrs["hidden"] = ""
+	attrs["aria-hidden"] = "true"
 
 	return conditionalFieldStyle.WrapHTML(
 		render.Tag("div", attrs, cfg.Children...))
@@ -88,12 +100,15 @@ func ConditionalFieldVisible(cfg ConditionalFieldConfig) render.HTML {
 		cls += " " + cfg.Class
 	}
 
-	attrs := map[string]string{
-		"data-fui-comp":   "ui-conditional-field",
-		"class":           cls,
-		"data-when-name":  cfg.WhenName,
-		"data-when-value": cfg.WhenValue,
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"data-when-name", "data-when-value", "hidden", "aria-hidden")
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["data-fui-comp"] = "ui-conditional-field"
+	attrs["class"] = cls
+	attrs["data-when-name"] = cfg.WhenName
+	attrs["data-when-value"] = cfg.WhenValue
 
 	return conditionalFieldStyle.WrapHTML(
 		render.Tag("div", attrs, cfg.Children...))

--- a/framework/ui/conditionalfield_test.go
+++ b/framework/ui/conditionalfield_test.go
@@ -86,3 +86,15 @@ func TestConditionalFieldEvaluateInitialState(t *testing.T) {
 		t.Error("should not match when value differs from WhenValue")
 	}
 }
+
+func TestConditionalFieldExtraAttrsOnRoot(t *testing.T) {
+	h := ConditionalField(ConditionalFieldConfig{
+		WhenName:   "plan",
+		WhenValue:  "pro",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/confirmaction.go
+++ b/framework/ui/confirmaction.go
@@ -94,6 +94,14 @@ type ConfirmActionConfig struct {
 	// Ctx carries the per-request context used to resolve the
 	// Confirm/Cancel button labels. When nil, English fallbacks apply.
 	Ctx context.Context
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) onto the dialog's own root
+	// (the ui-confirm-action panel; the modal chrome is widget
+	// machinery, and the trigger is a plain ui.Button — render a
+	// Button yourself for trigger-level extras). Keys the component
+	// owns are dropped: class, id, and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // ConfirmAction returns the trigger button and a *widget.Builder for
@@ -139,7 +147,7 @@ func ConfirmAction(cfg ConfirmActionConfig) (render.HTML, *widget.Builder) {
 		method = "POST"
 	}
 	trigger := buildConfirmTrigger(cfg.Name, cfg.TriggerLabel, variant)
-	modal := buildConfirmModal(cfg.Name, cfg.Title, cfg.Body, confirm, cancel, method, cfg.RPCPath, cfg.SuccessSignal, cfg.AutofocusConfirm)
+	modal := buildConfirmModal(cfg.Name, cfg.Title, cfg.Body, confirm, cancel, method, cfg.RPCPath, cfg.SuccessSignal, cfg.AutofocusConfirm, html.SafeExtraAttrs(cfg.ExtraAttrs))
 	return trigger, modal
 }
 
@@ -186,7 +194,7 @@ func validSuccessSignalName(name string) bool {
 	return true
 }
 
-func buildConfirmModal(name, title, body, confirmLabel, cancelLabel, method, rpcPath, successSignal string, autofocusConfirm bool) *widget.Builder {
+func buildConfirmModal(name, title, body, confirmLabel, cancelLabel, method, rpcPath, successSignal string, autofocusConfirm bool, extraAttrs html.Attrs) *widget.Builder {
 	titleID := name + "-title"
 	bodyID := name + "-body"
 	slot := &confirmDialogSlot{
@@ -200,6 +208,7 @@ func buildConfirmModal(name, title, body, confirmLabel, cancelLabel, method, rpc
 		rpcPath:          rpcPath,
 		successSignal:    successSignal,
 		autofocusConfirm: autofocusConfirm,
+		extraAttrs:       extraAttrs,
 	}
 	return preset.Modal(name).
 		Hidden().
@@ -215,6 +224,7 @@ type confirmDialogSlot struct {
 	confirmLabel, cancelLabel         string
 	rpcMethod, rpcPath, successSignal string
 	autofocusConfirm                  bool
+	extraAttrs                        html.Attrs
 }
 
 func (s *confirmDialogSlot) Render() render.HTML {
@@ -240,7 +250,7 @@ func (s *confirmDialogSlot) Render() render.HTML {
 		confirmAttrs["autofocus"] = ""
 	}
 
-	return confirmActionStyle.WrapHTML(html.Div(html.DivConfig{Class: "ui-confirm-action"},
+	return confirmActionStyle.WrapHTML(html.Div(html.DivConfig{Class: "ui-confirm-action", ExtraAttrs: s.extraAttrs},
 		html.Heading(html.HeadingConfig{Level: 2, Class: "ui-confirm-action__title", ID: s.titleID},
 			render.Text(s.title)),
 		html.Paragraph(html.TextConfig{Class: "ui-confirm-action__body", ID: s.bodyID},

--- a/framework/ui/confirmaction_test.go
+++ b/framework/ui/confirmaction_test.go
@@ -250,3 +250,19 @@ func TestConfirmActionSuccessSignalRejectedNames(t *testing.T) {
 		})
 	}
 }
+
+func TestConfirmActionExtraAttrsOnRoot(t *testing.T) {
+	_, b := ConfirmAction(ConfirmActionConfig{
+		Name:         "delete-x",
+		TriggerLabel: "Delete",
+		Title:        "Delete?",
+		Body:         "Sure?",
+		RPCPath:      "/x",
+		ExtraAttrs:   map[string]string{"data-test": "hook"},
+	})
+	body := string(b.Definition().Slots[0].Component.Render())
+	root := body[:strings.Index(body, ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("dialog root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/copybutton.go
+++ b/framework/ui/copybutton.go
@@ -80,6 +80,13 @@ type CopyButtonConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the root wrapper (the
+	// span carrying data-fui-comp). Keys the component owns are
+	// dropped: class, id (ID lands on the button, not the wrapper),
+	// and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // CopyButton renders the button.
@@ -185,7 +192,8 @@ func CopyButton(cfg CopyButtonConfig) render.HTML {
 	})
 
 	return copyButtonStyle.WrapHTML(html.Span(html.TextConfig{
-		Class: "ui-copy-btn-wrap",
+		Class:      "ui-copy-btn-wrap",
+		ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
 	}, btn, status))
 }
 

--- a/framework/ui/copybutton_test.go
+++ b/framework/ui/copybutton_test.go
@@ -79,3 +79,14 @@ func TestCopyButtonAriaLabelOverride(t *testing.T) {
 		t.Errorf("expected custom AriaLabel, got: %s", out)
 	}
 }
+
+func TestCopyButtonExtraAttrsOnRoot(t *testing.T) {
+	h := CopyButton(CopyButtonConfig{
+		Target:     "#code",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("wrapper root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/counter.go
+++ b/framework/ui/counter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/store"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
@@ -43,6 +44,12 @@ type CounterConfig struct {
 	// Ctx carries the per-request context used to resolve the Decrement,
 	// Increment and Counter group aria labels. When nil, English fallbacks apply.
 	Ctx context.Context
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the root element. Keys
+	// the component owns are dropped: class (use Class), id, and
+	// data-fui-*, plus role=group and the aria-label it derives.
+	ExtraAttrs html.Attrs
 }
 
 // Counter renders a counter with + and − buttons that mutate a signal
@@ -100,10 +107,13 @@ func Counter(cfg CounterConfig) render.HTML {
 	}
 	incBtn := render.Tag("button", incAttrs, render.Text("+"))
 
-	return render.Tag("div", map[string]string{
-		"class":         cls,
-		"data-fui-comp": "fui-counter",
-		"role":          "group",
-		"aria-label":    i18nui.T(ctx, i18nui.KeyCounterLabel),
-	}, decBtn, display, incBtn)
+	rootAttrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-label")
+	if rootAttrs == nil {
+		rootAttrs = map[string]string{}
+	}
+	rootAttrs["class"] = cls
+	rootAttrs["data-fui-comp"] = "fui-counter"
+	rootAttrs["role"] = "group"
+	rootAttrs["aria-label"] = i18nui.T(ctx, i18nui.KeyCounterLabel)
+	return render.Tag("div", rootAttrs, decBtn, display, incBtn)
 }

--- a/framework/ui/counter_test.go
+++ b/framework/ui/counter_test.go
@@ -86,3 +86,14 @@ func resultFromPanic(r any) string {
 	}
 	return ""
 }
+
+func TestCounterExtraAttrsOnRoot(t *testing.T) {
+	h := Counter(CounterConfig{
+		SignalName: "qty",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/datatable.go
+++ b/framework/ui/datatable.go
@@ -146,6 +146,13 @@ type DataTableConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the list's root element,
+	// on both the populated and the empty-state shape. Keys the
+	// component owns are dropped: class and id (use Class / ID), and
+	// data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // DataTable renders the table.
@@ -180,9 +187,11 @@ func DataTable(cfg DataTableConfig) render.HTML {
 				empty.Description = i18nui.T(ctx, i18nui.KeyTableEmptyDesc)
 			}
 		}
+		extra := html.SafeExtraAttrs(cfg.ExtraAttrs)
 		return dataTableStyle.WrapHTML(html.Div(html.DivConfig{
-			Class: wrapClass(cfg.Class, "ui-data-table is-empty"),
-			ID:    cfg.ID,
+			Class:      wrapClass(cfg.Class, "ui-data-table is-empty"),
+			ID:         cfg.ID,
+			ExtraAttrs: extra,
 		}, EmptyState(empty)))
 	}
 
@@ -270,7 +279,7 @@ func DataTable(cfg DataTableConfig) render.HTML {
 		base += " ui-data-table--responsive-cards"
 	}
 	return dataTableStyle.WrapHTML(html.Div(html.DivConfig{
-		Class: wrapClass(cfg.Class, base), ID: cfg.ID,
+		Class: wrapClass(cfg.Class, base), ID: cfg.ID, ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
 	}, children...))
 }
 

--- a/framework/ui/datatable_test.go
+++ b/framework/ui/datatable_test.go
@@ -307,3 +307,23 @@ func TestDataTable_ResponsiveCards_EmptyHeaderHasNoDataLabel(t *testing.T) {
 		t.Errorf("empty-header column should not emit data-label=\"\", got: %s", h)
 	}
 }
+
+func TestDataTableExtraAttrsOnEveryRootShape(t *testing.T) {
+	extra := map[string]string{"data-test": "hook"}
+	for name, h := range map[string]render.HTML{
+		"populated": DataTable(DataTableConfig{
+			Columns:    []Column{{Key: "id", Header: "ID"}},
+			Rows:       []Row{{Cells: map[string]render.HTML{"id": render.Text("1")}}},
+			ExtraAttrs: extra,
+		}),
+		"empty": DataTable(DataTableConfig{
+			Columns:    []Column{{Key: "id", Header: "ID"}},
+			ExtraAttrs: extra,
+		}),
+	} {
+		root := string(h)[:strings.Index(string(h), ">")+1]
+		if !strings.Contains(root, `data-test="hook"`) {
+			t.Errorf("%s root missing data-test:\n%s", name, root)
+		}
+	}
+}

--- a/framework/ui/detail_list.go
+++ b/framework/ui/detail_list.go
@@ -22,6 +22,12 @@ type DetailItem struct {
 type DetailListConfig struct {
 	Items []DetailItem
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the root <dl>. Keys the
+	// component owns are dropped: class (use Class), id, and
+	// data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // DetailList renders a label/value description list.
@@ -37,7 +43,12 @@ func DetailList(cfg DetailListConfig) render.HTML {
 	if cfg.Class != "" {
 		cls = cls + " " + cfg.Class
 	}
-	return detailListStyle.WrapHTML(render.Tag("dl", map[string]string{"class": cls}, rows...))
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["class"] = cls
+	return detailListStyle.WrapHTML(render.Tag("dl", attrs, rows...))
 }
 
 var detailListStyle = registry.RegisterStyle("ui-detail-list", detailListCSS)

--- a/framework/ui/detail_list_test.go
+++ b/framework/ui/detail_list_test.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+func TestDetailListRendersRows(t *testing.T) {
+	h := DetailList(DetailListConfig{
+		Items: []DetailItem{{Label: "Name", Value: render.Text("Ada")}},
+	})
+	for _, want := range []string{
+		`data-fui-comp="ui-detail-list"`,
+		"<dt",
+		"<dd",
+		"Ada",
+	} {
+		mustContain(t, h, want)
+	}
+}
+
+func TestDetailListExtraAttrsOnRoot(t *testing.T) {
+	h := DetailList(DetailListConfig{
+		Items:      []DetailItem{{Label: "Name", Value: render.Text("Ada")}},
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("dl root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/diffviewer.go
+++ b/framework/ui/diffviewer.go
@@ -44,6 +44,12 @@ type DiffViewerConfig struct {
 	RightLabel string
 	ID         string
 	Class      string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the root element. Keys
+	// the component owns are dropped: class and id (use Class / ID),
+	// and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // DiffViewer renders a unified-diff body as a styled view.
@@ -169,7 +175,11 @@ func DiffViewer(cfg DiffViewerConfig) render.HTML {
 		}
 	}
 
-	attrs := html.Attrs{"class": cls}
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["class"] = cls
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}

--- a/framework/ui/diffviewer_test.go
+++ b/framework/ui/diffviewer_test.go
@@ -85,3 +85,14 @@ func TestDiffViewerFileHeaderRenders(t *testing.T) {
 		t.Errorf("--- / +++ headers should render as .ui-diff-viewer__file:\n%s", h)
 	}
 }
+
+func TestDiffViewerExtraAttrsOnRoot(t *testing.T) {
+	h := DiffViewer(DiffViewerConfig{
+		Patch:      "+hello",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/divider.go
+++ b/framework/ui/divider.go
@@ -28,6 +28,13 @@ type DividerConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the root element (<hr>,
+	// or the role=separator div for vertical / labelled shapes).
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, role, and aria-orientation (use Orientation).
+	ExtraAttrs html.Attrs
 }
 
 // Divider renders a semantic separator. Plain horizontal dividers use
@@ -44,22 +51,27 @@ func Divider(cfg DividerConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
+	extra := html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-orientation")
 
 	// Native <hr> is the cleanest case: no label, horizontal, no
 	// extra DOM. Keeps "<hr>" findable in view-source for plain
 	// dividers and avoids unnecessary role announcements.
 	if cfg.Label == "" && cfg.Orientation == DividerHorizontal {
-		return dividerStyle.WrapHTML(render.Tag("hr", map[string]string{
-			"class": cls,
-			"id":    cfg.ID,
-		}))
+		attrs := map[string]string{"class": cls, "id": cfg.ID}
+		for k, v := range extra {
+			attrs[k] = v
+		}
+		return dividerStyle.WrapHTML(render.Tag("hr", attrs))
 	}
 
-	attrs := map[string]string{
-		"class":            cls,
-		"role":             "separator",
-		"aria-orientation": string(orientationOrHorizontal(cfg.Orientation)),
+	attrs := extra
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["class"] = cls
+	attrs["role"] = "separator"
+	attrs["aria-orientation"] = string(orientationOrHorizontal(cfg.Orientation))
+
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}

--- a/framework/ui/divider_test.go
+++ b/framework/ui/divider_test.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"strings"
 	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/render"
 )
 
 func TestDividerPlainEmitsHR(t *testing.T) {
@@ -27,4 +29,18 @@ func TestDividerVerticalAlwaysUsesRole(t *testing.T) {
 	mustContain(t, h, `role="separator"`)
 	mustContain(t, h, `aria-orientation="vertical"`)
 	mustContain(t, h, "ui-divider--vertical")
+}
+
+func TestDividerExtraAttrsOnEveryRootShape(t *testing.T) {
+	extra := map[string]string{"data-test": "hook"}
+	for name, h := range map[string]render.HTML{
+		"hr":       Divider(DividerConfig{ExtraAttrs: extra}),
+		"vertical": Divider(DividerConfig{Orientation: DividerVertical, ExtraAttrs: extra}),
+		"labelled": Divider(DividerConfig{Label: "OR", ExtraAttrs: extra}),
+	} {
+		root := string(h)[:strings.Index(string(h), ">")+1]
+		if !strings.Contains(root, `data-test="hook"`) {
+			t.Errorf("%s root missing data-test:\n%s", name, root)
+		}
+	}
 }

--- a/framework/ui/doc_layout.go
+++ b/framework/ui/doc_layout.go
@@ -51,6 +51,12 @@ type DocLayoutConfig struct {
 	Pager *DocPager
 	Class string
 	ID    string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the layout's root
+	// element. Keys the component owns are dropped: class and id
+	// (use Class / ID), and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // DocLayout assembles the doc page skeleton around the article body.
@@ -86,7 +92,7 @@ func DocLayout(cfg DocLayoutConfig, body ...render.HTML) render.HTML {
 		shellChildren = append(shellChildren, cfg.Toc)
 	}
 	return docLayoutStyle.WrapHTML(
-		html.Div(html.DivConfig{Class: cls, ID: cfg.ID}, shellChildren...))
+		html.Div(html.DivConfig{Class: cls, ID: cfg.ID, ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs)}, shellChildren...))
 }
 
 func docCrumbs(crumbs []DocCrumb, label string) render.HTML {

--- a/framework/ui/doc_layout_test.go
+++ b/framework/ui/doc_layout_test.go
@@ -83,3 +83,12 @@ func TestDocLayoutCSSCollapsesOnMobile(t *testing.T) {
 		t.Fatal("DocLayout must collapse to display:block on mobile")
 	}
 }
+
+func TestDocLayoutExtraAttrsOnRoot(t *testing.T) {
+	h := DocLayout(DocLayoutConfig{ExtraAttrs: map[string]string{"data-test": "hook"}},
+		render.Text("BODY"))
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/dropzone.go
+++ b/framework/ui/dropzone.go
@@ -54,6 +54,12 @@ type FileDropzoneConfig struct {
 	ID    string
 	Class string
 
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the dropzone's root div.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
+	ExtraAttrs html.Attrs
+
 	// Ctx carries the per-request context used to resolve the prompt
 	// and max-size help labels. When nil, English fallbacks apply.
 	Ctx context.Context
@@ -178,8 +184,12 @@ func FileDropzone(cfg FileDropzoneConfig) render.HTML {
 		}, render.Text(help)))
 	}
 
-	return dropzoneStyle.WrapHTML(render.Tag("div",
-		map[string]string{"class": cls}, children...))
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["class"] = cls
+	return dropzoneStyle.WrapHTML(render.Tag("div", attrs, children...))
 }
 
 func dropzoneIcon() string {

--- a/framework/ui/dropzone_test.go
+++ b/framework/ui/dropzone_test.go
@@ -94,3 +94,15 @@ func TestFileDropzoneMaxSizeMBInHelp(t *testing.T) {
 		t.Errorf("MaxSizeMB should be announced in help text:\n%s", h)
 	}
 }
+
+func TestFileDropzoneExtraAttrsOnRoot(t *testing.T) {
+	h := FileDropzone(FileDropzoneConfig{
+		Name:       "f",
+		Label:      "x",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("dropzone root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/extraattrs_contract_test.go
+++ b/framework/ui/extraattrs_contract_test.go
@@ -1,0 +1,116 @@
+package ui
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// extraAttrsExempt lists Config structs allowed to omit ExtraAttrs.
+// Every entry needs a reason; "not done yet" is not one.
+var extraAttrsExempt = map[string]string{}
+
+// TestEveryComponentConfigHasExtraAttrs is the completeness gate for the
+// ExtraAttrs contract (#251): every exported constructor in this package
+// that takes a *Config struct and returns render.HTML or
+// component.Component must offer an ExtraAttrs pass-through, so hosts
+// can attach data-* test hooks and analytics markers to the element the
+// component owns. It parses the package source rather than reflecting,
+// because the contract is about declared config surface.
+func TestEveryComponentConfigHasExtraAttrs(t *testing.T) {
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configHasField := map[string]bool{}
+	configDeclared := map[string]bool{}
+	constructors := map[string][]string{}
+
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch d := n.(type) {
+			case *ast.TypeSpec:
+				st, ok := d.Type.(*ast.StructType)
+				if !ok || !strings.HasSuffix(d.Name.Name, "Config") {
+					return true
+				}
+				configDeclared[d.Name.Name] = true
+				for _, fld := range st.Fields.List {
+					for _, id := range fld.Names {
+						if id.Name == "ExtraAttrs" {
+							configHasField[d.Name.Name] = true
+						}
+					}
+				}
+			case *ast.FuncDecl:
+				if d.Recv != nil || !d.Name.IsExported() || d.Type.Results == nil {
+					return true
+				}
+				if !returnsComponentType(d.Type.Results) {
+					return true
+				}
+				for _, p := range d.Type.Params.List {
+					typ := p.Type
+					if star, ok := typ.(*ast.StarExpr); ok {
+						typ = star.X
+					}
+					if id, ok := typ.(*ast.Ident); ok && strings.HasSuffix(id.Name, "Config") {
+						constructors[id.Name] = append(constructors[id.Name], d.Name.Name)
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	if len(constructors) < 40 {
+		t.Fatalf("found only %d component configs; the scan is broken", len(constructors))
+	}
+
+	for cfg, fns := range constructors {
+		if !configDeclared[cfg] {
+			continue // declared in another package; its own gate applies
+		}
+		if reason, ok := extraAttrsExempt[cfg]; ok {
+			if configHasField[cfg] {
+				t.Errorf("%s is exempt (%q) but has ExtraAttrs; drop the exemption", cfg, reason)
+			}
+			continue
+		}
+		if !configHasField[cfg] {
+			t.Errorf("%s (used by %s) lacks ExtraAttrs; forward it to the root element or exempt it with a reason",
+				cfg, strings.Join(fns, ", "))
+		}
+	}
+}
+
+func returnsComponentType(res *ast.FieldList) bool {
+	for _, r := range res.List {
+		sel, ok := r.Type.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		if (pkg.Name == "render" && sel.Sel.Name == "HTML") ||
+			(pkg.Name == "component" && sel.Sel.Name == "Component") {
+			return true
+		}
+	}
+	return false
+}

--- a/framework/ui/extraattrs_contract_test.go
+++ b/framework/ui/extraattrs_contract_test.go
@@ -99,7 +99,11 @@ func TestEveryComponentConfigHasExtraAttrs(t *testing.T) {
 
 func returnsComponentType(res *ast.FieldList) bool {
 	for _, r := range res.List {
-		sel, ok := r.Type.(*ast.SelectorExpr)
+		typ := r.Type
+		if star, ok := typ.(*ast.StarExpr); ok {
+			typ = star.X // *widget.Builder
+		}
+		sel, ok := typ.(*ast.SelectorExpr)
 		if !ok {
 			continue
 		}
@@ -108,9 +112,100 @@ func returnsComponentType(res *ast.FieldList) bool {
 			continue
 		}
 		if (pkg.Name == "render" && sel.Sel.Name == "HTML") ||
-			(pkg.Name == "component" && sel.Sel.Name == "Component") {
+			(pkg.Name == "component" && sel.Sel.Name == "Component") ||
+			(pkg.Name == "widget" && (sel.Sel.Name == "Builder" || sel.Sel.Name == "Definition")) {
 			return true
 		}
 	}
 	return false
+}
+
+// extraAttrsRawLegacy lists files whose ExtraAttrs forwarding predates
+// the SafeExtraAttrs contract and still forwards raw (issue #262).
+// Shrink this list as sites migrate; never add to it — new forwarding
+// must go through html.SafeExtraAttrs (or scrubAttrs where on* filtering
+// is the deliberate, documented contract).
+var extraAttrsRawLegacy = map[string]bool{
+	"animatedcounter.go": true, "banner.go": true, "carousel.go": true,
+	"components.go": true, "container.go": true, "filtertoolbar.go": true,
+	"form.go": true, "gallery.go": true, "link.go": true,
+	"markdown.go": true, "menu.go": true, "notificationbell.go": true,
+	"numberinput.go": true, "passwordinput.go": true, "progresssteps.go": true,
+	"rangeslider.go": true, "searchinput.go": true, "select.go": true,
+	"slider.go": true, "textarea.go": true, "timeline.go": true,
+	"toc.go": true, "toolbar.go": true, "workbench.go": true,
+}
+
+// TestExtraAttrsForwardingIsSanitized fails when a file outside the
+// legacy allow-list reads a config's ExtraAttrs without routing it
+// through html.SafeExtraAttrs (or scrubAttrs). Presence of the field
+// (the gate above) is not enough: a raw maps.Copy after the owned keys
+// lets a caller clobber roles, form names, and data-fui-* wiring —
+// exactly the miss that left 24 legacy sites on the old contract.
+func TestExtraAttrsForwardingIsSanitized(t *testing.T) {
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var sanitized []ast.Node // subtrees where a raw read is fine
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch d := n.(type) {
+			case *ast.CallExpr:
+				switch fun := d.Fun.(type) {
+				case *ast.SelectorExpr:
+					if fun.Sel.Name == "SafeExtraAttrs" {
+						sanitized = append(sanitized, d)
+					}
+				case *ast.Ident:
+					// chartEmpty sanitizes its extra argument internally.
+					if fun.Name == "scrubAttrs" || fun.Name == "chartEmpty" {
+						sanitized = append(sanitized, d)
+					}
+				}
+			case *ast.AssignStmt:
+				// Writes of framework-owned values INTO a primitive
+				// config's ExtraAttrs (thCfg.ExtraAttrs = thAttrs) are
+				// not caller-extras reads; skip the LHS only.
+				for _, lhs := range d.Lhs {
+					if sel, ok := lhs.(*ast.SelectorExpr); ok && sel.Sel.Name == "ExtraAttrs" {
+						sanitized = append(sanitized, sel)
+					}
+				}
+			}
+			return true
+		})
+		inSanitized := func(pos token.Pos) bool {
+			for _, c := range sanitized {
+				if pos >= c.Pos() && pos <= c.End() {
+					return true
+				}
+			}
+			return false
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "ExtraAttrs" {
+				return true
+			}
+			if inSanitized(sel.Pos()) {
+				return true
+			}
+			if extraAttrsRawLegacy[name] {
+				return true
+			}
+			t.Errorf("%s: raw ExtraAttrs read at %s; route it through html.SafeExtraAttrs (issue #262 tracks the legacy allow-list)",
+				name, fset.Position(sel.Pos()))
+			return true
+		})
+	}
 }

--- a/framework/ui/fact_box.go
+++ b/framework/ui/fact_box.go
@@ -44,6 +44,12 @@ type FactBoxConfig struct {
 	FullWidth bool
 	ID        string
 	Class     string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the fact's root div.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // FactBox renders one labelled tile. Pair with a CSS grid to lay out
@@ -82,7 +88,10 @@ func FactBox(cfg FactBoxConfig) render.HTML {
 	if cfg.Style == FactStyleValueFirst {
 		children = []render.HTML{val, label}
 	}
-	return factBoxStyle.WrapHTML(html.Div(html.DivConfig{Class: cls, ID: cfg.ID}, children...))
+	return factBoxStyle.WrapHTML(html.Div(html.DivConfig{
+		Class: cls, ID: cfg.ID,
+		ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+	}, children...))
 }
 
 var factBoxStyle = registry.RegisterStyle("ui-fact-box", factBoxCSS)

--- a/framework/ui/fact_box_test.go
+++ b/framework/ui/fact_box_test.go
@@ -87,3 +87,15 @@ func TestFactBoxRejectsUnknownStyle(t *testing.T) {
 	}()
 	FactBox(FactBoxConfig{Label: "x", Value: "y", Style: "huge"})
 }
+
+func TestFactBoxExtraAttrsOnRoot(t *testing.T) {
+	h := FactBox(FactBoxConfig{
+		Label:      "Prereqs",
+		Value:      "Go",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("fact box root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/fileupload.go
+++ b/framework/ui/fileupload.go
@@ -59,6 +59,12 @@ type FileUploadConfig struct {
 
 	Class string
 
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the field's root <label>
+	// element. Keys the component owns are dropped: class and id
+	// (use Class), data-fui-*, and for (the label→input pairing).
+	ExtraAttrs html.Attrs
+
 	// Ctx carries the per-request context used to resolve the prompt
 	// and max-size help labels. When nil, English fallbacks apply.
 	Ctx context.Context
@@ -158,10 +164,13 @@ func FileUpload(cfg FileUploadConfig) render.HTML {
 		}, render.Text(help)))
 	}
 
-	return fileUploadStyle.WrapHTML(render.Tag("label", map[string]string{
-		"class": cls,
-		"for":   id,
-	}, children...))
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "for")
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["class"] = cls
+	attrs["for"] = id
+	return fileUploadStyle.WrapHTML(render.Tag("label", attrs, children...))
 }
 
 func uploadPrompt(cfg FileUploadConfig) string {

--- a/framework/ui/fileupload_test.go
+++ b/framework/ui/fileupload_test.go
@@ -72,3 +72,15 @@ func TestFileUploadNoErrorKeepsHelpVisible(t *testing.T) {
 	}
 	mustContain(t, h, "ui-fileupload__help")
 }
+
+func TestFileUploadExtraAttrsOnRoot(t *testing.T) {
+	h := FileUpload(FileUploadConfig{
+		Name:       "f",
+		Label:      "x",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("file upload root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/filterchipbar.go
+++ b/framework/ui/filterchipbar.go
@@ -81,6 +81,12 @@ type FilterChipBarConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the toolbar's root div.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, role, and aria-label (use Label).
+	ExtraAttrs html.Attrs
 }
 
 // FilterChipBar renders the toolbar.
@@ -103,11 +109,13 @@ func FilterChipBar(cfg FilterChipBarConfig) render.HTML {
 		cls += " " + cfg.Class
 	}
 
-	wrapAttrs := html.Attrs{
-		"class":      cls,
-		"role":       "toolbar",
-		"aria-label": label,
+	wrapAttrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-label")
+	if wrapAttrs == nil {
+		wrapAttrs = html.Attrs{}
 	}
+	wrapAttrs["class"] = cls
+	wrapAttrs["role"] = "toolbar"
+	wrapAttrs["aria-label"] = label
 	if cfg.ID != "" {
 		wrapAttrs["id"] = cfg.ID
 	}

--- a/framework/ui/filterchipbar_test.go
+++ b/framework/ui/filterchipbar_test.go
@@ -115,3 +115,16 @@ func TestFilterChipBarCustomLabel(t *testing.T) {
 		t.Errorf("expected custom Label, got: %s", out)
 	}
 }
+
+func TestFilterChipBarExtraAttrsOnRoot(t *testing.T) {
+	h := FilterChipBar(FilterChipBarConfig{
+		Filters: []FilterChip{
+			{Label: "Status: Active", DismissPath: "/filters/status/clear"},
+		},
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("filter bar root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/form.go
+++ b/framework/ui/form.go
@@ -218,6 +218,13 @@ type ValidationSummaryConfig struct {
 	Title string
 	// Class adds extra CSS classes to the wrapper.
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the summary's root div.
+	// Keys the component owns are dropped: class and id (use Class),
+	// data-fui-*, role, and aria-live.
+	ExtraAttrs html.Attrs
+
 	// Ctx carries the per-request context used to resolve the i18n
 	// title. When nil, English fallbacks apply.
 	Ctx context.Context
@@ -294,11 +301,14 @@ func ValidationSummary(cfg ValidationSummaryConfig) render.HTML {
 		"class": "ui-validation-summary__list",
 	}, items...)
 
-	return validationSummaryStyle.WrapHTML(render.Tag("div", map[string]string{
-		"class":     cls,
-		"role":      "alert",
-		"aria-live": "assertive",
-	}, title, list))
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-live")
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["class"] = cls
+	attrs["role"] = "alert"
+	attrs["aria-live"] = "assertive"
+	return validationSummaryStyle.WrapHTML(render.Tag("div", attrs, title, list))
 }
 
 var validationSummaryStyle = registry.RegisterStyle("ui-validation-summary", validationSummaryCSS)

--- a/framework/ui/form_fields.go
+++ b/framework/ui/form_fields.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"maps"
 	"strconv"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
@@ -25,6 +26,15 @@ type TextFieldConfig struct {
 	Disabled     bool
 	MinLength    int
 	MaxLength    int
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) onto the field's <input>. The wrapper div
+	// belongs to FormField, which offers no attribute pass-through,
+	// so the input is this component's own root. Keys the input owns
+	// are dropped: class and id (use ID), data-fui-*, type, name,
+	// value, placeholder, autocomplete, minlength, maxlength,
+	// required, disabled, aria-invalid, and aria-describedby.
+	ExtraAttrs html.Attrs
 }
 
 // TextField renders a FormField containing an input[type=text].
@@ -40,6 +50,9 @@ func TextField(cfg TextFieldConfig) render.HTML {
 	if cfg.MaxLength > 0 {
 		attrs["maxlength"] = strconv.Itoa(cfg.MaxLength)
 	}
+	maps.Copy(attrs, html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"type", "name", "value", "placeholder", "autocomplete", "minlength", "maxlength",
+		"required", "disabled", "aria-invalid", "aria-describedby"))
 	return typedFormField(cfg.Label, cfg.Name, id, "text", cfg.Value, cfg.Placeholder,
 		cfg.Help, cfg.Error, cfg.Class, cfg.Required, attrs)
 }
@@ -60,6 +73,15 @@ type NumberFieldConfig struct {
 	Min         *float64
 	Max         *float64
 	Step        *float64
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) onto the field's <input>. The wrapper div
+	// belongs to FormField, which offers no attribute pass-through,
+	// so the input is this component's own root. Keys the input owns
+	// are dropped: class and id (use ID), data-fui-*, type, name,
+	// value, placeholder, min, max, step, required, disabled,
+	// aria-invalid, and aria-describedby.
+	ExtraAttrs html.Attrs
 }
 
 // NumberField renders a FormField containing an input[type=number]. For the
@@ -72,6 +94,9 @@ func NumberField(cfg NumberFieldConfig) render.HTML {
 			attrs[name] = strconv.FormatFloat(*value, 'f', -1, 64)
 		}
 	}
+	maps.Copy(attrs, html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"type", "name", "value", "placeholder", "min", "max", "step",
+		"required", "disabled", "aria-invalid", "aria-describedby"))
 	return typedFormField(cfg.Label, cfg.Name, id, "number", cfg.Value, cfg.Placeholder,
 		cfg.Help, cfg.Error, cfg.Class, cfg.Required, attrs)
 }
@@ -91,6 +116,15 @@ type DateFieldConfig struct {
 	Disabled    bool
 	Min         string
 	Max         string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) onto the field's <input>. The wrapper div
+	// belongs to FormField, which offers no attribute pass-through,
+	// so the input is this component's own root. Keys the input owns
+	// are dropped: class and id (use ID), data-fui-*, type, name,
+	// value, placeholder, min, max, required, disabled,
+	// aria-invalid, and aria-describedby.
+	ExtraAttrs html.Attrs
 }
 
 // DateField renders a FormField containing an input[type=date].
@@ -103,6 +137,9 @@ func DateField(cfg DateFieldConfig) render.HTML {
 	if cfg.Max != "" {
 		attrs["max"] = cfg.Max
 	}
+	maps.Copy(attrs, html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"type", "name", "value", "placeholder", "min", "max",
+		"required", "disabled", "aria-invalid", "aria-describedby"))
 	return typedFormField(cfg.Label, cfg.Name, id, "date", cfg.Value, cfg.Placeholder,
 		cfg.Help, cfg.Error, cfg.Class, cfg.Required, attrs)
 }

--- a/framework/ui/form_fields_test.go
+++ b/framework/ui/form_fields_test.go
@@ -70,3 +70,54 @@ func TestTypedFieldsRequireNameAndLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestTextFieldExtraAttrsOnInput(t *testing.T) {
+	h := string(TextField(TextFieldConfig{
+		Name: "email", Label: "Email", ExtraAttrs: map[string]string{"data-test": "hook"},
+	}))
+	start := strings.Index(h, "<input")
+	if start < 0 {
+		t.Fatalf("no input element:\n%s", h)
+	}
+	open := h[start : start+strings.Index(h[start:], ">")+1]
+	if !strings.Contains(open, `data-test="hook"`) {
+		t.Errorf("input missing data-test:\n%s", open)
+	}
+	if !strings.Contains(open, `type="text"`) {
+		t.Errorf("owned type lost:\n%s", open)
+	}
+}
+
+func TestNumberFieldExtraAttrsOnInput(t *testing.T) {
+	h := string(NumberField(NumberFieldConfig{
+		Name: "qty", Label: "Qty", ExtraAttrs: map[string]string{"data-test": "hook"},
+	}))
+	start := strings.Index(h, "<input")
+	if start < 0 {
+		t.Fatalf("no input element:\n%s", h)
+	}
+	open := h[start : start+strings.Index(h[start:], ">")+1]
+	if !strings.Contains(open, `data-test="hook"`) {
+		t.Errorf("input missing data-test:\n%s", open)
+	}
+	if !strings.Contains(open, `type="number"`) || !strings.Contains(open, `name="qty"`) {
+		t.Errorf("owned type/name lost:\n%s", open)
+	}
+}
+
+func TestDateFieldExtraAttrsOnInput(t *testing.T) {
+	h := string(DateField(DateFieldConfig{
+		Name: "when", Label: "When", ExtraAttrs: map[string]string{"data-test": "hook"},
+	}))
+	start := strings.Index(h, "<input")
+	if start < 0 {
+		t.Fatalf("no input element:\n%s", h)
+	}
+	open := h[start : start+strings.Index(h[start:], ">")+1]
+	if !strings.Contains(open, `data-test="hook"`) {
+		t.Errorf("input missing data-test:\n%s", open)
+	}
+	if !strings.Contains(open, `type="date"`) {
+		t.Errorf("owned type lost:\n%s", open)
+	}
+}

--- a/framework/ui/formrepeater.go
+++ b/framework/ui/formrepeater.go
@@ -40,6 +40,13 @@ type FormRepeaterConfig struct {
 	RemoveLabel string
 
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the repeater's root div.
+	// Keys the component owns are dropped: class and id (use Class),
+	// data-fui-*, aria-label, and aria-live.
+	ExtraAttrs html.Attrs
+
 	// Ctx carries the per-request context used to resolve i18n labels
 	// (Add / Remove). When nil, English fallbacks apply.
 	Ctx context.Context
@@ -134,12 +141,15 @@ func FormRepeater(cfg FormRepeaterConfig) render.HTML {
 		"class": "ui-form-repeater__add",
 	}, addBtn))
 
-	return formRepeaterStyle.WrapHTML(render.Tag("div", map[string]string{
-		"data-fui-comp": "ui-form-repeater",
-		"class":         cls,
-		"aria-label":    cfg.Name + " items",
-		"aria-live":     "polite",
-	}, children...))
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "aria-label", "aria-live")
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["data-fui-comp"] = "ui-form-repeater"
+	attrs["class"] = cls
+	attrs["aria-label"] = cfg.Name + " items"
+	attrs["aria-live"] = "polite"
+	return formRepeaterStyle.WrapHTML(render.Tag("div", attrs, children...))
 }
 
 // formRepeaterStyle is registered in styles_components.go

--- a/framework/ui/formrepeater_test.go
+++ b/framework/ui/formrepeater_test.go
@@ -143,3 +143,14 @@ func TestFormRepeaterHasAriaLive(t *testing.T) {
 		t.Errorf("repeater container should have aria-live=polite, got:\n%s", h)
 	}
 }
+
+func TestFormRepeaterExtraAttrsOnRoot(t *testing.T) {
+	h := FormRepeater(FormRepeaterConfig{
+		Name:       "items",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("form repeater root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/globalsearch.go
+++ b/framework/ui/globalsearch.go
@@ -54,6 +54,14 @@ type GlobalSearchConfig struct {
 	// Sticky toggles position: sticky on the wrapper. Default true.
 	Sticky bool
 	Class  string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the search bar's root
+	// wrapper div. Keys the component owns are dropped: class and id
+	// (use Class), data-fui-*, and the shortcut-focus wiring the
+	// runtime keys on.
+	ExtraAttrs html.Attrs
+
 	// Ctx carries the per-request context used to resolve i18n labels
 	// (placeholder). When nil, English fallbacks apply.
 	Ctx context.Context
@@ -125,7 +133,11 @@ func GlobalSearch(cfg GlobalSearchConfig) render.HTML {
 	// per-instance wrapper-level shortcut marker (data-fui-shortcut-
 	// focus + data-fui-shortcut-target="#<input-id>"). The runtime
 	// handler already supports targeting by selector.
-	wrapAttrs := html.Attrs{"class": clsGlobalSearch(cfg)}
+	wrapAttrs := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if wrapAttrs == nil {
+		wrapAttrs = html.Attrs{}
+	}
+	wrapAttrs["class"] = clsGlobalSearch(cfg)
 	if shortcut != "" {
 		wrapAttrs["data-fui-shortcut-focus"] = shortcut
 		wrapAttrs["data-fui-shortcut-target"] = "#" + cfg.ID

--- a/framework/ui/globalsearch_test.go
+++ b/framework/ui/globalsearch_test.go
@@ -81,3 +81,14 @@ func TestGlobalSearchStickyClass(t *testing.T) {
 		t.Errorf("Sticky=true should add modifier class:\n%s", on)
 	}
 }
+
+func TestGlobalSearchExtraAttrsOnRoot(t *testing.T) {
+	h := GlobalSearch(GlobalSearchConfig{
+		ID: "s", Name: "q", Label: "Search", RPCPath: "/s", SignalName: "sig",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("global search root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/helpers.go
+++ b/framework/ui/helpers.go
@@ -1,9 +1,32 @@
 package ui
 
 import (
+	"maps"
+	"slices"
 	"strconv"
+	"strings"
 	"sync/atomic"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
+	"github.com/DonaldMurillo/gofastr/core/render"
 )
+
+// serializeExtraAttrs renders already-sanitized extras for string-built
+// roots: one leading space per attribute, keys sorted so SSR output is
+// deterministic (map ranging would reorder attributes render to render).
+func serializeExtraAttrs(attrs html.Attrs) string {
+	if len(attrs) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for _, k := range slices.Sorted(maps.Keys(attrs)) {
+		if a := render.Attr(k, attrs[k]); a != "" {
+			sb.WriteByte(' ')
+			sb.WriteString(a)
+		}
+	}
+	return sb.String()
+}
 
 // autoIDCounter provides unique IDs for UI components.
 var autoIDCounter int64

--- a/framework/ui/hero.go
+++ b/framework/ui/hero.go
@@ -33,6 +33,12 @@ type HeroConfig struct {
 	AriaLabel string
 	// Class is appended to the ui-hero wrapper.
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the hero's root <section>.
+	// Keys the component owns are dropped: class and id (use Class),
+	// data-fui-*, and aria-label (use AriaLabel).
+	ExtraAttrs html.Attrs
 }
 
 // Hero renders a single-column (or copy+media split) hero section.
@@ -61,7 +67,11 @@ func Hero(cfg HeroConfig) render.HTML {
 	if label == "" {
 		label = cfg.Title
 	}
-	attrs := map[string]string{"class": cls}
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "aria-label")
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["class"] = cls
 	if label != "" {
 		attrs["aria-label"] = label
 	}

--- a/framework/ui/hero_split.go
+++ b/framework/ui/hero_split.go
@@ -45,6 +45,12 @@ type HeroSplitConfig struct {
 	AriaLabel string
 	// Class is appended to the ui-hero-split wrapper.
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the hero's root <section>.
+	// Keys the component owns are dropped: class and id (use Class),
+	// data-fui-*, and aria-label (use AriaLabel).
+	ExtraAttrs html.Attrs
 }
 
 // HeroSplit renders a two-column hero. The wrapper is a <section>;
@@ -64,7 +70,11 @@ func HeroSplit(cfg HeroSplitConfig) render.HTML {
 		cls = cls + " " + cfg.Class
 	}
 
-	attrs := map[string]string{"class": cls}
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "aria-label")
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["class"] = cls
 	if cfg.AriaLabel != "" {
 		attrs["aria-label"] = cfg.AriaLabel
 	}

--- a/framework/ui/hero_split_test.go
+++ b/framework/ui/hero_split_test.go
@@ -85,3 +85,15 @@ func TestHeroSplitRejectsUnknownRatio(t *testing.T) {
 	}()
 	HeroSplit(HeroSplitConfig{Copy: render.Raw("a"), Media: render.Raw("b"), Ratio: "huge"})
 }
+
+func TestHeroSplitExtraAttrsOnRoot(t *testing.T) {
+	h := HeroSplit(HeroSplitConfig{
+		Copy:       render.Raw("c"),
+		Media:      render.Raw("m"),
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("hero split root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/hero_test.go
+++ b/framework/ui/hero_test.go
@@ -1,0 +1,21 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+func TestHeroExtraAttrsOnRoot(t *testing.T) {
+	extra := map[string]string{"data-test": "hook"}
+	for name, h := range map[string]render.HTML{
+		"single": Hero(HeroConfig{Title: "T", ExtraAttrs: extra}),
+		"split":  Hero(HeroConfig{Title: "T", Media: render.Raw("<img src=x>"), ExtraAttrs: extra}),
+	} {
+		root := string(h)[:strings.Index(string(h), ">")+1]
+		if !strings.Contains(root, `data-test="hook"`) {
+			t.Errorf("%s hero root missing data-test:\n%s", name, root)
+		}
+	}
+}

--- a/framework/ui/icon.go
+++ b/framework/ui/icon.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core/render"
 )
 
@@ -35,6 +36,14 @@ type IconConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the icon's root <svg>
+	// element. Keys the component owns are dropped: class and id
+	// (use Class / ID), data-fui-*, and the drawing / accessibility
+	// keys the component derives (xmlns, width, height, viewBox,
+	// fill, stroke*, role, aria-label, aria-hidden).
+	ExtraAttrs html.Attrs
 }
 
 // Icon renders the registered icon with the given name. Returns empty
@@ -56,18 +65,23 @@ func Icon(name string, cfg IconConfig) render.HTML {
 		cls += " " + cfg.Class
 	}
 
-	attrs := map[string]string{
-		"class":           cls,
-		"xmlns":           "http://www.w3.org/2000/svg",
-		"width":           size,
-		"height":          size,
-		"viewBox":         "0 0 24 24",
-		"fill":            "none",
-		"stroke":          "currentColor",
-		"stroke-width":    "2",
-		"stroke-linecap":  "round",
-		"stroke-linejoin": "round",
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"xmlns", "width", "height", "viewBox", "fill", "stroke",
+		"stroke-width", "stroke-linecap", "stroke-linejoin",
+		"role", "aria-label", "aria-hidden")
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["class"] = cls
+	attrs["xmlns"] = "http://www.w3.org/2000/svg"
+	attrs["width"] = size
+	attrs["height"] = size
+	attrs["viewBox"] = "0 0 24 24"
+	attrs["fill"] = "none"
+	attrs["stroke"] = "currentColor"
+	attrs["stroke-width"] = "2"
+	attrs["stroke-linecap"] = "round"
+	attrs["stroke-linejoin"] = "round"
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}

--- a/framework/ui/icon_test.go
+++ b/framework/ui/icon_test.go
@@ -82,3 +82,11 @@ func TestRegisterIcon_AddsCustomIcon(t *testing.T) {
 		t.Errorf("expected registered SVG body to render, got: %s", got)
 	}
 }
+
+func TestIconExtraAttrsOnRoot(t *testing.T) {
+	h := Icon("check", IconConfig{ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("icon root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/image.go
+++ b/framework/ui/image.go
@@ -97,6 +97,13 @@ type OptimizedImageConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the image's root wrapper
+	// (the outer <span>, in both the single-source and <picture>
+	// shapes). Keys the component owns are dropped: class and id
+	// (use Class / ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // OptimizedImage renders a responsive, lazy-loaded image with
@@ -187,6 +194,7 @@ func OptimizedImage(cfg OptimizedImageConfig) render.HTML {
 	if len(cfg.Sources) == 0 {
 		return imageStyle.WrapHTML(html.Span(html.TextConfig{
 			Class: cls, ID: cfg.ID,
+			ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
 		}, lqip, html.Image(imgCfg)))
 	}
 
@@ -203,6 +211,7 @@ func OptimizedImage(cfg OptimizedImageConfig) render.HTML {
 	picture := render.Tag("picture", nil, source, html.Image(imgCfg))
 	return imageStyle.WrapHTML(html.Span(html.TextConfig{
 		Class: cls, ID: cfg.ID,
+		ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
 	}, lqip, picture))
 }
 

--- a/framework/ui/image_test.go
+++ b/framework/ui/image_test.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"strings"
 	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/render"
 )
 
 func TestOptimizedImageRequiresSrc(t *testing.T) {
@@ -84,5 +86,23 @@ func TestOptimizedImageDecorativeAllowsEmptyAlt(t *testing.T) {
 	})
 	if !strings.Contains(string(h), `alt=""`) {
 		t.Fatalf("decorative image must keep empty alt:\n%s", h)
+	}
+}
+
+func TestOptimizedImageExtraAttrsOnRoot(t *testing.T) {
+	extra := map[string]string{"data-test": "hook"}
+	for name, h := range map[string]render.HTML{
+		"single": OptimizedImage(OptimizedImageConfig{
+			Src: "/a.png", Alt: "a", Width: 1, Height: 1, ExtraAttrs: extra,
+		}),
+		"picture": OptimizedImage(OptimizedImageConfig{
+			Src: "/a.png", Alt: "a", Width: 1, Height: 1,
+			Sources: []ImageSource{{URL: "/a-2x.png", Width: 2}}, ExtraAttrs: extra,
+		}),
+	} {
+		root := string(h)[:strings.Index(string(h), ">")+1]
+		if !strings.Contains(root, `data-test="hook"`) {
+			t.Errorf("%s root missing data-test:\n%s", name, root)
+		}
 	}
 }

--- a/framework/ui/inputgroup.go
+++ b/framework/ui/inputgroup.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -22,6 +23,12 @@ type InputGroupConfig struct {
 	Append render.HTML
 	// Class adds extra CSS classes to the wrapper.
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the group's root wrapper
+	// div. Keys the component owns are dropped: class and id (use
+	// Class) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // InputGroup renders an input with optional prepend and append addons.
@@ -57,9 +64,12 @@ func InputGroup(cfg InputGroupConfig) render.HTML {
 			}, cfg.Append))
 	}
 
-	return inputGroupStyle.WrapHTML(render.Tag("div",
-		map[string]string{"class": cls},
-		children...))
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["class"] = cls
+	return inputGroupStyle.WrapHTML(render.Tag("div", attrs, children...))
 }
 
 var inputGroupStyle = registry.RegisterStyle("ui-input-group", inputGroupCSS)

--- a/framework/ui/inputgroup_test.go
+++ b/framework/ui/inputgroup_test.go
@@ -148,3 +148,14 @@ func TestInputGroupComposesPrependInputAppend(t *testing.T) {
 		t.Errorf("missing wrapper class ui-input-group:\n%s", h)
 	}
 }
+
+func TestInputGroupExtraAttrsOnRoot(t *testing.T) {
+	h := InputGroup(InputGroupConfig{
+		Input:      html.Input(html.InputConfig{Type: "text", Name: "price"}),
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("input group root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/interactive_components.go
+++ b/framework/ui/interactive_components.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/store"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
@@ -23,6 +24,13 @@ type TabsConfig struct {
 	Slice      *store.Slice[int] // optional; supplies the signal name + initial active index, takes precedence
 	Tabs       []TabItem         // required, at least 1
 	Class      string            // optional extra CSS class
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the tab strip's root
+	// wrapper div. Keys the component owns are dropped: class and id
+	// (use Class), data-fui-*, and data-active (the runtime mirrors
+	// the active tab index there).
+	ExtraAttrs html.Attrs
 }
 
 var tabsStyle = registry.RegisterStyle("fui-tabs", tabsCSS)
@@ -96,13 +104,16 @@ func Tabs(cfg TabsConfig) render.HTML {
 	}
 	// The signal binding lives on the outer wrapper, the common ancestor
 	// of the nav buttons and the panels, so one data-active drives both.
-	wrapper := render.Tag("div", map[string]string{
-		"class":                cls,
-		"data-fui-signal":      name,
-		"data-fui-signal-mode": "attr",
-		"data-fui-signal-attr": "data-active",
-		"data-active":          strconv.Itoa(active),
-	}, nav, content)
+	wrapperAttrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "data-active")
+	if wrapperAttrs == nil {
+		wrapperAttrs = html.Attrs{}
+	}
+	wrapperAttrs["class"] = cls
+	wrapperAttrs["data-fui-signal"] = name
+	wrapperAttrs["data-fui-signal-mode"] = "attr"
+	wrapperAttrs["data-fui-signal-attr"] = "data-active"
+	wrapperAttrs["data-active"] = strconv.Itoa(active)
+	wrapper := render.Tag("div", wrapperAttrs, nav, content)
 
 	return tabsStyle.WrapHTML(wrapper)
 }

--- a/framework/ui/interactive_components_test.go
+++ b/framework/ui/interactive_components_test.go
@@ -237,3 +237,15 @@ func TestTabsSingleTab(t *testing.T) {
 	// static class.
 	mustContain(t, html, `data-active="0"`)
 }
+
+func TestTabsExtraAttrsOnRoot(t *testing.T) {
+	html := Tabs(TabsConfig{
+		SignalName: "t",
+		Tabs:       []TabItem{{Label: "A"}},
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(html)[:strings.Index(string(html), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("tabs root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/jsonviewer.go
+++ b/framework/ui/jsonviewer.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -33,6 +34,12 @@ type JSONViewerConfig struct {
 	MaxStringLen int
 	ID           string
 	Class        string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the viewer's root <div>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // JSONViewer renders a collapsible tree view of any Go value.
@@ -50,7 +57,11 @@ func JSONViewer(cfg JSONViewerConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	attrs := map[string]string{"class": cls}
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["class"] = cls
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}

--- a/framework/ui/jsonviewer_test.go
+++ b/framework/ui/jsonviewer_test.go
@@ -79,3 +79,14 @@ func TestJSONViewerMaxStringLenTruncates(t *testing.T) {
 		t.Errorf("MaxStringLen should append ellipsis:\n%s", h)
 	}
 }
+
+func TestJSONViewerExtraAttrsOnRoot(t *testing.T) {
+	h := JSONViewer(JSONViewerConfig{
+		Value:      map[string]any{"k": 1},
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("json viewer root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/layout.go
+++ b/framework/ui/layout.go
@@ -62,6 +62,12 @@ type StackConfig struct {
 	Justify Justify // main-axis (vertical) alignment
 	ID      string
 	Class   string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the stack's root <div>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // Stack renders children in a vertical column with consistent gap.
@@ -69,8 +75,9 @@ type StackConfig struct {
 // flex-direction:column;gap:…">` patterns.
 func Stack(cfg StackConfig, children ...render.HTML) render.HTML {
 	return layoutStyle.WrapHTML(html.Div(html.DivConfig{
-		Class: layoutClass("ui-stack", cfg.Class, cfg.Gap, cfg.Align, cfg.Justify),
-		ID:    cfg.ID,
+		Class:      layoutClass("ui-stack", cfg.Class, cfg.Gap, cfg.Align, cfg.Justify),
+		ID:         cfg.ID,
+		ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
 	}, children...))
 }
 
@@ -86,6 +93,12 @@ type ClusterConfig struct {
 	NoWrap bool
 	ID     string
 	Class  string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the cluster's root <div>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // Cluster renders children in a horizontal row that wraps onto
@@ -96,7 +109,9 @@ func Cluster(cfg ClusterConfig, children ...render.HTML) render.HTML {
 	if cfg.NoWrap {
 		cls += " ui-cluster--nowrap"
 	}
-	return layoutStyle.WrapHTML(html.Div(html.DivConfig{Class: cls, ID: cfg.ID}, children...))
+	return layoutStyle.WrapHTML(html.Div(html.DivConfig{
+		Class: cls, ID: cfg.ID, ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+	}, children...))
 }
 
 // ─── Grid: responsive CSS grid ─────────────────────────────────────
@@ -110,6 +125,12 @@ type GridConfig struct {
 	Gap   Gap
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the grid's root <div>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, and data-min (use Min).
+	ExtraAttrs html.Attrs
 }
 
 // Grid renders children in an auto-fitting CSS grid. The default
@@ -129,7 +150,11 @@ func Grid(cfg GridConfig, children ...render.HTML) render.HTML {
 	// var() chaining for browsers that don't support attr() with
 	// non-string types yet (Chrome ≥ 125; we expose a class hook for
 	// the size buckets to keep older browsers usable).
-	attrs := html.Attrs{"data-min": min}
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "data-min")
+	if attrs == nil {
+		attrs = html.Attrs{}
+	}
+	attrs["data-min"] = min
 	return layoutStyle.WrapHTML(html.Div(html.DivConfig{
 		Class: cls, ID: cfg.ID, ExtraAttrs: attrs,
 	}, children...))
@@ -145,6 +170,12 @@ type CenterConfig struct {
 	MinHeight string
 	ID        string
 	Class     string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the region's root <div>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // Center centers its children both horizontally and vertically.
@@ -156,7 +187,9 @@ func Center(cfg CenterConfig, children ...render.HTML) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	return layoutStyle.WrapHTML(html.Div(html.DivConfig{Class: cls, ID: cfg.ID}, children...))
+	return layoutStyle.WrapHTML(html.Div(html.DivConfig{
+		Class: cls, ID: cfg.ID, ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+	}, children...))
 }
 
 // ─── Spacer: flexible filler ───────────────────────────────────────
@@ -192,6 +225,12 @@ type BoxConfig struct {
 	Outlined bool   // when true, applies a 1px border (pairs well with Surface=false)
 	ID       string
 	Class    string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the box's root <div>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // Box is a wrapper that applies token-scaled padding and optional
@@ -212,7 +251,9 @@ func Box(cfg BoxConfig, children ...render.HTML) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	return layoutStyle.WrapHTML(html.Div(html.DivConfig{Class: cls, ID: cfg.ID}, children...))
+	return layoutStyle.WrapHTML(html.Div(html.DivConfig{
+		Class: cls, ID: cfg.ID, ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+	}, children...))
 }
 
 // ─── Sticky ────────────────────────────────────────────────────────
@@ -269,6 +310,13 @@ type StickyConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the sticky wrapper's root
+	// <div>. Keys the component owns are dropped: class and id (use
+	// Class / ID) and data-fui-* (which covers the derived
+	// data-fui-z-tier).
+	ExtraAttrs html.Attrs
 }
 
 // Sticky wraps children in a position:sticky container.
@@ -295,10 +343,12 @@ func Sticky(cfg StickyConfig, children ...render.HTML) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	attrs := map[string]string{
-		"class":           cls,
-		"data-fui-z-tier": tier,
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if attrs == nil {
+		attrs = html.Attrs{}
 	}
+	attrs["class"] = cls
+	attrs["data-fui-z-tier"] = tier
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}
@@ -335,6 +385,12 @@ type AspectRatioConfig struct {
 
 	// ID sets the element id.
 	ID string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the wrapper's root <div>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // AspectRatio wraps a single child in a container with the given
@@ -348,10 +404,12 @@ func AspectRatioComponent(cfg AspectRatioConfig, child render.HTML) render.HTML 
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	attrs := map[string]string{
-		"data-fui-comp": "ui-aspect-ratio",
-		"class":         cls,
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if attrs == nil {
+		attrs = html.Attrs{}
 	}
+	attrs["data-fui-comp"] = "ui-aspect-ratio"
+	attrs["class"] = cls
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}

--- a/framework/ui/layout_test.go
+++ b/framework/ui/layout_test.go
@@ -80,3 +80,68 @@ func TestLayoutCustomClassAppended(t *testing.T) {
 	h := Stack(StackConfig{Class: "my-extra"}, render.Text("x"))
 	mustContain(t, h, "my-extra")
 }
+
+// ─── ExtraAttrs pass-through (#251) ───
+
+func TestStackExtraAttrsOnRoot(t *testing.T) {
+	h := Stack(StackConfig{ExtraAttrs: map[string]string{"data-test": "hook"}}, render.Text("x"))
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("Stack root missing data-test:\n%s", root)
+	}
+}
+
+func TestClusterExtraAttrsOnRoot(t *testing.T) {
+	h := Cluster(ClusterConfig{ExtraAttrs: map[string]string{"data-test": "hook"}}, render.Text("x"))
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("Cluster root missing data-test:\n%s", root)
+	}
+}
+
+func TestGridExtraAttrsOnRoot(t *testing.T) {
+	h := Grid(GridConfig{ExtraAttrs: map[string]string{"data-test": "hook", "data-min": "evil"}},
+		render.Text("x"))
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("Grid root missing data-test:\n%s", root)
+	}
+	mustContain(t, h, `data-min="16rem"`)
+}
+
+func TestCenterExtraAttrsOnRoot(t *testing.T) {
+	h := Center(CenterConfig{ExtraAttrs: map[string]string{"data-test": "hook"}}, render.Text("x"))
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("Center root missing data-test:\n%s", root)
+	}
+}
+
+func TestBoxExtraAttrsOnRoot(t *testing.T) {
+	h := Box(BoxConfig{ExtraAttrs: map[string]string{"data-test": "hook"}}, render.Text("x"))
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("Box root missing data-test:\n%s", root)
+	}
+}
+
+func TestStickyExtraAttrsOnRoot(t *testing.T) {
+	h := Sticky(StickyConfig{ExtraAttrs: map[string]string{"data-test": "hook", "data-fui-z-tier": "modal"}},
+		render.Text("x"))
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("Sticky root missing data-test:\n%s", root)
+	}
+	mustContain(t, h, `data-fui-z-tier="sticky"`)
+}
+
+func TestAspectRatioExtraAttrsOnRoot(t *testing.T) {
+	h := AspectRatioComponent(AspectRatioConfig{
+		Ratio: AspectRatio16_9, ExtraAttrs: map[string]string{"data-test": "hook"},
+	}, render.Text("x"))
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("AspectRatio root missing data-test:\n%s", root)
+	}
+	mustContain(t, h, `data-fui-comp="ui-aspect-ratio"`)
+}

--- a/framework/ui/lightbox.go
+++ b/framework/ui/lightbox.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"maps"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/component"
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
@@ -62,6 +63,14 @@ type LightboxConfig struct {
 	// context.Background() is used and English fallbacks are returned,
 	// preserving today's behaviour.
 	Ctx context.Context
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) onto the lightbox's own root
+	// (the ui-lightbox__viewer panel; the modal chrome is widget
+	// machinery, and triggers are caller-owned elements). Keys the
+	// component owns are dropped: class, id, and data-fui-* (the
+	// viewer and nav wiring).
+	ExtraAttrs html.Attrs
 }
 
 // Lightbox returns a *widget.Builder for the zoom-overlay modal.
@@ -82,6 +91,7 @@ func Lightbox(cfg LightboxConfig) *widget.Builder {
 		showCaption:   cfg.ShowCaption,
 		allowDownload: cfg.AllowDownload,
 		ctx:           cfg.Ctx,
+		extraAttrs:    html.SafeExtraAttrs(cfg.ExtraAttrs),
 	}
 	titleID := cfg.Name + "-title"
 	mb := preset.Modal(cfg.Name).
@@ -110,7 +120,8 @@ type lightboxSlot struct {
 	showCaption   bool
 	allowDownload bool
 	// ctx carries the per-request locale for i18n resolution. nil = context.Background().
-	ctx context.Context
+	ctx        context.Context
+	extraAttrs html.Attrs
 }
 
 func (s *lightboxSlot) Render() render.HTML {
@@ -181,10 +192,11 @@ func (s *lightboxSlot) Render() render.HTML {
 			render.Tag("div", map[string]string{"class": "ui-lightbox__toolbar"}, toolbar...))
 	}
 
-	wrapAttrs := map[string]string{
-		"class":             "ui-lightbox__viewer",
-		"data-fui-lightbox": s.name,
-	}
+	// Sanitized caller extras first, owned keys on top so they win.
+	wrapAttrs := map[string]string{}
+	maps.Copy(wrapAttrs, s.extraAttrs)
+	wrapAttrs["class"] = "ui-lightbox__viewer"
+	wrapAttrs["data-fui-lightbox"] = s.name
 	if s.navArrows {
 		wrapAttrs["data-fui-lightbox-nav"] = "true"
 	}

--- a/framework/ui/lightbox_test.go
+++ b/framework/ui/lightbox_test.go
@@ -108,3 +108,18 @@ func TestLightboxLabelledByPointsToCaptionTitle(t *testing.T) {
 		t.Errorf("LabelledBy should point to <name>-title; got %q", d.LabelledBy)
 	}
 }
+
+func TestLightboxExtraAttrsOnViewerRoot(t *testing.T) {
+	b := Lightbox(LightboxConfig{Name: "zoom", ExtraAttrs: map[string]string{
+		"data-test":         "hook",
+		"data-fui-lightbox": "spoof",
+	}})
+	body := string(b.Definition().Slots[0].Component.Render())
+	root := body[:strings.Index(body, ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("viewer root missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `data-fui-lightbox="zoom"`) {
+		t.Errorf("owned lightbox wiring overridden by spoof:\n%s", root)
+	}
+}

--- a/framework/ui/linechart.go
+++ b/framework/ui/linechart.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -45,12 +46,21 @@ type LineChartConfig struct {
 	LabelledBy string
 	ID         string
 	Class      string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the chart's root <svg>
+	// element, or to the shared zero-data placeholder when there is
+	// nothing to draw. Keys the component owns are dropped: class and id
+	// (use Class / ID), data-fui-*, and the geometry / accessibility
+	// keys the chart derives (width, height, viewBox, xmlns, role,
+	// aria-labelledby, aria-hidden).
+	ExtraAttrs html.Attrs
 }
 
 // LineChart renders a multi-series line chart.
 func LineChart(cfg LineChartConfig) render.HTML {
 	if len(cfg.Series) == 0 {
-		return chartEmpty(cfg.Height, cfg.LabelledBy, cfg.Class, "No data yet")
+		return chartEmpty(cfg.Height, cfg.LabelledBy, cfg.Class, "No data yet", cfg.ExtraAttrs)
 	}
 	for _, s := range cfg.Series {
 		if s.Name == "" {
@@ -59,7 +69,7 @@ func LineChart(cfg LineChartConfig) render.HTML {
 		// A line needs ≥2 points to draw a trend; with fewer there's simply
 		// not enough data yet. A calm empty state, not a crash.
 		if len(s.Values) < 2 {
-			return chartEmpty(cfg.Height, cfg.LabelledBy, cfg.Class, "Not enough data yet")
+			return chartEmpty(cfg.Height, cfg.LabelledBy, cfg.Class, "Not enough data yet", cfg.ExtraAttrs)
 		}
 	}
 	w := cfg.Width
@@ -128,7 +138,10 @@ func LineChart(cfg LineChartConfig) render.HTML {
 	} else {
 		sb.WriteString(` aria-hidden="true"`)
 	}
-	sb.WriteString(` data-fui-comp="ui-line-chart">`)
+	sb.WriteString(` data-fui-comp="ui-line-chart"`)
+	sb.WriteString(serializeExtraAttrs(html.SafeExtraAttrs(cfg.ExtraAttrs, "width", "height",
+		"viewBox", "xmlns", "role", "aria-labelledby", "aria-hidden")))
+	sb.WriteString(`>`)
 
 	palette := []string{"primary", "info", "success", "warning", "danger"}
 	for i, s := range cfg.Series {

--- a/framework/ui/linechart_test.go
+++ b/framework/ui/linechart_test.go
@@ -92,3 +92,14 @@ func TestLineChartEdgeLabelsAnchorInward(t *testing.T) {
 		t.Errorf("last label should anchor end:\n%s", h)
 	}
 }
+
+func TestLineChartExtraAttrsOnRoot(t *testing.T) {
+	h := LineChart(LineChartConfig{
+		Series:     []LineSeries{{Name: "a", Values: []float64{1, 2}}},
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("line chart root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/menu.go
+++ b/framework/ui/menu.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"strings"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core-ui/urlsafe"
@@ -90,6 +91,12 @@ type MenuConfig struct {
 	// lists (rare).
 	TriggerClass string
 	PanelClass   string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the menu's root <details>
+	// element. Keys the component owns are dropped: class, id, and
+	// data-fui-* (the disclosure wiring).
+	ExtraAttrs html.Attrs
 }
 
 var menuStyle = registry.RegisterStyle("ui-menu", menuCSS)
@@ -127,7 +134,9 @@ func Menu(cfg MenuConfig) render.HTML {
 	if cfg.PanelClass != "" {
 		cls += " " + cfg.PanelClass
 	}
-	b.WriteString(`<details class="` + render.Escape(cls) + `" data-fui-disclosure data-fui-menu="` + render.Escape(id) + `">`)
+	b.WriteString(`<details class="` + render.Escape(cls) + `" data-fui-disclosure data-fui-menu="` + render.Escape(id) + `"`)
+	b.WriteString(serializeExtraAttrs(html.SafeExtraAttrs(cfg.ExtraAttrs)))
+	b.WriteString(`>`)
 
 	// Summary = trigger. We bolt aria-haspopup="menu" so SR users know
 	// the activation type; the runtime mirrors aria-expanded.

--- a/framework/ui/menu_test.go
+++ b/framework/ui/menu_test.go
@@ -143,3 +143,15 @@ func TestMenuEscapesApostrophes(t *testing.T) {
 		}
 	}
 }
+
+func TestMenuExtraAttrsOnRoot(t *testing.T) {
+	out := string(ui.Menu(ui.MenuConfig{
+		Label:      "Actions",
+		Items:      []ui.MenuItem{{Label: "Edit"}},
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	}))
+	root := out[:strings.Index(out, ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("menu root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/networkretrybanner.go
+++ b/framework/ui/networkretrybanner.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -68,6 +69,13 @@ type NetworkRetryBannerConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the banner's root element.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, role, aria-live, and hidden (the runtime
+	// un-hides the banner when connectivity degrades).
+	ExtraAttrs html.Attrs
 }
 
 // NetworkRetryBanner renders the (initially hidden) banner.
@@ -96,15 +104,17 @@ func NetworkRetryBanner(cfg NetworkRetryBannerConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	attrs := map[string]string{
-		"class":                              cls,
-		"role":                               "alert",
-		"aria-live":                          "assertive",
-		"data-fui-network-retry-health":      cfg.HealthEndpoint,
-		"data-fui-network-retry-threshold":   fmt.Sprintf("%d", threshold),
-		"data-fui-network-retry-sse-silence": fmt.Sprintf("%d", cfg.SSESilenceMs),
-		"hidden":                             "",
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-live", "hidden")
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["class"] = cls
+	attrs["role"] = "alert"
+	attrs["aria-live"] = "assertive"
+	attrs["data-fui-network-retry-health"] = cfg.HealthEndpoint
+	attrs["data-fui-network-retry-threshold"] = fmt.Sprintf("%d", threshold)
+	attrs["data-fui-network-retry-sse-silence"] = fmt.Sprintf("%d", cfg.SSESilenceMs)
+	attrs["hidden"] = ""
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}

--- a/framework/ui/networkretrybanner_test.go
+++ b/framework/ui/networkretrybanner_test.go
@@ -65,3 +65,14 @@ func TestRetryBannerCustomRetryLabel(t *testing.T) {
 		t.Errorf("expected custom retry label, got: %s", got)
 	}
 }
+
+func TestRetryBannerExtraAttrsOnRoot(t *testing.T) {
+	h := NetworkRetryBanner(NetworkRetryBannerConfig{
+		HealthEndpoint: "/health",
+		ExtraAttrs:     map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("banner root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/notification.go
+++ b/framework/ui/notification.go
@@ -48,6 +48,12 @@ type NotificationConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the notification's root
+	// element. Keys the component owns are dropped: class and id
+	// (use Class / ID), data-fui-*, role, and aria-live.
+	ExtraAttrs html.Attrs
 }
 
 // NotificationPosition controls where a Notification renders.
@@ -95,10 +101,12 @@ func Notification(cfg NotificationConfig) render.HTML {
 		role = "alert"
 		live = "assertive"
 	}
-	attrs := html.Attrs{
-		"role":      role,
-		"aria-live": live,
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-live")
+	if attrs == nil {
+		attrs = html.Attrs{}
 	}
+	attrs["role"] = role
+	attrs["aria-live"] = live
 
 	icon := html.Span(html.TextConfig{
 		Class:      "ui-notification__icon",

--- a/framework/ui/notification_test.go
+++ b/framework/ui/notification_test.go
@@ -128,3 +128,14 @@ func TestNotificationGlyphPerVariant(t *testing.T) {
 		}
 	}
 }
+
+func TestNotificationExtraAttrsOnRoot(t *testing.T) {
+	h := Notification(NotificationConfig{
+		Title:      "Saved",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("notification root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/optimisticaction.go
+++ b/framework/ui/optimisticaction.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -65,6 +66,13 @@ type OptimisticActionConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the button's root
+	// element. Keys the component owns are dropped: class and id
+	// (use Class / ID), data-fui-* (endpoint and method wiring),
+	// type, and data-state — the optimistic lifecycle contract.
+	ExtraAttrs html.Attrs
 }
 
 // OptimisticAction renders the button. The runtime listens for clicks
@@ -100,13 +108,16 @@ func OptimisticAction(cfg OptimisticActionConfig) render.HTML {
 		cls += " " + cfg.Class
 	}
 
-	attrs := map[string]string{
-		"class":                        cls,
-		"type":                         "button",
-		"data-fui-optimistic-endpoint": cfg.Endpoint,
-		"data-fui-optimistic-method":   method,
-		"data-state":                   "idle",
+	// Sanitized extras first, owned keys on top so they win.
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "type", "data-state")
+	if attrs == nil {
+		attrs = html.Attrs{}
 	}
+	attrs["class"] = cls
+	attrs["type"] = "button"
+	attrs["data-fui-optimistic-endpoint"] = cfg.Endpoint
+	attrs["data-fui-optimistic-method"] = method
+	attrs["data-state"] = "idle"
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}

--- a/framework/ui/optimisticaction_test.go
+++ b/framework/ui/optimisticaction_test.go
@@ -89,3 +89,14 @@ func TestOptimisticExplicitPrimary(t *testing.T) {
 		t.Errorf("expected ui-button--primary on explicit primary variant, got: %s", got)
 	}
 }
+
+func TestOptimisticActionExtraAttrsOnRoot(t *testing.T) {
+	h := OptimisticAction(OptimisticActionConfig{
+		Endpoint: "/x", IdleLabel: "Follow", SuccessLabel: "Following",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("OptimisticAction root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/panehost.go
+++ b/framework/ui/panehost.go
@@ -38,6 +38,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -89,6 +90,12 @@ type PaneHostConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the host's root element.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-* (the pane-host marker and deep-link wiring).
+	ExtraAttrs html.Attrs
 }
 
 // PaneHost renders a primary pane plus one or two openable side panes.
@@ -118,10 +125,13 @@ func PaneHost(cfg PaneHostConfig) render.HTML {
 		cls += " " + cfg.Class
 	}
 
-	rootAttrs := map[string]string{
-		"class":              cls,
-		"data-fui-pane-host": "",
+	// Sanitized extras first, owned keys on top so they win.
+	rootAttrs := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if rootAttrs == nil {
+		rootAttrs = html.Attrs{}
 	}
+	rootAttrs["class"] = cls
+	rootAttrs["data-fui-pane-host"] = ""
 	if cfg.ID != "" {
 		rootAttrs["id"] = cfg.ID
 	}

--- a/framework/ui/panehost_test.go
+++ b/framework/ui/panehost_test.go
@@ -104,3 +104,14 @@ func TestPaneHostCSSHasBreakpoint(t *testing.T) {
 		t.Fatal("pane-host CSS missing overlay-mode drawer rules")
 	}
 }
+
+func TestPaneHostExtraAttrsOnRoot(t *testing.T) {
+	h := PaneHost(PaneHostConfig{
+		Primary:    render.Text("p"),
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("PaneHost root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/piechart.go
+++ b/framework/ui/piechart.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -47,6 +48,14 @@ type PieChartConfig struct {
 	LabelledBy string
 	ID         string
 	Class      string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the chart's <svg> root,
+	// or to the shared zero-data placeholder when there is nothing to
+	// draw. Keys the component owns are dropped: class and
+	// id (use Class / ID), data-fui-*, and the sizing and naming
+	// attributes the SVG derives from config (width, height, viewBox,
+	// xmlns, role, aria-labelledby, aria-hidden).
+	ExtraAttrs html.Attrs
 }
 
 var pieDefaultPalette = []string{"primary", "info", "success", "warning", "danger"}
@@ -54,7 +63,7 @@ var pieDefaultPalette = []string{"primary", "info", "success", "warning", "dange
 // PieChart renders a pie or donut chart.
 func PieChart(cfg PieChartConfig) render.HTML {
 	if len(cfg.Slices) == 0 {
-		return chartEmpty(cfg.Size, cfg.LabelledBy, cfg.Class, "No data yet")
+		return chartEmpty(cfg.Size, cfg.LabelledBy, cfg.Class, "No data yet", cfg.ExtraAttrs)
 	}
 	var total float64
 	for _, s := range cfg.Slices {
@@ -65,7 +74,7 @@ func PieChart(cfg PieChartConfig) render.HTML {
 	}
 	if total == 0 {
 		// Every slice is zero: nothing to draw, but a legitimate empty state.
-		return chartEmpty(cfg.Size, cfg.LabelledBy, cfg.Class, "No data yet")
+		return chartEmpty(cfg.Size, cfg.LabelledBy, cfg.Class, "No data yet", cfg.ExtraAttrs)
 	}
 
 	size := cfg.Size
@@ -87,6 +96,12 @@ func PieChart(cfg PieChartConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
+
+	// Caller extras land after the owned attributes. render.Attr
+	// validates the key and escapes the value, matching what the
+	// html primitives do for map-built roots.
+	extra := html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"width", "height", "viewBox", "xmlns", "role", "aria-labelledby", "aria-hidden")
 
 	var sb strings.Builder
 	sb.WriteString(`<svg width="`)
@@ -112,7 +127,9 @@ func PieChart(cfg PieChartConfig) render.HTML {
 	} else {
 		sb.WriteString(` aria-hidden="true"`)
 	}
-	sb.WriteString(` data-fui-comp="ui-pie-chart">`)
+	sb.WriteString(` data-fui-comp="ui-pie-chart"`)
+	sb.WriteString(serializeExtraAttrs(extra))
+	sb.WriteString(`>`)
 
 	// Draw slices as arc paths.
 	start := -math.Pi / 2 // 12 o'clock start

--- a/framework/ui/piechart_test.go
+++ b/framework/ui/piechart_test.go
@@ -86,3 +86,14 @@ func TestPieChartLabelledByAddsRole(t *testing.T) {
 		t.Errorf("LabelledBy should set aria-labelledby:\n%s", h)
 	}
 }
+
+func TestPieChartExtraAttrsOnRoot(t *testing.T) {
+	h := PieChart(PieChartConfig{
+		Slices:     []PieSlice{{Label: "A", Value: 2}, {Label: "B", Value: 1}},
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("PieChart root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/pipeline_image.go
+++ b/framework/ui/pipeline_image.go
@@ -104,6 +104,12 @@ type PipelineImageConfig struct {
 	Rounded      bool
 
 	ID, Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the image's root element
+	// (the wrapping <span>, not the inner <img>). Keys the component
+	// owns are dropped: class and id (use Class / ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // PipelineImage renders <picture> with one <source> per MIME type, plus
@@ -216,7 +222,9 @@ func PipelineImage(cfg PipelineImageConfig) render.HTML {
 	// over it in DOM order. Both are positioned, so tree order decides,
 	// with no z-index needed.
 	return imageStyle.WrapHTML(html.Span(html.TextConfig{
-		Class: cls, ID: cfg.ID,
+		Class:      cls,
+		ID:         cfg.ID,
+		ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
 	}, lqip, picture))
 }
 

--- a/framework/ui/pipeline_image_test.go
+++ b/framework/ui/pipeline_image_test.go
@@ -323,3 +323,14 @@ func TestSrcsetEscapesDataPayloadCommas(t *testing.T) {
 		})
 	}
 }
+
+func TestPipelineImageExtraAttrsOnRoot(t *testing.T) {
+	h := PipelineImage(PipelineImageConfig{
+		Fallback: "/img.jpg", Alt: "A", Width: 10, Height: 10,
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("PipelineImage root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/pollingindicator.go
+++ b/framework/ui/pollingindicator.go
@@ -27,6 +27,12 @@ type PollingIndicatorConfig struct {
 	Paused bool
 	ID     string
 	Class  string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the indicator's root
+	// element. Keys the component owns are dropped: class and id
+	// (use Class / ID), data-fui-*, role, and aria-live — the
+	// live-region contract.
+	ExtraAttrs html.Attrs
 	// Ctx carries the per-request context used to resolve the live label.
 	// When nil, English fallbacks apply.
 	Ctx context.Context
@@ -51,11 +57,14 @@ func PollingIndicator(cfg PollingIndicatorConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	attrs := map[string]string{
-		"class":     cls,
-		"role":      "status",
-		"aria-live": "polite",
+	// Sanitized extras first, owned keys on top so they win.
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-live")
+	if attrs == nil {
+		attrs = html.Attrs{}
 	}
+	attrs["class"] = cls
+	attrs["role"] = "status"
+	attrs["aria-live"] = "polite"
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}

--- a/framework/ui/pollingindicator_test.go
+++ b/framework/ui/pollingindicator_test.go
@@ -50,3 +50,11 @@ func TestPollingIndicator_CSSRegistered(t *testing.T) {
 		}
 	}
 }
+
+func TestPollingIndicatorExtraAttrsOnRoot(t *testing.T) {
+	h := PollingIndicator(PollingIndicatorConfig{ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("PollingIndicator root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/pricing.go
+++ b/framework/ui/pricing.go
@@ -30,6 +30,11 @@ type PricingCardConfig struct {
 	// intervening section <h2>) so axe's heading-order rule passes.
 	HeadingLevel int
 	Class        string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the card's root element.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // PricingCard renders a single plan card.
@@ -85,7 +90,11 @@ func PricingCard(cfg PricingCardConfig) render.HTML {
 		out = append(out, LinkButton(LinkButtonConfig{Label: label, Href: cfg.CTAHref, Variant: variant, Class: "ui-pricing-card__cta"}))
 	}
 
-	return pricingCardStyle.WrapHTML(html.Div(html.DivConfig{Class: cls, ID: cfg.ID}, out...))
+	return pricingCardStyle.WrapHTML(html.Div(html.DivConfig{
+		Class:      cls,
+		ID:         cfg.ID,
+		ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+	}, out...))
 }
 
 var pricingCardStyle = registry.RegisterStyle("ui-pricing-card", pricingCardCSS)

--- a/framework/ui/pricing_test.go
+++ b/framework/ui/pricing_test.go
@@ -1,0 +1,37 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPricingCardRendersPlan(t *testing.T) {
+	h := string(PricingCard(PricingCardConfig{
+		Name:     "Pro",
+		Price:    "$99",
+		Period:   "/mo",
+		Features: []string{"Seats: 10"},
+	}))
+	for _, want := range []string{
+		`data-fui-comp="ui-pricing-card"`,
+		"Pro",
+		"$99",
+		"/mo",
+		"Seats: 10",
+	} {
+		if !strings.Contains(h, want) {
+			t.Errorf("PricingCard missing %q:\n%s", want, h)
+		}
+	}
+}
+
+func TestPricingCardExtraAttrsOnRoot(t *testing.T) {
+	h := PricingCard(PricingCardConfig{
+		Name: "Pro", Price: "$99",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("PricingCard root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/rating.go
+++ b/framework/ui/rating.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"strconv"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -89,6 +90,12 @@ type RatingConfig struct {
 	Disabled bool
 	ID       string
 	Class    string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the rating's root
+	// <fieldset>. Keys the component owns are dropped: class and id
+	// (use Class / ID), data-fui-*, role, and aria-label — the
+	// radiogroup contract.
+	ExtraAttrs html.Attrs
 }
 
 // RatingInput renders a star/heart rating bound to a hidden radio
@@ -148,7 +155,14 @@ func RatingInput(cfg RatingConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	fsAttrs := map[string]string{"class": cls, "role": "radiogroup", "aria-label": cfg.Label}
+	// Sanitized extras first, owned keys on top so they win.
+	fsAttrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-label")
+	if fsAttrs == nil {
+		fsAttrs = html.Attrs{}
+	}
+	fsAttrs["class"] = cls
+	fsAttrs["role"] = "radiogroup"
+	fsAttrs["aria-label"] = cfg.Label
 	if cfg.ID != "" {
 		fsAttrs["id"] = cfg.ID
 	}

--- a/framework/ui/rating_test.go
+++ b/framework/ui/rating_test.go
@@ -115,3 +115,14 @@ func TestRatingRejectsUnknownGap(t *testing.T) {
 	}()
 	RatingInput(RatingConfig{Name: "r", Label: "Rate", Gap: RatingGap("nope")})
 }
+
+func TestRatingExtraAttrsOnRoot(t *testing.T) {
+	h := RatingInput(RatingConfig{
+		Name: "r", Label: "Rate",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("RatingInput root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/record_summary.go
+++ b/framework/ui/record_summary.go
@@ -45,6 +45,12 @@ type RecordSummaryConfig struct {
 	HeadingLevel int
 	ID           string
 	Class        string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the summary's root
+	// <article> element. Keys the component owns are dropped: class
+	// and id (use Class / ID), data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // RecordSummary renders a compact semantic <article>. It is the one dominant
@@ -112,7 +118,11 @@ func RecordSummary(cfg RecordSummaryConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	attrs := map[string]string{"class": cls}
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["class"] = cls
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}
@@ -132,6 +142,12 @@ type MetricBandConfig struct {
 	Label string
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) to the band's root <dl> element. Keys the
+	// component owns are dropped: class and id (use Class / ID),
+	// data-fui-*, and aria-label (derived from Label).
+	ExtraAttrs html.Attrs
 }
 
 // MetricBand renders a semantic <dl>. Wide viewports use one row; phones use
@@ -160,7 +176,11 @@ func MetricBand(cfg MetricBandConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	attrs := map[string]string{"class": cls}
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "aria-label")
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["class"] = cls
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}

--- a/framework/ui/record_summary_test.go
+++ b/framework/ui/record_summary_test.go
@@ -153,3 +153,28 @@ func assertUIPanics(t *testing.T, fn func()) {
 	}()
 	fn()
 }
+
+func TestRecordSummaryExtraAttrsOnRoot(t *testing.T) {
+	h := RecordSummary(RecordSummaryConfig{
+		Title:      "Deploy",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("article missing data-test:\n%s", root)
+	}
+}
+
+func TestMetricBandExtraAttrsOnRoot(t *testing.T) {
+	h := MetricBand(MetricBandConfig{
+		Items:      []MetricBandItem{{Label: "L", Value: "V"}},
+		ExtraAttrs: map[string]string{"data-test": "hook", "aria-label": "evil"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("dl missing data-test:\n%s", root)
+	}
+	if strings.Contains(root, "evil") {
+		t.Errorf("aria-label is owned by Label; ExtraAttrs copy must be dropped:\n%s", root)
+	}
+}

--- a/framework/ui/repeater.go
+++ b/framework/ui/repeater.go
@@ -35,6 +35,12 @@ type RepeaterConfig struct {
 	Items       []render.HTML
 	RPCPath     string
 
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the repeater's root
+	// element. Keys the component owns are dropped: class and
+	// data-fui-*.
+	ExtraAttrs html.Attrs
+
 	// Ctx carries the per-request context used to resolve i18n strings
 	// (AddLabel, RemoveLabel defaults). When nil, context.Background() is
 	// used and English fallbacks are returned, preserving today's behaviour.
@@ -112,7 +118,10 @@ func Repeater(cfg RepeaterConfig) render.HTML {
 		ExtraAttrs: addAttrs,
 	}))
 
-	return repeaterStyle.WrapHTML(html.Div(html.DivConfig{Class: "ui-repeater"}, children...))
+	return repeaterStyle.WrapHTML(html.Div(html.DivConfig{
+		Class:      "ui-repeater",
+		ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+	}, children...))
 }
 
 func repeaterRemoveBtn(cfg RepeaterConfig, index int) render.HTML {

--- a/framework/ui/repeater_test.go
+++ b/framework/ui/repeater_test.go
@@ -112,3 +112,11 @@ func TestRepeaterCustomLabels(t *testing.T) {
 	mustContain(t, h, "Add row")
 	mustContain(t, h, "Delete")
 }
+
+func TestRepeaterExtraAttrsOnRoot(t *testing.T) {
+	h := Repeater(RepeaterConfig{Name: "items", ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("Repeater root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/responsive.go
+++ b/framework/ui/responsive.go
@@ -41,9 +41,14 @@ type ResponsiveConfig struct {
 	// desktop variant; < Breakpoint renders the mobile variant.
 	// Defaults to 1024 when zero.
 	Breakpoint int
-
 	// Class is appended to the wrapping <div>'s class list.
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the swap's root element.
+	// Keys the component owns are dropped: class (use Class) and
+	// data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // Responsive emits both variants wrapped in viewport-toggled divs.
@@ -61,7 +66,10 @@ func Responsive(cfg ResponsiveConfig, desktop, mobile render.HTML) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	return style.WrapHTML(html.Div(html.DivConfig{Class: cls},
+	return style.WrapHTML(html.Div(html.DivConfig{
+		Class:      cls,
+		ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+	},
 		html.Div(html.DivConfig{
 			Class: "ui-responsive__desktop",
 		}, desktop),

--- a/framework/ui/responsive_test.go
+++ b/framework/ui/responsive_test.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+func TestResponsiveEmitsBothVariants(t *testing.T) {
+	h := string(Responsive(ResponsiveConfig{},
+		render.Text("DESKTOP"), render.Text("MOBILE")))
+	for _, want := range []string{
+		`data-fui-comp="ui-responsive-1024"`,
+		"DESKTOP",
+		"ui-responsive__mobile",
+		"MOBILE",
+	} {
+		if !strings.Contains(h, want) {
+			t.Errorf("Responsive missing %q:\n%s", want, h)
+		}
+	}
+}
+
+func TestResponsiveExtraAttrsOnRoot(t *testing.T) {
+	h := Responsive(ResponsiveConfig{
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	}, render.Text("d"), render.Text("m"))
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("Responsive root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/segmented.go
+++ b/framework/ui/segmented.go
@@ -70,6 +70,11 @@ type SegmentedControlConfig struct {
 
 	ID    string
 	Class string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the control's root
+	// element. Keys the component owns are dropped: class and id
+	// (use Class / ID), data-fui-*, role, aria-label, and data-count.
+	ExtraAttrs html.Attrs
 }
 
 // SegmentedControl renders the radiogroup with a sliding indicator.
@@ -102,11 +107,14 @@ func SegmentedControl(cfg SegmentedControlConfig) render.HTML {
 		cls += " " + cfg.Class
 	}
 
-	wrapAttrs := html.Attrs{
-		"class":      cls,
-		"role":       "radiogroup",
-		"data-count": itoaSmall(len(cfg.Options)),
+	// Sanitized extras first, owned keys on top so they win.
+	wrapAttrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "data-count", "aria-label")
+	if wrapAttrs == nil {
+		wrapAttrs = html.Attrs{}
 	}
+	wrapAttrs["class"] = cls
+	wrapAttrs["role"] = "radiogroup"
+	wrapAttrs["data-count"] = itoaSmall(len(cfg.Options))
 	if cfg.ID != "" {
 		wrapAttrs["id"] = cfg.ID
 	}

--- a/framework/ui/segmented_test.go
+++ b/framework/ui/segmented_test.go
@@ -195,3 +195,17 @@ func TestSegmentedControlPanics(t *testing.T) {
 		})
 	}
 }
+
+func TestSegmentedExtraAttrsOnRoot(t *testing.T) {
+	h := SegmentedControl(SegmentedControlConfig{
+		Name:    "view",
+		Options: []SegmentedOption{{Label: "A", Value: "a"}, {Label: "B", Value: "b"}},
+		ExtraAttrs: map[string]string{
+			"data-test": "hook",
+		},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("SegmentedControl root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/shortcuthint.go
+++ b/framework/ui/shortcuthint.go
@@ -45,6 +45,12 @@ type ShortcutHintConfig struct {
 
 	ID    string
 	Class string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the hint's root element.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, and aria-hidden — the wrapper must stay in the
+	// accessibility tree for its SR-only label.
+	ExtraAttrs html.Attrs
 }
 
 // ShortcutHint renders the visual chord chips.
@@ -74,9 +80,14 @@ func ShortcutHint(cfg ShortcutHintConfig) render.HTML {
 	chips = append(chips, html.Span(html.TextConfig{Class: "ui-visually-hidden"}, render.Text("Shortcut: "+srLabel)))
 
 	return shortcutHintStyle.WrapHTML(html.Span(html.TextConfig{
-		Class:      cls,
-		ID:         cfg.ID,
-		ExtraAttrs: html.Attrs{"aria-hidden": "false"},
+		Class: cls,
+		ID:    cfg.ID,
+		// Owned aria-hidden wins over any caller override (protected
+		// above), so the SR-only label stays reachable.
+		ExtraAttrs: html.MergeAttrs(
+			html.SafeExtraAttrs(cfg.ExtraAttrs, "aria-hidden"),
+			html.Attrs{"aria-hidden": "false"},
+		),
 	}, chips...))
 }
 

--- a/framework/ui/shortcuthint_test.go
+++ b/framework/ui/shortcuthint_test.go
@@ -71,3 +71,11 @@ func TestShortcutHintPanicsOnEmptyChord(t *testing.T) {
 	}()
 	ShortcutHint(ShortcutHintConfig{})
 }
+
+func TestShortcutHintExtraAttrsOnRoot(t *testing.T) {
+	h := ShortcutHint(ShortcutHintConfig{Chord: "Mod+K", ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("ShortcutHint root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/sidebar.go
+++ b/framework/ui/sidebar.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/component"
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core-ui/urlsafe"
@@ -108,6 +109,12 @@ type SidebarConfig struct {
 	// Sidebar (some apps put their hamburger in the page header
 	// instead and call MountSidebar themselves).
 	SuppressDrawerTrigger bool
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the sidebar's root
+	// element. Keys the component owns are dropped: class and
+	// data-fui-* (the sidebar marker and collapse-storage wiring).
+	ExtraAttrs html.Attrs
 }
 
 var sidebarStyle = registry.RegisterStyle("ui-sidebar", sidebarCSS,
@@ -215,6 +222,9 @@ func (s sidebarComponent) render() render.HTML {
 		}
 		b.WriteString(` data-fui-sidebar-storage="` + render.Escape(key) + `"`)
 	}
+	// Caller extras land after the owned attributes. render.Attr
+	// validates the key and escapes the value, matching render.Tag.
+	b.WriteString(serializeExtraAttrs(html.SafeExtraAttrs(cfg.ExtraAttrs)))
 	b.WriteString(`>`)
 
 	if !cfg.SuppressDrawerTrigger {

--- a/framework/ui/sidebar_test.go
+++ b/framework/ui/sidebar_test.go
@@ -126,3 +126,22 @@ func TestSidebarOffCanvasEmitsDrawerOnlyVariant(t *testing.T) {
 		t.Errorf("off-canvas sidebar should not emit a collapse control: %s", out)
 	}
 }
+
+func TestSidebarExtraAttrsOnRoot(t *testing.T) {
+	extra := map[string]string{"data-test": "hook"}
+	for name, variant := range map[string]ui.SidebarVariant{
+		"persistent":  ui.SidebarPersistent,
+		"collapsible": ui.SidebarCollapsible,
+	} {
+		out := string(ui.Sidebar(ui.SidebarConfig{
+			Variant:    variant,
+			DrawerName: "x",
+			Items:      []ui.SidebarItem{{Label: "A", Href: "/a"}},
+			ExtraAttrs: extra,
+		}).Render())
+		root := out[:strings.Index(out, ">")+1]
+		if !strings.Contains(root, `data-test="hook"`) {
+			t.Errorf("%s root missing data-test:\n%s", name, root)
+		}
+	}
+}

--- a/framework/ui/sign_out.go
+++ b/framework/ui/sign_out.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -21,6 +22,11 @@ type SignOutConfig struct {
 	// Variant styles the button; defaults to ButtonGhost.
 	Variant ButtonVariant
 	Class   string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the control's root <form>.
+	// Keys the component owns are dropped: class (use Class),
+	// data-fui-*, method, and action.
+	ExtraAttrs html.Attrs
 	// Ctx carries the per-request context used to resolve the sign-out label.
 	// When nil, English fallbacks apply.
 	Ctx context.Context
@@ -54,7 +60,11 @@ func SignOut(cfg SignOutConfig) render.HTML {
 	var b strings.Builder
 	// csrf-exempt: battery/auth's logout handler enforces same-origin requests,
 	// and auth.WithBFFPosture exempts only this route from its global CSRF gate.
-	b.WriteString(`<form data-fui-comp="ui-sign-out" class="` + render.Escape(cls) + `" method="post" action="` + render.Escape(action) + `">`)
+	b.WriteString(`<form data-fui-comp="ui-sign-out" class="` + render.Escape(cls) + `" method="post" action="` + render.Escape(action) + `"`)
+	// Caller extras land after the owned attributes. render.Attr
+	// validates the key and escapes the value, matching render.Tag.
+	b.WriteString(serializeExtraAttrs(html.SafeExtraAttrs(cfg.ExtraAttrs, "method", "action")))
+	b.WriteString(`>`)
 	if cfg.Next != "" {
 		b.WriteString(`<input type="hidden" name="next" value="` + render.Escape(cfg.Next) + `">`)
 	}

--- a/framework/ui/sign_out_test.go
+++ b/framework/ui/sign_out_test.go
@@ -1,0 +1,28 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSignOutRendersFormAndButton(t *testing.T) {
+	h := string(SignOut(SignOutConfig{}))
+	for _, want := range []string{
+		`data-fui-comp="ui-sign-out"`,
+		`method="post"`,
+		`action="/auth/logout"`,
+		`type="submit"`,
+	} {
+		if !strings.Contains(h, want) {
+			t.Errorf("SignOut missing %q:\n%s", want, h)
+		}
+	}
+}
+
+func TestSignOutExtraAttrsOnRoot(t *testing.T) {
+	h := SignOut(SignOutConfig{ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("SignOut root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/signal_toggle.go
+++ b/framework/ui/signal_toggle.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/store"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
@@ -38,6 +39,12 @@ type SignalToggleConfig struct {
 	Slice      *store.Slice[bool] // optional; supplies the signal name + initial value, takes precedence
 	Label      string             // optional:  aria-label (falls back to the signal name)
 	Class      string             // optional:  extra CSS classes
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the toggle's root
+	// <button>. Keys the component owns are dropped: class (use
+	// Class), data-fui-*, role, aria-checked, and aria-label — the
+	// switch contract and signal wiring the runtime drives.
+	ExtraAttrs html.Attrs
 }
 
 // SignalToggle renders a <button role="switch"> that toggles a boolean
@@ -75,6 +82,11 @@ func SignalToggle(cfg SignalToggleConfig) render.HTML {
 	escLabel := render.Escape(label)
 	escCls := render.Escape(cls)
 
+	// Caller extras land after the owned attributes. render.Attr
+	// validates the key and escapes the value, matching render.Tag.
+	extraAttrs := serializeExtraAttrs(html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"role", "aria-checked", "aria-label"))
+
 	// Build inner children as a single HTML string, static structure.
 	inner := fmt.Sprintf(
 		`<span class="fui-toggle__track"><span class="fui-toggle__thumb"></span></span>`+
@@ -89,7 +101,7 @@ func SignalToggle(cfg SignalToggleConfig) render.HTML {
 		`<button class="%s" data-fui-comp="fui-toggle"`+
 			` data-fui-signal-toggle="%s"`+
 			` data-fui-signal="%s" data-fui-signal-mode="attr" data-fui-signal-attr="aria-checked"`+
-			` role="switch" aria-checked="%s" aria-label="%s">%s</button>`,
-		escCls, escName, escName, initStr, escLabel, inner,
+			` role="switch" aria-checked="%s" aria-label="%s"%s>%s</button>`,
+		escCls, escName, escName, initStr, escLabel, extraAttrs, inner,
 	))
 }

--- a/framework/ui/signal_toggle_test.go
+++ b/framework/ui/signal_toggle_test.go
@@ -98,3 +98,11 @@ func TestSignalToggleCarriesCompMarker(t *testing.T) {
 		t.Fatalf("toggle missing comp marker: %s", s)
 	}
 }
+
+func TestSignalToggleExtraAttrsOnRoot(t *testing.T) {
+	s := string(SignalToggle(SignalToggleConfig{SignalName: "dark", ExtraAttrs: map[string]string{"data-test": "hook"}}))
+	root := s[:strings.Index(s, ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("SignalToggle root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/site_footer.go
+++ b/framework/ui/site_footer.go
@@ -38,6 +38,11 @@ type SiteFooterConfig struct {
 	Bottom []render.HTML
 	// Class is appended to the ui-site-footer wrapper.
 	Class string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the footer's root
+	// element. Keys the component owns are dropped: class (use
+	// Class) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // SiteFooter renders a multi-column footer. The wrapper is a <div>
@@ -77,7 +82,10 @@ func SiteFooter(cfg SiteFooterConfig) render.HTML {
 	if cfg.Class != "" {
 		cls = cls + " " + cfg.Class
 	}
-	return siteFooterStyle.WrapHTML(html.Div(html.DivConfig{Class: cls}, body...))
+	return siteFooterStyle.WrapHTML(html.Div(html.DivConfig{
+		Class:      cls,
+		ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+	}, body...))
 }
 
 var siteFooterStyle = registry.RegisterStyle("ui-site-footer", siteFooterCSS)

--- a/framework/ui/site_footer_test.go
+++ b/framework/ui/site_footer_test.go
@@ -78,3 +78,11 @@ func TestSiteFooterWithoutLeadOmitsLeadSlot(t *testing.T) {
 		t.Errorf("Lead slot should be omitted when nil:\n%s", h)
 	}
 }
+
+func TestSiteFooterExtraAttrsOnRoot(t *testing.T) {
+	h := SiteFooter(SiteFooterConfig{ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("SiteFooter root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/site_header.go
+++ b/framework/ui/site_header.go
@@ -79,6 +79,11 @@ type SiteHeaderConfig struct {
 	Drawer SiteHeaderDrawerVariant
 	// Class is appended to the ui-site-header wrapper.
 	Class string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the header's root
+	// element. Keys the component owns are dropped: class (use
+	// Class) and data-fui-*.
+	ExtraAttrs html.Attrs
 	// Ctx carries the per-request context used to resolve the nav
 	// aria-labels (primary, mobile, toggle). When nil, English fallbacks apply.
 	Ctx context.Context
@@ -203,7 +208,10 @@ func SiteHeader(cfg SiteHeaderConfig) render.HTML {
 	if cfg.Class != "" {
 		cls = cls + " " + cfg.Class
 	}
-	return siteHeaderStyle.WrapHTML(html.Div(html.DivConfig{Class: cls},
+	return siteHeaderStyle.WrapHTML(html.Div(html.DivConfig{
+		Class:      cls,
+		ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
+	},
 		brand, primary, right,
 	))
 }

--- a/framework/ui/site_header_test.go
+++ b/framework/ui/site_header_test.go
@@ -225,3 +225,11 @@ func TestSiteHeaderNavUnderlineVariantIsOptIn(t *testing.T) {
 		t.Errorf("default header should stay flat (no underline variant):\n%s", off)
 	}
 }
+
+func TestSiteHeaderExtraAttrsOnRoot(t *testing.T) {
+	h := SiteHeader(SiteHeaderConfig{ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("SiteHeader root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/skeletonpresets.go
+++ b/framework/ui/skeletonpresets.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/patterns/skeleton"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
@@ -24,6 +25,13 @@ type SkeletonCardConfig struct {
 	ShowFooter bool
 	ID         string
 	Class      string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) to the placeholder's root element. Keys the
+	// component owns are dropped: class and id (use Class / ID),
+	// data-fui-*, and aria-hidden (skeletons are always
+	// presentational; the surrounding container announces loading).
+	ExtraAttrs html.Attrs
 }
 
 // SkeletonCard renders a card-shaped loading placeholder: a title
@@ -36,10 +44,12 @@ func SkeletonCard(cfg SkeletonCardConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	attrs := map[string]string{
-		"class":       cls,
-		"aria-hidden": "true",
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "aria-hidden")
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["class"] = cls
+	attrs["aria-hidden"] = "true"
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}
@@ -66,6 +76,13 @@ type SkeletonRowConfig struct {
 	HideChevron bool
 	ID          string
 	Class       string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) to the placeholder's root element. Keys the
+	// component owns are dropped: class and id (use Class / ID),
+	// data-fui-*, and aria-hidden (skeletons are always
+	// presentational; the surrounding container announces loading).
+	ExtraAttrs html.Attrs
 }
 
 // SkeletonRow renders a list-row loading placeholder: a label line on
@@ -76,10 +93,12 @@ func SkeletonRow(cfg SkeletonRowConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	attrs := map[string]string{
-		"class":       cls,
-		"aria-hidden": "true",
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "aria-hidden")
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["class"] = cls
+	attrs["aria-hidden"] = "true"
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}
@@ -108,6 +127,13 @@ type SkeletonAvatarConfig struct {
 	HideSubline bool
 	ID          string
 	Class       string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) to the placeholder's root element. Keys the
+	// component owns are dropped: class and id (use Class / ID),
+	// data-fui-*, and aria-hidden (skeletons are always
+	// presentational; the surrounding container announces loading).
+	ExtraAttrs html.Attrs
 }
 
 // SkeletonAvatar renders an avatar-with-text loading placeholder: a
@@ -118,10 +144,12 @@ func SkeletonAvatar(cfg SkeletonAvatarConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	attrs := map[string]string{
-		"class":       cls,
-		"aria-hidden": "true",
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "aria-hidden")
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["class"] = cls
+	attrs["aria-hidden"] = "true"
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}

--- a/framework/ui/skeletonpresets_test.go
+++ b/framework/ui/skeletonpresets_test.go
@@ -111,3 +111,27 @@ func TestSkeletonPresets_AllRegisterCSS(t *testing.T) {
 		}
 	}
 }
+
+func TestSkeletonCardExtraAttrsOnRoot(t *testing.T) {
+	h := SkeletonCard(SkeletonCardConfig{ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+}
+
+func TestSkeletonRowExtraAttrsOnRoot(t *testing.T) {
+	h := SkeletonRow(SkeletonRowConfig{ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+}
+
+func TestSkeletonAvatarExtraAttrsOnRoot(t *testing.T) {
+	h := SkeletonAvatar(SkeletonAvatarConfig{ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/sparkline.go
+++ b/framework/ui/sparkline.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -47,6 +48,14 @@ type SparklineConfig struct {
 	LabelledBy string
 	ID         string
 	Class      string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the chart's root element:
+	// the <svg> itself, or the "no trend data" <span> when Values has
+	// fewer than two points. Keys the component owns are dropped:
+	// class and id (use Class / ID), data-fui-*, and the sizing and
+	// naming attributes the SVG derives from config (width, height,
+	// viewBox, xmlns, role, aria-labelledby, aria-hidden).
+	ExtraAttrs html.Attrs
 	// Ctx carries the per-request context used to resolve the no-trend-data label.
 	// When nil, English fallbacks apply.
 	Ctx context.Context
@@ -60,8 +69,14 @@ func Sparkline(cfg SparklineConfig) render.HTML {
 	}
 	if len(cfg.Values) < 2 {
 		// Inline trend with too few points: render a calm "no trend" dash
-		// rather than crashing the host that embeds it.
-		attrs := map[string]string{"data-fui-comp": "ui-sparkline", "aria-label": i18nui.T(ctx, i18nui.KeySparklineNoData)}
+		// rather than crashing the host that embeds it. Sanitized extras
+		// first, owned keys on top so they win.
+		attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "aria-label")
+		if attrs == nil {
+			attrs = html.Attrs{}
+		}
+		attrs["data-fui-comp"] = "ui-sparkline"
+		attrs["aria-label"] = i18nui.T(ctx, i18nui.KeySparklineNoData)
 		if cfg.Class != "" {
 			attrs["class"] = cfg.Class
 		}
@@ -117,6 +132,12 @@ func Sparkline(cfg SparklineConfig) render.HTML {
 		cls += " " + escapeXML(cfg.Class)
 	}
 
+	// Caller extras land after the owned attributes. render.Attr
+	// validates the key and escapes the value, matching what the
+	// html primitives do for map-built roots.
+	extraAttrs := serializeExtraAttrs(html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"width", "height", "viewBox", "xmlns", "role", "aria-labelledby", "aria-hidden"))
+
 	svgAttrs := strings.Builder{}
 	svgAttrs.WriteString(`width="`)
 	svgAttrs.WriteString(strconv.Itoa(w))
@@ -160,7 +181,7 @@ func Sparkline(cfg SparklineConfig) render.HTML {
 		body = `<path d="` + pathD.String() + `" class="ui-sparkline__line"/>`
 	}
 
-	out := `<svg ` + svgAttrs.String() + ` data-fui-comp="ui-sparkline">` + body + `</svg>`
+	out := `<svg ` + svgAttrs.String() + ` data-fui-comp="ui-sparkline"` + extraAttrs + `>` + body + `</svg>`
 	return sparklineStyle.WrapHTML(render.HTML(out))
 }
 

--- a/framework/ui/sparkline_test.go
+++ b/framework/ui/sparkline_test.go
@@ -68,3 +68,16 @@ func TestSparklineColorPreset(t *testing.T) {
 		t.Errorf("Color=danger should add modifier class:\n%s", h)
 	}
 }
+
+func TestSparklineExtraAttrsOnEveryRootShape(t *testing.T) {
+	extra := map[string]string{"data-test": "hook"}
+	for name, out := range map[string]string{
+		"svg":    string(Sparkline(SparklineConfig{Values: []float64{1, 2, 3}, ExtraAttrs: extra})),
+		"nodata": string(Sparkline(SparklineConfig{Values: []float64{1}, ExtraAttrs: extra})),
+	} {
+		root := out[:strings.Index(out, ">")+1]
+		if !strings.Contains(root, `data-test="hook"`) {
+			t.Errorf("%s root missing data-test:\n%s", name, root)
+		}
+	}
+}

--- a/framework/ui/spinner.go
+++ b/framework/ui/spinner.go
@@ -54,6 +54,12 @@ type SpinnerConfig struct {
 
 	ID    string
 	Class string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the spinner's root
+	// element. Keys the component owns are dropped: class and id
+	// (use Class / ID), data-fui-*, role, aria-live, and aria-busy —
+	// the live-region contract assistive tech depends on.
+	ExtraAttrs html.Attrs
 	// Ctx carries the per-request context used to resolve the loading label.
 	// When nil, English fallbacks apply.
 	Ctx context.Context
@@ -120,11 +126,13 @@ func Spinner(cfg SpinnerConfig) render.HTML {
 
 	return spinnerStyle.WrapHTML(html.Span(html.TextConfig{
 		Class: cls, ID: cfg.ID,
-		ExtraAttrs: html.Attrs{
-			"role":      "status",
-			"aria-live": "polite",
-			"aria-busy": "true",
-		},
+		ExtraAttrs: html.MergeAttrs(
+			html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-live", "aria-busy"),
+			html.Attrs{
+				"role":      "status",
+				"aria-live": "polite",
+				"aria-busy": "true",
+			}),
 	},
 		visual,
 		html.Span(html.TextConfig{Class: "ui-visually-hidden"}, render.Text(label)),

--- a/framework/ui/spinner_test.go
+++ b/framework/ui/spinner_test.go
@@ -54,3 +54,11 @@ func TestSpinnerGridVariantRendersNineCells(t *testing.T) {
 		t.Fatalf("grid variant should not render ring or dots elements:\n%s", h)
 	}
 }
+
+func TestSpinnerExtraAttrsOnRoot(t *testing.T) {
+	h := Spinner(SpinnerConfig{ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("Spinner root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/status_pill.go
+++ b/framework/ui/status_pill.go
@@ -36,6 +36,11 @@ type StatusPillConfig struct {
 	Dot   bool
 	Class string
 	ID    string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the pill's root element.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // StatusPill renders a presentational status kicker.
@@ -65,7 +70,7 @@ func StatusPill(cfg StatusPillConfig) render.HTML {
 	}
 	children = append(children, render.Text(cfg.Label))
 	return statusPillStyle.WrapHTML(
-		html.Span(html.TextConfig{Class: cls, ID: cfg.ID}, children...))
+		html.Span(html.TextConfig{Class: cls, ID: cfg.ID, ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs)}, children...))
 }
 
 var statusPillStyle = registry.RegisterStyle("ui-status-pill", statusPillCSS)

--- a/framework/ui/status_pill_test.go
+++ b/framework/ui/status_pill_test.go
@@ -56,3 +56,11 @@ func TestStatusPillRejectsUnknownTone(t *testing.T) {
 	}()
 	StatusPill(StatusPillConfig{Label: "x", Tone: "glow"})
 }
+
+func TestStatusPillExtraAttrsOnRoot(t *testing.T) {
+	h := StatusPill(StatusPillConfig{Label: "v0.1.0", ExtraAttrs: map[string]string{"data-test": "hook"}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("StatusPill root missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/step_rail.go
+++ b/framework/ui/step_rail.go
@@ -49,6 +49,12 @@ type StepRailConfig struct {
 	MetaHref string
 	// Class is appended to the ui-step-rail wrapper.
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the rail's root <aside>
+	// element. Keys the component owns are dropped: class (use
+	// Class), data-fui-*, role, and aria-label (derived from Title).
+	ExtraAttrs html.Attrs
 }
 
 // StepRail renders the sticky numbered nav. The wrapper is an <aside>
@@ -115,14 +121,14 @@ func StepRail(cfg StepRailConfig) render.HTML {
 			meta))
 	}
 
-	return stepRailStyle.WrapHTML(render.Tag("aside",
-		map[string]string{
-			"class":      cls,
-			"role":       "complementary",
-			"aria-label": aria,
-		},
-		body...,
-	))
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-label")
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["class"] = cls
+	attrs["role"] = "complementary"
+	attrs["aria-label"] = aria
+	return stepRailStyle.WrapHTML(render.Tag("aside", attrs, body...))
 }
 
 var stepRailStyle = registry.RegisterStyle("ui-step-rail", stepRailCSS)

--- a/framework/ui/step_rail_test.go
+++ b/framework/ui/step_rail_test.go
@@ -126,3 +126,17 @@ func TestStepRailRequiresAtLeastOneItem(t *testing.T) {
 	}()
 	StepRail(StepRailConfig{Items: nil})
 }
+
+func TestStepRailExtraAttrsOnRoot(t *testing.T) {
+	h := StepRail(StepRailConfig{
+		Items:      []StepRailItem{{Number: "01", Anchor: "s1", Label: "One"}},
+		ExtraAttrs: map[string]string{"data-test": "hook", "role": "banner"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("aside missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `role="complementary"`) {
+		t.Errorf("owned role must win over ExtraAttrs:\n%s", root)
+	}
+}

--- a/framework/ui/stepwizard.go
+++ b/framework/ui/stepwizard.go
@@ -47,6 +47,13 @@ type StepWizardConfig struct {
 
 	Class string
 
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the wizard's root <form>
+	// element. Keys the component owns are dropped: class and id
+	// (use Class / ID), data-fui-*, method, and action (both
+	// validated above; the form posts wizard_action through them).
+	ExtraAttrs html.Attrs
+
 	// Ctx carries the per-request context used to resolve i18n strings
 	// (Back, Continue, Submit button labels). When nil, context.Background()
 	// is used and English fallbacks are returned, preserving today's behaviour.
@@ -103,11 +110,18 @@ func StepWizard(cfg StepWizardConfig) render.HTML {
 	// 4. Navigation buttons.
 	children = append(children, renderStepActions(ctx, cfg.CurrentStep, len(cfg.Steps)))
 
+	// data-fui-comp is set by hand (not left to WrapHTML) so the
+	// marker survives next to the sanitized caller extras.
+	formAttrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "method", "action")
+	if formAttrs == nil {
+		formAttrs = html.Attrs{}
+	}
+	formAttrs["data-fui-comp"] = "ui-step-wizard"
 	return stepWizardStyle.WrapHTML(html.Form(html.FormConfig{
 		Method:     method,
 		Action:     cfg.Action,
 		Class:      cls,
-		ExtraAttrs: html.Attrs{"data-fui-comp": "ui-step-wizard"},
+		ExtraAttrs: formAttrs,
 	}, children...))
 }
 

--- a/framework/ui/stepwizard_test.go
+++ b/framework/ui/stepwizard_test.go
@@ -175,3 +175,21 @@ func TestStepWizardPanicOnInvalidMethod(t *testing.T) {
 		Method:      "DELETE",
 	})
 }
+
+func TestStepWizardExtraAttrsOnRoot(t *testing.T) {
+	h := StepWizard(StepWizardConfig{
+		Steps:      []StepWizardStep{{Heading: "A"}},
+		Action:     "/wizard",
+		ExtraAttrs: map[string]string{"data-test": "hook", "action": "javascript:alert(1)"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("form missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `action="/wizard"`) {
+		t.Errorf("owned action must win over ExtraAttrs:\n%s", root)
+	}
+	if !strings.Contains(root, `data-fui-comp="ui-step-wizard"`) {
+		t.Errorf("comp marker lost:\n%s", root)
+	}
+}

--- a/framework/ui/tag.go
+++ b/framework/ui/tag.go
@@ -50,6 +50,13 @@ type TagConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the tag's root element,
+	// whichever shape it takes (<a> or <span>). Keys the component
+	// owns are dropped: class and id (use Class / ID), data-fui-*,
+	// and href (use Href; it goes through the URL sanitizer).
+	ExtraAttrs html.Attrs
 }
 
 // Tag renders a small pill: optionally linked (filter chip), optionally
@@ -111,14 +118,17 @@ func Tag(cfg TagConfig) render.HTML {
 			href = "#"
 		}
 		return tagStyle.WrapHTML(html.LinkHTML(html.LinkHTMLConfig{
-			Href:    href,
-			Class:   cls,
-			ID:      cfg.ID,
-			Content: render.Join(body...),
+			Href:       href,
+			Class:      cls,
+			ID:         cfg.ID,
+			Content:    render.Join(body...),
+			ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs, "href"),
 		}))
 	}
 	return tagStyle.WrapHTML(html.Span(html.TextConfig{
-		Class: cls, ID: cfg.ID,
+		Class:      cls,
+		ID:         cfg.ID,
+		ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
 	}, body...))
 }
 

--- a/framework/ui/tag_test.go
+++ b/framework/ui/tag_test.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"strings"
 	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/render"
 )
 
 func TestTagRequiresLabel(t *testing.T) {
@@ -53,5 +55,18 @@ func TestTagNoDismissOmitsButton(t *testing.T) {
 	h := Tag(TagConfig{Label: "x"})
 	if strings.Contains(string(h), "ui-tag__dismiss") {
 		t.Fatalf("Tag without Dismiss should not render × button:\n%s", h)
+	}
+}
+
+func TestTagExtraAttrsOnEveryRootShape(t *testing.T) {
+	extra := map[string]string{"data-test": "hook"}
+	for name, h := range map[string]render.HTML{
+		"span": Tag(TagConfig{Label: "x", ExtraAttrs: extra}),
+		"link": Tag(TagConfig{Label: "x", Href: "/f", ExtraAttrs: extra}),
+	} {
+		root := string(h)[:strings.Index(string(h), ">")+1]
+		if !strings.Contains(root, `data-test="hook"`) {
+			t.Errorf("%s root missing data-test:\n%s", name, root)
+		}
 	}
 }

--- a/framework/ui/taginput.go
+++ b/framework/ui/taginput.go
@@ -37,6 +37,12 @@ type TagInputConfig struct {
 	Disabled bool
 	ID       string
 	Class    string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the field's root wrapper
+	// <div>. Keys the component owns are dropped: class and id
+	// (use Class / ID), data-fui-* (the tag-input runtime wiring).
+	ExtraAttrs html.Attrs
 }
 
 // TagInput renders a free-form tag input bound to a chip strip.
@@ -109,8 +115,12 @@ func TagInput(cfg TagInputConfig) render.HTML {
 		}, render.Text(cfg.Help)))
 	}
 
-	return tagInputStyle.WrapHTML(render.Tag("div",
-		map[string]string{"class": cls}, children...))
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["class"] = cls
+	return tagInputStyle.WrapHTML(render.Tag("div", attrs, children...))
 }
 
 func strItoa(n int) string {

--- a/framework/ui/taginput_test.go
+++ b/framework/ui/taginput_test.go
@@ -67,3 +67,13 @@ func TestTagInputMaxLength(t *testing.T) {
 		t.Errorf("expected maxlength attr:\n%s", h)
 	}
 }
+
+func TestTagInputExtraAttrsOnRoot(t *testing.T) {
+	h := TagInput(TagInputConfig{
+		Name: "tags", Label: "Tags", ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("wrapper div missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/terminal_block.go
+++ b/framework/ui/terminal_block.go
@@ -20,6 +20,12 @@ type TerminalBlockConfig struct {
 	Label string // required header text, e.g. "$ install"
 	Class string
 	ID    string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the block's root
+	// wrapper <div>. Keys the component owns are dropped: class
+	// and id (use Class / ID), data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // TerminalBlock renders a CLI mock. Body lines are rendered verbatim in a
@@ -41,7 +47,8 @@ func TerminalBlock(cfg TerminalBlockConfig, lines ...render.HTML) render.HTML {
 	)
 	body := html.Div(html.DivConfig{Class: "ui-terminal-block__body"}, lines...)
 	return terminalBlockStyle.WrapHTML(
-		html.Div(html.DivConfig{Class: cls, ID: cfg.ID}, head, body))
+		html.Div(html.DivConfig{Class: cls, ID: cfg.ID,
+			ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs)}, head, body))
 }
 
 // TerminalOut wraps a line of dim, secondary output (echoed commands, noise).

--- a/framework/ui/terminal_block_test.go
+++ b/framework/ui/terminal_block_test.go
@@ -44,3 +44,14 @@ func TestTerminalBlockRequiresLabel(t *testing.T) {
 	}()
 	TerminalBlock(TerminalBlockConfig{})
 }
+
+func TestTerminalBlockExtraAttrsOnRoot(t *testing.T) {
+	h := TerminalBlock(TerminalBlockConfig{
+		Label:      "$ install",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	}, render.Text("go install"))
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("wrapper div missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/themetoggle.go
+++ b/framework/ui/themetoggle.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core/render"
 	"github.com/DonaldMurillo/gofastr/framework/i18nui"
 )
@@ -39,6 +40,14 @@ type ThemeToggleConfig struct {
 
 	// Class is an optional extra CSS class.
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) to the toggle's root element, whichever
+	// shape it takes (<button> for icon/label, <div> for pill). Keys
+	// the component owns are dropped: class and id (use Class / ID),
+	// data-fui-* (the colorscheme runtime wiring), type, role, and
+	// aria-label (i18n-resolved).
+	ExtraAttrs html.Attrs
 
 	// LightLabel overrides the light-mode label for label/pill variants.
 	// Defaults to "Light".
@@ -92,11 +101,13 @@ func renderThemeToggleButton(cfg ThemeToggleConfig, cls string, variant ThemeTog
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	attrs := map[string]string{
-		"type":                  "button",
-		"data-fui-theme-toggle": "",
-		"aria-label":            i18nui.T(ctx, i18nui.KeyThemeToggle),
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "type", "role", "aria-label")
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["type"] = "button"
+	attrs["data-fui-theme-toggle"] = ""
+	attrs["aria-label"] = i18nui.T(ctx, i18nui.KeyThemeToggle)
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}
@@ -143,12 +154,14 @@ func renderThemeTogglePill(cfg ThemeToggleConfig, cls string) render.HTML {
 		autoLabel = i18nui.T(ctx, i18nui.KeyThemeAuto)
 	}
 
-	rootAttrs := map[string]string{
-		"class":                 cls + " ui-theme-toggle--pill",
-		"data-fui-theme-toggle": "pill",
-		"role":                  "radiogroup",
-		"aria-label":            i18nui.T(ctx, i18nui.KeyThemeColorScheme),
+	rootAttrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "type", "role", "aria-label")
+	if rootAttrs == nil {
+		rootAttrs = map[string]string{}
 	}
+	rootAttrs["class"] = cls + " ui-theme-toggle--pill"
+	rootAttrs["data-fui-theme-toggle"] = "pill"
+	rootAttrs["role"] = "radiogroup"
+	rootAttrs["aria-label"] = i18nui.T(ctx, i18nui.KeyThemeColorScheme)
 	if cfg.ID != "" {
 		rootAttrs["id"] = cfg.ID
 	}

--- a/framework/ui/themetoggle_test.go
+++ b/framework/ui/themetoggle_test.go
@@ -1,0 +1,25 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+func TestThemeToggleExtraAttrsOnEveryRootShape(t *testing.T) {
+	extra := map[string]string{"data-test": "hook", "aria-label": "evil"}
+	for name, h := range map[string]render.HTML{
+		"icon":  ThemeToggle(ThemeToggleConfig{ExtraAttrs: extra}),
+		"label": ThemeToggle(ThemeToggleConfig{Variant: ThemeToggleLabel, ExtraAttrs: extra}),
+		"pill":  ThemeToggle(ThemeToggleConfig{Variant: ThemeTogglePill, ExtraAttrs: extra}),
+	} {
+		root := string(h)[:strings.Index(string(h), ">")+1]
+		if !strings.Contains(root, `data-test="hook"`) {
+			t.Errorf("%s root missing data-test:\n%s", name, root)
+		}
+		if strings.Contains(root, "evil") {
+			t.Errorf("%s root: aria-label is i18n-owned; ExtraAttrs copy must be dropped:\n%s", name, root)
+		}
+	}
+}

--- a/framework/ui/timepicker.go
+++ b/framework/ui/timepicker.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"strconv"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -38,6 +39,12 @@ type TimePickerConfig struct {
 	Error string
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the picker's root
+	// wrapper <div>. Keys the component owns are dropped: class
+	// and id (use Class / ID), data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // TimePicker renders a styled native time input with a label.
@@ -116,8 +123,12 @@ func TimePicker(cfg TimePickerConfig) render.HTML {
 		}, render.Text(cfg.Help)))
 	}
 
-	return timePickerStyle.WrapHTML(render.Tag("div",
-		map[string]string{"class": cls}, children...))
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs)
+	if attrs == nil {
+		attrs = map[string]string{}
+	}
+	attrs["class"] = cls
+	return timePickerStyle.WrapHTML(render.Tag("div", attrs, children...))
 }
 
 var timePickerStyle = registry.RegisterStyle("ui-time-picker", timePickerCSS)

--- a/framework/ui/timepicker_test.go
+++ b/framework/ui/timepicker_test.go
@@ -71,3 +71,13 @@ func TestTimePickerErrorState(t *testing.T) {
 		t.Errorf("Error should mark aria-invalid:\n%s", h)
 	}
 }
+
+func TestTimePickerExtraAttrsOnRoot(t *testing.T) {
+	h := TimePicker(TimePickerConfig{
+		Name: "at", Label: "At", ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("wrapper div missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/toggle.go
+++ b/framework/ui/toggle.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"fmt"
-	"maps"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -49,7 +48,12 @@ type ToggleConfig struct {
 	// (aria-invalid="true", red ring, role="alert" message).
 	Error string
 
-	// Attrs lets callers attach data-fui-* attributes (e.g. for RPC).
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the control's root
+	// <label> element. Keys the component owns are dropped: class
+	// and id (use Class / ID), data-fui-*, and for (the label→input
+	// association; the runtime keys click and screen-reader wiring
+	// off it).
 	ExtraAttrs html.Attrs
 
 	Class string
@@ -132,7 +136,6 @@ func renderToggle(inputType, modifierClass string, cfg ToggleConfig) render.HTML
 	} else if cfg.Help != "" {
 		inputAttrs["aria-describedby"] = id + "-help"
 	}
-	maps.Copy(inputAttrs, cfg.ExtraAttrs)
 
 	// Switch uses an extra visual "track" element painted via CSS;
 	// no extra DOM beyond input + label needed because the
@@ -162,10 +165,13 @@ func renderToggle(inputType, modifierClass string, cfg ToggleConfig) render.HTML
 	// Native <label for=…> wraps the control. The for/id pairing is
 	// what the screen reader uses; the click-on-label-toggles-checkbox
 	// behavior is also native.
-	return toggleStyle.WrapHTML(render.Tag("label", map[string]string{
-		"class": cls,
-		"for":   id,
-	}, children...))
+	labelAttrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "for")
+	if labelAttrs == nil {
+		labelAttrs = map[string]string{}
+	}
+	labelAttrs["class"] = cls
+	labelAttrs["for"] = id
+	return toggleStyle.WrapHTML(render.Tag("label", labelAttrs, children...))
 }
 
 // ─── RadioGroup / CheckboxGroup ───────────────────────────────────────
@@ -197,6 +203,13 @@ type RadioGroupConfig struct {
 	Required bool
 	ID       string
 	Class    string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the group's root
+	// <fieldset> element. Keys the component owns are dropped: class
+	// and id (use Class / ID), data-fui-*, role, and
+	// aria-describedby (wired to the group's help/error message).
+	ExtraAttrs html.Attrs
 }
 
 // RadioGroup renders a <fieldset> of radio buttons with a shared
@@ -263,11 +276,13 @@ func RadioGroup(cfg RadioGroupConfig) render.HTML {
 		}, render.Text(cfg.Help)))
 	}
 
-	attrs := map[string]string{
-		"class": cls,
-		"id":    id,
-		"role":  "radiogroup",
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-describedby")
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["class"] = cls
+	attrs["id"] = id
+	attrs["role"] = "radiogroup"
 	if cfg.Error != "" {
 		attrs["aria-describedby"] = id + "-error"
 	} else if cfg.Help != "" {
@@ -301,6 +316,13 @@ type CheckboxGroupConfig struct {
 	Required bool
 	ID       string
 	Class    string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the group's root
+	// <fieldset> element. Keys the component owns are dropped: class
+	// and id (use Class / ID), data-fui-*, role, and
+	// aria-describedby (wired to the group's help/error message).
+	ExtraAttrs html.Attrs
 }
 
 // CheckboxGroup renders a <fieldset> of checkboxes with a shared
@@ -367,11 +389,13 @@ func CheckboxGroup(cfg CheckboxGroupConfig) render.HTML {
 		}, render.Text(cfg.Help)))
 	}
 
-	attrs := map[string]string{
-		"class": cls,
-		"id":    id,
-		"role":  "group",
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-describedby")
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["class"] = cls
+	attrs["id"] = id
+	attrs["role"] = "group"
 	if cfg.Error != "" {
 		attrs["aria-describedby"] = id + "-error"
 	} else if cfg.Help != "" {

--- a/framework/ui/toggle_test.go
+++ b/framework/ui/toggle_test.go
@@ -126,3 +126,52 @@ func TestToggleCSSStylesTheMarker(t *testing.T) {
 		t.Fatal("toggleCSS has no rule for .ui-form-field__required — group markers are unstyled unless ui-form-field happens to be on the page")
 	}
 }
+
+func TestToggleExtraAttrsOnRoot(t *testing.T) {
+	h := Checkbox(ToggleConfig{
+		Name: "n", Label: "x",
+		ExtraAttrs: map[string]string{"data-test": "hook", "for": "evil"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root label missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `for="n"`) {
+		t.Errorf("owned for= must win over ExtraAttrs:\n%s", root)
+	}
+	if !strings.Contains(string(h), `type="checkbox"`) {
+		t.Errorf("input type lost:\n%s", h)
+	}
+}
+
+func TestRadioGroupExtraAttrsOnRoot(t *testing.T) {
+	h := RadioGroup(RadioGroupConfig{
+		Name:       "plan",
+		Legend:     "Plan",
+		Options:    []RadioGroupOption{{Value: "pro", Label: "Pro"}},
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("fieldset missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `role="radiogroup"`) {
+		t.Errorf("owned role lost:\n%s", root)
+	}
+}
+
+func TestCheckboxGroupExtraAttrsOnRoot(t *testing.T) {
+	h := CheckboxGroup(CheckboxGroupConfig{
+		Name:       "feats",
+		Legend:     "Features",
+		Options:    []CheckboxGroupOption{{Value: "a", Label: "A"}},
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("fieldset missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `role="group"`) {
+		t.Errorf("owned role lost:\n%s", root)
+	}
+}

--- a/framework/ui/toggleaction.go
+++ b/framework/ui/toggleaction.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core-ui/style"
 	"github.com/DonaldMurillo/gofastr/core/render"
@@ -93,6 +94,13 @@ type ToggleActionConfig struct {
 
 	ID    string
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers) to the button's root <button> element. Keys
+	// the component owns are dropped: class and id (use Class / ID),
+	// data-fui-* (the toggle runtime wiring), type, data-state, and
+	// aria-pressed (mirrored from Committed by the runtime).
+	ExtraAttrs html.Attrs
 }
 
 // ToggleAction renders the button. The runtime listens for clicks via
@@ -129,14 +137,16 @@ func ToggleAction(cfg ToggleActionConfig) render.HTML {
 		cls += " " + cfg.Class
 	}
 
-	attrs := map[string]string{
-		"class":                    cls,
-		"type":                     "button",
-		"data-fui-toggle-endpoint": cfg.Endpoint,
-		"data-fui-toggle-method":   method,
-		"data-state":               state,
-		"aria-pressed":             pressed,
+	attrs := html.SafeExtraAttrs(cfg.ExtraAttrs, "type", "data-state", "aria-pressed")
+	if attrs == nil {
+		attrs = map[string]string{}
 	}
+	attrs["class"] = cls
+	attrs["type"] = "button"
+	attrs["data-fui-toggle-endpoint"] = cfg.Endpoint
+	attrs["data-fui-toggle-method"] = method
+	attrs["data-state"] = state
+	attrs["aria-pressed"] = pressed
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}

--- a/framework/ui/toggleaction_test.go
+++ b/framework/ui/toggleaction_test.go
@@ -160,3 +160,21 @@ func TestToggleActionPanics(t *testing.T) {
 		})
 	}
 }
+
+func TestToggleActionExtraAttrsOnRoot(t *testing.T) {
+	h := ToggleAction(ToggleActionConfig{
+		Endpoint:       "/api/follow",
+		IdleLabel:      "Follow",
+		CommittedLabel: "Following",
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "type": "submit", "data-state": "spoofed",
+		},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("button missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `type="button"`) || !strings.Contains(root, `data-state="idle"`) {
+		t.Errorf("owned type/data-state must win:\n%s", root)
+	}
+}

--- a/framework/ui/tooltip.go
+++ b/framework/ui/tooltip.go
@@ -41,6 +41,12 @@ type TooltipConfig struct {
 	ID string
 
 	Class string
+
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the tooltip's root
+	// wrapper <span>. Keys the component owns are dropped: class
+	// and id (use Class / ID), data-fui-*.
+	ExtraAttrs html.Attrs
 }
 
 // Tooltip wraps the given trigger HTML and appends a hidden tooltip
@@ -80,6 +86,7 @@ func Tooltip(cfg TooltipConfig, trigger render.HTML) render.HTML {
 	}, render.Text(cfg.Text))
 
 	return tooltipStyle.WrapHTML(html.Span(html.TextConfig{
-		Class: cls,
+		Class:      cls,
+		ExtraAttrs: html.SafeExtraAttrs(cfg.ExtraAttrs),
 	}, triggerWithDescribedBy, pop))
 }

--- a/framework/ui/tooltip_test.go
+++ b/framework/ui/tooltip_test.go
@@ -45,3 +45,14 @@ func TestTooltipCustomIDOverridesSlug(t *testing.T) {
 	mustContain(t, h, `aria-describedby="my-id"`)
 	mustContain(t, h, `id="my-id"`)
 }
+
+func TestTooltipExtraAttrsOnRoot(t *testing.T) {
+	h := Tooltip(TooltipConfig{
+		Text:       "tip",
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	}, render.Text("trigger"))
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("wrapper span missing data-test:\n%s", root)
+	}
+}

--- a/framework/ui/validationsummary_test.go
+++ b/framework/ui/validationsummary_test.go
@@ -125,3 +125,14 @@ func TestCustomTitle(t *testing.T) {
 		t.Errorf("expected custom title, got: %s", got)
 	}
 }
+
+func TestValidationSummaryExtraAttrsOnRoot(t *testing.T) {
+	h := ValidationSummary(ValidationSummaryConfig{
+		Errors:     FieldErrors{"email": "required"},
+		ExtraAttrs: map[string]string{"data-test": "hook"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("validation summary root missing data-test:\n%s", root)
+	}
+}


### PR DESCRIPTION
Closes #251, and resolves #245 item 2.

Every exported `framework/ui` constructor that takes a Config and returns `render.HTML` or `component.Component` now carries `ExtraAttrs html.Attrs`, forwarded to the component's root element — the one carrying `data-fui-comp` — for `data-*` test hooks, analytics markers, and ARIA overrides. When the root shape varies by config (a linked Card renders `<a>`, not `<section>`), the attributes follow the emitted root; charts forward them to the shared zero-data placeholder too, so a host's test hook still resolves when a dashboard has no rows yet.

The ticket counted 58 missing components by file name. Enumerating by the invariant instead (an AST scan over the package) found **93** configs, including ones inside files the file-level count marked compliant (Grid, Center, PageHeader, TextField, StatusBadge, …). That scan is now a permanent gate: `framework/ui/extraattrs_contract_test.go` fails the suite on any component config without the field, with an exemption map that requires a written reason (currently empty).

Sanitization is centralized in `html.SafeExtraAttrs`: drops case-variants of `class`/`id` (use `Class`/`ID`), every `data-fui-*` key (reserved for runtime wiring), and per-component protected keys (`href` on linked roots, form-control `type`/`name`, config-derived ARIA). Case-variants matter because HTML attribute names are case-insensitive — a `Class` entry survives a lowercase-only overwrite as a distinct map key and folds back onto the protected attribute in the parser. String-built roots (chart SVGs, sidebar, menu) serialize extras with sorted keys so SSR output stays deterministic.

One behavior change, changelogged under Changed: `ToggleConfig.ExtraAttrs` (Checkbox/Radio/Switch) moves from a raw copy onto the `<input>` to the sanitized contract on the root `<label>`. The raw copy was documented for `data-fui-*` RPC wiring but had zero callers.

Deliberately out of scope: 23 pre-existing forwarding sites (Banner, Carousel, Select, PasswordInput, …) still forward raw, several load-bearing (`FormConfig` documents raw `data-fui-rpc-*` pass-through; `link.go` has its own scrub). Unifying those needs a per-site decision about which override behavior is intentional — follow-up issue to come.

Testing: every component gained a root-tag assertion (`data-test="hook"` sliced from the root element, not the whole string); Card and the empty-placeholder additionally assert owned-key override attempts fail; the Card guard was mutation-proven (forwarding removed → test red → restored). `go test ./framework/ui/ ./core-ui/html/`, `go vet`, `gofmt`, and `go build ./...` are green locally; the full deterministic sweep runs here in CI (local pre-commit sweep was skipped with the documented `GOFASTR_SKIP_COMMIT_TESTS` escape — this machine killed two >10-minute local runs today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9
