### PR TITLE
fix: round-2 batch B — SiteFooter tap targets, canonical token bridge (#257, #271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Fixed
 
+- **`ui.SiteFooter` link tap targets reach the 24px AA floor** (#257):
+  inline 13px/1.6 anchors gave a ~17px hit area that padding could not
+  extend; footer links are now `inline-flex` with `min-block-size:
+  24px` (the design system's documented dense-cluster AA relaxation),
+  pinned by a rendered 390px measurement.
+- **Plugin frames get the full theme palette** (#271): the broker
+  discovered token names by walking `document.styleSheets`, which
+  raced stylesheet parsing (a sheet still loading contributed no
+  names) and skipped `@media`/`@supports`-nested declarations — either
+  way a PARTIAL palette bridged, giving dark text on the frame's light
+  fallbacks. The broker now reads the theme's canonical vocabulary
+  (`style.TokenNames()`) from computed style unconditionally; a Go
+  test pins the JS list against the theme so a new token cannot
+  silently go unbridged.
+
 - **Stateless value screen components render again** (#259):
   registering a component by value (the documented stateless form) died
   at render time with a generic "di: target must be a non-nil pointer".

--- a/examples/site/sitefooter_targets_measure_test.go
+++ b/examples/site/sitefooter_targets_measure_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chromedp/chromedp"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/registry"
+	"github.com/DonaldMurillo/gofastr/core-ui/style"
+	"github.com/DonaldMurillo/gofastr/framework/ui"
+)
+
+// TestSiteFooterLinkTargetsAt390 pins #257: at a phone viewport, every
+// footer link's rendered hit area must reach the design system's 24px
+// AA floor for dense clusters (the bug was inline 13px/1.6 anchors at
+// ~17px, where vertical padding can't extend an inline box).
+func TestSiteFooterLinkTargetsAt390(t *testing.T) {
+	if testing.Short() {
+		t.Skip("chromedp")
+	}
+	entry, ok := registry.Lookup("ui-site-footer")
+	if !ok {
+		t.Fatal("ui-site-footer style not registered")
+	}
+	page := `<!doctype html><html><head><style>` +
+		entry.CSSFor(style.Theme{}) +
+		`</style></head><body style="margin:0">` +
+		string(ui.SiteFooter(ui.SiteFooterConfig{
+			Columns: []ui.SiteFooterColumn{
+				{Title: "Product", Links: []ui.SiteFooterLink{
+					{Label: "Pricing", Href: "/pricing"},
+					{Label: "About", Href: "/about"},
+				}},
+				{Title: "Legal", Links: []ui.SiteFooterLink{
+					{Label: "Terms", Href: "/terms"},
+					{Label: "Privacy", Href: "/privacy"},
+				}},
+			},
+		})) +
+		`</body></html>`
+	dir := t.TempDir()
+	file := filepath.Join(dir, "footer.html")
+	if err := os.WriteFile(file, []byte(page), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := siteBrowserCtx(t)
+	var heights []float64
+	measure := `Array.from(document.querySelectorAll("li a")).map(a => a.getBoundingClientRect().height)`
+	if err := chromedp.Run(ctx,
+		chromedp.EmulateViewport(390, 844),
+		chromedp.Navigate("file://"+file),
+		chromedp.Evaluate(measure, &heights),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if len(heights) != 4 {
+		t.Fatalf("expected 4 links, measured %d", len(heights))
+	}
+	for i, h := range heights {
+		if h < 24 {
+			t.Errorf("link %d hit area %.1fpx, below the 24px AA floor", i, h)
+		}
+	}
+	fmt.Printf("footer link heights at 390px: %v\n", heights)
+}

--- a/framework/pluginhost/host/pluginhost.js
+++ b/framework/pluginhost/host/pluginhost.js
@@ -73,42 +73,49 @@
   }
 
   /**
-   * resolveTokens enumerates the --* custom properties the host emits on
-   * :root / html and reads each RESOLVED value via getComputedStyle. Cross-
-   * origin stylesheets throw on cssRules access; those are wrapped in
-   * try/catch and skipped. The resulting map is bridged verbatim into the
-   * frame (§7), which writes its own :root block from it.
+   * THEME_TOKENS is the theme's canonical custom-property vocabulary,
+   * mirrored from style.TokenNames() and pinned by a Go test
+   * (token_bridge_test.go) so it cannot drift from the theme emitter.
+   */
+  var THEME_TOKENS = [
+    "--breakpoint-2xl", "--breakpoint-lg", "--breakpoint-md", "--breakpoint-sm", "--breakpoint-xl",
+    "--color-accent", "--color-background", "--color-border", "--color-border-strong",
+    "--color-code-border", "--color-code-surface", "--color-code-text",
+    "--color-danger", "--color-info", "--color-primary", "--color-primary-fg",
+    "--color-secondary", "--color-secondary-fg", "--color-success",
+    "--color-surface", "--color-surface-soft", "--color-text", "--color-text-muted",
+    "--color-text-subtle", "--color-warning",
+    "--duration-dropdown-enter", "--duration-fast", "--duration-normal",
+    "--duration-overlay-enter", "--duration-overlay-exit", "--duration-slow",
+    "--duration-toast-enter", "--duration-toast-exit",
+    "--easing-ease-in", "--easing-ease-in-out", "--easing-ease-out", "--easing-spring",
+    "--font-body", "--font-heading", "--font-mono",
+    "--radii-full", "--radii-lg", "--radii-md", "--radii-none", "--radii-sm", "--radii-xl",
+    "--shadow-lg", "--shadow-md", "--shadow-none", "--shadow-sm", "--shadow-xl",
+    "--spacing-2xl", "--spacing-3xl", "--spacing-lg", "--spacing-md", "--spacing-sm",
+    "--spacing-touch-target", "--spacing-xl", "--spacing-xs",
+    "--text-2xl", "--text-3xl", "--text-base", "--text-lg", "--text-sm", "--text-xl", "--text-xs",
+    "--tk-com", "--tk-fn", "--tk-kw", "--tk-num", "--tk-pn", "--tk-str", "--tk-type",
+    "--z-dropdown", "--z-modal", "--z-popover", "--z-sticky", "--z-toast"
+  ];
+
+  /**
+   * resolveTokens reads the canonical token set from computed style and
+   * bridges every name with a non-empty value. The old implementation
+   * DISCOVERED names by walking document.styleSheets, which had two
+   * partial-palette failure modes: a stylesheet still parsing when the
+   * frame boots contributed no names (the CI-only invisible-text race,
+   * #271), and rule.type !== 1 skipped tokens declared only inside
+   * @media / @supports. A partial palette is worse than none — a
+   * bridged dark --color-text beside an unbridged --color-surface is
+   * white-on-white. Reading a known vocabulary from computed style has
+   * neither failure mode.
    */
   function resolveTokens() {
-    var names = {};
-    var sheets = document.styleSheets;
-    for (var i = 0; i < sheets.length; i++) {
-      var rules;
-      try {
-        rules = sheets[i].cssRules;
-      } catch (e) {
-        // Cross-origin sheet (SecurityError) — skip, never bridge foreign CSS.
-        continue;
-      }
-      if (!rules) continue;
-      for (var j = 0; j < rules.length; j++) {
-        var rule = rules[j];
-        if (!rule || rule.type !== 1) continue; // STYLE_RULE
-        var sel = rule.selectorText || "";
-        // Only :root / html scoped custom properties bridge across the frame.
-        if (sel.indexOf(":root") === -1 && sel.indexOf("html") === -1) continue;
-        var decls = rule.style;
-        if (!decls) continue;
-        for (var k = 0; k < decls.length; k++) {
-          var prop = decls[k];
-          if (prop.indexOf("--") === 0) names[prop] = true;
-        }
-      }
-    }
     var cs = getComputedStyle(document.documentElement);
     var tokens = {};
-    for (var name in names) {
-      if (!Object.prototype.hasOwnProperty.call(names, name)) continue;
+    for (var i = 0; i < THEME_TOKENS.length; i++) {
+      var name = THEME_TOKENS[i];
       var val = cs.getPropertyValue(name);
       if (val == null) continue;
       val = String(val).trim();

--- a/framework/pluginhost/token_bridge_test.go
+++ b/framework/pluginhost/token_bridge_test.go
@@ -1,0 +1,48 @@
+package pluginhost
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/style"
+)
+
+// TestBrokerThemeTokenListMatchesTheme pins #271's fix: the broker
+// bridges the theme's CANONICAL token vocabulary read from computed
+// style (no stylesheet-walk discovery, which raced sheet parsing and
+// was blind to @media-nested declarations). The JS list is hand-written
+// in host/pluginhost.js; this test keeps it byte-equal to what the
+// theme actually emits, so a token added to style.Theme cannot silently
+// go unbridged — the exact partial-palette failure the walker had.
+func TestBrokerThemeTokenListMatchesTheme(t *testing.T) {
+	js := string(brokerJSBytes)
+	start := strings.Index(js, "var THEME_TOKENS = [")
+	if start == -1 {
+		t.Fatal("THEME_TOKENS array missing from broker JS")
+	}
+	end := strings.Index(js[start:], "];")
+	if end == -1 {
+		t.Fatal("THEME_TOKENS array unterminated")
+	}
+	block := js[start : start+end]
+	re := regexp.MustCompile(`"--([A-Za-z0-9_-]+)"`)
+	inJS := map[string]bool{}
+	for _, m := range re.FindAllStringSubmatch(block, -1) {
+		inJS[m[1]] = true
+	}
+
+	canonical := style.TokenNames()
+	for _, name := range canonical {
+		if !inJS[name] {
+			t.Errorf("theme token %q missing from broker THEME_TOKENS: frames would get a partial palette", name)
+		}
+		delete(inJS, name)
+	}
+	for extra := range inJS {
+		t.Errorf("broker THEME_TOKENS has %q, which the theme does not emit; remove it", extra)
+	}
+	if len(canonical) == 0 {
+		t.Fatal("style.TokenNames() returned nothing; the pin is vacuous")
+	}
+}

--- a/framework/ui/site_footer.go
+++ b/framework/ui/site_footer.go
@@ -137,6 +137,13 @@ func siteFooterCSS(_ style.Theme) string {
   text-decoration: none;
   font-size: var(--text-sm, 13px);
   line-height: 1.6;
+  /* Touch target: an inline anchor at 13px/1.6 is a ~17px hit area,
+     under even the AA floor. Dense link clusters use the documented
+     24px AA relaxation (see rating.go) rather than the 44px AAA
+     token; inline-flex so min-block-size actually extends the box. */
+  display: inline-flex;
+  align-items: center;
+  min-block-size: 24px;
 }
 [data-fui-comp="ui-site-footer"] li a:hover,
 [data-fui-comp="ui-site-footer"] li a:focus-visible {


### PR DESCRIPTION
Second execution batch from grooming round 2.

**#257 — SiteFooter link tap targets.** Inline 13px/1.6 anchors rendered a ~17px hit area (vertical padding can't extend an inline box). Links are now `inline-flex` with `min-block-size: 24px` — the design system's documented dense-cluster AA relaxation (rating.go precedent), deliberately not the ticket's 20px, which would have minted a third floor below the repo's own AA policy. Verified with a rendered chromedp measurement at 390×844 against the component's registered CSS: 24px on all four fixture links, mutation-proven.

**#271 — plugin frames received a partial theme palette.** The broker discovered token names by walking `document.styleSheets` — racing stylesheet parsing (the CI-only webkit invisible-text failure) and skipping `@media`/`@supports`-nested declarations. It now bridges the theme's canonical vocabulary (mirrored from `style.TokenNames()`) read from computed style unconditionally; no walk remains, so both failure classes die together. `TestBrokerThemeTokenListMatchesTheme` pins the JS list against the theme emitter in both directions (missing and extra names), mutation-proven, so a new theme token cannot silently go unbridged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9