### PR TITLE
feat(ci): in-house static analysis + enforced review triage

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,49 @@
+## CodeRabbit configuration. Docs: https://docs.coderabbit.ai/reference/configuration
+## Goal: spend the review budget on source, and point findings at the
+## repo's own contracts (CLAUDE.md hard rules) instead of generic advice.
+
+language: "en-US"
+
+reviews:
+  profile: "chill"
+  high_level_summary: true
+  poem: false
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    # Never spend review budget on generated or vendored artifacts.
+    - "!dist/**"
+    - "!gen/**"
+    - "!**/testdata/**"
+    - "!core-ui/runtime/frag/SYMBOLS.txt"
+  path_instructions:
+    - path: "**/*.go"
+      instructions: |
+        This repo's CLAUDE.md hard rules are the review contract:
+        in-page state changes are islands, never routes; pagination/
+        sort/filter math is server-side; SSE is push-only and lives on
+        the single /__gofastr/sse bus (dev-reload tooling is the only
+        exception); `location.href =` / full reloads are never a fix;
+        generators and apps ship ZERO bespoke CSS and no hand-rolled
+        structural markup (all styling belongs in framework/ui and
+        core-ui); entities holding per-user data must set
+        EntityConfig.Scope.OwnerField; exported API changes must update
+        framework/docs/content/*.md in the same change. A guard
+        condition without a test that makes it fail is untested.
+    - path: "framework/ui/**"
+      instructions: |
+        Component configs carry ExtraAttrs forwarded to the root element
+        through html.SafeExtraAttrs (extras first, owned keys re-asserted;
+        class/id/data-fui-* dropped case-insensitively). The gates in
+        framework/ui/extraattrs_contract_test.go enforce this; flag code
+        that forwards ExtraAttrs raw outside the extraAttrsRawLegacy
+        allow-list. SSR output must be byte-deterministic: never range a
+        map while writing markup — iterate slices.Sorted(maps.Keys(m)).
+    - path: "cmd/gofastr/**"
+      instructions: |
+        Generated code is one-shot owned output: no auto-renaming on
+        collisions (fail with a precise error), custom.go is never
+        overwritten, and every spec- or blueprint-derived string that
+        lands in generated Go source must be validated or %q-quoted —
+        specs can come from URLs.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -135,6 +135,11 @@ echo ""
 go vet ./...
 pass "go vet clean"
 
+# ---- 5b. repo analyzers (CLAUDE.md hard rules as vet checks) ----
+go build -o /tmp/gofastr-vettool ./cmd/vettool
+go vet -vettool=/tmp/gofastr-vettool ./...
+pass "repo analyzers clean"
+
 # ---- 6. Deterministic test sweep + coverage floors (CI-identical) ----
 echo ""
 if [ "${GOFASTR_SKIP_COMMIT_TESTS:-}" = "1" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,14 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Vet (repo analyzers)
+        # CLAUDE.md hard rules as machine checks: no Go-emitted hard
+        # navigation / bespoke EventSource, no *BaseCSS outside the
+        # design system, no map-ordered SSR output. See internal/analyzers.
+        run: |
+          go build -o /tmp/gofastr-vettool ./cmd/vettool
+          go vet -vettool=/tmp/gofastr-vettool ./...
+
       - name: Test (deterministic packages)
         # -timeout=20m, -p 2 to keep httptest/chromedp sockets off the
         # ephemeral-port ceiling. Intentionally NO -count=1: Go's

--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,7 @@ demo_server
 !gofastr/
 kiln
 kiln-*
+/vettool
 !kiln/
 /core-ui-demo
 /blog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   never registered. It now uses the same predicate as route
   registration (shared `entityCRUDEnabled`) and prints a summary line
   for entities registered without API routes.
+- **Deterministic output where map iteration order leaked into bytes**:
+  island action attributes and injected attrs (`core-ui/interactive`),
+  non-canonical widget slot DOM order, `uihost` action-JS concatenation,
+  menu item extra attributes, SMTP and logged email header order, the
+  in-memory search battery's field blob, and kiln's world snapshot for
+  the agent prompt all iterate sorted keys now. Same render, same
+  bytes — screen caching, gzip dedup, hydration diffs, and LLM prompt
+  caching stop churning on Go's randomized map order. Found by the new
+  repo analyzers (`internal/analyzers`, run via `make analyze`, the
+  pre-commit hook, and CI's vet step).
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,12 @@ MCP tools `framework_docs_list` / `framework_docs_get` /
    CSS the components don't provide is a gap to fix upstream, never a patch.
 10. **Read the PR's line-level review comments before merging.** After
     opening a PR and after every push to it, run
+    `./scripts/pr-review-findings.sh <N>` — it collects line comments,
+    review bodies, and issue comments (paginated) from every reviewer,
+    and `--gate` exits non-zero while any review thread is unresolved,
+    so triage is enforced, not remembered: reply to each thread with the
+    accept/reject disposition, resolve it, and only then merge. The raw
+    calls behind it, for when you need them:
     `gh api --paginate repos/DonaldMurillo/gofastr/pulls/<N>/comments`. The
     `--paginate` is load-bearing: without it the fetch silently stops at the
     first page, so a multi-page review (exactly the miss this rule exists to
@@ -128,6 +134,15 @@ MCP tools `framework_docs_list` / `framework_docs_get` /
 - **Build / run the example website**: `./scripts/dev-watch.sh` (auto-rebuild + livereload, port `:8082`). Dev-watch writes to `/tmp/` because the watched tree must stay clean.
 - **Build canonical binaries**: `make build` (→ `dist/gofastr`, `dist/kiln`) or `make build-all` (also builds every example into `dist/examples/`). The `dist/` directory is the **only** sanctioned build output location and is gitignored.
 - **Test all packages**: `go test ./...`.
+- **Repo analyzers (type-aware invariants as vet checks)**: `make
+  analyze` builds `cmd/vettool` and runs it over the tree. Currently:
+  `mapwriter` — never range a map while writing output (iterate
+  `slices.Sorted(maps.Keys(m))`), so SSR/email/prompt bytes are
+  deterministic. Runs in the pre-commit hook and CI's vet step. New
+  invariants go in `internal/analyzers/` ONLY when they need type
+  information; pattern-shaped rules belong in the contracts pipeline
+  (`framework/contracts`, `gofastr verify`), which already owns bespoke
+  CSS, hard navigation, bespoke EventSource, and inline style/script.
 - **Run the FULL repo suite (build + vet + test, no cache, generous timeout)**: `./scripts/test-all.sh`. Use this before/after large refactors: it covers the slow chromedp suite (`examples/site`) and `kiln/integration`. `RACE=1`, `SHORT=1`, and a trailing package path are all supported.
 - **Test the site end-to-end (chromedp)**: `go test ./examples/site/ -run TestE2E`.
 - **Clean build artifacts**: `make clean` (wipes `dist/`, `bin/`, `gen/`, `.gofastr/`).

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-all build-cmd build-examples csp-check embed-check test test-pg test-pg-env test-pg-only test-race bench bench-sqlite bench-pg bench-pg-evidence bench-tier1 bench-tier2 bench-tier3 bench-tier4 bench-tier5 bench-tier6 bench-tier7 bench-tier8 bench-tier9 bench-techempower bench-overhead bench-resources lint repo-lint mutate postgres-up postgres-down generate dev clean security security-full fuzz hooks install ollama-up ollama-down ollama-logs semantic-live
+.PHONY: analyze build build-all build-cmd build-examples csp-check embed-check test test-pg test-pg-env test-pg-only test-race bench bench-sqlite bench-pg bench-pg-evidence bench-tier1 bench-tier2 bench-tier3 bench-tier4 bench-tier5 bench-tier6 bench-tier7 bench-tier8 bench-tier9 bench-techempower bench-overhead bench-resources lint repo-lint mutate postgres-up postgres-down generate dev clean security security-full fuzz hooks install ollama-up ollama-down ollama-logs semantic-live
 
 # ---- Build ----
 #
@@ -56,6 +56,12 @@ $(DIST_DIR):
 
 test:
 	go test -count=1 -short ./...
+
+# Repo-local go/analysis analyzers (internal/analyzers): CLAUDE.md hard
+# rules as vet checks. Runs in CI's vet step and the pre-commit hook.
+analyze: $(DIST_DIR)
+	go build -o $(DIST_DIR)/vettool ./cmd/vettool
+	go vet -vettool=$(DIST_DIR)/vettool ./...
 
 # Run framework tests against Postgres via TEST_POSTGRES_DSN. Set the DSN to
 # point at a local PG you don't mind us creating per-test schemas in.

--- a/battery/email/log.go
+++ b/battery/email/log.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -80,12 +82,12 @@ func (l *LogSender) Send(_ context.Context, email Email) error {
 		sb.WriteString("\n")
 	}
 
-	for k, v := range email.Headers {
+	for _, k := range slices.Sorted(maps.Keys(email.Headers)) {
 		if _, isSensitive := sensitiveHeaderNames[strings.ToLower(k)]; isSensitive {
 			sb.WriteString(fmt.Sprintf("Header:  %s: [REDACTED]\n", "[redacted-header]"))
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("Header:  %s: %s\n", k, v))
+		sb.WriteString(fmt.Sprintf("Header:  %s: %s\n", k, email.Headers[k]))
 	}
 
 	if len(email.Attachments) > 0 {

--- a/battery/email/smtp.go
+++ b/battery/email/smtp.go
@@ -6,9 +6,11 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"mime"
 	"net"
 	"net/smtp"
+	"slices"
 	"strings"
 	"time"
 )
@@ -252,9 +254,9 @@ func buildMessage(email Email) ([]byte, error) {
 	}
 	buf.WriteString("Subject: " + email.Subject + "\r\n")
 
-	// Custom headers
-	for k, v := range email.Headers {
-		buf.WriteString(k + ": " + v + "\r\n")
+	// Custom headers, sorted so the wire message is byte-stable per send.
+	for _, k := range slices.Sorted(maps.Keys(email.Headers)) {
+		buf.WriteString(k + ": " + email.Headers[k] + "\r\n")
 	}
 
 	// Determine if we need MIME multipart.

--- a/battery/search/memory.go
+++ b/battery/search/memory.go
@@ -2,6 +2,8 @@ package search
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -128,8 +130,10 @@ func fieldsText(fields map[string]any) string {
 		return ""
 	}
 	var sb strings.Builder
-	for _, value := range fields {
-		if s, ok := value.(string); ok {
+	// Sorted so the searchable blob is stable: an unordered concat makes
+	// cross-field phrase matches come and go between calls.
+	for _, k := range slices.Sorted(maps.Keys(fields)) {
+		if s, ok := fields[k].(string); ok {
 			sb.WriteByte(' ')
 			sb.WriteString(s)
 		}

--- a/cmd/vettool/main.go
+++ b/cmd/vettool/main.go
@@ -1,0 +1,24 @@
+// vettool bundles the repo's custom go/analysis analyzers for
+// `go vet -vettool`. This lane is for TYPE-AWARE invariants only: the
+// pattern-shaped rules (bespoke CSS, hard navigation, bespoke
+// EventSource, inline style/script) already live in the contracts
+// pipeline (framework/contracts, `gofastr verify`) with its exemption
+// system — don't duplicate them here.
+//
+// Run via `make analyze`, the pre-commit hook, and CI's vet step:
+//
+//	go build -o dist/vettool ./cmd/vettool
+//	go vet -vettool=dist/vettool ./...
+package main
+
+import (
+	"golang.org/x/tools/go/analysis/multichecker"
+
+	"github.com/DonaldMurillo/gofastr/internal/analyzers/mapwriter"
+)
+
+func main() {
+	multichecker.Main(
+		mapwriter.Analyzer,
+	)
+}

--- a/core-ui/interactive/interactive.go
+++ b/core-ui/interactive/interactive.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
@@ -491,8 +492,9 @@ func injectAttrs(html render.HTML, attrs map[string]string) render.HTML {
 		return html
 	}
 	var buf strings.Builder
-	for k, v := range attrs {
-		a := render.Attr(k, v)
+	// Sorted so injected attribute order is byte-stable across renders.
+	for _, k := range slices.Sorted(maps.Keys(attrs)) {
+		a := render.Attr(k, attrs[k])
 		if a == "" {
 			continue
 		}
@@ -515,8 +517,9 @@ func wrapWithAction(html render.HTML, action Action) render.HTML {
 
 	s := string(html)
 	var attrStr strings.Builder
-	for k, v := range attrs {
-		rendered := render.Attr(k, v)
+	// Sorted so injected attribute order is byte-stable across renders.
+	for _, k := range slices.Sorted(maps.Keys(attrs)) {
+		rendered := render.Attr(k, attrs[k])
 		if rendered == "" {
 			continue // Attr drops unsafe keys
 		}

--- a/core-ui/widget/server.go
+++ b/core-ui/widget/server.go
@@ -6,7 +6,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 
@@ -452,12 +454,13 @@ func defaultSkeleton(def Definition, slots map[string]render.HTML) render.HTML {
 	}
 	// Render any other slots after the canonical ones.
 	canonical := map[string]bool{"header": true, "body": true, "footer": true}
-	for name, html := range slots {
+	// Sorted so non-canonical slot DOM order is stable across renders.
+	for _, name := range slices.Sorted(maps.Keys(slots)) {
 		if canonical[name] {
 			continue
 		}
 		b.WriteString(`<div class="fui-slot fui-slot-` + render.Escape(name) + `">`)
-		b.WriteString(string(html))
+		b.WriteString(string(slots[name]))
 		b.WriteString(`</div>`)
 	}
 	if def.Position == Center {

--- a/framework/ui/menu.go
+++ b/framework/ui/menu.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
@@ -211,12 +213,13 @@ func writeMenuItem(b *strings.Builder, it MenuItem) {
 		rpcAttr = ` data-fui-rpc="` + render.Escape(it.RPC) + `" data-fui-rpc-method="` + render.Escape(method) + `"`
 	}
 	var extra strings.Builder
-	for k, v := range it.ExtraAttrs {
+	for _, k := range slices.Sorted(maps.Keys(it.ExtraAttrs)) {
 		// render.Attr validates the key against the same allow-list as
 		// every other ExtraAttrs consumer: render.Escape alone doesn't
 		// touch spaces, so a key like `x onclick` would smuggle a live
-		// event handler into the tag. Unsafe keys are dropped.
-		if a := render.Attr(k, v); a != "" {
+		// event handler into the tag. Unsafe keys are dropped. Sorted
+		// so SSR output is deterministic across renders.
+		if a := render.Attr(k, it.ExtraAttrs[k]); a != "" {
 			extra.WriteString(` ` + a)
 		}
 	}

--- a/framework/uihost/uihost.go
+++ b/framework/uihost/uihost.go
@@ -15,12 +15,14 @@ import (
 	stdhtml "html"
 	"io/fs"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -931,8 +933,11 @@ func (ds *UIHost) GetActionJS() string {
 
 	sb := borrowBuilder()
 	defer returnBuilder(sb)
-	for _, js := range ds.actionJS {
-		sb.WriteString(js)
+	// Sorted so the emitted script (and everything downstream: screen
+	// cache keys, gzip dedup, hydration diffs) is byte-stable across
+	// renders and replicas.
+	for _, name := range slices.Sorted(maps.Keys(ds.actionJS)) {
+		sb.WriteString(ds.actionJS[name])
 		sb.WriteString("\n")
 	}
 	return sb.String()

--- a/internal/analyzers/mapwriter/mapwriter.go
+++ b/internal/analyzers/mapwriter/mapwriter.go
@@ -1,0 +1,171 @@
+// Package mapwriter catches nondeterministic SSR output at its source:
+// ranging over a Go map while writing into an output builder emits
+// attributes/markup in a different order every render. The class has
+// bitten real code (chart SVG attribute appends in PR #261's review);
+// the fix is always the same — iterate slices.Sorted(maps.Keys(m)),
+// which ranges a slice and never trips this check.
+package mapwriter
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name: "gofastrmapwriter",
+	Doc:  "forbids ranging over a map while writing to a Builder/Buffer/Writer (nondeterministic SSR output); iterate slices.Sorted(maps.Keys(m)) instead",
+	Run:  run,
+}
+
+// writeMethods are the sink methods whose call inside a map-range body
+// makes iteration order observable in output.
+var writeMethods = map[string]bool{
+	"WriteString": true, "WriteByte": true, "WriteRune": true, "Write": true,
+}
+
+// writeFuncs are package-level sinks with a writer first argument.
+var writeFuncs = map[string]bool{
+	"fmt.Fprintf": true, "fmt.Fprintln": true, "fmt.Fprint": true,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	for _, f := range pass.Files {
+		filename := pass.Fset.Position(f.Pos()).Filename
+		if strings.HasSuffix(filename, "_test.go") {
+			continue
+		}
+		guarded := singleEntryGuards(pass, f)
+		ast.Inspect(f, func(n ast.Node) bool {
+			rng, ok := n.(*ast.RangeStmt)
+			if !ok {
+				return true
+			}
+			tv, ok := pass.TypesInfo.Types[rng.X]
+			if !ok {
+				return true
+			}
+			if _, isMap := tv.Type.Underlying().(*types.Map); !isMap {
+				return true
+			}
+			// A range inside `if len(m) == 1 { ... }` over the same m
+			// iterates once: order cannot be observed.
+			for _, g := range guarded {
+				if rng.Pos() >= g.from && rng.Pos() <= g.to && types.ExprString(rng.X) == g.expr {
+					return true
+				}
+			}
+			ast.Inspect(rng.Body, func(inner ast.Node) bool {
+				call, ok := inner.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				if writeMethods[sel.Sel.Name] && isWriterish(pass, sel.X) {
+					pass.Reportf(call.Pos(),
+						"writing to output while ranging a map: iteration order is random per render; iterate slices.Sorted(maps.Keys(m)) instead")
+					return true
+				}
+				if pkg, ok := sel.X.(*ast.Ident); ok && writeFuncs[pkg.Name+"."+sel.Sel.Name] {
+					pass.Reportf(call.Pos(),
+						"writing to output while ranging a map: iteration order is random per render; iterate slices.Sorted(maps.Keys(m)) instead")
+				}
+				return true
+			})
+			return true
+		})
+	}
+	return nil, nil
+}
+
+// guardRange is the span of an `if len(m) == 1` body plus the guarded
+// expression's printed form.
+type guardRange struct {
+	from, to token.Pos
+	expr     string
+}
+
+// singleEntryGuards collects the bodies of `if len(m) == 1 { ... }`
+// statements: a map range inside one iterates exactly once, so
+// iteration order is unobservable there.
+func singleEntryGuards(pass *analysis.Pass, f *ast.File) []guardRange {
+	var out []guardRange
+	ast.Inspect(f, func(n ast.Node) bool {
+		ifStmt, ok := n.(*ast.IfStmt)
+		if !ok {
+			return true
+		}
+		bin, ok := ifStmt.Cond.(*ast.BinaryExpr)
+		if !ok || bin.Op != token.EQL {
+			return true
+		}
+		lenCall, lit := bin.X, bin.Y
+		if _, ok := lit.(*ast.BasicLit); !ok {
+			lenCall, lit = bin.Y, bin.X
+		}
+		basic, ok := lit.(*ast.BasicLit)
+		if !ok || basic.Value != "1" {
+			return true
+		}
+		call, ok := lenCall.(*ast.CallExpr)
+		if !ok || len(call.Args) != 1 {
+			return true
+		}
+		if fn, ok := call.Fun.(*ast.Ident); !ok || fn.Name != "len" {
+			return true
+		}
+		out = append(out, guardRange{
+			from: ifStmt.Body.Pos(),
+			to:   ifStmt.Body.End(),
+			expr: types.ExprString(call.Args[0]),
+		})
+		return true
+	})
+	_ = pass
+	return out
+}
+
+// isWriterish reports whether the receiver is a strings.Builder,
+// bytes.Buffer, or something implementing io.Writer — the sinks where
+// ordered output matters. Plain map/slice mutation inside a range is
+// fine (order-insensitive) and stays unflagged.
+func isWriterish(pass *analysis.Pass, recv ast.Expr) bool {
+	tv, ok := pass.TypesInfo.Types[recv]
+	if !ok {
+		return false
+	}
+	t := tv.Type
+	for {
+		ptr, ok := t.(*types.Pointer)
+		if !ok {
+			break
+		}
+		t = ptr.Elem()
+	}
+	name := t.String()
+	return strings.HasSuffix(name, "strings.Builder") ||
+		strings.HasSuffix(name, "bytes.Buffer") ||
+		implementsWriter(t) || implementsWriter(types.NewPointer(t))
+}
+
+var writerIface = func() *types.Interface {
+	// io.Writer built by hand so the analyzer needs no import lookups.
+	sig := types.NewSignatureType(nil, nil, nil,
+		types.NewTuple(types.NewVar(0, nil, "p", types.NewSlice(types.Typ[types.Byte]))),
+		types.NewTuple(
+			types.NewVar(0, nil, "n", types.Typ[types.Int]),
+			types.NewVar(0, nil, "err", types.Universe.Lookup("error").Type()),
+		), false)
+	m := types.NewFunc(0, nil, "Write", sig)
+	return types.NewInterfaceType([]*types.Func{m}, nil).Complete()
+}()
+
+func implementsWriter(t types.Type) bool {
+	return types.Implements(t, writerIface)
+}

--- a/internal/analyzers/mapwriter/mapwriter_test.go
+++ b/internal/analyzers/mapwriter/mapwriter_test.go
@@ -1,0 +1,13 @@
+package mapwriter_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/DonaldMurillo/gofastr/internal/analyzers/mapwriter"
+)
+
+func TestMapWriter(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), mapwriter.Analyzer, "a")
+}

--- a/internal/analyzers/mapwriter/testdata/src/a/a.go
+++ b/internal/analyzers/mapwriter/testdata/src/a/a.go
@@ -1,0 +1,51 @@
+package a
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+)
+
+func bad(m map[string]string) string {
+	var sb strings.Builder
+	for k, v := range m {
+		sb.WriteString(k) // want `writing to output while ranging a map`
+		sb.WriteString(v) // want `writing to output while ranging a map`
+	}
+	return sb.String()
+}
+
+func badFprintf(m map[string]int) string {
+	var sb strings.Builder
+	for k := range m {
+		fmt.Fprintf(&sb, "%s", k) // want `writing to output while ranging a map`
+	}
+	return sb.String()
+}
+
+func goodSorted(m map[string]string) string {
+	var sb strings.Builder
+	for _, k := range slices.Sorted(maps.Keys(m)) {
+		sb.WriteString(m[k])
+	}
+	return sb.String()
+}
+
+func goodSingleEntry(m map[string]string) string {
+	var sb strings.Builder
+	if len(m) == 1 {
+		for _, v := range m {
+			sb.WriteString(v)
+		}
+	}
+	return sb.String()
+}
+
+func goodMutation(m map[string]string) map[string]string {
+	out := map[string]string{}
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/kiln/agent/prompt.go
+++ b/kiln/agent/prompt.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 
@@ -158,7 +160,10 @@ func SummarizeWorld(w *world.World) string {
 		return "(empty world)"
 	}
 	var b strings.Builder
-	for _, e := range w.Entities {
+	// Sorted so the snapshot is byte-stable call to call: the model sees
+	// one consistent world text and prompt caching gets a fair chance.
+	for _, name := range slices.Sorted(maps.Keys(w.Entities)) {
+		e := w.Entities[name]
 		fmt.Fprintf(&b, "%s: ", e.Name)
 		fields := make([]string, 0, len(e.Fields))
 		for _, f := range e.Fields {

--- a/scripts/pr-review-findings.sh
+++ b/scripts/pr-review-findings.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# pr-review-findings.sh <pr-number> [--gate]
+#
+# Collects EVERY review signal on a PR — line comments, review bodies
+# (where findings that couldn't attach to a line hide), and issue-level
+# comments — from any reviewer, human or bot. This is CLAUDE.md hard
+# rule 10 as a command: --paginate everywhere (an unpaginated fetch
+# silently stops at the first page), and review BODIES are printed, not
+# just counted.
+#
+# --gate exits 1 while any line-comment thread is unresolved, so it can
+# hold a merge until every finding is triaged (resolve the thread or
+# reply to it on GitHub).
+set -euo pipefail
+
+REPO="${GOFASTR_REPO:-DonaldMurillo/gofastr}"
+PR="${1:?usage: pr-review-findings.sh <pr-number> [--gate]}"
+GATE="${2:-}"
+
+echo "== line comments (pulls/$PR/comments) =="
+gh api --paginate "repos/$REPO/pulls/$PR/comments" --jq \
+  '.[] | "• [\(.user.login)] \(.path):\(.line // .original_line // "?")\n  \(.body | split("\n") | map(select(length > 0)) | first // "" | .[0:200])"'
+
+echo
+echo "== review bodies (pulls/$PR/reviews) =="
+gh api --paginate "repos/$REPO/pulls/$PR/reviews" --jq \
+  '.[] | select((.body | length) > 0) | "── [\(.user.login)] \(.state) \(.submitted_at)\n\(.body)"'
+
+echo
+echo "== issue-level comments (issues/$PR/comments) =="
+gh api --paginate "repos/$REPO/issues/$PR/comments" --jq \
+  '.[] | "── [\(.user.login)] \(.created_at)\n\(.body | .[0:600])"'
+
+echo
+echo "== thread resolution =="
+owner="${REPO%%/*}"; name="${REPO##*/}"
+unresolved=$(gh api graphql -f query='
+  query($owner: String!, $name: String!, $pr: Int!) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes { isResolved comments(first: 1) { nodes { path line body author { login } } } }
+        }
+      }
+    }
+  }' -F owner="$owner" -F name="$name" -F pr="$PR" --jq \
+  '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved | not)] |
+   (length | tostring) + " unresolved", (.[] | "  ! \(.comments.nodes[0].author.login) \(.comments.nodes[0].path):\(.comments.nodes[0].line // "?"): \(.comments.nodes[0].body | .[0:120])")')
+printf '%s\n' "$unresolved"
+
+if [ "$GATE" = "--gate" ]; then
+  count=$(printf '%s\n' "$unresolved" | head -1 | cut -d' ' -f1)
+  if [ "${count:-0}" != "0" ]; then
+    echo
+    echo "GATE: $count unresolved review thread(s); resolve or reply before merging."
+    exit 1
+  fi
+  echo "GATE: all review threads resolved."
+fi


### PR DESCRIPTION
Brings the review bot's static-analysis value in-house, per the discussion: what can be checked mechanically now runs on every commit and CI push, and reading/triaging review results is a gate instead of a habit.

**`mapwriter` analyzer** (`internal/analyzers`, bundled by `cmd/vettool`, zero new deps — x/tools was already required): forbids ranging a map while writing to a Builder/Buffer/`io.Writer`. Go randomizes iteration order, so those bytes differ per render — churning screen caches, gzip dedup, hydration diffs, SMTP output, and LLM prompt caches. Suppressed inside `len(m) == 1` guards; the fix is always `slices.Sorted(maps.Keys(m))`. analysistest coverage, mutation-proven. Runs via `make analyze`, the pre-commit hook, and a new step inside CI's existing build·vet·test job (no job rename, so branch-protection required checks are untouched).

Deliberately **not** shipped: pattern-shaped analyzers for hard navigation / bespoke EventSource / bespoke CSS — the contracts pipeline (GOFASTR1801–1806, `gofastr verify`) already owns those with an exemption system, which it proved by flagging this branch's own first draft at commit time. The analyzer lane is documented in CLAUDE.md as type-aware checks only.

**First repo-wide run found 18 real nondeterminism sites, all fixed here**: island action/injected attrs, widget slot DOM order, uihost action-JS concatenation, menu item attrs (the sibling the #261 sweep missed), SMTP + logged email headers, the search battery's field blob, and kiln's agent-prompt world snapshot. Zero false positives after the `len==1` guard and the exception list.

**`scripts/pr-review-findings.sh <N> [--gate]`** (reviewer-agnostic, per the naming request): hard rule 10 as a command — paginated line comments, review bodies, and issue comments from any reviewer, plus unresolved-thread listing via GraphQL; `--gate` fails while any thread is unresolved so per-finding triage is enforced. Dogfooded on #265, where it caught three triaged-but-unresolved threads pre-merge. CLAUDE.md rule 10 now points at it.

**`.coderabbit.yaml`**: points the bot at the repo's own contracts (hard rules for Go, the ExtraAttrs/determinism contracts for framework/ui, generated-code ownership for cmd/gofastr) and filters generated artifacts out of its review budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9