### PR TITLE
feat(router): per-route and per-group request-timeout overrides (#246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Added
 
+- **Per-route request timeouts** (#246): `Router.SetRouteTimeout(method,
+  pattern, d)` overrides `AppConfig.RequestTimeout` for one route, and
+  `group.SetTimeout(d)` for every route under a group — route beats
+  group, nearest group wins, `router.NoTimeout` exempts entirely. The
+  resolution is stamped on the request before the middleware chain runs,
+  so apps that never configure an override pay nothing. When the
+  deadline fires, the 504 now logs a structured `request timeout` line
+  naming the method, path, matched route pattern, and budget.
+
 - **`ExtraAttrs` on every `framework/ui` component Config** (#251): the
   94 component configs that lacked the field (Lightbox included) now
   forward extra attributes (`data-*` test hooks, analytics markers,

--- a/core/middleware/timeout.go
+++ b/core/middleware/timeout.go
@@ -212,6 +212,35 @@ func (c *timeoutCtx) cancel(err error) {
 	close(c.done)
 }
 
+// RouteTimeout is the per-route request-timeout resolution stamped onto
+// the request context by the router before the middleware chain runs.
+// Budget > 0 replaces the app-wide duration for this request; a negative
+// Budget (router.NoTimeout) exempts the request from the deadline
+// entirely. Method and Pattern identify the matched route (the
+// registered pattern, not the request path) so the timeout log line
+// points at the route.
+type RouteTimeout struct {
+	Method  string
+	Pattern string
+	Budget  time.Duration
+}
+
+type routeTimeoutKey struct{}
+
+// WithRouteTimeout returns a context carrying the route's timeout
+// resolution. Called by core/router when a route or group override is
+// configured; the Timeout middleware consumes it.
+func WithRouteTimeout(ctx context.Context, rt RouteTimeout) context.Context {
+	return context.WithValue(ctx, routeTimeoutKey{}, rt)
+}
+
+// RouteTimeoutFromContext reports the route's timeout resolution, if the
+// router stamped one.
+func RouteTimeoutFromContext(ctx context.Context) (RouteTimeout, bool) {
+	rt, ok := ctx.Value(routeTimeoutKey{}).(RouteTimeout)
+	return rt, ok
+}
+
 // Timeout returns middleware that enforces a deadline on request processing.
 // If the downstream handler does not complete within the given duration,
 // a 504 Gateway Timeout response is returned.
@@ -233,9 +262,24 @@ func (c *timeoutCtx) cancel(err error) {
 // Handlers that never start streaming keep the hard guarantee: a hung
 // handler gets its 504 at the deadline, with the context completed as
 // DeadlineExceeded.
+//
+// Per-route budgets: when the router stamped a RouteTimeout on the
+// request context (a route or group override is configured), its Budget
+// replaces d for this request; a negative Budget skips the deadline
+// entirely. When the deadline fires on a buffered response, a structured
+// warning names the method, path, matched pattern, and budget.
 func Timeout(d time.Duration) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			effective := d
+			rt, hasRoute := RouteTimeoutFromContext(r.Context())
+			if hasRoute {
+				if rt.Budget < 0 {
+					next.ServeHTTP(w, r)
+					return
+				}
+				effective = rt.Budget
+			}
 			ctx := newTimeoutCtx(r.Context())
 			// End-of-request cleanup: release the propagation callback
 			// and anyone still selecting on ctx.Done(). A context that
@@ -250,7 +294,7 @@ func Timeout(d time.Duration) Middleware {
 				ctx.cancel(r.Context().Err())
 			})
 			defer stop()
-			timer := time.NewTimer(d)
+			timer := time.NewTimer(effective)
 			defer timer.Stop()
 
 			tw := newTimeoutWriter(w)
@@ -275,7 +319,9 @@ func Timeout(d time.Duration) Middleware {
 			// not": the deadline fired, or the client disconnected while
 			// the handler was still running. cause completes the
 			// handler's context when it hasn't completed already.
-			abandon := func(cause error) {
+			// Reports whether the 504 was actually written (false for a
+			// streaming response, where the deadline no longer applies).
+			abandon := func(cause error) bool {
 				if !tw.expire() {
 					// The response is already streaming (or hijacked): the
 					// handler owns the connection lifetime and the deadline
@@ -294,7 +340,7 @@ func Timeout(d time.Duration) Middleware {
 					if childPanic != nil {
 						panic(childPanic)
 					}
-					return
+					return false
 				}
 				ctx.cancel(cause)
 				http.Error(w, "Gateway Timeout", http.StatusGatewayTimeout)
@@ -314,6 +360,7 @@ func Timeout(d time.Duration) Middleware {
 						)
 					}
 				}()
+				return true
 			}
 
 			select {
@@ -330,7 +377,20 @@ func Timeout(d time.Duration) Middleware {
 				// written for parity, observed by no one.
 				abandon(r.Context().Err())
 			case <-timer.C:
-				abandon(context.DeadlineExceeded)
+				if abandon(context.DeadlineExceeded) {
+					// Name the route, not just the path: "why does this
+					// endpoint 504" starts from this line. Streaming
+					// responses don't get here; their deadline is shed.
+					attrs := []any{
+						"method", truncate(safeLogMethod(r.Method), maxRecoveryMethodLen),
+						"path", truncate(safeLogPath(r.URL.Path), maxRecoveryPathLen),
+						"timeout", effective,
+					}
+					if hasRoute && rt.Pattern != "" {
+						attrs = append(attrs, "pattern", rt.Pattern)
+					}
+					slog.Warn("request timeout", attrs...)
+				}
 			}
 		})
 	}

--- a/core/middleware/timeout.go
+++ b/core/middleware/timeout.go
@@ -214,8 +214,9 @@ func (c *timeoutCtx) cancel(err error) {
 
 // RouteTimeout is the per-route request-timeout resolution stamped onto
 // the request context by the router before the middleware chain runs.
-// Budget > 0 replaces the app-wide duration for this request; a negative
-// Budget (router.NoTimeout) exempts the request from the deadline
+// Budget > 0 replaces the app-wide duration for this request; Budget <= 0
+// (router.NoTimeout, or an explicit zero, matching net/http where a zero
+// duration means "no timeout") exempts the request from the deadline
 // entirely. Method and Pattern identify the matched route (the
 // registered pattern, not the request path) so the timeout log line
 // points at the route.
@@ -274,7 +275,7 @@ func Timeout(d time.Duration) Middleware {
 			effective := d
 			rt, hasRoute := RouteTimeoutFromContext(r.Context())
 			if hasRoute {
-				if rt.Budget < 0 {
+				if rt.Budget <= 0 {
 					next.ServeHTTP(w, r)
 					return
 				}

--- a/core/middleware/timeout_route_test.go
+++ b/core/middleware/timeout_route_test.go
@@ -85,6 +85,64 @@ func TestTimeoutFireLogsMethodAndPattern(t *testing.T) {
 	}
 }
 
+func TestTimeoutStreamingPastDeadlineDoesNotLog(t *testing.T) {
+	// A flushed response sheds the deadline; the timer still fires but
+	// no 504 is written, so no "request timeout" line may appear.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	handler := Timeout(20 * time.Millisecond)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.(http.Flusher).Flush()
+		time.Sleep(80 * time.Millisecond)
+	}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, stampedRequest(20*time.Millisecond))
+	if strings.Contains(buf.String(), "request timeout") {
+		t.Errorf("streaming response must not log a timeout:\n%s", buf.String())
+	}
+}
+
+func TestTimeoutClientDisconnectDoesNotLog(t *testing.T) {
+	// A client that leaves mid-handler abandons the request through the
+	// same path as the deadline, but it is not a timeout and must not
+	// log as one.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	handler := Timeout(5 * time.Second)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	ctx, cancel := context.WithCancel(context.Background())
+	req := stampedRequest(5 * time.Second).WithContext(WithRouteTimeout(ctx, RouteTimeout{
+		Method: "GET", Pattern: "/reports/{id}", Budget: 5 * time.Second,
+	}))
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if strings.Contains(buf.String(), "request timeout") {
+		t.Errorf("client disconnect must not log a timeout:\n%s", buf.String())
+	}
+}
+
+func TestTimeoutZeroBudgetExempts(t *testing.T) {
+	handler := Timeout(30 * time.Millisecond)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(120 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, stampedRequest(0))
+	if rec.Code != http.StatusOK {
+		t.Errorf("zero budget means no timeout (net/http convention), got %d", rec.Code)
+	}
+}
+
 func TestRouteTimeoutFromContextRoundTrip(t *testing.T) {
 	rt := RouteTimeout{Method: "POST", Pattern: "/x", Budget: time.Minute}
 	got, ok := RouteTimeoutFromContext(WithRouteTimeout(context.Background(), rt))

--- a/core/middleware/timeout_route_test.go
+++ b/core/middleware/timeout_route_test.go
@@ -1,0 +1,97 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func stampedRequest(budget time.Duration) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/reports/big", nil)
+	return req.WithContext(WithRouteTimeout(req.Context(), RouteTimeout{
+		Method:  http.MethodGet,
+		Pattern: "/reports/{id}",
+		Budget:  budget,
+	}))
+}
+
+func TestTimeoutRouteOverrideLengthens(t *testing.T) {
+	handler := Timeout(30 * time.Millisecond)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(120 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, stampedRequest(2*time.Second))
+	if rec.Code != http.StatusOK {
+		t.Errorf("route budget above sleep must serve 200, got %d", rec.Code)
+	}
+}
+
+func TestTimeoutRouteOverrideShortens(t *testing.T) {
+	handler := Timeout(2 * time.Second)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(2 * time.Second):
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	start := time.Now()
+	handler.ServeHTTP(rec, stampedRequest(40*time.Millisecond))
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Errorf("route budget below sleep must 504, got %d", rec.Code)
+	}
+	if time.Since(start) > time.Second {
+		t.Errorf("504 should arrive at the route budget, not the default")
+	}
+}
+
+func TestTimeoutNoTimeoutBudgetExempts(t *testing.T) {
+	handler := Timeout(30 * time.Millisecond)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(120 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, stampedRequest(-1)) // router.NoTimeout stamps a negative budget
+	if rec.Code != http.StatusOK {
+		t.Errorf("negative budget must exempt the route, got %d", rec.Code)
+	}
+}
+
+func TestTimeoutFireLogsMethodAndPattern(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	handler := Timeout(20 * time.Millisecond)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, stampedRequest(20*time.Millisecond))
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("expected 504, got %d", rec.Code)
+	}
+	log := buf.String()
+	for _, want := range []string{"request timeout", "method=GET", "pattern=/reports/{id}", "path=/reports/big"} {
+		if !strings.Contains(log, want) {
+			t.Errorf("timeout log missing %q:\n%s", want, log)
+		}
+	}
+}
+
+func TestRouteTimeoutFromContextRoundTrip(t *testing.T) {
+	rt := RouteTimeout{Method: "POST", Pattern: "/x", Budget: time.Minute}
+	got, ok := RouteTimeoutFromContext(WithRouteTimeout(context.Background(), rt))
+	if !ok || got != rt {
+		t.Errorf("round trip failed: got %+v ok=%v", got, ok)
+	}
+	if _, ok := RouteTimeoutFromContext(context.Background()); ok {
+		t.Error("bare context must report no route timeout")
+	}
+}

--- a/core/router/route_timeout_test.go
+++ b/core/router/route_timeout_test.go
@@ -1,0 +1,106 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DonaldMurillo/gofastr/core/middleware"
+)
+
+func stampFor(t *testing.T, r *Router, method, path string) (middleware.RouteTimeout, bool) {
+	t.Helper()
+	var got middleware.RouteTimeout
+	var ok bool
+	r.Handle(method, path, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		got, ok = middleware.RouteTimeoutFromContext(req.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(method, r.Prefix()+path, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("route did not serve: %d", rec.Code)
+	}
+	return got, ok
+}
+
+func TestNoOverridesLeavesRequestUnstamped(t *testing.T) {
+	r := New()
+	if _, ok := stampFor(t, r, "GET", "/plain"); ok {
+		t.Error("no overrides configured, request must carry no stamp")
+	}
+}
+
+func TestSetRouteTimeoutStampsBudgetAndPattern(t *testing.T) {
+	r := New()
+	r.SetRouteTimeout("GET", "/reports/{id}", 90*time.Second)
+	got, ok := stampFor(t, r, "GET", "/reports/{id}")
+	if !ok {
+		t.Fatal("route override configured, stamp missing")
+	}
+	if got.Budget != 90*time.Second || got.Pattern != "/reports/{id}" || got.Method != "GET" {
+		t.Errorf("wrong stamp: %+v", got)
+	}
+}
+
+func TestGroupTimeoutAppliesToGroupRoutes(t *testing.T) {
+	r := New()
+	g := r.Group("/admin")
+	g.SetTimeout(5 * time.Minute)
+	got, ok := stampFor(t, g, "GET", "/exports")
+	if !ok || got.Budget != 5*time.Minute {
+		t.Errorf("group timeout not resolved: %+v ok=%v", got, ok)
+	}
+	// A sibling route outside the group stays unstamped.
+	if _, ok := stampFor(t, r, "GET", "/outside"); ok {
+		t.Error("route outside the group must carry no stamp")
+	}
+}
+
+func TestRouteOverrideBeatsGroupNearestWins(t *testing.T) {
+	r := New()
+	outer := r.Group("/api")
+	outer.SetTimeout(time.Minute)
+	inner := outer.Group("/slow")
+	inner.SetTimeout(10 * time.Minute)
+	if got, _ := stampFor(t, inner, "GET", "/nested"); got.Budget != 10*time.Minute {
+		t.Errorf("nearest group must win, got %v", got.Budget)
+	}
+	if got, _ := stampFor(t, outer, "GET", "/direct"); got.Budget != time.Minute {
+		t.Errorf("outer group budget expected, got %v", got.Budget)
+	}
+	inner.SetRouteTimeout("GET", "/pinned", time.Second)
+	if got, _ := stampFor(t, inner, "GET", "/pinned"); got.Budget != time.Second {
+		t.Errorf("route override must beat groups, got %v", got.Budget)
+	}
+}
+
+func TestRouteTimeoutThroughRealChain(t *testing.T) {
+	// End to end: the app-wide Timeout middleware honors the router's
+	// stamp. Default 30ms would kill the 120ms handler; the route
+	// budget keeps it alive.
+	r := New()
+	r.Use(middleware.Timeout(30 * time.Millisecond))
+	r.SetRouteTimeout("GET", "/slow", time.Second)
+	r.Handle("GET", "/slow", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		time.Sleep(120 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	r.Handle("GET", "/fast-default", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		select {
+		case <-req.Context().Done():
+		case <-time.After(time.Second):
+		}
+	}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/slow", nil))
+	if rec.Code != http.StatusOK {
+		t.Errorf("route budget must outlast default: got %d", rec.Code)
+	}
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/fast-default", nil))
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Errorf("un-overridden route keeps the default budget: got %d", rec.Code)
+	}
+}

--- a/core/router/router.go
+++ b/core/router/router.go
@@ -461,8 +461,10 @@ func (c *cachedRoute) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func (r *Router) Prefix() string { return r.prefix }
 
 // NoTimeout, passed to SetTimeout or SetRouteTimeout, exempts the
-// route(s) from the request timeout entirely. Prefer a finite budget;
-// streaming handlers already shed the deadline on first Flush.
+// route(s) from the request timeout entirely. A zero duration means the
+// same thing (net/http convention: zero disables the deadline; see
+// HTTPServerTimeoutsConfig). Prefer a finite budget; streaming handlers
+// already shed the deadline on first Flush.
 const NoTimeout time.Duration = -1
 
 // SetTimeout sets the request-timeout budget for every route registered
@@ -481,9 +483,11 @@ func (r *Router) SetTimeout(d time.Duration) {
 
 // SetRouteTimeout sets the request-timeout budget for one route. The
 // pattern is relative to this router, exactly as passed to Handle; the
-// override is keyed by the registered "METHOD /full/pattern". Pass
-// NoTimeout to exempt the route. See SetTimeout for how the value is
-// consumed.
+// override is keyed by the registered "METHOD /full/pattern" and must
+// byte-match it — a key that matches no registered route (typo'd
+// wildcard name, wrong method, wrong router) is silently inert and the
+// route keeps the app-wide default. Pass NoTimeout (or zero) to exempt
+// the route. See SetTimeout for how the value is consumed.
 func (r *Router) SetRouteTimeout(method, pattern string, d time.Duration) {
 	key := method + " " + r.prefix + pattern
 	root := r.root

--- a/core/router/router.go
+++ b/core/router/router.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/DonaldMurillo/gofastr/core/middleware"
 )
@@ -37,6 +38,16 @@ type Router struct {
 	mu          sync.RWMutex
 	middlewares []Middleware
 	patterns    []RegisteredRoute // populated by Handle for introspection
+
+	// timeout is this router's request-timeout override for every route
+	// registered under it (SetTimeout). nil = inherit. Guarded by mu.
+	// routeTimeouts (ROOT only) holds exact-route overrides keyed
+	// "METHOD /full/pattern" (SetRouteTimeout). timeoutOverrides (ROOT
+	// only) flips once any override exists so the per-request resolution
+	// costs nothing until the feature is used.
+	timeout          *time.Duration
+	routeTimeouts    map[string]time.Duration
+	timeoutOverrides atomic.Bool
 
 	// notFound / methodNotAllowed are read on the request path by
 	// effectiveNotFound / effectiveMethodNotAllowed and written by the
@@ -413,6 +424,18 @@ func (c *cachedRoute) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if served != nil {
 		served(c.method, c.pattern)
 	}
+	// Per-route timeout: stamp the resolution BEFORE the chain runs so
+	// middleware.Timeout picks it up. Behind the root's atomic flag, an
+	// app that never configures an override pays nothing here.
+	if c.router.root.timeoutOverrides.Load() {
+		if d, ok := c.router.effectiveRouteTimeout(c.method, c.pattern); ok {
+			req = req.WithContext(middleware.WithRouteTimeout(req.Context(), middleware.RouteTimeout{
+				Method:  c.method,
+				Pattern: c.pattern,
+				Budget:  d,
+			}))
+		}
+	}
 	curVer := c.router.root.chainVersion.Load()
 	if h := c.cached.Load(); h != nil && c.cachedV.Load() == curVer {
 		(*h).ServeHTTP(w, req)
@@ -436,6 +459,66 @@ func (c *cachedRoute) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // routes by URL (the entity MCP tools re-dispatch through the router) must
 // use this, not the innermost segment.
 func (r *Router) Prefix() string { return r.prefix }
+
+// NoTimeout, passed to SetTimeout or SetRouteTimeout, exempts the
+// route(s) from the request timeout entirely. Prefer a finite budget;
+// streaming handlers already shed the deadline on first Flush.
+const NoTimeout time.Duration = -1
+
+// SetTimeout sets the request-timeout budget for every route registered
+// under this router (typically a Group). Routes resolve the nearest
+// enclosing router with a timeout set; an exact SetRouteTimeout override
+// wins over any group. Pass NoTimeout to exempt the group. The value is
+// consumed by the default middleware's timeout
+// (middleware.Timeout); with DisableRequestTimeout or without that
+// middleware, it has no effect.
+func (r *Router) SetTimeout(d time.Duration) {
+	r.mu.Lock()
+	r.timeout = &d
+	r.mu.Unlock()
+	r.root.timeoutOverrides.Store(true)
+}
+
+// SetRouteTimeout sets the request-timeout budget for one route. The
+// pattern is relative to this router, exactly as passed to Handle; the
+// override is keyed by the registered "METHOD /full/pattern". Pass
+// NoTimeout to exempt the route. See SetTimeout for how the value is
+// consumed.
+func (r *Router) SetRouteTimeout(method, pattern string, d time.Duration) {
+	key := method + " " + r.prefix + pattern
+	root := r.root
+	root.mu.Lock()
+	if root.routeTimeouts == nil {
+		root.routeTimeouts = make(map[string]time.Duration)
+	}
+	root.routeTimeouts[key] = d
+	root.mu.Unlock()
+	root.timeoutOverrides.Store(true)
+}
+
+// effectiveRouteTimeout resolves the timeout override for a matched
+// route: exact route override first, then the nearest enclosing router
+// with SetTimeout, walking from the registering router to the root.
+// ok=false means no override is configured and the app-wide default
+// applies.
+func (r *Router) effectiveRouteTimeout(method, pattern string) (time.Duration, bool) {
+	root := r.root
+	root.mu.RLock()
+	d, ok := root.routeTimeouts[method+" "+pattern]
+	root.mu.RUnlock()
+	if ok {
+		return d, true
+	}
+	for cur := r; cur != nil; cur = cur.parent {
+		cur.mu.RLock()
+		t := cur.timeout
+		cur.mu.RUnlock()
+		if t != nil {
+			return *t, true
+		}
+	}
+	return 0, false
+}
 
 // Group creates a sub-router with the given path prefix and optional middleware.
 // The sub-router inherits its parent's middleware chain, resolved at

--- a/framework/docs/content/deploy.md
+++ b/framework/docs/content/deploy.md
@@ -214,6 +214,34 @@ Prefer the smallest raise that covers your slowest real request over disabling
 the deadline entirely. `WriteTimeout` is a whole-response backstop: without
 it, a handler that hangs holds its connection (and a goroutine) forever.
 
+The per-request middleware deadline (`AppConfig.RequestTimeout`, default
+30s) can be overridden per route or per group instead of app-wide:
+
+<!-- gofastr:compile
+stmt: _ = app
+import "github.com/DonaldMurillo/gofastr/framework"
+import "github.com/DonaldMurillo/gofastr/core/router"
+import "time"
+-->
+```go
+app := framework.NewApp()
+// One slow dashboard keeps its own budget; every other route stays at 30s.
+app.Router().SetRouteTimeout("GET", "/reports/{id}", 2*time.Minute)
+// Or budget a whole group; the nearest enclosing group wins, and an
+// exact SetRouteTimeout beats any group.
+admin := app.Router().Group("/admin")
+admin.SetTimeout(5 * time.Minute)
+// router.NoTimeout exempts a route from the middleware deadline entirely.
+app.Router().SetRouteTimeout("POST", "/exports", router.NoTimeout)
+```
+
+When the deadline fires, the 504 logs a structured `request timeout`
+line naming the method, path, matched pattern, and budget. Two caveats:
+the server-level `WriteTimeout` above still bounds the whole response,
+so a route budget beyond it needs `WithHTTPServerTimeouts` raised too;
+and `DisableRequestTimeout` removes the middleware entirely, taking the
+per-route budgets with it.
+
 ### SSE and streaming
 
 `WriteTimeout` bounds the whole response, and a Server-Sent Events stream is a

--- a/framework/docs/content/deploy.md
+++ b/framework/docs/content/deploy.md
@@ -236,7 +236,8 @@ app.Router().SetRouteTimeout("POST", "/exports", router.NoTimeout)
 ```
 
 When the deadline fires, the 504 logs a structured `request timeout`
-line naming the method, path, matched pattern, and budget. Two caveats:
+line naming the method, path, budget, and — when a route or group
+override is configured — the matched pattern. Two caveats:
 the server-level `WriteTimeout` above still bounds the whole response,
 so a route budget beyond it needs `WithHTTPServerTimeouts` raised too;
 and `DisableRequestTimeout` removes the middleware entirely, taking the


### PR DESCRIPTION
Closes #246.

`AppConfig.RequestTimeout` stays the app-wide default (30s); routes and groups can now carry their own budget:

```go
app.Router().SetRouteTimeout("GET", "/reports/{id}", 2*time.Minute)
admin := app.Router().Group("/admin")
admin.SetTimeout(5 * time.Minute)
app.Router().SetRouteTimeout("POST", "/exports", router.NoTimeout)
```

Precedence: exact route → nearest enclosing group → app default; `router.NoTimeout` exempts entirely. `DisableRequestTimeout` still removes the middleware (budgets with it), and the server-level `WriteTimeout` remains the outer bound — both caveats documented in deploy.md's long-running-requests section.

Mechanics: `cachedRoute.ServeHTTP` already knows the matched method and registered pattern before the middleware chain runs, so it resolves the override there and stamps it on the request context; `middleware.Timeout` consumes the stamp. The resolution sits behind an atomic flag — an app that never configures an override runs exactly today's path, and the cached-chain single-atomic-load fast path is untouched. No public signatures changed; `DefaultMiddleware`'s composition is unchanged, so nothing nests two timeout writers.

Second ask from the issue: when the deadline fires on a buffered response, the 504 now logs a structured `request timeout` line with method, path, matched pattern, and budget. Streaming responses still shed the deadline (unchanged #159 contract) and log nothing — the log fires only when the 504 was actually written.

Two corrections to the issue, posted there too: the quoted `shell template error: http: Handler timeout` string is stdlib `http.TimeoutHandler`'s error and appears nowhere in this framework (our middleware writes `Gateway Timeout`), and `Flush()` already sheds the deadline as a documented escape for streaming handlers.

Testing: middleware tests cover lengthen/shorten/exempt/log-content; router tests cover stamp resolution, group nearest-wins, route-beats-group, no-override-no-stamp, and an end-to-end through `Use(middleware.Timeout(...))` where the same chain serves one overridden and one default route. Both guards were mutation-proven (budget consumption and route-override lookup each knocked out → tests red → restored). Doc example passes the `gofastr:compile` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable request timeouts for individual routes and route groups.
  * Added support for exempting routes from request deadlines.
  * Route-specific settings take precedence over group settings.

* **Bug Fixes**
  * Timeout responses now include structured details such as method, path, route pattern, and timeout duration.

* **Documentation**
  * Documented timeout configuration, precedence rules, exemptions, logging, and server-level timeout considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->