### PR TITLE
feat(experimental): WebMCP bridge — expose server-declared tools to in-browser agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Added
 
+- **WebMCP bridge (experimental)** (#267): `framework/experimental/webmcp`
+  exposes server-declared tools to in-browser agents through the Chrome
+  WebMCP origin-trial API (the page's `modelContext`). Declare tools
+  (name, description, JSON Schema, same-origin endpoint) and `Mount`
+  serves a bridge script that registers them; each `execute()` proxies
+  to its endpoint with the visitor's session cookies and the app's
+  double-submit CSRF token, so an in-browser agent acts strictly as the
+  signed-in user. Separate from the server MCP surface by design
+  (session auth vs token auth). No-op on browsers without the API;
+  automation enables it with `--enable-blink-features=WebMCP`.
+  Reference: `framework/docs/content/webmcp.md`.
+
 - **`gofastr generate cli --from-openapi <file|url>`** (#240): generates
   the terminal client from an OpenAPI 3 document instead of the entity
   set, for apps with hand-written APIs. One subcommand per

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Start with:
 - [Contracts](framework/docs/content/contracts.md): the `gofastr verify` rule catalog and semantic coverage
 - [Deployment](framework/docs/content/deploy.md) and [horizontal scaling](framework/docs/content/scaling.md)
 - [Agent-ready](framework/docs/content/agent-ready.md): llms.txt, the agent card, and MCP discovery
+- [WebMCP bridge (experimental)](framework/docs/content/webmcp.md): expose server-declared tools to in-browser agents via the page's `modelContext`
 
 ## Project status
 

--- a/cmd/gofastr/examples_blueprint_test.go
+++ b/cmd/gofastr/examples_blueprint_test.go
@@ -547,6 +547,13 @@ func bootGeneratedApp(t *testing.T, name, bin, appDir string) (string, *syncBuff
 		// Scratch-scoped DB file: the scratch dir's cleanup removes it, so
 		// repeated runs never inherit a stale, already-seeded database.
 		"DATABASE_URL=file:"+filepath.Join(appDir, "boot-gate.db"),
+		// The scratch dir lives inside the repo module, so when the repo is
+		// checked out as a linked git worktree, framework/isolation activates
+		// by default and deterministically remaps the listen port — the app
+		// then serves on the remapped port while this probe polls the
+		// assigned one until the 90s deadline. The test assigns its own free
+		// port, so isolation buys it nothing: pin it off.
+		"GOFASTR_ISOLATION=off",
 	)
 	configureTestProcessGroup(cmd)
 	// syncBuffer: exerciseGeneratedApp reads this while the app is running,

--- a/examples/site/docs_catalog.go
+++ b/examples/site/docs_catalog.go
@@ -163,7 +163,7 @@ var docIntents = []docIntent{
 			{"agent-ready", "Agent-readiness", "Discovery surface scanners (isitagentready.com) look for: llms.txt, A2A card, MCP/OAuth well-knowns, markdown negotiation."},
 			{"contracts", "Contracts", "gofastr verify: one pipeline of rules with IDs, reasons, and fixes, plus semantic coverage and machine-readable diagnostics."},
 			{"kiln", "Kiln overview", "Experimental: the agent-driven build-mode binary."},
-			{"webmcp", "WebMCP bridge", "Experimental: expose server-declared tools to in-browser agents via navigator.modelContext."},
+			{"webmcp", "WebMCP bridge", "Experimental: expose server-declared tools to in-browser agents via the page's modelContext."},
 			{"semantic-search", "Semantic search", "Local semantic search via brute-force cosine. No API key."},
 			{"audit-deps", "Audit deps", "Detect packages an agent shouldn't import."},
 			{"blueprints", "Blueprints", "Reusable bundles of entities + screens an agent can apply."},

--- a/examples/site/docs_catalog.go
+++ b/examples/site/docs_catalog.go
@@ -163,6 +163,7 @@ var docIntents = []docIntent{
 			{"agent-ready", "Agent-readiness", "Discovery surface scanners (isitagentready.com) look for: llms.txt, A2A card, MCP/OAuth well-knowns, markdown negotiation."},
 			{"contracts", "Contracts", "gofastr verify: one pipeline of rules with IDs, reasons, and fixes, plus semantic coverage and machine-readable diagnostics."},
 			{"kiln", "Kiln overview", "Experimental: the agent-driven build-mode binary."},
+			{"webmcp", "WebMCP bridge", "Experimental: expose server-declared tools to in-browser agents via navigator.modelContext."},
 			{"semantic-search", "Semantic search", "Local semantic search via brute-force cosine. No API key."},
 			{"audit-deps", "Audit deps", "Detect packages an agent shouldn't import."},
 			{"blueprints", "Blueprints", "Reusable bundles of entities + screens an agent can apply."},

--- a/framework/ARCHITECTURE.md
+++ b/framework/ARCHITECTURE.md
@@ -294,6 +294,11 @@ framework/
 Out-of-contract (NOT part of the layering rules below):
   experimental/apiversions   API versioning (URL prefix, deprecation
                              headers, projections). Experimental surface.
+  experimental/webmcp        WebMCP bridge: registers server-declared
+                             tools on navigator.modelContext (Chrome
+                             origin-trial API) and proxies execute() to
+                             same-origin endpoints with the visitor's
+                             session. Experimental surface.
   testkit/, testdata/        Public test helpers + fixtures for host apps.
   factory/                   Rails-style fixture/factory helpers (tests).
   isolation/                 Per-worktree local runtime resource resolution.

--- a/framework/ARCHITECTURE.md
+++ b/framework/ARCHITECTURE.md
@@ -295,10 +295,11 @@ Out-of-contract (NOT part of the layering rules below):
   experimental/apiversions   API versioning (URL prefix, deprecation
                              headers, projections). Experimental surface.
   experimental/webmcp        WebMCP bridge: registers server-declared
-                             tools on navigator.modelContext (Chrome
-                             origin-trial API) and proxies execute() to
-                             same-origin endpoints with the visitor's
-                             session. Experimental surface.
+                             tools on the page's modelContext (the
+                             Chrome origin-trial API on Document, with
+                             the legacy Navigator binding) and proxies
+                             execute() to same-origin endpoints with
+                             the visitor's session. Experimental.
   testkit/, testdata/        Public test helpers + fixtures for host apps.
   factory/                   Rails-style fixture/factory helpers (tests).
   isolation/                 Per-worktree local runtime resource resolution.

--- a/framework/docs/content/README.md
+++ b/framework/docs/content/README.md
@@ -89,6 +89,10 @@ results, the harness contract) are exempt. The exemption list lives in
   under `gofastr dev`; env kill switches for prod.
 - [Runtime JS minification](runtime-minification.md): embedded
   `runtime.js` minifier, env gating, prod-wins defaults.
+- [WebMCP bridge (experimental)](webmcp.md): expose server-declared
+  tools to in-browser agents via the page's `modelContext` (the Chrome
+  origin-trial WebMCP API); execute() proxies to same-origin endpoints
+  with the visitor's session.
 
 ## Building UI
 

--- a/framework/docs/content/webmcp.md
+++ b/framework/docs/content/webmcp.md
@@ -1,0 +1,177 @@
+# WebMCP bridge (experimental)
+
+`framework/experimental/webmcp` exposes server-declared tools to
+in-browser AI agents through the [WebMCP proposal](https://developer.chrome.com/docs/ai/webmcp)
+(`navigator.modelContext`). The server declares each tool's name,
+description, JSON Schema, and the same-origin endpoint that implements
+it; a mounted bridge script registers the set on `navigator.modelContext`
+and proxies each `execute()` call back to that endpoint with the
+visitor's own session credentials.
+
+This is the browser-side twin of the server MCP surface (`WithMCP*`):
+the server surface serves agents that connect to the app over HTTP with
+a token; the WebMCP bridge serves agents that live in the visitor's
+browser (Gemini in Chrome, the Model Context Tool Inspector extension,
+CDP-driven automation) and act as the signed-in user.
+
+Everything here is experimental twice over: the package lives under
+`framework/experimental` (no stability contract), and WebMCP itself is a
+Chrome origin-trial API. Chromium 146+ exposes it behind
+`chrome://flags/#enable-webmcp-testing`; the origin trial runs from
+Chrome 149. Automation and tests enable it with
+`--enable-blink-features=WebMCP`. On any browser without the API the
+bridge script feature-detects and does nothing.
+
+## Declaring and mounting tools
+
+<!-- gofastr:compile
+import "log"
+import "encoding/json"
+import "github.com/DonaldMurillo/gofastr/framework"
+import "github.com/DonaldMurillo/gofastr/framework/uihost"
+var app *framework.App
+var uiHost *uihost.UIHost
+-->
+```go
+import (
+    "github.com/DonaldMurillo/gofastr/framework/experimental/webmcp"
+)
+
+// app is the *framework.App, uiHost the mounted *uihost.UIHost.
+h := webmcp.New()
+if err := h.Register(webmcp.Tool{
+    Name:        "create_note",
+    Description: "Create a note for the signed-in user.",
+    InputSchema: json.RawMessage(`{"type":"object","properties":{"body":{"type":"string"}},"required":["body"]}`),
+    Method:      "POST",
+    Path:        "/api/notes",
+}); err != nil {
+    log.Fatal(err) // misdeclared tool: fix it, don't swallow it
+}
+
+// Register every tool before Mount; the set freezes here. Mount serves
+// the bridge + manifest and puts the script on every full-page render.
+if _, err := h.Mount(app.Router(), uiHost); err != nil {
+    log.Fatal(err)
+}
+```
+
+`Mount` freezes the tool set, serves the bridge at
+`/__gofastr/webmcp.js` (hash-versioned, immutable caching) and the
+manifest at `/__gofastr/webmcp/tools.json` (for tests, introspection,
+and server-side agents), and registers the script URL through the
+`ScriptRegistrar` seam. Pass `nil` for the registrar to inject the
+returned `scriptURL` into your own markup instead.
+
+## Tool fields
+
+| Field | Required | Meaning |
+|---|---|---|
+| `Name` | yes | Unique per page, constrained to the WebMCP spec grammar `[A-Za-z0-9_.-]{1,128}` (the browser rejects anything else asynchronously, which reads as a tool that never existed; `Register` fails loudly instead). The browser also refuses duplicate registrations, so it must not collide with tools the app registers from its own JS. |
+| `Title` | no | Human-readable display name. |
+| `Description` | yes | What the tool does and when to use it. An agent cannot pick an undescribed tool, so `Register` refuses a blank one. |
+| `InputSchema` | no | JSON Schema object for the input. Defaults to `{"type":"object","properties":{}}`. |
+| `Method` | no | `GET`, `POST`, `PUT`, `PATCH`, or `DELETE`. Defaults to `POST`. |
+| `Path` | yes | Same-origin absolute path of the implementing endpoint. Query strings allowed; schemes, hosts, fragments, backslashes, control characters, and `.`/`..` segments are rejected. |
+
+`Register` returns an error naming the exact field for any violation,
+and refuses registration after `Mount` (the script and manifest are
+frozen so every render ships the same set). `Mount` refuses a zero-tool
+mount, a second mount, and a router that already holds the bridge
+routes (mount one Host per router). A failed `Mount` registers nothing
+and leaves the Host re-mountable.
+
+## The endpoint contract
+
+When an agent invokes a tool, the bridge issues a same-origin `fetch` to
+the declared endpoint:
+
+- **Credentials**: `same-origin`, so the visitor's session cookies ride
+  along like any first-party fetch.
+- **CSRF**: on unsafe methods (everything but `GET`) the bridge reads
+  `meta[name="csrf-token"]` at dispatch time and sends it as
+  `X-CSRF-Token`, the same double-submit convention the core runtime's
+  RPCs use, so endpoints behind `middleware.CSRF` work unchanged. A
+  page that renders no such meta tag sends no token; behind the CSRF
+  middleware those calls 403 and surface to the agent as `isError`.
+- **Marker header**: `X-Gofastr-WebMCP: 1` on every call. This is a
+  hint any page script can forge, so use it for annotation (audit-log
+  notes, differentiated rate limits), never for authorization.
+- **Input mapping**: `GET` folds the input object into the query
+  string: objects and arrays are JSON-encoded, other values are
+  stringified, `null`/`undefined` values are skipped, and an input key
+  overrides a baked-in query param of the same name on the declared
+  `Path`. Every other method sends the input as a JSON body with
+  `Content-Type: application/json`.
+- **Result**: the response body is returned to the agent verbatim as
+  one `text` content item. A non-2xx status sets the MCP `isError`
+  flag; a network failure produces an `isError` result rather than a
+  thrown exception, so the agent always gets a structured answer.
+
+## Security model
+
+A WebMCP tool call is exactly a `fetch` the page could already make:
+it re-enters the app through normal HTTP with the user's cookies, so
+auth, CSRF, owner scoping, tenant scoping, and rate limits all apply
+unchanged, and the agent can do nothing the signed-in user couldn't do
+from the devtools console.
+
+## Testing with a real browser
+
+The package's own e2e (`browser_test.go`) is the template: launch
+Chromium with the flag, load a page carrying the bridge, and drive
+`navigator.modelContext` directly.
+
+chromedp:
+
+```go
+opts := append(chromedp.DefaultExecAllocatorOptions[:],
+    chromedp.Flag("enable-blink-features", "WebMCP"),
+)
+```
+
+Playwright:
+
+```js
+const browser = await chromium.launch({
+  args: ['--enable-blink-features=WebMCP'],
+});
+```
+
+Empirical notes on the Chromium 151 API surface (this is what the
+bridge and tests are written against; it may change while the proposal
+is in trial):
+
+- The spec's IDL exposes `modelContext` on `Document`; Chromium
+  additionally exposes the same object on `Navigator` (the legacy
+  binding). The bridge probes `document.modelContext` first and falls
+  back to `navigator.modelContext`.
+- `registerTool(descriptor)` returns a promise resolving to
+  `undefined`; tool handles come from `getTools()`.
+- `executeTool(handle, input)` takes the handle from `getTools()` plus
+  the input as a **JSON string**, and resolves with the tool's return
+  value JSON-stringified.
+- Duplicate names reject with `InvalidStateError`.
+- The API only exists in secure contexts (`data:` URLs don't get it).
+
+Chromium also ships a `WebMCP` CDP domain (`WebMCP.enable`,
+`WebMCP.invokeTool`), so automation can invoke page tools without
+evaluating script; the bridge does not depend on it.
+
+## Common mistakes
+
+- **Declaring an endpoint more powerful than the page**, on the theory
+  that "only the agent will call it". Any page script can call the same
+  endpoint. Only declare endpoints you are comfortable exposing to the
+  signed-in user directly, because that is the actual trust boundary.
+- **Registering tools after `Mount`.** The script and manifest freeze
+  at `Mount` so every render ships the same set; late registrations
+  return an error. Declare everything first, mount once.
+- **Testing against a `data:` URL.** `modelContext` only exists in
+  secure contexts, so a `data:` page reports the API absent even with
+  the flag on. Use `http://localhost`, `file://`, or HTTPS.
+- **CSRF-protected tools on a page without the token meta tag.** The
+  bridge can only send what the page renders: if the shell does not
+  emit `meta[name="csrf-token"]`, every unsafe-method tool behind
+  `middleware.CSRF` 403s. Render the meta tag (the token is available
+  server-side via `middleware.TokenFromContext`).

--- a/framework/docs/content/webmcp.md
+++ b/framework/docs/content/webmcp.md
@@ -2,7 +2,8 @@
 
 `framework/experimental/webmcp` exposes server-declared tools to
 in-browser AI agents through the [WebMCP proposal](https://developer.chrome.com/docs/ai/webmcp)
-(`navigator.modelContext`). The server declares each tool's name,
+(`document.modelContext`; Chromium also exposes the legacy
+`navigator.modelContext` binding). The server declares each tool's name,
 description, JSON Schema, and the same-origin endpoint that implements
 it; a mounted bridge script registers the set on `navigator.modelContext`
 and proxies each `execute()` call back to that endpoint with the
@@ -73,6 +74,8 @@ returned `scriptURL` into your own markup instead.
 | `InputSchema` | no | JSON Schema object for the input. Defaults to `{"type":"object","properties":{}}`. |
 | `Method` | no | `GET`, `POST`, `PUT`, `PATCH`, or `DELETE`. Defaults to `POST`. |
 | `Path` | yes | Same-origin absolute path of the implementing endpoint. Query strings allowed; schemes, hosts, fragments, backslashes, control characters, and `.`/`..` segments are rejected. |
+| `ReadOnlyHint` | no | Advertises the tool as non-mutating (`annotations.readOnlyHint`). Advisory only — never a substitute for endpoint authorization. |
+| `UntrustedContentHint` | no | Warns the agent the result may carry content the app does not control (`annotations.untrustedContentHint`). Advisory only — never a substitute for output sanitization. |
 
 `Register` returns an error naming the exact field for any violation,
 and refuses registration after `Mount` (the script and manifest are

--- a/framework/experimental/webmcp/bridge.js
+++ b/framework/experimental/webmcp/bridge.js
@@ -66,12 +66,19 @@
     var warn = function (err) {
       console.warn('gofastr webmcp: registerTool(' + t.name + ') failed: ' + err);
     };
+    var ann;
+    if (t.readOnlyHint || t.untrustedContentHint) {
+      ann = {};
+      if (t.readOnlyHint) ann.readOnlyHint = true;
+      if (t.untrustedContentHint) ann.untrustedContentHint = true;
+    }
     try {
       var p = mc.registerTool({
         name: t.name,
         title: t.title || undefined,
         description: t.description,
         inputSchema: t.inputSchema,
+        annotations: ann,
         execute: function (input) { return dispatch(t, input); }
       });
       if (p && typeof p.catch === 'function') p.catch(warn);

--- a/framework/experimental/webmcp/bridge.js
+++ b/framework/experimental/webmcp/bridge.js
@@ -1,0 +1,82 @@
+// GoFastr WebMCP bridge (experimental).
+//
+// Registers the server-declared tool manifest on the page's ModelContext
+// (the WebMCP proposal, Chrome 146+ behind a flag / origin trial) and
+// proxies each tool's execute() to its same-origin endpoint with the
+// visitor's session credentials. No-op on browsers without the API.
+//
+// The spec's IDL hangs modelContext off Document; Chromium additionally
+// exposes the same object on Navigator (the legacy binding), so probe
+// Document first and fall back.
+(function () {
+  'use strict';
+  var mc = document.modelContext || navigator.modelContext;
+  if (!mc || typeof mc.registerTool !== 'function') return;
+  // The placeholder is a QUOTED JSON string; JSON.parse (unlike an
+  // object literal) keeps "__proto__" an ordinary own key and accepts
+  // duplicates, so no declarable schema can break or poison the bridge.
+  var tools = JSON.parse(__GOFASTR_WEBMCP_TOOLS__);
+
+  function dispatch(t, input) {
+    return Promise.resolve().then(function () {
+      var u = new URL(t.path, location.origin);
+      var opts = {
+        method: t.method,
+        credentials: 'same-origin',
+        headers: { 'Accept': 'application/json', 'X-Gofastr-WebMCP': '1' }
+      };
+      if (t.method === 'GET') {
+        // Merge input into the URL so an input key overrides a
+        // baked-in query param of the same name instead of being
+        // silently shadowed by it (servers read the first value).
+        if (input && typeof input === 'object') {
+          Object.keys(input).forEach(function (k) {
+            var v = input[k];
+            if (v === null || v === undefined) return;
+            u.searchParams.set(k, typeof v === 'object' ? JSON.stringify(v) : String(v));
+          });
+        }
+      } else {
+        // Unsafe methods carry the app's CSRF token the same way the
+        // core runtime's RPCs do (double-submit: header must match the
+        // cookie). Read at dispatch time; the meta tag may render
+        // after this script parses.
+        var meta = document.querySelector('meta[name="csrf-token"]');
+        if (meta && meta.content) opts.headers['X-CSRF-Token'] = meta.content;
+        opts.headers['Content-Type'] = 'application/json';
+        opts.body = JSON.stringify(input === undefined ? {} : input);
+      }
+      return fetch(u.pathname + u.search, opts).then(function (res) {
+        return res.text().then(function (text) {
+          return { content: [{ type: 'text', text: text }], isError: !res.ok };
+        });
+      });
+    }).catch(function (err) {
+      // Terminal: covers fetch rejection AND body-read failure, so the
+      // agent always gets a structured isError result, never a throw.
+      return { content: [{ type: 'text', text: 'request failed: ' + err }], isError: true };
+    });
+  }
+
+  tools.forEach(function (t) {
+    // A failure here — sync throw or async rejection — means the tool
+    // is silently absent from getTools() (e.g. the app's own page JS
+    // already registered the name). Scream so the collision is
+    // debuggable, and keep registering the remaining tools either way.
+    var warn = function (err) {
+      console.warn('gofastr webmcp: registerTool(' + t.name + ') failed: ' + err);
+    };
+    try {
+      var p = mc.registerTool({
+        name: t.name,
+        title: t.title || undefined,
+        description: t.description,
+        inputSchema: t.inputSchema,
+        execute: function (input) { return dispatch(t, input); }
+      });
+      if (p && typeof p.catch === 'function') p.catch(warn);
+    } catch (err) {
+      warn(err);
+    }
+  });
+})();

--- a/framework/experimental/webmcp/browser_test.go
+++ b/framework/experimental/webmcp/browser_test.go
@@ -1,0 +1,369 @@
+package webmcp
+
+// Browser end-to-end proof for the WebMCP bridge: a real Chromium
+// launched with --enable-blink-features=WebMCP (the flag that exposes
+// navigator.modelContext without waiting for the origin trial), loading
+// a page whose only script tag is the mounted bridge, then registering
+// and executing tools through the actual browser API.
+//
+// Skips (loudly) in -short mode, when no Chromium-family browser is
+// installed, and when the installed browser predates WebMCP (needs
+// Chromium 146+).
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	cdpruntime "github.com/chromedp/cdproto/runtime"
+	"github.com/chromedp/chromedp"
+
+	"github.com/DonaldMurillo/gofastr/core/middleware"
+	"github.com/DonaldMurillo/gofastr/core/router"
+	"github.com/DonaldMurillo/gofastr/internal/browserpath"
+)
+
+// webmcpServer mounts a Host with four tools on a real router and
+// records what the endpoints observed.
+type webmcpServer struct {
+	srv *httptest.Server
+
+	mu           sync.Mutex
+	echoBody     string
+	echoHdr      http.Header
+	searchQ      string
+	searchSource string
+}
+
+func newWebmcpServer(t *testing.T) *webmcpServer {
+	t.Helper()
+	ws := &webmcpServer{}
+	rt := router.New()
+
+	rt.Post("/api/echo", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		ws.mu.Lock()
+		ws.echoBody = string(b)
+		ws.echoHdr = r.Header.Clone()
+		ws.mu.Unlock()
+		var in struct {
+			Msg string `json:"msg"`
+		}
+		_ = json.Unmarshal(b, &in)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"msg": strings.ToUpper(in.Msg)})
+	}))
+	rt.Get("/api/search", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws.mu.Lock()
+		ws.searchQ = r.URL.Query().Get("q")
+		ws.searchSource = r.URL.Query().Get("source")
+		ws.mu.Unlock()
+		fmt.Fprintf(w, `{"hits":["%s-1"]}`, r.URL.Query().Get("q"))
+	}))
+	rt.Post("/api/broken", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+
+	h := New()
+	for _, tl := range []Tool{
+		{
+			Name:        "echo_upper",
+			Description: "Uppercases msg.",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"msg":{"type":"string"}},"required":["msg"]}`),
+			Method:      http.MethodPost,
+			Path:        "/api/echo",
+		},
+		{
+			Name:        "search",
+			Description: "Searches by q.",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"q":{"type":"string"}},"required":["q"]}`),
+			Method:      http.MethodGet,
+			// The baked-in query param collides with an input key on
+			// purpose: the bridge must let the input override it.
+			Path: "/api/search?source=baked",
+		},
+		{
+			Name:        "broken",
+			Description: "Always fails server-side.",
+			Method:      http.MethodPost,
+			Path:        "/api/broken",
+		},
+		{
+			// Regression: a schema with an own "__proto__" key must not
+			// break the bridge (it embeds via JSON.parse, not an object
+			// literal, where "__proto__" is a prototype setter).
+			Name:        "proto_probe",
+			Description: "Schema stress: own __proto__ property.",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"__proto__":{"type":"string"}}}`),
+			Method:      http.MethodPost,
+			Path:        "/api/echo",
+		},
+	} {
+		if err := h.Register(tl); err != nil {
+			t.Fatalf("register %s: %v", tl.Name, err)
+		}
+	}
+	scriptURL, err := h.Mount(rt, nil)
+	if err != nil {
+		t.Fatalf("mount: %v", err)
+	}
+
+	rt.Get("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "session", Value: "user-42", Path: "/"})
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		// The CSRF middleware minted a token on this GET; expose it the
+		// way the app shell does, via the meta tag the bridge reads.
+		fmt.Fprintf(w, `<!doctype html><html><head><title>webmcp e2e</title>`+
+			`<meta name="csrf-token" content=%q>`+
+			`<script defer src=%q></script></head><body><h1>webmcp</h1></body></html>`,
+			middleware.TokenFromContext(r.Context()), scriptURL)
+	}))
+
+	// The real double-submit CSRF middleware wraps everything: the
+	// bridge's unsafe-method calls must carry X-CSRF-Token matching the
+	// cookie or the echo/broken tools 403.
+	handler := middleware.CSRF(middleware.CSRFConfig{
+		SecretKey: []byte("webmcp-e2e-test-key"),
+	})(rt)
+	ws.srv = httptest.NewServer(handler)
+	t.Cleanup(ws.srv.Close)
+	return ws
+}
+
+func webmcpBrowserCtx(t *testing.T) context.Context {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("browser E2E disabled in short mode")
+	}
+	execPath, ok := browserpath.Find()
+	if !ok {
+		t.Skip("browser E2E requires Chrome, Chromium, or Edge")
+	}
+	opts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.ExecPath(execPath),
+		chromedp.Flag("headless", true),
+		chromedp.Flag("disable-gpu", true),
+		chromedp.Flag("no-sandbox", true),
+		// The whole point: WebMCP is a flagged experimental web platform
+		// feature; this exposes navigator.modelContext on Chromium 146+.
+		chromedp.Flag("enable-blink-features", "WebMCP"),
+		chromedp.WSURLReadTimeout(90*time.Second),
+	)
+	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), opts...)
+	t.Cleanup(allocCancel)
+	ctx, cancel := chromedp.NewContext(allocCtx)
+	t.Cleanup(cancel)
+	ctx, tcancel := context.WithTimeout(ctx, 90*time.Second)
+	t.Cleanup(tcancel)
+	return ctx
+}
+
+// waitForTools polls getTools until the sorted name list matches want.
+// The bridge script is deferred and registration is async, so a fixed
+// wait would flake.
+func waitForTools(t *testing.T, ctx context.Context, want string) {
+	t.Helper()
+	var names string
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		if err := evalAwait(ctx,
+			`(document.modelContext || navigator.modelContext).getTools().then(ts => ts.map(t => t.name).sort().join(","))`,
+			&names); err != nil {
+			t.Fatalf("getTools: %v", err)
+		}
+		if names == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("tools never registered; getTools() = %q, want %q", names, want)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// evalAwait evaluates a promise-returning expression and decodes its
+// JSON-string resolution into out.
+func evalAwait(ctx context.Context, expr string, out *string) error {
+	return chromedp.Run(ctx, chromedp.Evaluate(expr, out,
+		func(p *cdpruntime.EvaluateParams) *cdpruntime.EvaluateParams {
+			return p.WithAwaitPromise(true)
+		}))
+}
+
+func TestBridgeRegistersAndExecutesTools(t *testing.T) {
+	ws := newWebmcpServer(t)
+	ctx := webmcpBrowserCtx(t)
+
+	if err := chromedp.Run(ctx, chromedp.Navigate(ws.srv.URL+"/")); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+
+	var has bool
+	if err := chromedp.Run(ctx, chromedp.Evaluate(
+		`("modelContext" in document) || ("modelContext" in navigator)`, &has)); err != nil {
+		t.Fatalf("feature probe: %v", err)
+	}
+	if !has {
+		t.Skip("modelContext absent even with --enable-blink-features=WebMCP; browser predates WebMCP (needs Chromium 146+)")
+	}
+
+	waitForTools(t, ctx, "broken,echo_upper,proto_probe,search")
+
+	// POST tool: input arrives as a JSON body, session cookie and the
+	// WebMCP marker header ride along, result text is the endpoint body.
+	var res string
+	if err := evalAwait(ctx, execToolExpr("echo_upper", `{msg:"hi"}`), &res); err != nil {
+		t.Fatalf("execute echo_upper: %v", err)
+	}
+	assertToolResult(t, res, false, `{"msg":"HI"}`)
+	ws.mu.Lock()
+	if ws.echoBody != `{"msg":"hi"}` {
+		t.Fatalf("server saw body %q", ws.echoBody)
+	}
+	if c := ws.echoHdr.Get("Cookie"); !strings.Contains(c, "session=user-42") {
+		t.Fatalf("session cookie missing; Cookie: %q", c)
+	}
+	if ws.echoHdr.Get("X-Gofastr-WebMCP") != "1" {
+		t.Fatal("X-Gofastr-WebMCP marker header missing")
+	}
+	// Reaching the handler at all proves the double-submit check
+	// passed; assert the header was the reason, not a middleware hole.
+	if ws.echoHdr.Get("X-CSRF-Token") == "" {
+		t.Fatal("bridge sent no X-CSRF-Token; the CSRF middleware should have 403'd")
+	}
+	ws.mu.Unlock()
+
+	// GET tool: input folds into the query string, and an input key
+	// overrides the path's baked-in param of the same name.
+	if err := evalAwait(ctx, execToolExpr("search", `{q:"gopher", source:"agent"}`), &res); err != nil {
+		t.Fatalf("execute search: %v", err)
+	}
+	assertToolResult(t, res, false, `{"hits":["gopher-1"]}`)
+	ws.mu.Lock()
+	if ws.searchQ != "gopher" {
+		t.Fatalf("server saw q=%q", ws.searchQ)
+	}
+	if ws.searchSource != "agent" {
+		t.Fatalf("input did not override the baked-in query param; server saw source=%q", ws.searchSource)
+	}
+	ws.mu.Unlock()
+
+	// A null input value is skipped, not stringified: the baked-in
+	// param survives instead of becoming the literal "null".
+	if err := evalAwait(ctx, execToolExpr("search", `{q:"nulltest", source:null}`), &res); err != nil {
+		t.Fatalf("execute search with null: %v", err)
+	}
+	assertToolResult(t, res, false, `{"hits":["nulltest-1"]}`)
+	ws.mu.Lock()
+	if ws.searchSource != "baked" {
+		t.Fatalf("null input value was not skipped; server saw source=%q", ws.searchSource)
+	}
+	ws.mu.Unlock()
+
+	// Non-2xx endpoint: the agent sees isError, not a throw.
+	if err := evalAwait(ctx, execToolExpr("broken", `{}`), &res); err != nil {
+		t.Fatalf("execute broken: %v", err)
+	}
+	assertToolResult(t, res, true, "boom")
+}
+
+// TestBridgeReadsCSRFMetaAtDispatchTime proves the CSRF token is read
+// when a tool executes, not when the bridge script parses: removing the
+// meta tag makes the next unsafe call 403 (isError), and restoring it
+// makes the call succeed again. A parse-time read would keep succeeding
+// after removal and a missing-meta page would never recover.
+func TestBridgeReadsCSRFMetaAtDispatchTime(t *testing.T) {
+	ws := newWebmcpServer(t)
+	ctx := webmcpBrowserCtx(t)
+
+	if err := chromedp.Run(ctx, chromedp.Navigate(ws.srv.URL+"/")); err != nil {
+		t.Fatalf("navigate: %v", err)
+	}
+	var has bool
+	if err := chromedp.Run(ctx, chromedp.Evaluate(
+		`("modelContext" in document) || ("modelContext" in navigator)`, &has)); err != nil {
+		t.Fatalf("feature probe: %v", err)
+	}
+	if !has {
+		t.Skip("modelContext absent even with --enable-blink-features=WebMCP; browser predates WebMCP (needs Chromium 146+)")
+	}
+	waitForTools(t, ctx, "broken,echo_upper,proto_probe,search")
+
+	// Stash the token, then remove the meta tag entirely.
+	var token string
+	if err := chromedp.Run(ctx, chromedp.Evaluate(`(() => {
+		const m = document.querySelector('meta[name="csrf-token"]');
+		const v = m.content;
+		m.remove();
+		return v;
+	})()`, &token)); err != nil {
+		t.Fatalf("remove meta: %v", err)
+	}
+	if token == "" {
+		t.Fatal("page rendered an empty CSRF token")
+	}
+
+	var res string
+	if err := evalAwait(ctx, execToolExpr("echo_upper", `{msg:"blocked"}`), &res); err != nil {
+		t.Fatalf("execute without meta: %v", err)
+	}
+	assertToolResult(t, res, true, "csrf")
+
+	// Restore the meta tag; the very next dispatch picks it up.
+	if err := chromedp.Run(ctx, chromedp.Evaluate(fmt.Sprintf(`(() => {
+		const m = document.createElement('meta');
+		m.name = 'csrf-token';
+		m.content = %q;
+		document.head.appendChild(m);
+		return true;
+	})()`, token), &has)); err != nil {
+		t.Fatalf("restore meta: %v", err)
+	}
+	if err := evalAwait(ctx, execToolExpr("echo_upper", `{msg:"ok"}`), &res); err != nil {
+		t.Fatalf("execute with restored meta: %v", err)
+	}
+	assertToolResult(t, res, false, `{"msg":"OK"}`)
+}
+
+// execToolExpr looks the named tool handle up via getTools and executes
+// it with the given input object literal. executeTool takes the
+// RegisteredTool handle plus the input as a JSON string, and resolves
+// with the execute() return value JSON-stringified (Chromium 151
+// behavior, established empirically).
+func execToolExpr(name, inputLiteral string) string {
+	return fmt.Sprintf(`(async () => {
+		const mc = document.modelContext || navigator.modelContext;
+		const tools = await mc.getTools();
+		const tool = tools.find(t => t.name === %q);
+		if (!tool) return JSON.stringify({missing: true});
+		return mc.executeTool(tool, JSON.stringify(%s));
+	})()`, name, inputLiteral)
+}
+
+func assertToolResult(t *testing.T, raw string, wantErr bool, wantText string) {
+	t.Helper()
+	var res struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		IsError bool `json:"isError"`
+	}
+	if err := json.Unmarshal([]byte(raw), &res); err != nil {
+		t.Fatalf("tool result not JSON: %v\nraw: %s", err, raw)
+	}
+	if res.IsError != wantErr {
+		t.Fatalf("isError = %v, want %v; raw: %s", res.IsError, wantErr, raw)
+	}
+	if len(res.Content) != 1 || res.Content[0].Type != "text" ||
+		!strings.Contains(res.Content[0].Text, wantText) {
+		t.Fatalf("content = %+v, want text containing %q", res.Content, wantText)
+	}
+}

--- a/framework/experimental/webmcp/browser_test.go
+++ b/framework/experimental/webmcp/browser_test.go
@@ -88,6 +88,10 @@ func newWebmcpServer(t *testing.T) *webmcpServer {
 			// The baked-in query param collides with an input key on
 			// purpose: the bridge must let the input override it.
 			Path: "/api/search?source=baked",
+			// Registration succeeding with annotations set proves the
+			// browser accepts the forwarded annotations object.
+			ReadOnlyHint:         true,
+			UntrustedContentHint: true,
 		},
 		{
 			Name:        "broken",

--- a/framework/experimental/webmcp/webmcp.go
+++ b/framework/experimental/webmcp/webmcp.go
@@ -1,0 +1,358 @@
+// Package webmcp exposes an app's server-declared tools to in-browser AI
+// agents through the WebMCP proposal (navigator.modelContext).
+//
+// EXPERIMENTAL. WebMCP itself is a Chrome origin-trial API (Chrome 146+
+// behind chrome://flags/#enable-webmcp-testing, origin trial from Chrome
+// 149; automation passes --enable-blink-features=WebMCP). The API surface
+// of this package tracks that proposal and may change or be removed
+// without a major version bump, like everything under
+// framework/experimental.
+//
+// The server declares tools (name, description, JSON Schema, and the
+// same-origin endpoint that implements them). Mount serves a small
+// bridge script that registers each tool on navigator.modelContext; the
+// tool's execute() proxies to the declared endpoint with the visitor's
+// own session credentials. An in-browser agent therefore acts strictly
+// as the signed-in user: every call re-enters the app through normal
+// HTTP with the user's cookies, so auth, CSRF, owner scoping, and rate
+// limits all apply unchanged. Only declare endpoints you would let the
+// signed-in user call from their own devtools console, because that is
+// exactly what a WebMCP tool call is.
+//
+// Usage:
+//
+//	h := webmcp.New()
+//	err := h.Register(webmcp.Tool{
+//	    Name:        "create_note",
+//	    Description: "Create a note for the signed-in user.",
+//	    InputSchema: json.RawMessage(`{"type":"object","properties":{"body":{"type":"string"}},"required":["body"]}`),
+//	    Method:      "POST",
+//	    Path:        "/api/notes",
+//	})
+//	// ...
+//	scriptURL, err := h.Mount(app.Router(), uiHost)
+//
+// On a browser without WebMCP the bridge script is a no-op: it feature-
+// detects navigator.modelContext and returns.
+package webmcp
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/DonaldMurillo/gofastr/core/router"
+	"github.com/DonaldMurillo/gofastr/framework/uihost"
+)
+
+const (
+	// ScriptRoute serves the bridge script with the tool manifest baked
+	// in. The URL registered on the page carries a content-hash query so
+	// it caches immutably and busts when the tool set changes.
+	ScriptRoute = "/__gofastr/webmcp.js"
+
+	// ManifestRoute serves the frozen tool manifest as JSON, for tests,
+	// introspection, and server-side agents that want to know what the
+	// page will register.
+	ManifestRoute = "/__gofastr/webmcp/tools.json"
+)
+
+// defaultInputSchema is used when a Tool declares no InputSchema: a tool
+// that takes an empty object.
+const defaultInputSchema = `{"type":"object","properties":{}}`
+
+//go:embed bridge.js
+var bridgeJS string
+
+// toolNameRe is the WebMCP spec's tool-name grammar (1–128 ASCII
+// alphanumerics, "_", "-", "."). The browser enforces the same rule in
+// registerTool and rejects violations asynchronously, which from the
+// agent's viewpoint is a tool that silently never existed; failing at
+// Register keeps the misdeclaration loud and server-side.
+var toolNameRe = regexp.MustCompile(`^[A-Za-z0-9_.-]{1,128}$`)
+
+// toolsPlaceholder is the token in bridge.js the frozen manifest replaces.
+const toolsPlaceholder = "__GOFASTR_WEBMCP_TOOLS__"
+
+// Tool declares one WebMCP tool: what the agent sees (Name, Title,
+// Description, InputSchema) and where execute() proxies to (Method,
+// Path). The endpoint is called same-origin with the visitor's session
+// credentials and a "X-Gofastr-WebMCP: 1" request header; its response
+// body is returned to the agent verbatim as text content, with the MCP
+// isError flag set on any non-2xx status.
+type Tool struct {
+	// Name uniquely identifies the tool on the page. Required, and
+	// constrained to the WebMCP spec's tool-name grammar: 1–128 ASCII
+	// alphanumerics, "_", "-", or "." (the browser rejects anything
+	// else at registerTool time, silently from the agent's viewpoint,
+	// so Register enforces it up front). Registration is per browsing
+	// context, so the name must also be unique against any tools the
+	// app registers through its own JS.
+	Name string `json:"name"`
+
+	// Title is an optional human-readable display name.
+	Title string `json:"title,omitempty"`
+
+	// Description tells the agent what the tool does and when to use
+	// it. Required: an undescribed tool is dead weight the agent cannot
+	// pick.
+	Description string `json:"description"`
+
+	// InputSchema is the JSON Schema for the tool's input, as a JSON
+	// object. Defaults to {"type":"object","properties":{}}.
+	InputSchema json.RawMessage `json:"inputSchema"`
+
+	// Method is the HTTP method execute() uses: GET, POST, PUT, PATCH,
+	// or DELETE. Defaults to POST. GET folds the input object into the
+	// query string; every other method sends it as a JSON body.
+	Method string `json:"method"`
+
+	// Path is the same-origin absolute path of the implementing
+	// endpoint ("/api/notes"). A query string is allowed; schemes,
+	// hosts, fragments, backslashes, control characters, and "."/".."
+	// segments are rejected.
+	Path string `json:"path"`
+}
+
+// ScriptRegistrar is the seam through which Mount puts the bridge script
+// on every full-page render. *uihost.UIHost satisfies it.
+type ScriptRegistrar interface {
+	RegisterExternalScript(src string) error
+}
+
+// Host collects tool declarations and, once mounted, serves the bridge
+// script and manifest. Zero value is not usable; call New.
+type Host struct {
+	mu      sync.Mutex
+	tools   []Tool
+	names   map[string]bool
+	mounted bool
+}
+
+// New returns an empty Host.
+func New() *Host {
+	return &Host{names: make(map[string]bool)}
+}
+
+// Register adds a tool declaration. It returns an error (naming the
+// exact field) for a missing name or description, a duplicate name, an
+// unsupported method, a path that is not a same-origin absolute path, or
+// an InputSchema that is not a JSON object. Registration after Mount is
+// refused: the script and manifest are frozen at Mount so every page
+// render ships the same tool set.
+func (h *Host) Register(t Tool) error {
+	if !toolNameRe.MatchString(t.Name) {
+		return fmt.Errorf("webmcp: Register: tool name %q must match the WebMCP grammar [A-Za-z0-9_.-]{1,128}; the browser rejects anything else and the tool would silently never appear in getTools()", t.Name)
+	}
+	if strings.TrimSpace(t.Description) == "" {
+		return fmt.Errorf("webmcp: Register(%q): Description is required; an agent cannot pick an undescribed tool", t.Name)
+	}
+	switch t.Method {
+	case "":
+		t.Method = http.MethodPost
+	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+	default:
+		return fmt.Errorf("webmcp: Register(%q): unsupported method %q (GET, POST, PUT, PATCH, DELETE)", t.Name, t.Method)
+	}
+	if !validToolPath(t.Path) {
+		return fmt.Errorf("webmcp: Register(%q): Path %q must be a same-origin absolute path (\"/api/x\", query allowed; no scheme, host, fragment, backslash, control chars, or \".\"/\"..\" segments)", t.Name, t.Path)
+	}
+	if len(t.InputSchema) == 0 {
+		t.InputSchema = json.RawMessage(defaultInputSchema)
+	} else {
+		// Clone: the caller owns the RawMessage's backing array, and a
+		// later mutation of it would bypass the validation below and
+		// corrupt the manifest frozen at Mount.
+		t.InputSchema = append(json.RawMessage(nil), t.InputSchema...)
+	}
+	if !json.Valid(t.InputSchema) || !strings.HasPrefix(strings.TrimSpace(string(t.InputSchema)), "{") {
+		return fmt.Errorf("webmcp: Register(%q): InputSchema must be a JSON object", t.Name)
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.mounted {
+		return fmt.Errorf("webmcp: Register(%q) refused: Mount already froze the tool set; register every tool before Mount", t.Name)
+	}
+	if h.names[t.Name] {
+		return fmt.Errorf("webmcp: Register: duplicate tool name %q (the browser refuses duplicate registrations)", t.Name)
+	}
+	h.names[t.Name] = true
+	h.tools = append(h.tools, t)
+	return nil
+}
+
+// Mount freezes the tool set, registers ScriptRoute and ManifestRoute on
+// rt, and (when scripts is non-nil) registers the hash-versioned script
+// URL so every full-page render includes the bridge. It returns that
+// script URL so hosts that render their own <script> tags can inject it
+// themselves (pass scripts == nil in that case).
+//
+// Mounting with zero tools is an error: the wiring would silently do
+// nothing. Mounting twice, or onto a router that already holds either
+// route, is an error. A failed Mount (route conflict, bad embedded
+// asset, script-rail refusal) registers nothing and leaves the Host
+// re-mountable after the cause is fixed. On a grouped router the
+// served routes and the returned script URL carry the group prefix.
+func (h *Host) Mount(rt *router.Router, scripts ScriptRegistrar) (string, error) {
+	h.mu.Lock()
+	if h.mounted {
+		h.mu.Unlock()
+		return "", fmt.Errorf("webmcp: Mount called twice")
+	}
+	if len(h.tools) == 0 {
+		h.mu.Unlock()
+		return "", fmt.Errorf("webmcp: Mount refused with zero registered tools: the bridge script would do nothing; call Register first")
+	}
+	// Latch now so a concurrent Register can't grow the set mid-mount,
+	// but un-latch on any failure below: everything fallible runs
+	// before the first route registration, so a failed Mount leaves no
+	// half-mounted state behind.
+	h.mounted = true
+	tools := h.tools
+	h.mu.Unlock()
+	fail := func(err error) (string, error) {
+		h.mu.Lock()
+		h.mounted = false
+		h.mu.Unlock()
+		return "", err
+	}
+
+	manifest, err := json.Marshal(struct {
+		Tools []Tool `json:"tools"`
+	}{Tools: tools})
+	if err != nil {
+		return fail(fmt.Errorf("webmcp: Mount: marshal manifest: %w", err))
+	}
+	toolsJSON, err := json.Marshal(tools)
+	if err != nil {
+		return fail(fmt.Errorf("webmcp: Mount: marshal tools: %w", err))
+	}
+	// The manifest is embedded as a QUOTED JSON string the bridge feeds
+	// to JSON.parse, never as a bare JS object literal: in a literal,
+	// "__proto__" is a prototype setter (an own key in the schema would
+	// vanish) and duplicate "__proto__" keys — which json.Valid accepts
+	// — are a SyntaxError that would kill the whole bridge. JSON.parse
+	// has neither behavior.
+	quotedTools, err := json.Marshal(string(toolsJSON))
+	if err != nil {
+		return fail(fmt.Errorf("webmcp: Mount: quote tools manifest: %w", err))
+	}
+	if !strings.Contains(bridgeJS, toolsPlaceholder) {
+		return fail(fmt.Errorf("webmcp: Mount: bridge.js is missing the %s placeholder; the embedded asset is corrupt", toolsPlaceholder))
+	}
+	script := []byte(strings.Replace(bridgeJS, toolsPlaceholder, string(quotedTools), 1))
+
+	// A grouped router prepends its prefix to every registration, so
+	// the served paths (and therefore the rail URL and the conflict
+	// pre-flight) must carry it too: without this, mounting on
+	// Group("/v1") would serve the bridge at /v1/... while registering
+	// the unprefixed URL on the script rail, a guaranteed 404.
+	scriptPath := rt.Prefix() + ScriptRoute
+	manifestPath := rt.Prefix() + ManifestRoute
+
+	// Pre-flight the route patterns: the router panics on conflicts, so
+	// a second Host on the same router (or an app squatting on the
+	// routes) must surface as a clean error BEFORE the script rail is
+	// touched, keeping "a failed Mount leaves nothing behind" true.
+	// Routes() reports full (prefix-joined) patterns.
+	for _, route := range rt.Routes() {
+		if route.Method == http.MethodGet &&
+			(route.Pattern == scriptPath || route.Pattern == manifestPath) {
+			return fail(fmt.Errorf("webmcp: Mount: %s is already registered on this router (a second webmcp Host on the same router? mount one Host per router)", route.Pattern))
+		}
+	}
+
+	scriptURL := uihost.ScriptURL(scriptPath, script)
+	if scripts != nil {
+		if err := scripts.RegisterExternalScript(scriptURL); err != nil {
+			return fail(fmt.Errorf("webmcp: Mount: register bridge script: %w", err))
+		}
+	}
+
+	rt.Get(ScriptRoute, uihost.ScriptHandler(script))
+	rt.Get(ManifestRoute, manifestHandler(manifest))
+	return scriptURL, nil
+}
+
+// manifestHandler serves the frozen manifest with a strong ETag.
+func manifestHandler(body []byte) http.Handler {
+	etag := fmt.Sprintf("%q", fmt.Sprintf("%x", len(body))+"-"+hashHex(body))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("Content-Type", "application/json; charset=utf-8")
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("Cache-Control", "no-cache")
+		h.Set("ETag", etag)
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		_, _ = w.Write(body)
+	})
+}
+
+// hashHex is a small FNV-1a content hash for the manifest ETag. The
+// script route's caching comes from uihost.ScriptHandler and is not
+// affected by this.
+func hashHex(b []byte) string {
+	const (
+		offset = 14695981039346656037
+		prime  = 1099511628211
+	)
+	var h uint64 = offset
+	for _, c := range b {
+		h ^= uint64(c)
+		h *= prime
+	}
+	return fmt.Sprintf("%016x", h)
+}
+
+// validToolPath mirrors the same-origin grammar uihost applies to
+// external script srcs: single leading "/", no scheme or host, no
+// backslash, no control bytes, no fragment, no "."/".." path segments,
+// with the segment/backslash/control checks applied to BOTH the raw
+// path and its percent-decoded form (browser URL normalization treats
+// "%2e%2e" as "..", so a raw-only check would declare one path and
+// fetch another); query strings allowed.
+func validToolPath(p string) bool {
+	if p == "" || !strings.HasPrefix(p, "/") || strings.HasPrefix(p, "//") {
+		return false
+	}
+	if strings.ContainsAny(p, "\\#") {
+		return false
+	}
+	for _, r := range p {
+		if r < 0x20 || r == 0x7f {
+			return false
+		}
+	}
+	pathOnly := p
+	if i := strings.IndexByte(p, '?'); i >= 0 {
+		pathOnly = p[:i]
+	}
+	decoded, err := url.PathUnescape(pathOnly)
+	if err != nil {
+		return false
+	}
+	if strings.ContainsRune(decoded, '\\') {
+		return false
+	}
+	for _, r := range decoded {
+		if r < 0x20 || r == 0x7f {
+			return false
+		}
+	}
+	for _, form := range []string{pathOnly, decoded} {
+		for _, seg := range strings.Split(form, "/") {
+			if seg == "." || seg == ".." {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/framework/experimental/webmcp/webmcp.go
+++ b/framework/experimental/webmcp/webmcp.go
@@ -117,6 +117,18 @@ type Tool struct {
 	// hosts, fragments, backslashes, control characters, and "."/".."
 	// segments are rejected.
 	Path string `json:"path"`
+
+	// ReadOnlyHint advertises the tool as non-mutating (forwarded to
+	// the browser as annotations.readOnlyHint). Advisory only: agents
+	// may prefer read-only tools when exploring, but the hint never
+	// replaces endpoint authorization.
+	ReadOnlyHint bool `json:"readOnlyHint,omitempty"`
+
+	// UntrustedContentHint tells the agent the tool's result can carry
+	// content the app does not control (user-generated text), forwarded
+	// as annotations.untrustedContentHint. Advisory only: it never
+	// replaces output sanitization.
+	UntrustedContentHint bool `json:"untrustedContentHint,omitempty"`
 }
 
 // ScriptRegistrar is the seam through which Mount puts the bridge script

--- a/framework/experimental/webmcp/webmcp_test.go
+++ b/framework/experimental/webmcp/webmcp_test.go
@@ -1,0 +1,418 @@
+package webmcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/router"
+)
+
+func validTool() Tool {
+	return Tool{
+		Name:        "echo",
+		Description: "Echoes its input.",
+		Method:      http.MethodPost,
+		Path:        "/api/echo",
+	}
+}
+
+func TestRegisterEnforcesToolNameGrammar(t *testing.T) {
+	h := New()
+	// The WebMCP spec grammar: 1–128 of [A-Za-z0-9_.-]. Outside it the
+	// browser rejects registerTool and the tool silently never appears.
+	for _, bad := range []string{
+		"", " echo", "create note", "café", "a/b", "a:b",
+		strings.Repeat("x", 129),
+	} {
+		tl := validTool()
+		tl.Name = bad
+		if err := h.Register(tl); err == nil {
+			t.Fatalf("name %q accepted", bad)
+		}
+	}
+	for i, good := range []string{"echo", "Create.Note_v2-x", strings.Repeat("x", 128)} {
+		tl := validTool()
+		tl.Name = good
+		tl.Path = fmt.Sprintf("/api/echo%d", i)
+		if err := h.Register(tl); err != nil {
+			t.Fatalf("name %q rejected: %v", good, err)
+		}
+	}
+}
+
+func TestRegisterRejectsEmptyDescription(t *testing.T) {
+	h := New()
+	tl := validTool()
+	tl.Description = "  "
+	if err := h.Register(tl); err == nil {
+		t.Fatal("blank description accepted")
+	}
+}
+
+func TestRegisterRejectsDuplicateName(t *testing.T) {
+	h := New()
+	if err := h.Register(validTool()); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+	err := h.Register(validTool())
+	if err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("duplicate name accepted: %v", err)
+	}
+}
+
+func TestRegisterRejectsBadMethod(t *testing.T) {
+	h := New()
+	tl := validTool()
+	tl.Method = "TRACE"
+	if err := h.Register(tl); err == nil {
+		t.Fatal("TRACE accepted")
+	}
+}
+
+func TestRegisterRejectsBadPaths(t *testing.T) {
+	h := New()
+	for _, p := range []string{
+		"", "api/echo", "//evil.example/x", "https://evil.example/x",
+		"/api/../admin", "/api/./echo", "/api\\echo", "/api/echo#frag",
+		"/api/\x00echo",
+		// percent-encoded forms: browser URL normalization decodes
+		// these, so the declared path and the fetched path would differ
+		"/api/%2e%2e/admin", "/api/%2E%2E/admin", "/api/echo%5Cadmin",
+		"/api/%00echo", "/api/%zzbad",
+	} {
+		tl := validTool()
+		tl.Path = p
+		if err := h.Register(tl); err == nil {
+			t.Fatalf("path %q accepted", p)
+		}
+	}
+	// query strings are fine
+	tl := validTool()
+	tl.Path = "/api/echo?mode=fast"
+	if err := h.Register(tl); err != nil {
+		t.Fatalf("query path rejected: %v", err)
+	}
+}
+
+func TestRegisterRejectsNonObjectSchema(t *testing.T) {
+	h := New()
+	for _, s := range []string{`"str"`, `[1]`, `{broken`} {
+		tl := validTool()
+		tl.InputSchema = json.RawMessage(s)
+		if err := h.Register(tl); err == nil {
+			t.Fatalf("schema %q accepted", s)
+		}
+	}
+}
+
+func TestMountRefusesZeroTools(t *testing.T) {
+	if _, err := New().Mount(router.New(), nil); err == nil {
+		t.Fatal("zero-tool mount accepted")
+	}
+}
+
+func TestMountRefusesDoubleMount(t *testing.T) {
+	h := New()
+	if err := h.Register(validTool()); err != nil {
+		t.Fatal(err)
+	}
+	rt := router.New()
+	if _, err := h.Mount(rt, nil); err != nil {
+		t.Fatalf("first mount: %v", err)
+	}
+	if _, err := h.Mount(rt, nil); err == nil {
+		t.Fatal("second mount accepted")
+	}
+}
+
+func TestRegisterAfterMountRefused(t *testing.T) {
+	h := New()
+	if err := h.Register(validTool()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.Mount(router.New(), nil); err != nil {
+		t.Fatal(err)
+	}
+	tl := validTool()
+	tl.Name = "late"
+	if err := h.Register(tl); err == nil {
+		t.Fatal("post-mount register accepted")
+	}
+}
+
+type recordingRegistrar struct{ srcs []string }
+
+func (r *recordingRegistrar) RegisterExternalScript(src string) error {
+	r.srcs = append(r.srcs, src)
+	return nil
+}
+
+type failingRegistrar struct{}
+
+func (failingRegistrar) RegisterExternalScript(string) error {
+	return fmt.Errorf("rail closed")
+}
+
+func TestMountFailureLeavesHostRemountable(t *testing.T) {
+	h := New()
+	if err := h.Register(validTool()); err != nil {
+		t.Fatal(err)
+	}
+	rt := router.New()
+	if _, err := h.Mount(rt, failingRegistrar{}); err == nil {
+		t.Fatal("mount with refusing registrar succeeded")
+	}
+	// Nothing half-mounted: the failed Mount registered no routes...
+	rec := httptest.NewRecorder()
+	rt.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, ScriptRoute, nil))
+	if rec.Code == http.StatusOK {
+		t.Fatal("failed Mount left the script route serving")
+	}
+	// ...the Host still accepts registrations...
+	late := validTool()
+	late.Name = "late"
+	late.Path = "/api/late"
+	if err := h.Register(late); err != nil {
+		t.Fatalf("register after failed mount: %v", err)
+	}
+	// ...and a retry mounts cleanly.
+	if _, err := h.Mount(rt, nil); err != nil {
+		t.Fatalf("re-mount after failure: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	rt.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, ScriptRoute, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("script route after re-mount: %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `\"name\":\"late\"`) {
+		t.Fatal("re-mounted script is missing the late-registered tool")
+	}
+}
+
+func TestMountOnGroupedRouterCarriesThePrefix(t *testing.T) {
+	h := New()
+	if err := h.Register(validTool()); err != nil {
+		t.Fatal(err)
+	}
+	root := router.New()
+	reg := &recordingRegistrar{}
+	url, err := h.Mount(root.Group("/v1"), reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The rail URL must point where the route actually serves: under
+	// the group prefix. An unprefixed URL is a guaranteed 404.
+	if !strings.HasPrefix(url, "/v1"+ScriptRoute+"?v=") {
+		t.Fatalf("script URL %q does not carry the group prefix", url)
+	}
+	rec := httptest.NewRecorder()
+	root.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1"+ScriptRoute, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("prefixed script route: %d", rec.Code)
+	}
+	rec = httptest.NewRecorder()
+	root.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1"+ManifestRoute, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("prefixed manifest route: %d", rec.Code)
+	}
+}
+
+func TestMountConflictDetectionSeesGroupPrefix(t *testing.T) {
+	h := New()
+	if err := h.Register(validTool()); err != nil {
+		t.Fatal(err)
+	}
+	root := router.New()
+	grp := root.Group("/v1")
+	grp.Get(ManifestRoute, http.NotFoundHandler())
+	reg := &recordingRegistrar{}
+	if _, err := h.Mount(grp, reg); err == nil {
+		t.Fatal("conflict on the prefixed manifest route escaped the pre-flight")
+	}
+	if len(reg.srcs) != 0 {
+		t.Fatalf("failed grouped Mount touched the script rail: %v", reg.srcs)
+	}
+}
+
+func TestRegisterClonesInputSchema(t *testing.T) {
+	h := New()
+	schema := json.RawMessage(`{"type":"object"}`)
+	tl := validTool()
+	tl.InputSchema = schema
+	if err := h.Register(tl); err != nil {
+		t.Fatal(err)
+	}
+	// The caller still owns its slice; corrupting it after Register
+	// must not reach the manifest frozen at Mount.
+	copy(schema, `X"type":"objec`)
+	rt := router.New()
+	if _, err := h.Mount(rt, nil); err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	rt.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, ManifestRoute, nil))
+	var m struct{ Tools []Tool }
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatalf("manifest corrupted by caller-side mutation: %v\n%s", err, rec.Body.String())
+	}
+	if string(m.Tools[0].InputSchema) != `{"type":"object"}` {
+		t.Fatalf("manifest schema aliased the caller's buffer: %s", m.Tools[0].InputSchema)
+	}
+}
+
+func TestMountRefusesConflictingRoutes(t *testing.T) {
+	h := New()
+	if err := h.Register(validTool()); err != nil {
+		t.Fatal(err)
+	}
+	rt := router.New()
+	rt.Get(ManifestRoute, http.NotFoundHandler())
+	reg := &recordingRegistrar{}
+	if _, err := h.Mount(rt, reg); err == nil {
+		t.Fatal("Mount onto a router already holding the manifest route succeeded; the router would have panicked mid-mount")
+	}
+	if len(reg.srcs) != 0 {
+		t.Fatalf("failed Mount touched the script rail: %v", reg.srcs)
+	}
+	if _, err := h.Mount(router.New(), nil); err != nil {
+		t.Fatalf("re-mount on a clean router: %v", err)
+	}
+}
+
+func TestScriptEscapesHostileToolFields(t *testing.T) {
+	h := New()
+	tl := validTool()
+	// Name is grammar-locked, so hostile content can only arrive via
+	// the free-text fields and schema strings. The served script must
+	// keep all of it inside the JS string literals: encoding/json
+	// escapes < > & (to \u003c etc.) and U+2028/U+2029, and this pins
+	// that property against a future serializer swap.
+	tl.Title = "</script><script>alert(1)</script>"
+	tl.Description = "line sep \u2028 quoted \" back\\slash \u2029 end"
+	tl.InputSchema = json.RawMessage("{\"type\":\"object\",\"description\":\"</script> end\"}")
+	if err := h.Register(tl); err != nil {
+		t.Fatal(err)
+	}
+	rt := router.New()
+	if _, err := h.Mount(rt, nil); err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	rt.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, ScriptRoute, nil))
+	body := rec.Body.String()
+	if strings.Contains(body, "</script>") {
+		t.Fatal("raw </script> reached the served script")
+	}
+	if strings.Contains(body, "\u2028") || strings.Contains(body, "\u2029") {
+		t.Fatal("raw U+2028/U+2029 reached the served script")
+	}
+	// The escaped forms prove the hostile content IS in the manifest,
+	// inert inside the quoted JSON.parse payload, not silently dropped.
+	// The manifest is double-encoded (JSON string inside a JSON string),
+	// so the inner \u escapes appear with doubled backslashes.
+	if !strings.Contains(body, `\\u003c/script\\u003e`) {
+		t.Fatal("escaped script-close sequence missing; manifest not embedded?")
+	}
+	if !strings.Contains(body, `\\u2028`) || !strings.Contains(body, `\\u2029`) {
+		t.Fatal("escaped U+2028/U+2029 missing; manifest not embedded?")
+	}
+}
+
+func TestMountServesScriptAndManifest(t *testing.T) {
+	h := New()
+	tl := validTool()
+	tl.Title = "Echo"
+	tl.InputSchema = json.RawMessage(`{"type":"object","properties":{"msg":{"type":"string"}}}`)
+	if err := h.Register(tl); err != nil {
+		t.Fatal(err)
+	}
+	rt := router.New()
+	reg := &recordingRegistrar{}
+	url, err := h.Mount(rt, reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reg.srcs) != 1 || reg.srcs[0] != url {
+		t.Fatalf("registrar got %v, Mount returned %q", reg.srcs, url)
+	}
+	if !strings.HasPrefix(url, ScriptRoute+"?v=") {
+		t.Fatalf("script URL %q is not hash-versioned", url)
+	}
+
+	// script: placeholder replaced with the tool set
+	rec := httptest.NewRecorder()
+	rt.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, ScriptRoute, nil))
+	body := rec.Body.String()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("script route: %d", rec.Code)
+	}
+	if strings.Contains(body, toolsPlaceholder) {
+		t.Fatal("script still contains the tools placeholder")
+	}
+	// The manifest embeds as a quoted JSON string fed to JSON.parse, so
+	// the tool fields appear with escaped quotes.
+	if !strings.Contains(body, "JSON.parse(") {
+		t.Fatal("script does not parse the manifest via JSON.parse")
+	}
+	if !strings.Contains(body, `\"name\":\"echo\"`) || !strings.Contains(body, `\"title\":\"Echo\"`) {
+		t.Fatalf("script does not carry the tool manifest:\n%s", body)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/javascript") {
+		t.Fatalf("script content type %q", ct)
+	}
+
+	// manifest: JSON with the same tool, ETag revalidation works
+	rec = httptest.NewRecorder()
+	rt.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, ManifestRoute, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("manifest route: %d", rec.Code)
+	}
+	var m struct{ Tools []Tool }
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatalf("manifest not JSON: %v", err)
+	}
+	if len(m.Tools) != 1 || m.Tools[0].Name != "echo" || m.Tools[0].Method != http.MethodPost {
+		t.Fatalf("manifest tools: %+v", m.Tools)
+	}
+	etag := rec.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("manifest has no ETag")
+	}
+	req := httptest.NewRequest(http.MethodGet, ManifestRoute, nil)
+	req.Header.Set("If-None-Match", etag)
+	rec = httptest.NewRecorder()
+	rt.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("If-None-Match revalidation: %d", rec.Code)
+	}
+}
+
+func TestMountDefaultsMethodAndSchema(t *testing.T) {
+	h := New()
+	tl := validTool()
+	tl.Method = ""
+	tl.InputSchema = nil
+	if err := h.Register(tl); err != nil {
+		t.Fatal(err)
+	}
+	rt := router.New()
+	if _, err := h.Mount(rt, nil); err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	rt.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, ManifestRoute, nil))
+	var m struct{ Tools []Tool }
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m.Tools[0].Method != http.MethodPost {
+		t.Fatalf("method not defaulted: %q", m.Tools[0].Method)
+	}
+	if string(m.Tools[0].InputSchema) != defaultInputSchema {
+		t.Fatalf("schema not defaulted: %s", m.Tools[0].InputSchema)
+	}
+}

--- a/framework/experimental/webmcp/webmcp_test.go
+++ b/framework/experimental/webmcp/webmcp_test.go
@@ -391,6 +391,40 @@ func TestMountServesScriptAndManifest(t *testing.T) {
 	}
 }
 
+func TestManifestCarriesAnnotationHints(t *testing.T) {
+	h := New()
+	tl := validTool()
+	tl.ReadOnlyHint = true
+	tl.UntrustedContentHint = true
+	if err := h.Register(tl); err != nil {
+		t.Fatal(err)
+	}
+	plain := validTool()
+	plain.Name = "plain"
+	plain.Path = "/api/plain"
+	if err := h.Register(plain); err != nil {
+		t.Fatal(err)
+	}
+	rt := router.New()
+	if _, err := h.Mount(rt, nil); err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	rt.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, ManifestRoute, nil))
+	var m struct{ Tools []Tool }
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatal(err)
+	}
+	if !m.Tools[0].ReadOnlyHint || !m.Tools[0].UntrustedContentHint {
+		t.Fatalf("annotation hints lost in the manifest: %+v", m.Tools[0])
+	}
+	// omitempty: an unhinted tool must not serialize the fields at all.
+	raw, _ := json.Marshal(m.Tools[1])
+	if strings.Contains(string(raw), "readOnlyHint") || strings.Contains(string(raw), "untrustedContentHint") {
+		t.Fatalf("unhinted tool serialized hint fields: %s", raw)
+	}
+}
+
 func TestMountDefaultsMethodAndSchema(t *testing.T) {
 	h := New()
 	tl := validTool()


### PR DESCRIPTION
## What

New `framework/experimental/webmcp` package: declare tools server-side (name, description, JSON Schema, same-origin endpoint) and `Mount` serves an embedded bridge script that registers them on the page's ModelContext — the Chrome WebMCP origin-trial API (`document.modelContext`, with the legacy `navigator` binding as fallback). Each tool's `execute()` proxies to its endpoint with the visitor's session cookies plus the app's double-submit CSRF token, so an in-browser agent acts strictly as the signed-in user: auth, CSRF, owner scoping, and rate limits all re-run server-side.

Deliberately separate from the server MCP surface (`WithMCP*`): different consumers (in-browser agents vs HTTP+token agents), different auth model (session vs token). Experimental, out-of-contract, like `experimental/apiversions`.

## Design constraints honored

- Zero CSS, zero markup — the package ships one script, on the existing `RegisterExternalScript` rail with `uihost.ScriptHandler` caching (the `analytics_demo` pattern).
- Manifest embeds as a quoted JSON string fed to `JSON.parse`, never a JS object literal (`__proto__` is a prototype setter in literals, and duplicate `__proto__` keys — which `json.Valid` accepts — would SyntaxError the whole bridge).
- Tool names enforce the spec grammar `[A-Za-z0-9_.-]{1,128}` at `Register`; the browser rejects violations asynchronously, i.e. silently.
- Path validation checks raw and percent-decoded forms, mirroring uihost's script-src grammar.
- `Mount` is atomic and prefix-aware: route pre-flight via `rt.Routes()` (grouped routers get working rail URLs), fallible script-rail registration before any route lands, un-latch on failure.

## Verification

- 19 tests; the browser e2e launches Chromium with `--enable-blink-features=WebMCP` (skips in `-short` / pre-146 browsers) and drives the real API behind the real `middleware.CSRF`: registration, POST body + cookie + CSRF header, GET input overriding baked-in query params, `isError` on 500, dispatch-time CSRF meta reading, `__proto__` schema regression.
- Five guards proven red/green by mutation (CSRF pickup, WebMCP flag, marker header, grouped-router URL, escaping pins).
- API contract established empirically against live Chromium 151 (`executeTool` takes JSON-string input; handles come from `getTools()`; `registerTool` resolves `undefined`) and documented in `framework/docs/content/webmcp.md`, whose main sample compiles under the docs `gofastr:compile` gate.
- Review: three rounds (Claude + GLM + Sol), 15 findings fixed, 3 reviewer claims rejected with rationale (details in the feat commit message).

## Also in this PR

`test(gofastr)`: `bootGeneratedApp` now pins `GOFASTR_ISOLATION=off` in the child env. On any linked-worktree checkout, `framework/isolation` activates by default and remaps the generated app's port, so `TestExampleBlueprintsBoot` (every blueprint) and `TestExampleReadScopeBoots` burned a 90s deadline per app while polling the un-remapped port. Proven both ways on a worktree: 92s timeout without the pin, 2.5s boot with it. CI never saw it because CI isn't a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnA5y1Dynm4T1AGvAMbPMe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental WebMCP bridge that exposes server-declared tools to in-browser AI agents.
  * Supports tool registration, schema validation, same-origin execution, session credentials, and CSRF protection.
  * Added a WebMCP example and documentation, including browser setup and usage guidance.
  * Browsers without WebMCP support safely ignore the integration.

* **Tests**
  * Added comprehensive browser and integration coverage for registration, execution, errors, security, and route handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->