### PR TITLE
fix: round-2 grooming batch A — DI values, ResponseController deadlines, silent-clobber screams (#258 #259 #260 #268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to GoFastr. Follows
 calendar versions (`YYYY-MM-DD` per substantive release until the API
 stabilises). Breaking changes are clearly marked with **BREAKING**.
 
+## [Unreleased]
+
+### Fixed
+
+- **Stateless value screen components render again** (#259):
+  registering a component by value (the documented stateless form) died
+  at render time with a generic "di: target must be a non-nil pointer".
+  DI is now skipped for value components; a value struct that *asks*
+  for injection via `inject` tags fails with the type and the
+  register-a-pointer remedy named.
+- **`http.NewResponseController` deadlines reach the connection through
+  the logging wrappers** (#260): `middleware.Logging`'s and
+  `battery/log`'s response writers gained `Unwrap`, matching the
+  cors/metrics/tracing wrappers, so streaming handlers behind an access
+  logger can set per-write deadlines instead of getting a silent
+  `ErrNotSupported` (a half-open client then pinned the goroutine).
+- **Silent clobbers now scream** (#258, #268): replacing a router's
+  NotFound handler warns (a UI host dispatches every screen through it,
+  so the replacement disabled all pages; `Router.WrapNotFound` is the
+  compose path, `uihost.WithNotFoundScreen` the supported custom 404),
+  and worktree isolation remapping an explicitly-assigned listen
+  address warns with both addresses and the kill switches instead of
+  banner-printing the remapped port as if it were the configured one.
+
 ## [0.73.0] - 2026-08-28
 
 ### Fixed

--- a/battery/log/middleware.go
+++ b/battery/log/middleware.go
@@ -174,6 +174,13 @@ func (rw *countingResponseWriter) Push(target string, opts *http.PushOptions) er
 	return http.ErrNotSupported
 }
 
+// Unwrap lets http.NewResponseController walk through this wrapper so
+// per-write deadlines reach the real connection. battery/log is the
+// production access-log path, so without this every streaming handler
+// behind it silently loses SetWriteDeadline (ErrNotSupported). Mirrors
+// core/middleware's cors/metrics/tracing/logging wrappers.
+func (rw *countingResponseWriter) Unwrap() http.ResponseWriter { return rw.ResponseWriter }
+
 // remoteAddr returns the client address the access log should record.
 // When trustXFF is false (default) it returns r.RemoteAddr only;
 // X-Forwarded-For / X-Real-IP are still emitted as a separate

--- a/battery/log/middleware_unwrap_test.go
+++ b/battery/log/middleware_unwrap_test.go
@@ -1,0 +1,41 @@
+package log
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type deadlineRecorder struct {
+	http.ResponseWriter
+	writeDeadlineSet bool
+}
+
+func (d *deadlineRecorder) SetWriteDeadline(t time.Time) error {
+	d.writeDeadlineSet = true
+	return nil
+}
+
+// Pins #260's battery half: the access-log wrapper must let
+// http.NewResponseController reach the underlying writer's deadlines.
+// battery/log is the production access-log path, so this is the one a
+// deployed streaming handler actually sits behind.
+func TestAccessLogWriterUnwrapsForResponseController(t *testing.T) {
+	base := &deadlineRecorder{ResponseWriter: httptest.NewRecorder()}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	var innerErr error
+	h := accessMiddleware(logger, false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerErr = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(time.Second))
+	}))
+	h.ServeHTTP(base, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if innerErr != nil {
+		t.Fatalf("SetWriteDeadline through access-log wrapper: %v", innerErr)
+	}
+	if !base.writeDeadlineSet {
+		t.Fatal("deadline never reached the underlying writer")
+	}
+}

--- a/core-ui/app/app.go
+++ b/core-ui/app/app.go
@@ -263,6 +263,27 @@ func (a *App) RenderPage(ctx context.Context, path string) (render.HTML, error) 
 //     screen's component; HTML holds the full document.
 //   - DecisionBlock: Status holds the HTTP status code; HTML is empty.
 //
+// injectComponent applies the DI/value-component contract (#259) for
+// every render path (full page AND partial): pointer components get
+// injection; value components are the documented stateless form and
+// skip DI; a value STRUCT that asks for injection via inject tags is a
+// wiring mistake that fails naming the type and the pointer remedy —
+// silently rendering it with nil services would be worse.
+func (a *App) injectComponent(comp component.Component, path string) error {
+	if cv := reflect.ValueOf(comp); cv.Kind() == reflect.Pointer {
+		if err := a.Inject(comp); err != nil {
+			return fmt.Errorf("app: DI injection failed for %q: %w", path, err)
+		}
+		return nil
+	}
+	if n := injectTagCount(reflect.TypeOf(comp)); n > 0 {
+		return fmt.Errorf(
+			"app: screen component for %q has %d inject-tagged field(s) but was registered by value as %T; register a pointer (&%T{...}) so DI can fill them",
+			path, n, comp, comp)
+	}
+	return nil
+}
+
 // injectTagCount reports how many inject-tagged fields a component
 // type declares (directly, for struct types). Used to distinguish a
 // legitimately stateless value component from a value struct that
@@ -311,21 +332,10 @@ func (a *App) RenderPageResult(ctx context.Context, path string) (RenderResult, 
 		}
 	}
 
-	// Inject DI services into component fields tagged `inject:""`.
-	// Value components are the documented stateless form (newInstance
-	// returns them as-is) and cannot receive injection, so DI is
-	// skipped for them — unless the value struct ASKS for injection
-	// via inject tags, which is a wiring mistake that must fail with
-	// the type and the fix named, not a generic DI error at render
-	// time (#259).
-	if cv := reflect.ValueOf(comp); cv.Kind() == reflect.Pointer {
-		if err := a.Inject(comp); err != nil {
-			return RenderResult{}, fmt.Errorf("app: DI injection failed for %q: %w", path, err)
-		}
-	} else if n := injectTagCount(reflect.TypeOf(comp)); n > 0 {
-		return RenderResult{}, fmt.Errorf(
-			"app: screen component for %q has %d inject-tagged field(s) but was registered by value as %T; register a pointer (&%T{...}) so DI can fill them",
-			path, n, comp, comp)
+	// Inject DI services into component fields tagged `inject:""`;
+	// see injectComponent for the value-component contract (#259).
+	if err := a.injectComponent(comp, path); err != nil {
+		return RenderResult{}, err
 	}
 
 	// Run the component's Load hook if present. Loaders run AFTER DI so they can
@@ -555,8 +565,8 @@ func (a *App) renderPartial(ctx context.Context, path string, overlay *ScreenTyp
 		}
 	}
 
-	if err := a.Inject(comp); err != nil {
-		return RenderResult{}, fmt.Errorf("app: DI injection failed for %q: %w", path, err)
+	if err := a.injectComponent(comp, path); err != nil {
+		return RenderResult{}, err
 	}
 
 	if loader, ok := comp.(ScreenLoader); ok {

--- a/core-ui/app/app.go
+++ b/core-ui/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -261,6 +262,24 @@ func (a *App) RenderPage(ctx context.Context, path string) (render.HTML, error) 
 //   - DecisionRenderAlt: the alt component took the place of the
 //     screen's component; HTML holds the full document.
 //   - DecisionBlock: Status holds the HTTP status code; HTML is empty.
+//
+// injectTagCount reports how many inject-tagged fields a component
+// type declares (directly, for struct types). Used to distinguish a
+// legitimately stateless value component from a value struct that
+// wanted injection and would otherwise render with nil services.
+func injectTagCount(t reflect.Type) int {
+	if t == nil || t.Kind() != reflect.Struct {
+		return 0
+	}
+	n := 0
+	for i := 0; i < t.NumField(); i++ {
+		if _, ok := t.Field(i).Tag.Lookup("inject"); ok {
+			n++
+		}
+	}
+	return n
+}
+
 func (a *App) RenderPageResult(ctx context.Context, path string) (RenderResult, error) {
 	screen, params, ok := a.Router.Resolve(path)
 	if !ok {
@@ -292,9 +311,21 @@ func (a *App) RenderPageResult(ctx context.Context, path string) (RenderResult, 
 		}
 	}
 
-	// Inject DI services into component fields tagged `inject:""`
-	if err := a.Inject(comp); err != nil {
-		return RenderResult{}, fmt.Errorf("app: DI injection failed for %q: %w", path, err)
+	// Inject DI services into component fields tagged `inject:""`.
+	// Value components are the documented stateless form (newInstance
+	// returns them as-is) and cannot receive injection, so DI is
+	// skipped for them — unless the value struct ASKS for injection
+	// via inject tags, which is a wiring mistake that must fail with
+	// the type and the fix named, not a generic DI error at render
+	// time (#259).
+	if cv := reflect.ValueOf(comp); cv.Kind() == reflect.Pointer {
+		if err := a.Inject(comp); err != nil {
+			return RenderResult{}, fmt.Errorf("app: DI injection failed for %q: %w", path, err)
+		}
+	} else if n := injectTagCount(reflect.TypeOf(comp)); n > 0 {
+		return RenderResult{}, fmt.Errorf(
+			"app: screen component for %q has %d inject-tagged field(s) but was registered by value as %T; register a pointer (&%T{...}) so DI can fill them",
+			path, n, comp, comp)
 	}
 
 	// Run the component's Load hook if present. Loaders run AFTER DI so they can

--- a/core-ui/app/value_component_test.go
+++ b/core-ui/app/value_component_test.go
@@ -38,6 +38,23 @@ func TestRenderValueComponentStateless(t *testing.T) {
 	}
 }
 
+// The partial (SPA navigation) path shares the same contract: a value
+// component that renders as a full page must also render as a partial
+// (PR #274 review finding — renderPartial had its own unconditional
+// Inject call).
+func TestRenderPartialValueComponentStateless(t *testing.T) {
+	a := NewApp("t")
+	a.Register("/", statelessValue{}, nil)
+
+	res, err := a.RenderPartialResult(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("stateless value component must render as a partial: %v", err)
+	}
+	if !strings.Contains(string(res.HTML), "value ok") {
+		t.Fatalf("partial body missing: %s", res.HTML)
+	}
+}
+
 // The other half of #259: a value struct that DECLARES inject tags
 // would silently render with nil services if DI were merely skipped;
 // it must fail naming the type and the pointer remedy.

--- a/core-ui/app/value_component_test.go
+++ b/core-ui/app/value_component_test.go
@@ -1,0 +1,57 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+// statelessValue is the documented value-component form: no state, no
+// injection, registered without a pointer (newInstance returns it
+// as-is).
+type statelessValue struct{}
+
+func (statelessValue) Render() render.HTML { return render.HTML("<p>value ok</p>") }
+
+// wantsInjectionValue is the wiring mistake: a value component whose
+// struct asks for DI, which can never be filled without a pointer.
+type wantsInjectionValue struct {
+	Svc *struct{} `inject:""`
+}
+
+func (wantsInjectionValue) Render() render.HTML { return render.HTML("x") }
+
+// Pins #259: a stateless value component is a supported form and must
+// render, not die with "di: target must be a non-nil pointer".
+func TestRenderValueComponentStateless(t *testing.T) {
+	a := NewApp("t")
+	a.Register("/", statelessValue{}, nil)
+
+	res, err := a.RenderPageResult(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("stateless value component must render: %v", err)
+	}
+	if !strings.Contains(string(res.HTML), "value ok") {
+		t.Fatalf("body missing: %s", res.HTML)
+	}
+}
+
+// The other half of #259: a value struct that DECLARES inject tags
+// would silently render with nil services if DI were merely skipped;
+// it must fail naming the type and the pointer remedy.
+func TestRenderValueComponentWithInjectTagsFails(t *testing.T) {
+	a := NewApp("t")
+	a.Register("/", wantsInjectionValue{}, nil)
+
+	_, err := a.RenderPageResult(context.Background(), "/")
+	if err == nil {
+		t.Fatal("value component with inject tags must error")
+	}
+	for _, want := range []string{"wantsInjectionValue", "pointer", "inject-tagged"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q: %v", want, err)
+		}
+	}
+}

--- a/core/middleware/logging.go
+++ b/core/middleware/logging.go
@@ -210,6 +210,15 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
+// Unwrap lets http.NewResponseController walk through this wrapper so
+// SetReadDeadline/SetWriteDeadline reach the real connection instead of
+// failing with a silent ErrNotSupported (a streaming handler that
+// ignores that error then has no per-write deadline, and a half-open
+// client pins its goroutine). Every variant below embeds this type, so
+// the one method covers the whole family — matching the Unwrap the
+// cors/metrics/tracing wrappers already carry.
+func (rw *responseWriter) Unwrap() http.ResponseWriter { return rw.ResponseWriter }
+
 // optional-interface wrappers; we conditionally expose just what the
 // underlying writer actually supports, so a caller's interface assertion
 // reflects the real capabilities of the stack.

--- a/core/middleware/logging_unwrap_test.go
+++ b/core/middleware/logging_unwrap_test.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// deadlineWriter fakes the net/http response writer's deadline surface
+// so ResponseController has something real to reach at the bottom of
+// the wrapper chain.
+type deadlineWriter struct {
+	http.ResponseWriter
+	writeDeadlineSet bool
+}
+
+func (d *deadlineWriter) SetWriteDeadline(t time.Time) error {
+	d.writeDeadlineSet = true
+	return nil
+}
+
+// Pins #260: http.NewResponseController must resolve SetWriteDeadline
+// through the logging wrapper via Unwrap. Before the fix it returned a
+// silent ErrNotSupported, so streaming handlers behind logging had no
+// per-write deadline and a half-open client pinned the goroutine.
+func TestLoggingWriterUnwrapsForResponseController(t *testing.T) {
+	base := &deadlineWriter{ResponseWriter: httptest.NewRecorder()}
+	var innerErr error
+	h := Logging()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rc := http.NewResponseController(w)
+		innerErr = rc.SetWriteDeadline(time.Now().Add(time.Second))
+	}))
+	h.ServeHTTP(base, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if innerErr != nil {
+		t.Fatalf("SetWriteDeadline through logging wrapper: %v", innerErr)
+	}
+	if !base.writeDeadlineSet {
+		t.Fatal("deadline never reached the underlying writer")
+	}
+}

--- a/core/router/notfound_replace_test.go
+++ b/core/router/notfound_replace_test.go
@@ -1,0 +1,44 @@
+package router
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"testing"
+)
+
+// Pins #258's scream: NotFound is last-write-wins, and the discarded
+// handler can be load-bearing (a UI host dispatches every screen
+// through it). Replacing must warn; a first install must not.
+func TestNotFoundReplaceWarns(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	r := New()
+	r.NotFound(http.NotFoundHandler())
+	if buf.Len() != 0 {
+		t.Fatalf("first NotFound install must not warn:\n%s", buf.String())
+	}
+	r.NotFound(http.NotFoundHandler())
+	if got := buf.String(); !bytes.Contains([]byte(got), []byte("NotFound handler replaced")) {
+		t.Fatalf("second install must warn about the discarded handler:\n%s", got)
+	}
+}
+
+// WrapNotFound is the compose path and must stay silent: it delegates
+// to the previous handler instead of discarding it.
+func TestWrapNotFoundDoesNotWarn(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	r := New()
+	r.NotFound(http.NotFoundHandler())
+	r.WrapNotFound(func(next http.Handler) http.Handler { return next })
+	if buf.Len() != 0 {
+		t.Fatalf("WrapNotFound composes; it must not warn:\n%s", buf.String())
+	}
+}

--- a/core/router/router.go
+++ b/core/router/router.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"slices"
 	"sort"
@@ -573,8 +574,20 @@ func (r *Router) effectiveNotFound() http.Handler {
 func (r *Router) NotFound(handler http.Handler) {
 	route := &cachedRoute{raw: handler, router: r}
 	r.mu.Lock()
+	replaced := r.notFound != nil
 	r.notFound = route
 	r.mu.Unlock()
+	// The setter is last-write-wins, and the discarded handler may have
+	// been load-bearing: a UI host dispatches every SCREEN through
+	// NotFound, so an app installing a custom 404 after Mount silently
+	// disables all pages (and the inverse order silently eats the app's
+	// 404) — #258. Scream instead of guessing which side was intended.
+	// (Generic on purpose: this is the framework-agnostic core layer;
+	// the UI host's docs point at its own WithNotFoundScreen.)
+	if replaced {
+		slog.Warn("router: NotFound handler replaced; the previous handler is discarded",
+			"hint", "compose with Router.WrapNotFound if both should run")
+	}
 }
 
 // WrapNotFound wraps the router's NotFound fall-through with mw. mw receives

--- a/framework/app.go
+++ b/framework/app.go
@@ -2764,8 +2764,10 @@ func (a *App) Start(addr string) error {
 	// isolation.md), but silently honoring a different port than the
 	// one the caller assigned is configuration accepted-but-not-honored:
 	// anything polling the requested port hangs to its deadline (#268).
-	// Scream once with both addresses and both kill switches.
-	if requestedAddr != "" && addr != requestedAddr {
+	// Scream once with both addresses and both kill switches. Gated on
+	// Active(): Addr also normalizes a bare "8080" to ":8080" with
+	// isolation off, and that spelling change is not a remap.
+	if runtimeIsolation.Active() && requestedAddr != "" && addr != requestedAddr {
 		a.Logger().Warn("isolation remapped the listen address",
 			"requested", requestedAddr,
 			"resolved", addr,

--- a/framework/app.go
+++ b/framework/app.go
@@ -796,8 +796,10 @@ func WithGrantStore(gs *access.GrantStore) AppOption {
 }
 
 // WithoutDefaultMiddleware disables the default middleware chain
-// (recovery, request-id, logging, security headers, timeout). Use this
-// when you want full control over middleware composition via Use().
+// (recovery, request-id, security headers, timeout; access logging is
+// NOT in the default chain — battery/log or middleware.LoggingFn add
+// it). Use this when you want full control over middleware composition
+// via Use().
 func WithoutDefaultMiddleware() AppOption {
 	return func(a *App) {
 		a.noDefaults = true
@@ -2753,9 +2755,22 @@ func (a *App) Start(addr string) error {
 	if err != nil {
 		return fmt.Errorf("resolve isolation: %w", err)
 	}
+	requestedAddr := addr
 	addr, err = runtimeIsolation.Addr(addr)
 	if err != nil {
 		return fmt.Errorf("resolve isolated addr: %w", err)
+	}
+	// Worktree isolation deliberately remaps the listen address (see
+	// isolation.md), but silently honoring a different port than the
+	// one the caller assigned is configuration accepted-but-not-honored:
+	// anything polling the requested port hangs to its deadline (#268).
+	// Scream once with both addresses and both kill switches.
+	if requestedAddr != "" && addr != requestedAddr {
+		a.Logger().Warn("isolation remapped the listen address",
+			"requested", requestedAddr,
+			"resolved", addr,
+			"isolation", runtimeIsolation.ID(),
+			"disable", "GOFASTR_ISOLATION=off (or GOFASTR_ISOLATION_REWRITE=0 for explicit values only)")
 	}
 
 	// Create the app's lifecycle context early so AutoMigrate, RunSeeds,

--- a/framework/app_isolation_warn_test.go
+++ b/framework/app_isolation_warn_test.go
@@ -1,0 +1,73 @@
+package framework
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Pins #268: worktree isolation remapping an explicitly-assigned listen
+// address is documented behavior, but doing it SILENTLY is
+// configuration accepted-but-not-honored — anything polling the
+// requested port hangs to its deadline. Start must scream with both
+// addresses and the kill switch.
+func TestStartWarnsWhenIsolationRemapsAddr(t *testing.T) {
+	dir := t.TempDir()
+	// A linked-worktree checkout is a .git FILE pointing into the
+	// parent repo's worktrees dir (same fixture the isolation package
+	// tests use); that alone activates the default worktree mode.
+	gitdir := filepath.Join(t.TempDir(), ".git", "worktrees", "feature")
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: "+gitdir+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(oldWD) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	// Neutralize any isolation env leaking in from the test runner's
+	// own environment (this repo's suites often run inside a worktree).
+	for _, k := range []string{"GOFASTR_ISOLATION", "GOFASTR_ISOLATION_APPLIED", "GOFASTR_ISOLATION_ID", "GOFASTR_ISOLATION_REWRITE"} {
+		t.Setenv(k, "")
+	}
+
+	var logs bytes.Buffer
+	app := NewApp(WithoutDefaultMiddleware(), WithLogger(slog.New(slog.NewTextHandler(&logs, nil))))
+	var banner bytes.Buffer
+	app.startupOutput = &banner
+	ready := make(chan string, 1)
+	app.OnReady(func(addr string) { ready <- addr })
+
+	done := make(chan error, 1)
+	go func() { done <- app.Start("127.0.0.1:8080") }()
+
+	select {
+	case bound := <-ready:
+		got := logs.String()
+		if !strings.Contains(got, "isolation remapped the listen address") {
+			t.Errorf("remap warning missing; logs:\n%s", got)
+		}
+		if !strings.Contains(got, "127.0.0.1:8080") || !strings.Contains(got, "GOFASTR_ISOLATION=off") {
+			t.Errorf("warning must name the requested address and the kill switch; logs:\n%s", got)
+		}
+		if bound == "127.0.0.1:8080" {
+			t.Errorf("expected isolation to remap away from the requested port, bound %s", bound)
+		}
+	case err := <-done:
+		t.Fatalf("Start returned before OnReady: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("OnReady never fired")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_ = app.Shutdown(ctx)
+	<-done
+}

--- a/framework/app_isolation_warn_test.go
+++ b/framework/app_isolation_warn_test.go
@@ -71,3 +71,35 @@ func TestStartWarnsWhenIsolationRemapsAddr(t *testing.T) {
 	_ = app.Shutdown(ctx)
 	<-done
 }
+
+// The warn must be gated on isolation being ACTIVE: Addr also
+// normalizes a bare port ("0" → ":0") when isolation is off, and that
+// spelling change is not a remap (PR #274 review finding).
+func TestStartDoesNotWarnWithoutIsolation(t *testing.T) {
+	t.Setenv("GOFASTR_ISOLATION", "off")
+
+	var logs bytes.Buffer
+	app := NewApp(WithoutDefaultMiddleware(), WithLogger(slog.New(slog.NewTextHandler(&logs, nil))))
+	var banner bytes.Buffer
+	app.startupOutput = &banner
+	ready := make(chan string, 1)
+	app.OnReady(func(addr string) { ready <- addr })
+
+	done := make(chan error, 1)
+	go func() { done <- app.Start("0") }() // bare port: normalized to ":0", not remapped
+
+	select {
+	case <-ready:
+		if strings.Contains(logs.String(), "isolation remapped") {
+			t.Errorf("bare-port normalization must not warn with isolation off:\n%s", logs.String())
+		}
+	case err := <-done:
+		t.Fatalf("Start returned before OnReady: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("OnReady never fired")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_ = app.Shutdown(ctx)
+	<-done
+}

--- a/framework/docs/content/ui-wiring.md
+++ b/framework/docs/content/ui-wiring.md
@@ -139,6 +139,11 @@ Useful options:
   without recompiling.
 - `uihost.WithNotFoundScreen(c)`, `WithFavicon`, `WithDescription`,
   `WithOpenGraph`, `WithCanonicalURL`: 404 page and head metadata.
+  Custom 404s go through `WithNotFoundScreen`, never
+  `app.Router().NotFound(...)`: screens dispatch through the router's
+  NotFound fall-through, so replacing it disables every page (the
+  router now warns when a NotFound handler is replaced; compose with
+  `Router.WrapNotFound` when both must run).
 
 **`fwApp.Start`** runs migrations, binds the port, serves. Nothing
 UI-specific.


### PR DESCRIPTION
First execution batch from grooming round 2 (three-model pass on #252–#273; verdicts being posted to the issues).

**#260 — logging wrappers block `http.NewResponseController` deadlines.** One `Unwrap` on `middleware.Logging`'s base writer (embedding promotes it to every variant) and one on `battery/log`'s `countingResponseWriter` — the production access-log path the issue missed. Regression tests drive `SetWriteDeadline` through each chain to a fake connection; mutation-proven. Issue corrections applied: logging is not in the default chain (stale doc comment fixed), and `Flush` was never affected.

**#259 — value screen components died with a generic DI error.** `newInstance` documents value components as the supported stateless form; render now skips DI for them instead of rejecting, and a value struct that *asks* for injection via `inject` tags fails naming the type and the `&T{}` remedy (silently rendering with nil services would be worse). The ticket's proposed always-panic guard would have broken the documented contract — declined in favor of honoring it.

**#258 + #268 — silent clobbers now scream (feature asks declined as groomed).** `Router.NotFound` warns when it replaces an existing handler — a UI host dispatches every screen through NotFound, so an app's later custom 404 silently disabled every page (and the inverse order ate the app's 404); `WrapNotFound` composes silently, `uihost.WithNotFoundScreen` is the supported custom 404 and ui-wiring.md now says so. `App.Start` warns when worktree isolation remaps an explicitly-assigned address, naming requested/resolved/both kill switches; the test fabricates a linked-worktree checkout and asserts both the warn and the actual port move. Honoring explicit `PORT` (the ticket's option 2) is declined: it would reintroduce exactly the sibling-worktree collisions the documented default prevents.

All four packages' suites green; guards mutation-proven where behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Stateless value components now render correctly without dependency injection.
  - Streaming responses preserve per-write connection deadlines through middleware.
  - Warnings now identify replaced 404 handlers and remapped listen addresses instead of failing silently.

- **Documentation**
  - Clarified how to configure custom 404 screens and compose not-found handlers.
  - Clarified that access logging remains available through dedicated logging middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->