### PR TITLE
fix(docs): generated API docs match mounted routes (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Fixed
 
+- **Generated API docs describe routes that exist** (#266, sibling of
+  the v0.73.0 banner fix): `/openapi.json` and `/api/llm.md` documented
+  auto-CRUD endpoints for entities whose routes registration never
+  mounted (no DB attached, or in llm.md's case even `Exposure.CRUD=
+  false`). Both generators now take the app's route predicate: CRUD-less
+  entities keep their declared custom endpoints (unlinked in the llm.md
+  index — the per-entity page rides the CRUD mount), and entities with
+  no routes at all are omitted. **BREAKING for direct callers**:
+  `openapi.EntityOpenAPI` and `crud.RegistryLLMMD`/`RegistryLLMMDHandler`
+  gained a `crudMounted func(*entity.Entity) bool` parameter — pass nil
+  for the previous Exposure-only behavior (the `framework.EntityOpenAPI`
+  re-export is unchanged and passes nil).
+
 - **`battery/auth` treats emails as case-insensitive end-to-end**
   (#270): `Owner@Example.com` and `owner@example.com` were two
   different accounts — login failed across casings, OAuth created

--- a/framework/agentready_isagentic_test.go
+++ b/framework/agentready_isagentic_test.go
@@ -89,6 +89,10 @@ func TestAgentReady_IsAgentic(t *testing.T) {
 		WithConfig(AppConfig{Name: "isagentic"}),
 		WithMCP(),
 		WithPublicOpenAPI(),
+		// The spec documents route reality (#266): without a DB the
+		// entity has no CRUD routes and the self-describing check would
+		// rightly see an empty paths object.
+		WithDB(bannerTestDB(t)),
 	)
 	fwApp.Entity("posts", entity.EntityConfig{
 		Table:  "posts",

--- a/framework/app.go
+++ b/framework/app.go
@@ -2919,7 +2919,7 @@ func (a *App) Start(addr string) error {
 		if appName == "" {
 			appName = "GoFastr API"
 		}
-		spec := openapi.EntityOpenAPI(a.Registry, appName, "1.0.0", a.apiPrefix())
+		spec := openapi.EntityOpenAPI(a.Registry, appName, "1.0.0", a.entityCRUDEnabled, a.apiPrefix())
 		if a.Config.PublicOpenAPI {
 			a.router.Get("/openapi.json", coreoa.PublicHandler(spec))
 		} else {
@@ -2941,7 +2941,7 @@ func (a *App) Start(addr string) error {
 			// per-request-filtered crud handler, and per-entity
 			// /{table}/llm.md routes keep their own scope gate either way.
 			if a.Config.PublicOpenAPI {
-				doc := []byte(crud.RegistryLLMMD(a.Registry, appName))
+				doc := []byte(crud.RegistryLLMMD(a.Registry, appName, a.entityCRUDEnabled))
 				a.router.Get("/api/llm.md", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					w.Header().Set("Cache-Control", "no-store")
 					w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
@@ -2949,7 +2949,7 @@ func (a *App) Start(addr string) error {
 					w.Write(doc)
 				}))
 			} else {
-				a.router.Get("/api/llm.md", crud.RegistryLLMMDHandler(a.Registry, appName))
+				a.router.Get("/api/llm.md", crud.RegistryLLMMDHandler(a.Registry, appName, a.entityCRUDEnabled))
 			}
 			hasLLMMD = true
 		}

--- a/framework/crud/cov_pure_test.go
+++ b/framework/crud/cov_pure_test.go
@@ -77,7 +77,7 @@ func TestRegistryLLMMD_ListsEntities(t *testing.T) {
 		"posts": covRelEntity(),
 		"acct":  entity.Define("acct", entity.EntityConfig{Name: "acct", Table: "acct", Scope: &entity.ScopeConfig{MultiTenant: true, SoftDelete: true}, Fields: []schema.Field{{Name: "n", Type: schema.String}}}.WithTimestamps(false)),
 	}}
-	md := RegistryLLMMD(reg, "MyApp")
+	md := RegistryLLMMD(reg, "MyApp", nil)
 	for _, want := range []string{"MyApp: API Reference", "posts", "acct", "soft-delete", "multi-tenant", "Quick Reference"} {
 		if !strings.Contains(md, want) {
 			t.Errorf("RegistryLLMMD missing %q", want)
@@ -87,7 +87,7 @@ func TestRegistryLLMMD_ListsEntities(t *testing.T) {
 
 func TestRegistryLLMMD_EmptyAndDefaultTitle(t *testing.T) {
 	reg := stubRegistry{byName: map[string]*entity.Entity{}}
-	md := RegistryLLMMD(reg, "")
+	md := RegistryLLMMD(reg, "", nil)
 	if !strings.Contains(md, "API: API Reference") {
 		t.Errorf("default title missing: %s", md[:40])
 	}

--- a/framework/crud/cov_routes_mcp_test.go
+++ b/framework/crud/cov_routes_mcp_test.go
@@ -206,7 +206,7 @@ func TestLLMMDHandler_AuthGate(t *testing.T) {
 
 func TestRegistryLLMMDHandler_AuthGate(t *testing.T) {
 	reg := stubRegistry{byName: map[string]*entity.Entity{"posts": covRelEntity()}}
-	h := RegistryLLMMDHandler(reg, "App")
+	h := RegistryLLMMDHandler(reg, "App", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest("GET", "/llm.md", nil))
 	if rec.Code != http.StatusUnauthorized {

--- a/framework/crud/llmmd.go
+++ b/framework/crud/llmmd.go
@@ -275,12 +275,18 @@ func EntityLLMMD(ent *entity.Entity) string {
 }
 
 // RegistryLLMMD generates a top-level LLM-friendly markdown index that
-// lists every registered entity with a link to its detailed llm.md page. It
-// lists every entity, callers that serve this to a request (the /api/llm.md
-// index) MUST filter per request via [registryLLMMD] so the index does not
-// disclose entities the caller cannot read.
-func RegistryLLMMD(registry entity.Registry, appName string) string {
-	return registryLLMMD(registry, appName, nil)
+// lists every registered entity with a link to its detailed llm.md page.
+// crudMounted reports whether the entity's auto-CRUD routes were actually
+// registered (the app passes its route predicate: DB attached AND
+// Exposure.CRUD); nil documents standard CRUD for every entity, the
+// pre-#266 behavior. Entities without CRUD routes list only their declared
+// custom endpoints, and entities with no routes at all are omitted — the
+// index must describe routes that exist. It lists every (routed) entity;
+// callers that serve this to a request (the /api/llm.md index) MUST filter
+// per request via [registryLLMMD] so the index does not disclose entities
+// the caller cannot read.
+func RegistryLLMMD(registry entity.Registry, appName string, crudMounted func(*entity.Entity) bool) string {
+	return registryLLMMD(registry, appName, nil, crudMounted)
 }
 
 // registryLLMMD renders the index, keeping only entities for which keep
@@ -288,7 +294,7 @@ func RegistryLLMMD(registry entity.Registry, appName string) string {
 // per-request keep that mirrors List's read-scope predicate (owner, tenant,
 // RBAC) so an authenticated caller with no grant for an entity gets 403 on
 // its rows AND never sees its name, base path or flags in the index.
-func registryLLMMD(registry entity.Registry, appName string, keep func(*entity.Entity) bool) string {
+func registryLLMMD(registry entity.Registry, appName string, keep, crudMounted func(*entity.Entity) bool) string {
 	var b strings.Builder
 	title := appName
 	if title == "" {
@@ -310,6 +316,17 @@ func registryLLMMD(registry entity.Registry, appName string, keep func(*entity.E
 		if keep != nil && !keep(ent) {
 			continue
 		}
+		// crudMounted mirrors route registration: nil (direct callers)
+		// documents standard CRUD as before; false lists only declared
+		// custom endpoints; an entity with no routes at all is omitted.
+		crud := crudMounted == nil || crudMounted(ent)
+		numEndpoints := len(ent.Config.Endpoints)
+		if crud {
+			numEndpoints += 8 // standard CRUD + batch + events
+		}
+		if numEndpoints == 0 {
+			continue
+		}
 		table := ent.GetTable()
 		basePath := "/" + table
 		llmLink := "/" + table + "/llm.md"
@@ -317,8 +334,6 @@ func registryLLMMD(registry entity.Registry, appName string, keep func(*entity.E
 			basePath = ent.Version + basePath
 			llmLink = ent.Version + "/" + table + "/llm.md"
 		}
-		numEndpoints := 8 // standard CRUD + batch + events
-		numEndpoints += len(ent.Config.Endpoints)
 		desc := ""
 		if ent.Config.Scope.SoftDelete {
 			desc = "soft-delete"
@@ -329,7 +344,13 @@ func registryLLMMD(registry entity.Registry, appName string, keep func(*entity.E
 			}
 			desc += "multi-tenant"
 		}
-		fmt.Fprintf(&b, "| [%s](%s) | `%s` | %d | %s |\n", ent.GetName(), llmLink, basePath, numEndpoints, desc)
+		if crud {
+			fmt.Fprintf(&b, "| [%s](%s) | `%s` | %d | %s |\n", ent.GetName(), llmLink, basePath, numEndpoints, desc)
+		} else {
+			// The per-entity llm.md route rides the CRUD mount; without
+			// it the link would 404, so list the name unlinked.
+			fmt.Fprintf(&b, "| %s | `%s` | %d | %s |\n", ent.GetName(), basePath, numEndpoints, desc)
+		}
 	}
 	b.WriteString("\n")
 
@@ -407,7 +428,7 @@ func LLMMDHandlerFor(ch *CrudHandler) http.Handler {
 // instead disclosed every entity's name, base path, endpoint count and
 // soft-delete/multi-tenant flags to an authenticated caller who would get
 // 403 on the rows. The index is the disclosure, not the row.
-func RegistryLLMMDHandler(registry entity.Registry, appName string) http.Handler {
+func RegistryLLMMDHandler(registry entity.Registry, appName string, crudMounted func(*entity.Entity) bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-store")
 		ctx := r.Context()
@@ -417,7 +438,7 @@ func RegistryLLMMDHandler(registry entity.Registry, appName string) http.Handler
 		}
 		md := registryLLMMD(registry, appName, func(ent *entity.Entity) bool {
 			return canListEntity(ctx, ent)
-		})
+		}, crudMounted)
 		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
 		w.Header().Set("Content-Length", strconv.Itoa(len(md)))
 		w.Write([]byte(md))

--- a/framework/crud/llmmd_authz_security_test.go
+++ b/framework/crud/llmmd_authz_security_test.go
@@ -91,7 +91,7 @@ func TestLLMMDIndexHidesUngrantedEntities(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/llm.md", nil)
 	req = reqWithRolesOnly(req, "u1") // signed in, holds no orders:read grant
-	RegistryLLMMDHandler(reg, "Test API").ServeHTTP(rec, req)
+	RegistryLLMMDHandler(reg, "Test API", nil).ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("index refused an authenticated caller: %d %s", rec.Code, rec.Body.String())
@@ -116,7 +116,7 @@ func TestLLMMDIndexShowsGrantedEntity(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/llm.md", nil)
 	req = reqWithGrant(req, "u1", "orders:read")
-	RegistryLLMMDHandler(reg, "Test API").ServeHTTP(rec, req)
+	RegistryLLMMDHandler(reg, "Test API", nil).ServeHTTP(rec, req)
 
 	if !strings.Contains(rec.Body.String(), "orders") {
 		t.Error("index hid orders from a caller who holds orders:read")

--- a/framework/crud/llmmd_route_reality_test.go
+++ b/framework/crud/llmmd_route_reality_test.go
@@ -1,0 +1,53 @@
+package crud
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+	"github.com/DonaldMurillo/gofastr/core/schema"
+)
+
+// Pins #266 for /api/llm.md: the index must describe routes that exist.
+// With a route predicate, a CRUD-less entity lists only its declared
+// custom endpoints (unlinked: its per-entity llm.md route rides the
+// CRUD mount), and an entity with no routes at all is omitted.
+func TestRegistryLLMMD_RouteReality(t *testing.T) {
+	reg := stubRegistry{byName: map[string]*entity.Entity{
+		"posts": covRelEntity(), // CRUD mounted, 2 custom endpoints
+		"jobs": entity.Define("jobs", entity.EntityConfig{
+			Name: "jobs", Table: "jobs",
+			Fields: []schema.Field{{Name: "n", Type: schema.String}},
+			Endpoints: []entity.Endpoint{
+				{Method: "POST", Path: "/jobs/retry", Description: "retry"},
+			},
+		}.WithTimestamps(false)), // CRUD off: custom endpoint only
+		"secrets": entity.Define("secrets", entity.EntityConfig{
+			Name: "secrets", Table: "secrets",
+			Fields: []schema.Field{{Name: "n", Type: schema.String}},
+		}.WithTimestamps(false)), // CRUD off, no endpoints: no routes at all
+	}}
+	crudMounted := func(e *entity.Entity) bool { return e.GetTable() == "posts" }
+
+	md := RegistryLLMMD(reg, "MyApp", crudMounted)
+
+	if !strings.Contains(md, "[posts](/posts/llm.md)") {
+		t.Errorf("CRUD-mounted entity should keep its linked row:\n%s", md)
+	}
+	if !strings.Contains(md, "| jobs | `/jobs` | 1 |") {
+		t.Errorf("CRUD-less entity should list only its 1 custom endpoint, unlinked:\n%s", md)
+	}
+	if strings.Contains(md, "jobs/llm.md") {
+		t.Errorf("CRUD-less entity must not link a per-entity llm.md that 404s:\n%s", md)
+	}
+	if strings.Contains(md, "secrets") {
+		t.Errorf("entity with no routes must be omitted from the index:\n%s", md)
+	}
+
+	// nil predicate keeps the historical Exposure-blind behavior for
+	// direct callers.
+	legacy := RegistryLLMMD(reg, "MyApp", nil)
+	if !strings.Contains(legacy, "secrets") {
+		t.Errorf("nil predicate must keep the pre-#266 behavior:\n%s", legacy)
+	}
+}

--- a/framework/crud/llmmd_route_reality_test.go
+++ b/framework/crud/llmmd_route_reality_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DonaldMurillo/gofastr/framework/entity"
 	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
 )
 
 // Pins #266 for /api/llm.md: the index must describe routes that exist.

--- a/framework/docs/content/security.md
+++ b/framework/docs/content/security.md
@@ -270,7 +270,10 @@ verify-email, forgot-password, reset-password, /auth/accounts,
 auto-generated OpenAPI spec.
 
 `framework/openapi.EntityOpenAPI` walks the entity registry to emit
-schemas for entity CRUD routes. Plugin-registered HTTP handlers go
+schemas for entity CRUD routes; the app passes its route predicate so
+the served spec never documents CRUD paths registration did not mount
+(no DB, or `Exposure.CRUD=false` — declared custom endpoints stay
+documented either way). Plugin-registered HTTP handlers go
 through `router.Post / router.Get / …` directly and don't carry
 schema metadata that the spec generator can consume. There is no
 plugin → OpenAPI extension hook today.

--- a/framework/exposure_security_test.go
+++ b/framework/exposure_security_test.go
@@ -74,7 +74,7 @@ func TestEntityLLMMDHandler_RequiresAuth(t *testing.T) {
 func TestRegistryLLMMDHandler_RequiresAuth(t *testing.T) {
 	app := securityExposureApp(t)
 	rec := httptest.NewRecorder()
-	crudpkg.RegistryLLMMDHandler(app.Registry, "Test App").ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/llm.md", nil))
+	crudpkg.RegistryLLMMDHandler(app.Registry, "Test App", nil).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/llm.md", nil))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("SECURITY: [llmmd] unauthenticated registry llm.md returned %d. Attack: global schema disclosure without auth.", rec.Code)
 	}
@@ -93,7 +93,7 @@ func TestDebugStatsEndpoint_RequiresAuth(t *testing.T) {
 
 func TestOpenAPISpecHandler_RequiresAuth(t *testing.T) {
 	app := securityExposureApp(t)
-	spec := openapipkg.EntityOpenAPI(app.Registry, "Test App", "1.0.0")
+	spec := openapipkg.EntityOpenAPI(app.Registry, "Test App", "1.0.0", nil)
 
 	rec := httptest.NewRecorder()
 	coreoa.Handler(spec).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/openapi.json", nil))
@@ -104,7 +104,7 @@ func TestOpenAPISpecHandler_RequiresAuth(t *testing.T) {
 
 func TestDocsHandler_RequiresAuth(t *testing.T) {
 	app := securityExposureApp(t)
-	spec := openapipkg.EntityOpenAPI(app.Registry, "Test App", "1.0.0")
+	spec := openapipkg.EntityOpenAPI(app.Registry, "Test App", "1.0.0", nil)
 
 	rec := httptest.NewRecorder()
 	coreoa.DocsHandler(spec, "/api/docs", false).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/docs/", nil))

--- a/framework/llmmd_public_test.go
+++ b/framework/llmmd_public_test.go
@@ -11,10 +11,12 @@ import (
 )
 
 // llmmdApp builds an app with one entity so the /api/llm.md index route
-// registers (hasAPI gates it on a non-empty registry).
+// registers (hasAPI gates it on a non-empty registry). It attaches a DB:
+// the index documents route reality (#266), and without a DB no entity
+// has CRUD routes to document.
 func llmmdApp(t *testing.T, opts ...AppOption) *App {
 	t.Helper()
-	app := NewApp(opts...)
+	app := NewApp(append([]AppOption{WithDB(bannerTestDB(t))}, opts...)...)
 	app.Entity("posts", entity.EntityConfig{
 		Table:  "posts",
 		Fields: []schema.Field{{Name: "title", Type: schema.String}},

--- a/framework/llmmd_test.go
+++ b/framework/llmmd_test.go
@@ -205,7 +205,7 @@ func TestRegistryLLMMD_Index(t *testing.T) {
 		},
 	)
 
-	md := crud.RegistryLLMMD(reg, "Test App")
+	md := crud.RegistryLLMMD(reg, "Test App", nil)
 
 	if !strings.Contains(md, "# Test App") {
 		t.Error("expected app title header")
@@ -303,7 +303,7 @@ func TestRegistryLLMMDHandler_HTTP(t *testing.T) {
 
 	// RegistryLLMMDHandler now requires an authenticated context. See
 	// exposure_security_test.go::TestRegistryLLMMDHandler_RequiresAuth.
-	h := crud.RegistryLLMMDHandler(reg, "Test")
+	h := crud.RegistryLLMMDHandler(reg, "Test", nil)
 	req := httptest.NewRequest("GET", "/llm.md", nil)
 	req = req.WithContext(handlerpkg.SetUser(req.Context(), map[string]string{"id": "test-user"}))
 	rec := httptest.NewRecorder()

--- a/framework/multiversion_test.go
+++ b/framework/multiversion_test.go
@@ -105,7 +105,7 @@ func TestVersionedOpenAPI(t *testing.T) {
 		Fields: []schema.Field{{Name: "title", Type: schema.String}, {Name: "summary", Type: schema.Text}},
 	})
 
-	spec := frameworkopenapi.EntityOpenAPI(app.Registry, "Test", "1.0.0")
+	spec := frameworkopenapi.EntityOpenAPI(app.Registry, "Test", "1.0.0", nil)
 	doc := spec.Build()
 
 	paths, _ := doc["paths"].(map[string]map[string]any)

--- a/framework/openapi/collision_test.go
+++ b/framework/openapi/collision_test.go
@@ -31,5 +31,5 @@ func TestSchemaNameCollisionPanics(t *testing.T) {
 			t.Fatal("EntityOpenAPI with colliding schema names did not panic")
 		}
 	}()
-	EntityOpenAPI(reg(versioned, shadow), "Test", "1.0.0")
+	EntityOpenAPI(reg(versioned, shadow), "Test", "1.0.0", nil)
 }

--- a/framework/openapi/crud_exposure_test.go
+++ b/framework/openapi/crud_exposure_test.go
@@ -31,7 +31,7 @@ func TestCRUDDisabledEntityEmitsNoPaths(t *testing.T) {
 		Fields: []schema.Field{{Name: "title", Type: schema.String}},
 	}.WithTimestamps(false))
 
-	doc := EntityOpenAPI(reg(off, on), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(off, on), "Test", "1.0.0", nil).Build()
 	paths, ok := asMap(doc["paths"])
 	if !ok {
 		t.Fatalf("spec has no paths object")
@@ -47,6 +47,34 @@ func TestCRUDDisabledEntityEmitsNoPaths(t *testing.T) {
 	}
 }
 
+// Pins #266: the crudMounted predicate is route reality — an entity
+// whose CRUD routes were never registered (e.g. the app has no DB) must
+// lose its generated paths even when Exposure.CRUD says "auto", while
+// its declared custom Endpoints stay documented (App mounts those
+// outside the CRUD branch).
+func TestCrudMountedPredicateOverridesExposure(t *testing.T) {
+	auto := entity.Define("posts", entity.EntityConfig{
+		Table:  "posts",
+		Fields: []schema.Field{{Name: "title", Type: schema.String}},
+		Endpoints: []entity.Endpoint{
+			{Method: "POST", Path: "/posts/{id}/publish", Description: "publish"},
+		},
+	}.WithTimestamps(false))
+
+	notMounted := func(*entity.Entity) bool { return false }
+	doc := EntityOpenAPI(reg(auto), "Test", "1.0.0", notMounted).Build()
+	paths, ok := asMap(doc["paths"])
+	if !ok {
+		t.Fatalf("spec has no paths object")
+	}
+	if _, ok := paths["/posts"]; ok {
+		t.Errorf("predicate=false must drop generated CRUD paths; emitted %v", mapKeys(paths))
+	}
+	if _, ok := paths["/posts/{id}/publish"]; !ok {
+		t.Errorf("declared custom endpoint must stay documented; emitted %v", mapKeys(paths))
+	}
+}
+
 // A nil CRUD pointer means "auto", the router enables CRUD for it, so the
 // spec must too. Only an explicit false opts out.
 func TestNilCRUDStillEmitsPaths(t *testing.T) {
@@ -56,7 +84,7 @@ func TestNilCRUDStillEmitsPaths(t *testing.T) {
 		Exposure: &entity.ExposureConfig{},
 	}.WithTimestamps(false))
 
-	doc := EntityOpenAPI(reg(auto), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(auto), "Test", "1.0.0", nil).Build()
 	paths, ok := asMap(doc["paths"])
 	if !ok {
 		t.Fatalf("spec has no paths object")
@@ -77,7 +105,7 @@ func TestCRUDDisabledEntityKeepsSchema(t *testing.T) {
 		Exposure: &entity.ExposureConfig{CRUD: new(false)},
 	}.WithTimestamps(false))
 
-	doc := EntityOpenAPI(reg(off), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(off), "Test", "1.0.0", nil).Build()
 	components := getMap(t, doc, "components")
 	schemas, ok := asMap(components["schemas"])
 	if !ok {
@@ -107,7 +135,7 @@ func TestCRUDDisabledEntityKeepsEndpoints(t *testing.T) {
 		}},
 	}.WithTimestamps(false))
 
-	doc := EntityOpenAPI(reg(off), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(off), "Test", "1.0.0", nil).Build()
 	paths, ok := asMap(doc["paths"])
 	if !ok {
 		t.Fatalf("spec has no paths object")

--- a/framework/openapi/endpoint_schema_test.go
+++ b/framework/openapi/endpoint_schema_test.go
@@ -43,7 +43,7 @@ func postsWithBareEndpoint() *entity.Entity {
 }
 
 func TestEndpointTypedRequestBody(t *testing.T) {
-	doc := EntityOpenAPI(reg(postsWithTypedEndpoint()), "t", "1").Build()
+	doc := EntityOpenAPI(reg(postsWithTypedEndpoint()), "t", "1", nil).Build()
 	paths := getMap(t, doc, "paths")
 	op := getMap(t, getMap(t, paths, "/posts/{id}/publish"), "post")
 
@@ -84,7 +84,7 @@ func resp200(t *testing.T, op map[string]any) map[string]any {
 }
 
 func TestEndpointBareUnchanged(t *testing.T) {
-	doc := EntityOpenAPI(reg(postsWithBareEndpoint()), "t", "1").Build()
+	doc := EntityOpenAPI(reg(postsWithBareEndpoint()), "t", "1", nil).Build()
 	paths := getMap(t, doc, "paths")
 	op := getMap(t, getMap(t, paths, "/posts/{id}/publish"), "post")
 

--- a/framework/openapi/fields_trashed_test.go
+++ b/framework/openapi/fields_trashed_test.go
@@ -14,7 +14,7 @@ func TestListGetDeclareFields(t *testing.T) {
 		Table:  "posts",
 		Fields: []schema.Field{{Name: "title", Type: schema.String}},
 	})
-	doc := EntityOpenAPI(reg(e), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(e), "Test", "1.0.0", nil).Build()
 	paths := getMap(t, doc, "paths")
 
 	listOp := getMap(t, getMap(t, paths, "/posts"), "get")
@@ -32,7 +32,7 @@ func TestListGetDeclareFields(t *testing.T) {
 // list op only for soft-delete entities.
 func TestSoftDeleteListDeclaresTrashed(t *testing.T) {
 	soft := entity.Define("notes", entity.EntityConfig{Table: "notes", Scope: &entity.ScopeConfig{SoftDelete: true}, Fields: []schema.Field{{Name: "title", Type: schema.String}}})
-	doc := EntityOpenAPI(reg(soft), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(soft), "Test", "1.0.0", nil).Build()
 	listOp := getMap(t, getMap(t, getMap(t, doc, "paths"), "/notes"), "get")
 	if findParam(listOp["parameters"], "trashed") == nil {
 		t.Error("soft-delete list op missing 'trashed' parameter")
@@ -46,7 +46,7 @@ func TestNonSoftDeleteHasNoTrashed(t *testing.T) {
 		Table:  "posts",
 		Fields: []schema.Field{{Name: "title", Type: schema.String}},
 	})
-	doc := EntityOpenAPI(reg(hard), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(hard), "Test", "1.0.0", nil).Build()
 	listOp := getMap(t, getMap(t, getMap(t, doc, "paths"), "/posts"), "get")
 	if findParam(listOp["parameters"], "trashed") != nil {
 		t.Error("non-soft-delete list op should not declare 'trashed'")

--- a/framework/openapi/hidden_fields_security_test.go
+++ b/framework/openapi/hidden_fields_security_test.go
@@ -36,7 +36,7 @@ func TestHiddenFieldAbsentFromEverySurface(t *testing.T) {
 		},
 	}.WithTimestamps(false))
 
-	doc := EntityOpenAPI(reg(ent), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(ent), "Test", "1.0.0", nil).Build()
 
 	// 1. Schema component properties.
 	comps := getMap(t, doc, "components")

--- a/framework/openapi/openapi.go
+++ b/framework/openapi/openapi.go
@@ -31,7 +31,14 @@ import (
 // and its deterministic grader, and ranked fixing it as the most valuable
 // change available. Repeating the prefix in `servers` as well would double it
 // to /api/api/posts for any client that composes the two, so it does not.
-func EntityOpenAPI(registry entity.Registry, title, version string, basePath ...string) *openapi.Spec {
+//
+// crudMounted reports whether an entity's auto-CRUD routes were actually
+// registered. The app passes its route predicate (DB attached AND
+// Exposure.CRUD), so the spec cannot advertise CRUD paths registration
+// never mounted — the Exposure flag alone misses the no-DB case (#266).
+// nil falls back to the Exposure-only check. Declared custom Endpoints
+// are documented either way; App mounts those outside its CRUD branch.
+func EntityOpenAPI(registry entity.Registry, title, version string, crudMounted func(*entity.Entity) bool, basePath ...string) *openapi.Spec {
 	s := openapi.NewSpec(title, version)
 	apiPrefix := ""
 	if len(basePath) > 0 && basePath[0] != "" && basePath[0] != "/" {
@@ -184,6 +191,9 @@ func EntityOpenAPI(registry entity.Registry, title, version string, basePath ...
 		// neither CRUD nor endpoints would otherwise render as an empty
 		// group.
 		crudExposed := ent.Config.Exposure.CRUD == nil || *ent.Config.Exposure.CRUD
+		if crudMounted != nil {
+			crudExposed = crudMounted(ent)
+		}
 		if !crudExposed {
 			if hasCustomEndpoints(ent) {
 				s.AddTag(tagName, entityName+" operations")

--- a/framework/openapi/openapi_sec_test.go
+++ b/framework/openapi/openapi_sec_test.go
@@ -166,7 +166,7 @@ func TestOwnerScopedOpsDeclare401(t *testing.T) {
 		{Name: "title", Type: schema.String, Required: true},
 	},
 	})
-	doc := EntityOpenAPI(reg(e), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(e), "Test", "1.0.0", nil).Build()
 	for label, op := range gatedOpsFor(t, doc, "notes") {
 		if !hasResponse(op, "401") {
 			t.Errorf("owner-scoped op %q missing 401 response", label)
@@ -179,7 +179,7 @@ func TestMultiTenantOpsDeclare401(t *testing.T) {
 		{Name: "amount", Type: schema.Int, Required: true},
 	},
 	})
-	doc := EntityOpenAPI(reg(e), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(e), "Test", "1.0.0", nil).Build()
 	for label, op := range gatedOpsFor(t, doc, "invoices") {
 		if !hasResponse(op, "401") {
 			t.Errorf("multi-tenant op %q missing 401 response", label)
@@ -194,7 +194,7 @@ func TestUnguardedOpsHaveNo401(t *testing.T) {
 		{Name: "title", Type: schema.String},
 	},
 	})
-	doc := EntityOpenAPI(reg(e), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(e), "Test", "1.0.0", nil).Build()
 	paths := getMap(t, doc, "paths")
 	base := getMap(t, paths, "/public_posts")
 	get := getMap(t, base, "get")
@@ -214,7 +214,7 @@ func TestBoolFieldOmitsRangeFilters(t *testing.T) {
 			{Name: "active", Type: schema.Bool},
 		},
 	}.WithTimestamps(false))
-	doc := EntityOpenAPI(reg(e), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(e), "Test", "1.0.0", nil).Build()
 	paths := getMap(t, doc, "paths")
 	base := getMap(t, paths, "/flags")
 	get := getMap(t, base, "get")
@@ -238,7 +238,7 @@ func TestJSONFieldOmitsRangeFilters(t *testing.T) {
 			{Name: "payload", Type: schema.JSON},
 		},
 	}.WithTimestamps(false))
-	doc := EntityOpenAPI(reg(e), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(e), "Test", "1.0.0", nil).Build()
 	paths := getMap(t, doc, "paths")
 	base := getMap(t, paths, "/blobs")
 	get := getMap(t, base, "get")
@@ -272,7 +272,7 @@ func rbacOnlyEntity() *entity.Entity {
 
 func TestRBACAccessOpsDeclare401And403(t *testing.T) {
 	e := rbacOnlyEntity()
-	doc := EntityOpenAPI(reg(e), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(e), "Test", "1.0.0", nil).Build()
 	for label, op := range gatedOpsFor(t, doc, "rbac_items") {
 		if !hasResponse(op, "401") {
 			t.Errorf("RBAC-only op %q missing 401 response", label)
@@ -285,7 +285,7 @@ func TestRBACAccessOpsDeclare401And403(t *testing.T) {
 
 func TestBatchOpsDeclare401And403WhenGated(t *testing.T) {
 	e := rbacOnlyEntity()
-	doc := EntityOpenAPI(reg(e), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(e), "Test", "1.0.0", nil).Build()
 	paths := getMap(t, doc, "paths")
 	batchPath := getMap(t, paths, "/rbac_items/_batch")
 	for _, method := range []string{"post", "patch", "delete"} {
@@ -301,7 +301,7 @@ func TestBatchOpsDeclare401And403WhenGated(t *testing.T) {
 
 func TestSSEOpDeclares401And403WhenGated(t *testing.T) {
 	e := rbacOnlyEntity()
-	doc := EntityOpenAPI(reg(e), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(e), "Test", "1.0.0", nil).Build()
 	paths := getMap(t, doc, "paths")
 	eventsPath := getMap(t, paths, "/rbac_items/_events")
 	get := getMap(t, eventsPath, "get")
@@ -319,7 +319,7 @@ func TestUnguardedBatchAndSSEHaveNo401(t *testing.T) {
 		{Name: "val", Type: schema.Int},
 	},
 	}.WithTimestamps(false))
-	doc := EntityOpenAPI(reg(e), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(e), "Test", "1.0.0", nil).Build()
 	paths := getMap(t, doc, "paths")
 	batchPath := getMap(t, paths, "/pub_items/_batch")
 	post := getMap(t, batchPath, "post")
@@ -343,7 +343,7 @@ func TestComparableFieldsKeepRangeFilters(t *testing.T) {
 			{Name: "label", Type: schema.String},
 		},
 	}.WithTimestamps(false))
-	doc := EntityOpenAPI(reg(e), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(e), "Test", "1.0.0", nil).Build()
 	paths := getMap(t, doc, "paths")
 	base := getMap(t, paths, "/metrics")
 	get := getMap(t, base, "get")

--- a/framework/openapi/security_schemes_test.go
+++ b/framework/openapi/security_schemes_test.go
@@ -69,7 +69,7 @@ func TestGatedEntityDeclaresSchemes(t *testing.T) {
 		{Name: "title", Type: schema.String, Required: true},
 	},
 	})
-	doc := EntityOpenAPI(reg(e), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(e), "Test", "1.0.0", nil).Build()
 
 	schemes := securitySchemesFor(t, doc)
 	if schemes == nil {
@@ -114,7 +114,7 @@ func TestGatedOpsCarryBothSchemes(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			doc := EntityOpenAPI(reg(tc.ent), "Test", "1.0.0").Build()
+			doc := EntityOpenAPI(reg(tc.ent), "Test", "1.0.0", nil).Build()
 			for label, op := range allGatedOps(t, doc, tc.table) {
 				if !hasOpScheme(op, "bearerAuth") {
 					t.Errorf("%s op %q missing bearerAuth in security", tc.name, label)
@@ -134,7 +134,7 @@ func TestUngatedEntityHasNoSecurity(t *testing.T) {
 		{Name: "title", Type: schema.String},
 	},
 	})
-	doc := EntityOpenAPI(reg(e), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(e), "Test", "1.0.0", nil).Build()
 
 	if schemes := securitySchemesFor(t, doc); schemes != nil {
 		t.Errorf("ungated entity: expected no securitySchemes, got %v", schemes)
@@ -155,7 +155,7 @@ func TestUngatedEntityHasNoSecurity(t *testing.T) {
 // Custom (ent.Config.Endpoints) operations are not gated today and must not
 // gain a spurious security block.
 func TestCustomEndpointCarriesNoSecurity(t *testing.T) {
-	doc := EntityOpenAPI(reg(postsWithTypedEndpoint()), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(postsWithTypedEndpoint()), "Test", "1.0.0", nil).Build()
 	paths := getMap(t, doc, "paths")
 	op := getMap(t, getMap(t, paths, "/posts/{id}/publish"), "post")
 	if _, ok := op["security"]; ok {

--- a/framework/openapi/wirekey_test.go
+++ b/framework/openapi/wirekey_test.go
@@ -26,7 +26,7 @@ func TestWireNameInFieldsDescAndRequestExclusion(t *testing.T) {
 		},
 	}.WithTimestamps(false))
 
-	doc := EntityOpenAPI(reg(e), "Test", "1.0.0").Build()
+	doc := EntityOpenAPI(reg(e), "Test", "1.0.0", nil).Build()
 	paths := getMap(t, doc, "paths")
 
 	// --- ?fields= description must advertise the WireName, not camelCase ---

--- a/framework/openapi_determinism_test.go
+++ b/framework/openapi_determinism_test.go
@@ -32,7 +32,7 @@ func TestOpenAPI_DeterministicAcrossBuilds(t *testing.T) {
 	}
 
 	render := func(reg *Registry) []byte {
-		spec := openapi.EntityOpenAPI(reg, "Test", "1.0.0")
+		spec := openapi.EntityOpenAPI(reg, "Test", "1.0.0", nil)
 		raw, err := json.Marshal(spec.Build())
 		if err != nil {
 			t.Fatal(err)

--- a/framework/openapi_noquery_test.go
+++ b/framework/openapi_noquery_test.go
@@ -27,7 +27,7 @@ func TestOpenAPIOmitsNoQueryFilterParams(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	raw, err := json.Marshal(openapi.EntityOpenAPI(reg, "Test", "1.0.0").Build())
+	raw, err := json.Marshal(openapi.EntityOpenAPI(reg, "Test", "1.0.0", nil).Build())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/framework/openapi_readonly_security_test.go
+++ b/framework/openapi_readonly_security_test.go
@@ -52,7 +52,7 @@ func TestEntityOpenAPI_PreservesReadOnly(t *testing.T) {
 					field,
 				},
 			}.WithTimestamps(false))
-			spec := frameworkopenapi.EntityOpenAPI(app.Registry, "Test", "1.0.0").Build()
+			spec := frameworkopenapi.EntityOpenAPI(app.Registry, "Test", "1.0.0", nil).Build()
 			components := spec["components"].(map[string]any)
 			schemas := components["schemas"].(map[string]map[string]any)
 			ent := schemas[name]

--- a/framework/reexports_openapi.go
+++ b/framework/reexports_openapi.go
@@ -9,7 +9,11 @@ import (
 // Re-exports of framework/openapi so existing callers (kiln/live, framework
 // tests) using framework.X keep compiling after the openapi extraction.
 
-// EntityOpenAPI wraps openapi.EntityOpenAPI.
+// EntityOpenAPI wraps openapi.EntityOpenAPI with the Exposure-only CRUD
+// check (crudMounted=nil). App.Start passes its route predicate instead,
+// so the served /openapi.json never advertises CRUD paths registration
+// did not mount (#266); direct callers of this wrapper document per
+// Exposure, the historical behavior.
 func EntityOpenAPI(registry entity.Registry, title string, version string, basePath ...string) *coreopenapi.Spec {
-	return openapi.EntityOpenAPI(registry, title, version, basePath...)
+	return openapi.EntityOpenAPI(registry, title, version, nil, basePath...)
 }


### PR DESCRIPTION
Round-2 batch D — the sibling of v0.73.0's banner fix (#244), surfaced by CodeRabbit's review of #265.

`/openapi.json` and `/api/llm.md` documented auto-CRUD endpoints for entities whose routes registration never mounted: OpenAPI missed the no-DB half of the predicate, and llm.md never checked `Exposure.CRUD` at all. Both generators now take the app's route predicate (`App.Start` passes `entityCRUDEnabled`, the same shared predicate as registration and the banner):

- CRUD-less entities keep their **declared custom endpoints** documented (App mounts those outside the CRUD branch — dropping them was the trap a naive registry filter would have hit).
- In the llm.md index they render **unlinked** (the per-entity llm.md page rides the CRUD mount and would 404) with only the custom-endpoint count.
- Entities with no routes at all are omitted; the handler's per-request read-scope filter composes with the route filter.
- MCP tool docs already gate on `a.DB != nil` — checked against the same invariant, consistent.

**BREAKING for direct callers**: `openapi.EntityOpenAPI` and `crud.RegistryLLMMD`/`RegistryLLMMDHandler` gained a `crudMounted func(*entity.Entity) bool` parameter; nil = previous Exposure-only behavior. The `framework.EntityOpenAPI` re-export is unchanged (passes nil), so kiln and host apps using the re-export compile as before. Changelog carries the note.

Two fixture suites (`llmmd_public_test`, `agentready_isagentic_test`) had enshrined the bug by asserting docs content on no-DB apps — the exact pattern the banner fix hit in #265 — and now attach the in-memory DB. New tests pin the four llm.md row behaviors and the spec's predicate-false case (CRUD paths dropped, custom endpoints kept). Full framework/crud/openapi/kiln suites green; doc compile gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected generated OpenAPI and LLM documentation to include only CRUD routes that are actually available.
  - Prevented documentation from listing CRUD endpoints when no database is configured or CRUD exposure is disabled.
  - Custom endpoints continue to appear correctly, even when standard CRUD routes are unavailable.
  - Improved accuracy of self-describing API documentation and route listings.

- **Breaking Changes**
  - Direct integrations using documentation-generation APIs must provide the new optional route-availability parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->