### PR TITLE
fix(auth): canonical email identity end to end (#270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Fixed
 
+- **`battery/auth` treats emails as case-insensitive end to end**
+  (#270): `Owner@Example.com` and `owner@example.com` were two
+  different accounts — login failed across casings, OAuth created
+  duplicate accounts on a case-mismatched provider email, and the
+  rate limiter lowercased while the lookup three lines later did not.
+  Every flow (login, registration, magic links, OAuth matching,
+  password reset, limiter keys) now canonicalizes via the new exported
+  `auth.CanonicalEmail` at its ingestion point, so custom `UserStore`
+  implementations receive canonical input too. **Stores with existing
+  mixed-case rows need the one-time migration in auth.md** (collision
+  check first, then `LOWER(email)` rewrite + expression unique index).
+
 - **`ui.SiteFooter` link tap targets reach the 24px AA floor** (#257):
   inline 13px/1.6 anchors gave a ~17px hit area that padding could not
   extend; footer links are now `inline-flex` with `min-block-size:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Fixed
 
-- **`battery/auth` treats emails as case-insensitive end to end**
+- **`battery/auth` treats emails as case-insensitive end-to-end**
   (#270): `Owner@Example.com` and `owner@example.com` were two
   different accounts — login failed across casings, OAuth created
   duplicate accounts on a case-mismatched provider email, and the

--- a/battery/auth/core.go
+++ b/battery/auth/core.go
@@ -182,7 +182,7 @@ func (c *CorePlugin) loginHandler() http.HandlerFunc {
 		// account existence by measuring per-account 429s either,
 		// every non-empty email gets the same treatment.
 		if c.loginLimitAccount != nil {
-			key := "account:" + strings.ToLower(strings.TrimSpace(email))
+			key := "account:" + CanonicalEmail(email)
 			allowed, retry := c.loginLimitAccount.AllowContext(r.Context(), key)
 			if !allowed {
 				w.Header().Set("Retry-After", fmt.Sprintf("%.0f", retry.Seconds()))

--- a/battery/auth/email_canonical_test.go
+++ b/battery/auth/email_canonical_test.go
@@ -1,0 +1,63 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestCanonicalEmail(t *testing.T) {
+	cases := map[string]string{
+		"Owner@Example.COM":    "owner@example.com",
+		"  bob@example.com  ":  "bob@example.com",
+		"MiXeD@CaSe.Io":        "mixed@case.io",
+		"already@lower.dev":    "already@lower.dev",
+		"":                     "",
+		"\tTabbed@Example.com": "tabbed@example.com",
+	}
+	for in, want := range cases {
+		if got := CanonicalEmail(in); got != want {
+			t.Errorf("CanonicalEmail(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// Pins #270: an operator whose account is owner@example.com typing
+// Owner@Example.com must log in, not get invalid_credentials. The
+// fixture store matches literally (map key), so this fails unless the
+// handler canonicalizes before the lookup.
+func TestLoginEmailCaseInsensitive(t *testing.T) {
+	f := auditHarness(t)
+	f.seedUser(t, "u-case", "owner@example.com", "supersecret1")
+
+	jar := &cookieJar{}
+	rec := jar.do(f.router, http.MethodPost, "/auth/login",
+		map[string]string{"email": "  Owner@Example.COM ", "password": "supersecret1"}, "203.0.113.9:5555")
+	mustStatus(t, rec, http.StatusOK)
+}
+
+// Registration must STORE the canonical form, so the same person can
+// sign up with one casing and log in with another — and so two casings
+// cannot become two accounts.
+func TestRegisterStoresCanonicalEmail(t *testing.T) {
+	f := auditHarness(t)
+	jar := &cookieJar{}
+	rec := jar.do(f.router, http.MethodPost, "/auth/register",
+		map[string]string{"email": "Bob@Example.COM", "password": "supersecret1"}, "203.0.113.9:5555")
+	if rec.Code != http.StatusOK && rec.Code != http.StatusCreated {
+		t.Fatalf("register: %d %s", rec.Code, rec.Body.String())
+	}
+	if _, ok := f.store.users["bob@example.com"]; !ok {
+		t.Fatalf("store should hold the canonical email; keys: %v", storeKeys(f.store.memoryUserStore))
+	}
+	rec = jar.do(f.router, http.MethodPost, "/auth/login",
+		map[string]string{"email": "bob@example.com", "password": "supersecret1"}, "203.0.113.9:5555")
+	mustStatus(t, rec, http.StatusOK)
+}
+
+func storeKeys(s *memoryUserStore) []string {
+	keys := make([]string, 0, len(s.users))
+	for k := range s.users {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/battery/auth/form_decode.go
+++ b/battery/auth/form_decode.go
@@ -80,7 +80,7 @@ func decodeAuthCredentials(w http.ResponseWriter, r *http.Request) (email, passw
 			writeAuthError(w, http.StatusBadRequest, "invalid form body")
 			return "", "", true, false
 		}
-		email = r.PostFormValue("email")
+		email = CanonicalEmail(r.PostFormValue("email"))
 		password = r.PostFormValue("password")
 		if !emailWithinLimit(w, email) {
 			return "", "", true, false
@@ -95,10 +95,23 @@ func decodeAuthCredentials(w http.ResponseWriter, r *http.Request) (email, passw
 	if !decodeJSONLimited(w, r, &body) {
 		return "", "", false, false
 	}
-	if !emailWithinLimit(w, body.Email) {
+	email = CanonicalEmail(body.Email)
+	if !emailWithinLimit(w, email) {
 		return "", "", false, false
 	}
-	return body.Email, body.Password, false, true
+	return email, body.Password, false, true
+}
+
+// CanonicalEmail is the battery's single definition of email identity:
+// trimmed and lowercased. Every flow that looks an email up or stores
+// one (login, registration, magic links, OAuth matching, password
+// reset, the login rate-limiter key) canonicalizes at its ingestion
+// point, so custom UserStore implementations always receive canonical
+// input and the limiter key and the lookup key agree by construction
+// (#270). Hosts wrapping UserStore should use it too when they accept
+// emails from their own surfaces.
+func CanonicalEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
 }
 
 // maxEmailLen is RFC 5321's 254-octet ceiling on a forward-path address.

--- a/battery/auth/magiclink.go
+++ b/battery/auth/magiclink.go
@@ -266,6 +266,10 @@ func (p *MagicLinkPlugin) sendHandler(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSONLimited(w, r, &body) {
 		return
 	}
+	// Canonicalize at ingestion (#270): the email rides inside the
+	// token and comes back out at consume time, so canonical-in means
+	// the eventual FindByEmail/CreateUser see canonical too.
+	body.Email = CanonicalEmail(body.Email)
 	if body.Email == "" {
 		writeAuthError(w, http.StatusBadRequest, "email is required")
 		return

--- a/battery/auth/oauth2.go
+++ b/battery/auth/oauth2.go
@@ -378,6 +378,10 @@ func (p *OAuth2Plugin) callbackHandler() http.HandlerFunc {
 			writeAuthError(w, http.StatusInternalServerError, "failed to fetch user info")
 			return
 		}
+		// Canonicalize at the single consumer of every provider (#270):
+		// a provider reporting Bob@example.com must match an existing
+		// bob@example.com account instead of creating a duplicate.
+		info.Email = CanonicalEmail(info.Email)
 
 		// Bind the durable (provider, provider_id) link namespace to the
 		// STATE-VALIDATED registry key, NOT the provider-returned Name().

--- a/battery/auth/password_reset.go
+++ b/battery/auth/password_reset.go
@@ -122,6 +122,7 @@ func (p *PasswordResetPlugin) forgotHandler(w http.ResponseWriter, r *http.Reque
 		_ = json.NewEncoder(w).Encode(map[string]any{"sent": true})
 	}()
 
+	body.Email = CanonicalEmail(body.Email) // #270: lookups and token payloads use canonical identity
 	if body.Email == "" {
 		return
 	}

--- a/framework/docs/content/auth.md
+++ b/framework/docs/content/auth.md
@@ -589,18 +589,20 @@ those must be resolved by the operator (merge or delete), not by the
 migration:
 
 ```sql
-SELECT LOWER(email), COUNT(*) FROM auth_users
-GROUP BY LOWER(email) HAVING COUNT(*) > 1;
+SELECT LOWER(TRIM(email)), COUNT(*) FROM auth_users
+GROUP BY LOWER(TRIM(email)) HAVING COUNT(*) > 1;
 ```
 
 With zero collisions, normalize and then keep the invariant honest
-with an expression index (PostgreSQL shown; SQLite supports the same
-expression-index form):
+with an expression index. `TRIM` mirrors the runtime canonicalization
+(`CanonicalEmail` trims before lowercasing) so a legacy
+`"  Bob@Example.com  "` row collapses to the same identity. PostgreSQL
+shown; SQLite supports the same expression-index form:
 
 ```sql
-UPDATE auth_users SET email = LOWER(email);
+UPDATE auth_users SET email = LOWER(TRIM(email));
 CREATE UNIQUE INDEX auth_users_email_canonical
-  ON auth_users (LOWER(email));
+  ON auth_users (LOWER(TRIM(email)));
 ```
 
 ## Listing users

--- a/framework/docs/content/auth.md
+++ b/framework/docs/content/auth.md
@@ -572,6 +572,37 @@ setting a boolean `FALSE` default. This self-heals tables created by
 older GoFastr versions. Back up production data before the first boot
 after upgrading.
 
+## Email identity is canonical (lowercased + trimmed)
+
+Every flow that reads or stores an email — login, registration, magic
+links, OAuth account matching, password reset, and the login
+rate-limiter key — canonicalizes it with `auth.CanonicalEmail`
+(trim + lowercase) at its ingestion point. Custom `UserStore`
+implementations therefore always receive canonical input; a host that
+accepts emails on its own surfaces should call `auth.CanonicalEmail`
+too so its lookups agree with the battery's.
+
+**Upgrading a store with mixed-case rows**: rows written by older
+versions keep their original casing and will no longer match. Before
+rewriting, find casings that would collapse into the same account —
+those must be resolved by the operator (merge or delete), not by the
+migration:
+
+```sql
+SELECT LOWER(email), COUNT(*) FROM auth_users
+GROUP BY LOWER(email) HAVING COUNT(*) > 1;
+```
+
+With zero collisions, normalize and then keep the invariant honest
+with an expression index (PostgreSQL shown; SQLite supports the same
+expression-index form):
+
+```sql
+UPDATE auth_users SET email = LOWER(email);
+CREATE UNIQUE INDEX auth_users_email_canonical
+  ON auth_users (LOWER(email));
+```
+
 ## Listing users
 
 Back-offices that need to enumerate accounts (an admin user list, a

--- a/framework/uihost/embed_test.go
+++ b/framework/uihost/embed_test.go
@@ -406,6 +406,14 @@ func TestEmbedExchangeIsIdempotent(t *testing.T) {
 	}
 }
 
+// flipChar returns a base64url character guaranteed to differ from c.
+func flipChar(c byte) string {
+	if c == 'A' {
+		return "B"
+	}
+	return "A"
+}
+
 // Which check failed is an oracle: it tells a caller probing with a captured
 // nonce exactly how far they got. Every rejection answers identically.
 func TestEmbedExchangeFailuresAreIndistinguishable(t *testing.T) {
@@ -428,10 +436,16 @@ func TestEmbedExchangeFailuresAreIndistinguishable(t *testing.T) {
 	}
 	time.Sleep(50 * time.Millisecond)
 
+	// Tamper by SUBSTITUTING the final signature character with a
+	// different one, not by appending a fixed suffix: replacing the
+	// tail with a constant ("xy") made the tampered token equal the
+	// real one whenever the HMAC happened to end in that constant — a
+	// 1-in-4096 CI flake that presented as "tampered token accepted".
+	tampered := good[:len(good)-1] + flipChar(good[len(good)-1])
 	cases := map[string]string{
 		"garbage":             "not-a-token",
 		"wrong prefix":        "emg_" + strings.TrimPrefix(good, "emb_"),
-		"tampered":            good[:len(good)-2] + "xy",
+		"tampered":            tampered,
 		"wrong framed origin": good,
 		"already used":        spent,
 	}


### PR DESCRIPTION
Round-2 batch C. `Owner@Example.com` and `owner@example.com` were two different accounts: login failed across casings, OAuth created a duplicate account on a case-mismatched provider email (proven path: `ErrUserNotFound → CreateUserNoPassword`), and the login rate limiter lowercased its key while the lookup three lines later matched literally.

**Fix shape, per the reconciled grooming**: the new exported `auth.CanonicalEmail` (trim + lowercase) applies at every *ingestion point*, not inside `EntityUserStore` — the `UserStore` interface invites custom implementations (hosts wrap it), so store-level normalization would recreate the exact two-contracts drift this bug is. Boundary normalization means every store receives canonical input, and the limiter key and lookup key agree by construction. Covered: `decodeAuthCredentials` (login + registration, form and JSON), magic-link request (the email rides inside the token, so canonical-in covers consume), password reset (a sixth affected flow the issue hadn't listed), the OAuth callback (the single consumer of every provider's `FetchUserInfo`), and the limiter key now uses the same helper.

**Migration**: documented in auth.md — stores with existing mixed-case rows run a collision check first (casings that collapse into one account must be operator-resolved, never auto-merged), then the `LOWER(email)` rewrite and an expression unique index. Changelog carries the upgrade warning.

Tests: mixed-case + padded login succeeds against a literal-matching store; registration stores the canonical form; both go red when `CanonicalEmail` is neutered (mutation-proven). Full `battery/auth` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email addresses are now handled consistently without regard to capitalization or surrounding spaces across login, registration, magic links, OAuth matching, password resets, and rate limiting.
  * Prevents duplicate accounts and improves authentication lookup reliability.

* **Documentation**
  * Added upgrade guidance for existing accounts with mixed-case email addresses, including migration and collision checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->