### PR TITLE
fix(ui): migrate the last 23 legacy ExtraAttrs sites to the sanitization contract (#262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Changed
+
+- **The last 23 `framework/ui` components join the ExtraAttrs
+  sanitization contract** (#262, completing the migration PR #261
+  started): AnimatedCounter, Banner, Button, Carousel, Container,
+  FilterToolbar, Gallery, Link, LinkButton, Markdown, Menu items,
+  NotificationBell, NumberInput, PasswordInput, ProgressSteps,
+  RangeSlider, SearchInput, Select, Slider, TextArea, Timeline,
+  TableOfContents, Toolbar, and Workbench now route caller extras
+  through `html.SafeExtraAttrs`. A caller-supplied ExtraAttrs key can
+  no longer override the attributes a component derives from its
+  config (a Slider's `min`/`max`/`step`/`value`, a FilterToolbar's
+  sanitized form `action`, a TextArea's `maxlength`, a Workbench's
+  CSP-safe `style`, …) or spoof `class`/`id`/`data-fui-*` — including
+  case-variant keys (`"Type"`), which previously slipped past the
+  hand-rolled guards in SearchInput, PasswordInput, and FilterToolbar.
+  Set owned values through the config fields instead. `ui.Form` stays
+  raw by documented contract. `extraAttrsRawLegacy` in the contract
+  test shrinks to that one entry.
+
+- **`ui.Button` and `ui.Link` are documented wiring carriers**: they
+  keep forwarding `data-fui-*` (via the new `html.SafeCarrierAttrs`,
+  which still drops `class`/`id`/the component's owned keys/the
+  `data-fui-comp` style marker) so the
+  `interactive.Action.Attrs()`-into-ExtraAttrs pattern from
+  interactive-patterns.md keeps working — the resource UI's
+  delete/transition buttons, the admin battery, and uinoderender's
+  href-fallback + `data-fui-rpc` ActionRef links depend on it.
+
+### Added
+
+- **`ui.MenuItem.Confirm`**: pre-flight confirmation for RPC menu
+  items, emitted as `data-fui-confirm` alongside the item's
+  `data-fui-rpc` wiring. Previously the Danger field's doc pointed at
+  an attribute there was no way to set once item extras were
+  sanitized.
+
 ### Fixed
 
 - **Generated API docs describe routes that exist** (#266, sibling of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,15 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Changed
 
-- **The last 23 `framework/ui` components join the ExtraAttrs
-  sanitization contract** (#262, completing the migration PR #261
-  started): AnimatedCounter, Banner, Button, Carousel, Container,
+- **The last 23 legacy `framework/ui` files (24 components) join the
+  ExtraAttrs sanitization contract** (#262, completing the migration
+  PR #261 started): AnimatedCounter, Banner, Button, Carousel, Container,
   FilterToolbar, Gallery, Link, LinkButton, Markdown, Menu items,
   NotificationBell, NumberInput, PasswordInput, ProgressSteps,
   RangeSlider, SearchInput, Select, Slider, TextArea, Timeline,
   TableOfContents, Toolbar, and Workbench now route caller extras
-  through `html.SafeExtraAttrs`. A caller-supplied ExtraAttrs key can
+  through `html.SafeExtraAttrs` (Button and Link through the carrier
+  variant below). A caller-supplied ExtraAttrs key can
   no longer override the attributes a component derives from its
   config (a Slider's `min`/`max`/`step`/`value`, a FilterToolbar's
   sanitized form `action`, a TextArea's `maxlength`, a Workbench's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   config (a Slider's `min`/`max`/`step`/`value`, a FilterToolbar's
   sanitized form `action`, a TextArea's `maxlength`, a Workbench's
   CSP-safe `style`, …) or spoof `class`/`id`/`data-fui-*` — including
-  case-variant keys (`"Type"`), which previously slipped past the
-  hand-rolled guards in SearchInput, PasswordInput, and FilterToolbar.
+  case-variant keys (`"Type"`), which slipped past PasswordInput's
+  lowercase-only re-assert, and the owned keys (placeholder, method,
+  role, aria-label) that SearchInput's and FilterToolbar's hand-rolled
+  guards never covered at all.
   Set owned values through the config fields instead. `ui.Form` stays
   raw by documented contract. `extraAttrsRawLegacy` in the contract
   test shrinks to that one entry.

--- a/core-ui/html/attrs.go
+++ b/core-ui/html/attrs.go
@@ -83,6 +83,44 @@ func SafeExtraAttrs(attrs Attrs, protected ...string) Attrs {
 	return out
 }
 
+// SafeCarrierAttrs is SafeExtraAttrs for wiring carriers: components
+// whose ExtraAttrs are the documented attachment point for runtime
+// wiring (interactive.Action.Attrs(), data-fui-open, …) and that emit
+// no data-fui-* wiring of their own. It drops every case-variant of
+// "class", "id", "data-fui-comp" (the style-scope marker WrapHTML
+// injects), and the listed protected keys, but keeps the rest of
+// "data-fui-*" so the interactive package's attrs pass through.
+// ui.Button and ui.Link are the carriers; a component that renders its
+// own data-fui-* attributes must use SafeExtraAttrs instead, or a
+// caller could spoof its wiring.
+func SafeCarrierAttrs(attrs Attrs, protected ...string) Attrs {
+	if len(attrs) == 0 {
+		return nil
+	}
+	out := make(Attrs, len(attrs))
+	for k, v := range attrs {
+		if strings.EqualFold(k, "class") || strings.EqualFold(k, "id") ||
+			strings.EqualFold(k, "data-fui-comp") {
+			continue
+		}
+		drop := false
+		for _, p := range protected {
+			if strings.EqualFold(k, p) {
+				drop = true
+				break
+			}
+		}
+		if drop {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // DataAttrs converts a map of key-value pairs into data-* attributes.
 // Keys should not include the "data-" prefix; it is added automatically.
 func DataAttrs(data map[string]string) Attrs {

--- a/core-ui/html/attrs_test.go
+++ b/core-ui/html/attrs_test.go
@@ -26,6 +26,41 @@ func TestSafeExtraAttrsDropsProtectedKeys(t *testing.T) {
 	}
 }
 
+func TestSafeCarrierAttrsKeepsWiring(t *testing.T) {
+	got := SafeCarrierAttrs(Attrs{
+		"class":            "evil",
+		"ID":               "evil-case-variant",
+		"Type":             "hidden",
+		"data-fui-comp":    "spoofed-style-scope",
+		"data-test":        "hook",
+		"data-fui-rpc":     "/api/items/42",
+		"data-fui-confirm": "Delete?",
+	}, "type")
+
+	want := Attrs{
+		"data-test":        "hook",
+		"data-fui-rpc":     "/api/items/42",
+		"data-fui-confirm": "Delete?",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("key %q: got %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestSafeCarrierAttrsNilOnEmptyResult(t *testing.T) {
+	if got := SafeCarrierAttrs(nil); got != nil {
+		t.Errorf("nil input: got %v, want nil", got)
+	}
+	if got := SafeCarrierAttrs(Attrs{"class": "x", "Name": "y"}, "name"); got != nil {
+		t.Errorf("all-dropped input: got %v, want nil", got)
+	}
+}
+
 func TestSafeExtraAttrsNilOnEmptyResult(t *testing.T) {
 	if got := SafeExtraAttrs(nil); got != nil {
 		t.Errorf("nil input: got %v, want nil", got)

--- a/framework/docs/content/interactive-patterns.md
+++ b/framework/docs/content/interactive-patterns.md
@@ -223,6 +223,10 @@ interactive.OnClick(deleteBtn,
 
 Attribute injected: `data-fui-confirm="message"`.
 
+Menu items have the same gate as a config field: `ui.MenuItem.Confirm`
+emits `data-fui-confirm` alongside the item's `RPC` wiring (ignored on
+non-RPC items — the runtime reads the attribute only on rpc dispatch).
+
 `window.confirm` is native, unthemed, and **blocks browser automation**
 (headless tests can't dismiss it without a dialog handler). For a
 design-system-styled confirmation that matches the rest of your app and is

--- a/framework/docs/content/ui-getting-started.md
+++ b/framework/docs/content/ui-getting-started.md
@@ -559,17 +559,20 @@ component derives from its config (`href` on linked roots, `type` /
 linked Card renders `<a>` instead of `<section>` — the attributes
 follow whichever root is emitted.
 
-A set of components that predate this contract still forwards extras
-raw, where a caller-supplied key can override component-owned
-attributes (Banner, Select, Carousel, and the other files on the
-`extraAttrsRawLegacy` list in
-`framework/ui/extraattrs_contract_test.go`). Until those migrate,
-treat their pass-through as unprotected. `FormConfig`'s raw
-`data-fui-rpc-*` pass-through is deliberate and documented on the
-field.
+Two documented exceptions forward more than the contract's default.
+`FormConfig` forwards raw: its ExtraAttrs may override the form's own
+attributes, which the blueprint generator's `data-entity-form` +
+RPC-wiring pattern relies on. `ButtonConfig` and `LinkConfig` are
+*wiring carriers*: they drop their owned keys like any component but
+keep `data-fui-*`, because attaching `interactive.Action.Attrs()` to a
+button's ExtraAttrs is the documented way to wire a click RPC (the
+resource UI and the admin battery both do it), and an ActionRef link
+ships an href fallback plus a `data-fui-rpc` upgrade the same way.
 
 Component authors: sanitize with `html.SafeExtraAttrs(cfg.ExtraAttrs,
-protected...)` before forwarding. Two gates in
+protected...)` before forwarding — or `html.SafeCarrierAttrs` for a
+component that emits no `data-fui-*` wiring of its own and is meant to
+carry the interactive package's attrs. Two gates in
 `framework/ui/extraattrs_contract_test.go` enforce the contract: one
 fails on any component Config without the field, the other fails on
 any new raw forwarding outside the legacy list.

--- a/framework/docs/content/ui-getting-started.md
+++ b/framework/docs/content/ui-getting-started.md
@@ -564,7 +564,9 @@ Two documented exceptions forward more than the contract's default.
 attributes, which the blueprint generator's `data-entity-form` +
 RPC-wiring pattern relies on. `ButtonConfig` and `LinkConfig` are
 *wiring carriers*: they drop their owned keys like any component but
-keep `data-fui-*`, because attaching `interactive.Action.Attrs()` to a
+keep `data-fui-*` — except `data-fui-comp`, the style-scope marker,
+which drops case-insensitively — because attaching
+`interactive.Action.Attrs()` to a
 button's ExtraAttrs is the documented way to wire a click RPC (the
 resource UI and the admin battery both do it), and an ActionRef link
 ships an href fallback plus a `data-fui-rpc` upgrade the same way.

--- a/framework/ui/animatedcounter.go
+++ b/framework/ui/animatedcounter.go
@@ -30,9 +30,13 @@ type AnimatedCounterConfig struct {
 	// Prefix="$", Suffix="+", Suffix=" users").
 	Prefix string
 	Suffix string
-	// ID / Class / Attrs are passed through.
-	ID         string
-	Class      string
+	// ID / Class are passed through.
+	ID    string
+	Class string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the counter's root <span>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-* (the animation wiring).
 	ExtraAttrs html.Attrs
 }
 
@@ -56,7 +60,7 @@ func AnimatedCounter(cfg AnimatedCounterConfig) render.HTML {
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}
-	maps.Copy(attrs, cfg.ExtraAttrs)
+	maps.Copy(attrs, html.SafeExtraAttrs(cfg.ExtraAttrs))
 
 	children := []render.HTML{}
 	if cfg.Prefix != "" {

--- a/framework/ui/animatedcounter_test.go
+++ b/framework/ui/animatedcounter_test.go
@@ -45,3 +45,21 @@ func TestAnimatedCounterPrefixSuffix(t *testing.T) {
 		t.Errorf("Suffix should render:\n%s", h)
 	}
 }
+
+func TestAnimatedCounterExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := AnimatedCounter(AnimatedCounterConfig{To: 42, ExtraAttrs: map[string]string{
+		"data-test": "hook", "data-fui-animated-counter": "999", "Class": "evil",
+	}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `data-fui-animated-counter="42"`) {
+		t.Errorf("animation marker lost its framework value:\n%s", root)
+	}
+	for _, banned := range []string{"999", "evil"} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+}

--- a/framework/ui/banner.go
+++ b/framework/ui/banner.go
@@ -54,9 +54,14 @@ type BannerConfig struct {
 	// Action is an optional inline call-to-action (a Link or Button
 	// rendered to the right of the body).
 	Action render.HTML
-	// ID / Class / Attrs are passed through to the outer element.
-	ID         string
-	Class      string
+	// ID / Class are passed through to the outer element.
+	ID    string
+	Class string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the banner's root <div>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, and the severity contract (role, aria-live,
+	// derived from Variant).
 	ExtraAttrs html.Attrs
 	// Ctx carries the per-request context used to resolve the dismiss label.
 	// When nil, English fallbacks apply.
@@ -115,7 +120,7 @@ func Banner(cfg BannerConfig) render.HTML {
 		attrs["role"] = "status"
 		attrs["aria-live"] = "polite"
 	}
-	maps.Copy(attrs, cfg.ExtraAttrs)
+	maps.Copy(attrs, html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-live"))
 
 	children := []render.HTML{
 		render.Tag("div", map[string]string{"class": "ui-banner__icon", "aria-hidden": "true"},

--- a/framework/ui/banner_test.go
+++ b/framework/ui/banner_test.go
@@ -102,3 +102,21 @@ func TestBannerCSSAvoidsDecorativeSideStripe(t *testing.T) {
 		t.Errorf("banner variants should still provide a full-outline accent:\n%s", css)
 	}
 }
+
+func TestBannerExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := Banner(BannerConfig{Title: "Heads up", ExtraAttrs: map[string]string{
+		"data-test": "hook", "role": "evil", "Class": "evil",
+	}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `role="status"`) {
+		t.Errorf("severity role lost its framework value:\n%s", root)
+	}
+	for _, banned := range []string{"evil", `role="alert"`} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+}

--- a/framework/ui/carousel.go
+++ b/framework/ui/carousel.go
@@ -85,7 +85,12 @@ type CarouselConfig struct {
 	VirtualPlaceholderHeight string
 	ID                       string
 	Class                    string
-	ExtraAttrs               html.Attrs
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the carousel's root <div>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-* (the runtime wiring), and the region contract
+	// (role, aria-roledescription, aria-label).
+	ExtraAttrs html.Attrs
 	// Ctx carries the per-request context used to resolve the Previous/Next,
 	// Go-to-slide and pagination aria labels. When nil, English fallbacks apply.
 	Ctx context.Context
@@ -142,7 +147,7 @@ func Carousel(cfg CarouselConfig) render.HTML {
 	if cfg.Loop {
 		attrs["data-fui-carousel-loop"] = "true"
 	}
-	maps.Copy(attrs, cfg.ExtraAttrs)
+	maps.Copy(attrs, html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-roledescription", "aria-label"))
 
 	// VirtualScroll prep: figure out the inline window.
 	virtualWindow := 0

--- a/framework/ui/carousel_test.go
+++ b/framework/ui/carousel_test.go
@@ -257,3 +257,28 @@ func TestCarouselVirtualScrollManifestEscapesScripts(t *testing.T) {
 		t.Errorf("manifest body contains an unescaped </script>:\n%s", h)
 	}
 }
+
+func TestCarouselExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := Carousel(CarouselConfig{
+		Label:  "Featured",
+		Slides: []CarouselSlide{{Content: render.Text("a")}},
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "aria-label": "evil", "Class": "evil",
+		},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `aria-label="Featured"`) {
+		t.Errorf("region label lost its framework value:\n%s", root)
+	}
+	for _, banned := range []string{"evil", `role="presentation"`} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+	if !strings.Contains(root, `role="region"`) {
+		t.Errorf("region role lost:\n%s", root)
+	}
+}

--- a/framework/ui/components.go
+++ b/framework/ui/components.go
@@ -636,7 +636,16 @@ func LinkButton(cfg LinkButtonConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	extra := html.SafeExtraAttrs(cfg.ExtraAttrs, "href")
+	extraProtected := []string{"href"}
+	if cfg.External {
+		// External owns target/rel, so their case-variants must drop
+		// too: an unprotected "TARGET"/"REL" entry sorts before the
+		// owned lowercase attr in the rendered tag and wins the
+		// parser's first-occurrence fold, clobbering the noopener
+		// contract.
+		extraProtected = append(extraProtected, "target", "rel")
+	}
+	extra := html.SafeExtraAttrs(cfg.ExtraAttrs, extraProtected...)
 	if cfg.External {
 		if extra == nil {
 			extra = html.Attrs{}

--- a/framework/ui/components.go
+++ b/framework/ui/components.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"context"
-	"maps"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -514,10 +513,20 @@ const (
 
 // ButtonConfig configures a button.
 type ButtonConfig struct {
-	Label      string        // required visible text + aria-label
-	Variant    ButtonVariant // defaults to ButtonPrimary
-	Size       ButtonSize    // defaults to ButtonSizeDefault
-	Type       string        // "button" (default) | "submit" | "reset"
+	Label string // required visible text + aria-label
+	// Variant defaults to ButtonPrimary.
+	Variant ButtonVariant
+	// Size defaults to ButtonSizeDefault.
+	Size ButtonSize
+	// Type is the button type: "button" (default), "submit", or "reset".
+	Type string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the rendered <button>.
+	// Button is the documented carrier for runtime wiring, so
+	// data-fui-* keys pass through — attach interactive wiring with
+	// interactive.Action.Attrs() (see interactive-patterns). Keys the
+	// component owns are dropped: class and id (use Class / ID), type
+	// (use Type), and aria-label (use Label).
 	ExtraAttrs html.Attrs
 	ID         string
 	Class      string
@@ -558,7 +567,7 @@ func Button(cfg ButtonConfig) render.HTML {
 		Type:       cfg.Type,
 		Class:      cls,
 		ID:         cfg.ID,
-		ExtraAttrs: cfg.ExtraAttrs,
+		ExtraAttrs: html.SafeCarrierAttrs(cfg.ExtraAttrs, "type", "aria-label"),
 	}))
 }
 
@@ -583,9 +592,14 @@ type LinkButtonConfig struct {
 	// Icon, when set, renders the named registered icon (see
 	// RegisterIcon / Icon) before the label. The button's inline-flex
 	// gap handles spacing. Unknown names render the label alone.
-	Icon       string
-	ID         string
-	Class      string
+	Icon  string
+	ID    string
+	Class string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the rendered <a>. Keys the
+	// component owns are dropped: class and id (use Class / ID),
+	// data-fui-*, and href (use Href). With External, target and rel
+	// are owned too; without it a caller may still set them.
 	ExtraAttrs html.Attrs
 }
 
@@ -622,9 +636,11 @@ func LinkButton(cfg LinkButtonConfig) render.HTML {
 	if cfg.Class != "" {
 		cls += " " + cfg.Class
 	}
-	extra := html.Attrs{}
-	maps.Copy(extra, cfg.ExtraAttrs)
+	extra := html.SafeExtraAttrs(cfg.ExtraAttrs, "href")
 	if cfg.External {
+		if extra == nil {
+			extra = html.Attrs{}
+		}
 		extra["target"] = "_blank"
 		extra["rel"] = "noopener noreferrer"
 	}

--- a/framework/ui/components_test.go
+++ b/framework/ui/components_test.go
@@ -684,3 +684,77 @@ func TestSkipLinkExtraAttrsOnRoot(t *testing.T) {
 		t.Errorf("SkipLink root missing data-test:\n%s", root)
 	}
 }
+
+func TestButtonExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := Button(ButtonConfig{Label: "Save", ExtraAttrs: map[string]string{
+		"data-test": "hook", "type": "evil", "Class": "evil",
+	}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `type="button"`) {
+		t.Errorf("button type lost its framework value:\n%s", root)
+	}
+	for _, banned := range []string{"evil", `aria-label="evil"`} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+}
+
+func TestButtonExtraAttrsCarriesWiring(t *testing.T) {
+	// Button is the documented carrier for interactive wiring
+	// (interactive-patterns.md attaches Action.Attrs() via ExtraAttrs):
+	// data-fui-* must pass through, unlike components that own their
+	// own wiring. framework/ui/resource and battery/admin depend on it.
+	h := Button(ButtonConfig{Label: "Delete", ExtraAttrs: map[string]string{
+		"data-fui-rpc":        "/api/items/42",
+		"data-fui-rpc-method": "DELETE",
+		"data-fui-confirm":    "Delete this item?",
+	}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	for _, want := range []string{
+		`data-fui-rpc="/api/items/42"`,
+		`data-fui-rpc-method="DELETE"`,
+		`data-fui-confirm="Delete this item?"`,
+	} {
+		if !strings.Contains(root, want) {
+			t.Errorf("wiring attr %s dropped from carrier button:\n%s", want, root)
+		}
+	}
+}
+
+func TestLinkButtonExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := LinkButton(LinkButtonConfig{Label: "Go", Href: "/real", ExtraAttrs: map[string]string{
+		"data-test": "hook", "href": "javascript:alert(1)", "Class": "evil",
+	}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `href="/real"`) {
+		t.Errorf("framework href lost:\n%s", root)
+	}
+	for _, banned := range []string{"evil", "javascript:"} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+}
+
+func TestLinkButtonExternalOwnsTargetAndRel(t *testing.T) {
+	// External must win even when extras try to set target/rel — and
+	// the all-dropped (nil-map) branch must still emit both.
+	h := LinkButton(LinkButtonConfig{
+		Label: "Docs", Href: "https://example.com", External: true,
+		ExtraAttrs: map[string]string{"target": "evil", "rel": "evil"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `target="_blank"`) || !strings.Contains(root, `rel="noopener noreferrer"`) {
+		t.Errorf("External target/rel lost:\n%s", root)
+	}
+	if strings.Contains(root, "evil") {
+		t.Errorf("ExtraAttrs target/rel overrode External:\n%s", root)
+	}
+}

--- a/framework/ui/components_test.go
+++ b/framework/ui/components_test.go
@@ -688,6 +688,7 @@ func TestSkipLinkExtraAttrsOnRoot(t *testing.T) {
 func TestButtonExtraAttrsCannotOverrideOwned(t *testing.T) {
 	h := Button(ButtonConfig{Label: "Save", ExtraAttrs: map[string]string{
 		"data-test": "hook", "type": "evil", "Class": "evil",
+		"aria-label": "evil", "data-fui-comp": "evil",
 	}})
 	root := string(h)[:strings.Index(string(h), ">")+1]
 	if !strings.Contains(root, `data-test="hook"`) {
@@ -696,10 +697,8 @@ func TestButtonExtraAttrsCannotOverrideOwned(t *testing.T) {
 	if !strings.Contains(root, `type="button"`) {
 		t.Errorf("button type lost its framework value:\n%s", root)
 	}
-	for _, banned := range []string{"evil", `aria-label="evil"`} {
-		if strings.Contains(root, banned) {
-			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
-		}
+	if strings.Contains(root, "evil") {
+		t.Errorf("owned attr overridden by ExtraAttrs:\n%s", root)
 	}
 }
 
@@ -739,6 +738,26 @@ func TestLinkButtonExtraAttrsCannotOverrideOwned(t *testing.T) {
 	for _, banned := range []string{"evil", "javascript:"} {
 		if strings.Contains(root, banned) {
 			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+}
+
+func TestLinkButtonExternalDropsCaseVariantTargetRel(t *testing.T) {
+	// "TARGET"/"REL" survive a lowercase-only overwrite as distinct map
+	// keys, sort BEFORE the owned lowercase attrs in the rendered tag,
+	// and first-occurrence-wins in the parser — so without protection a
+	// case-variant clobbers External's noopener contract.
+	h := LinkButton(LinkButtonConfig{
+		Label: "Docs", Href: "https://example.com", External: true,
+		ExtraAttrs: map[string]string{"TARGET": "evil", "REL": "evil"},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if strings.Contains(root, "evil") {
+		t.Errorf("case-variant target/rel survived on an External link:\n%s", root)
+	}
+	for _, want := range []string{`target="_blank"`, `rel="noopener noreferrer"`} {
+		if !strings.Contains(root, want) {
+			t.Errorf("External link missing %s:\n%s", want, root)
 		}
 	}
 }

--- a/framework/ui/container.go
+++ b/framework/ui/container.go
@@ -35,9 +35,13 @@ type ContainerConfig struct {
 	Width ContainerWidth
 	// As lets the caller pick a non-<div> tag (e.g. "section", "main").
 	// Defaults to "div".
-	As         string
-	ID         string
-	Class      string
+	As    string
+	ID    string
+	Class string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the wrapper element.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
 	ExtraAttrs html.Attrs
 }
 
@@ -64,7 +68,7 @@ func Container(cfg ContainerConfig, children ...render.HTML) render.HTML {
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}
-	maps.Copy(attrs, cfg.ExtraAttrs)
+	maps.Copy(attrs, html.SafeExtraAttrs(cfg.ExtraAttrs))
 	return containerStyle.WrapHTML(render.Tag(tag, attrs, children...))
 }
 

--- a/framework/ui/container_test.go
+++ b/framework/ui/container_test.go
@@ -53,3 +53,22 @@ func TestContainerRejectsUnknownWidth(t *testing.T) {
 	}()
 	Container(ContainerConfig{Width: ContainerWidth("huge")})
 }
+
+func TestContainerExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := Container(ContainerConfig{ID: "real", ExtraAttrs: map[string]string{
+		"data-test": "hook", "id": "evil", "Class": "evil",
+	}}, render.Text("x"))
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `id="real"`) {
+		t.Errorf("framework id lost:\n%s", root)
+	}
+	if !strings.Contains(root, "ui-container") {
+		t.Errorf("framework class lost:\n%s", root)
+	}
+	if strings.Contains(root, "evil") {
+		t.Errorf("owned attr overridden by ExtraAttrs:\n%s", root)
+	}
+}

--- a/framework/ui/extraattrs_contract_test.go
+++ b/framework/ui/extraattrs_contract_test.go
@@ -222,7 +222,7 @@ func TestExtraAttrsForwardingIsSanitized(t *testing.T) {
 			if extraAttrsRawLegacy[name] {
 				return true
 			}
-			t.Errorf("%s: raw ExtraAttrs read at %s; route it through html.SafeExtraAttrs (issue #262 tracks the legacy allow-list)",
+			t.Errorf("%s: raw ExtraAttrs read at %s; route it through html.SafeExtraAttrs (or html.SafeCarrierAttrs for a pinned wiring carrier — see safeCarrierAllowed)",
 				name, fset.Position(sel.Pos()))
 			return true
 		})

--- a/framework/ui/extraattrs_contract_test.go
+++ b/framework/ui/extraattrs_contract_test.go
@@ -134,6 +134,19 @@ var extraAttrsRawLegacy = map[string]bool{
 	"form.go": true,
 }
 
+// safeCarrierAllowed pins the wiring-carrier set: only these files may
+// call html.SafeCarrierAttrs. A carrier keeps data-fui-* pass-through,
+// so a component that emits its own data-fui-* wiring (TextArea
+// autogrow, NotificationBell's trigger, RangeSlider's mirror, …) must
+// never be one — a caller could spoof its wiring, the exact class the
+// SafeExtraAttrs contract closes. Adding an entry is a design
+// decision: the component must emit no wiring of its own and be a
+// documented attachment point for interactive.Action.Attrs().
+var safeCarrierAllowed = map[string]bool{
+	"components.go": true, // ui.Button (interactive-patterns.md)
+	"link.go":       true, // ui.Link (uinoderender ActionRef links)
+}
+
 // TestExtraAttrsForwardingIsSanitized fails when a file outside the
 // legacy allow-list reads a config's ExtraAttrs without routing it
 // through html.SafeExtraAttrs (or scrubAttrs). Presence of the field
@@ -161,11 +174,16 @@ func TestExtraAttrsForwardingIsSanitized(t *testing.T) {
 			case *ast.CallExpr:
 				switch fun := d.Fun.(type) {
 				case *ast.SelectorExpr:
-					// SafeCarrierAttrs is the wiring-carrier variant
-					// (ui.Button): owned keys still drop, data-fui-*
-					// passes through by documented contract.
+					// SafeCarrierAttrs is the wiring-carrier variant:
+					// owned keys still drop, data-fui-* passes through
+					// by documented contract — allowed only in the
+					// pinned carrier files.
 					if fun.Sel.Name == "SafeExtraAttrs" || fun.Sel.Name == "SafeCarrierAttrs" {
 						sanitized = append(sanitized, d)
+					}
+					if fun.Sel.Name == "SafeCarrierAttrs" && !safeCarrierAllowed[name] {
+						t.Errorf("%s: SafeCarrierAttrs at %s — the carrier set is pinned to %v; a component with its own data-fui-* wiring must use SafeExtraAttrs (see safeCarrierAllowed)",
+							name, fset.Position(d.Pos()), []string{"components.go", "link.go"})
 					}
 				case *ast.Ident:
 					// chartEmpty sanitizes its extra argument internally.

--- a/framework/ui/extraattrs_contract_test.go
+++ b/framework/ui/extraattrs_contract_test.go
@@ -126,14 +126,12 @@ func returnsComponentType(res *ast.FieldList) bool {
 // must go through html.SafeExtraAttrs (or scrubAttrs where on* filtering
 // is the deliberate, documented contract).
 var extraAttrsRawLegacy = map[string]bool{
-	"animatedcounter.go": true, "banner.go": true, "carousel.go": true,
-	"components.go": true, "container.go": true, "filtertoolbar.go": true,
-	"form.go": true, "gallery.go": true, "link.go": true,
-	"markdown.go": true, "menu.go": true, "notificationbell.go": true,
-	"numberinput.go": true, "passwordinput.go": true, "progresssteps.go": true,
-	"rangeslider.go": true, "searchinput.go": true, "select.go": true,
-	"slider.go": true, "textarea.go": true, "timeline.go": true,
-	"toc.go": true, "toolbar.go": true, "workbench.go": true,
+	// form.go stays raw on purpose: its doc comment promises that
+	// ExtraAttrs may override the form's own attributes (the
+	// data-entity-form / interactive wiring pattern the blueprint
+	// generator and examples rely on). It is the documented exception,
+	// not migration debt.
+	"form.go": true,
 }
 
 // TestExtraAttrsForwardingIsSanitized fails when a file outside the
@@ -163,7 +161,10 @@ func TestExtraAttrsForwardingIsSanitized(t *testing.T) {
 			case *ast.CallExpr:
 				switch fun := d.Fun.(type) {
 				case *ast.SelectorExpr:
-					if fun.Sel.Name == "SafeExtraAttrs" {
+					// SafeCarrierAttrs is the wiring-carrier variant
+					// (ui.Button): owned keys still drop, data-fui-*
+					// passes through by documented contract.
+					if fun.Sel.Name == "SafeExtraAttrs" || fun.Sel.Name == "SafeCarrierAttrs" {
 						sanitized = append(sanitized, d)
 					}
 				case *ast.Ident:

--- a/framework/ui/filtertoolbar.go
+++ b/framework/ui/filtertoolbar.go
@@ -2,7 +2,7 @@ package ui
 
 import (
 	"context"
-	"strings"
+	"maps"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
@@ -144,8 +144,13 @@ type FilterToolbarConfig struct {
 	// When nil, English fallbacks are returned.
 	Ctx context.Context
 
-	ID         string
-	Class      string
+	ID    string
+	Class string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the toolbar's root <form>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, and the form contract (method, action, role,
+	// aria-label) — the sanitized Action is never overridable.
 	ExtraAttrs html.Attrs
 }
 
@@ -245,17 +250,7 @@ func FilterToolbar(cfg FilterToolbarConfig) render.HTML {
 	if cfg.ID != "" {
 		formAttrs["id"] = cfg.ID
 	}
-	for k, v := range cfg.ExtraAttrs {
-		// HTML attribute names are case-insensitive, so a case-variant key
-		// ("Action"/"ACTION"/"AcTiOn") would survive a lowercase-only drop,
-		// render as a second attribute, and fold back onto "action" in the
-		// parser (first occurrence wins), silently reversing the
-		// urlsafe.CleanAnchor pass below. Drop every case-variant here.
-		if strings.EqualFold(k, "action") {
-			continue
-		}
-		formAttrs[k] = v
-	}
+	maps.Copy(formAttrs, html.SafeExtraAttrs(cfg.ExtraAttrs, "action", "method", "role", "aria-label"))
 	// The sanitized action must win: ExtraAttrs is a developer escape hatch,
 	// but letting it rewrite "action" would silently undo the
 	// urlsafe.CleanAnchor pass above (a "javascript:" action would come back

--- a/framework/ui/filtertoolbar_test.go
+++ b/framework/ui/filtertoolbar_test.go
@@ -226,3 +226,25 @@ func TestFilterToolbarSearchOnly(t *testing.T) {
 		t.Errorf("expected search field, got: %s", out)
 	}
 }
+
+func TestFilterToolbarExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := FilterToolbar(FilterToolbarConfig{
+		Action: "/list",
+		Sort:   []SortOption{{Value: "x", Label: "X"}},
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "action": "javascript:alert(1)", "method": "evil", "Class": "evil",
+		},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("form root missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `action="/list"`) || !strings.Contains(root, `method="GET"`) {
+		t.Errorf("form action/method lost their framework values:\n%s", root)
+	}
+	for _, banned := range []string{"evil", "javascript:"} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+}

--- a/framework/ui/gallery.go
+++ b/framework/ui/gallery.go
@@ -93,9 +93,13 @@ type GalleryConfig struct {
 	HrefFn func(i int, it GalleryItem) string
 	// CaptionMode controls caption rendering. Default Below.
 	CaptionMode GalleryCaptionMode
-	// ID / Class / Attrs pass through to the wrapper.
-	ID         string
-	Class      string
+	// ID / Class are passed through to the wrapper.
+	ID    string
+	Class string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the gallery's root <ul>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, and aria-label (use Label).
 	ExtraAttrs html.Attrs
 }
 
@@ -157,7 +161,7 @@ func Gallery(cfg GalleryConfig) render.HTML {
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}
-	maps.Copy(attrs, cfg.ExtraAttrs)
+	maps.Copy(attrs, html.SafeExtraAttrs(cfg.ExtraAttrs, "aria-label"))
 
 	rows := make([]render.HTML, 0, len(cfg.Items))
 	for i, it := range cfg.Items {

--- a/framework/ui/gallery_test.go
+++ b/framework/ui/gallery_test.go
@@ -170,3 +170,23 @@ func TestGalleryColumnsAreResponsiveMaximum(t *testing.T) {
 		}
 	}
 }
+
+func TestGalleryExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := Gallery(GalleryConfig{
+		Label: "Trips",
+		Items: []GalleryItem{{Src: "/a.jpg", Alt: "A trip"}},
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "aria-label": "evil", "Class": "evil",
+		},
+	})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `aria-label="Trips"`) {
+		t.Errorf("gallery label lost its framework value:\n%s", root)
+	}
+	if strings.Contains(root, "evil") {
+		t.Errorf("owned attr overridden by ExtraAttrs:\n%s", root)
+	}
+}

--- a/framework/ui/link.go
+++ b/framework/ui/link.go
@@ -26,11 +26,19 @@ const (
 
 // LinkConfig configures a Link.
 type LinkConfig struct {
-	Href       string // required
-	Text       string // required visible text
-	Variant    LinkVariant
-	Class      string
-	ID         string
+	Href    string // required
+	Text    string // required visible text
+	Variant LinkVariant
+	Class   string
+	ID      string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the rendered <a>. Link is
+	// a wiring carrier: data-fui-* passes through, which is how a
+	// progressive-enhancement link ships an href fallback plus a
+	// data-fui-rpc upgrade (uinoderender's ActionRef links). Keys the
+	// component owns are dropped: class and id (use Class / ID) and
+	// href (use Href). on* event handlers and values with control
+	// bytes are also scrubbed (see scrubAttrs).
 	ExtraAttrs html.Attrs
 }
 
@@ -62,8 +70,13 @@ func Link(cfg LinkConfig) render.HTML {
 		cls += " " + cfg.Class
 	}
 	// Drop unsafe href (javascript:, data:, control bytes, …) and
-	// scrub event-handler attributes out of ExtraAttrs. See
-	// framework/ui/safety.go for the allow-list.
+	// route ExtraAttrs through the sanitizer: scrubAttrs removes on*
+	// event handlers and control-byte values, SafeCarrierAttrs removes
+	// the keys this component owns (class, id, href) while letting
+	// data-fui-* wiring through. Both filters must survive any future
+	// refactor: on* filtering is pinned by
+	// TestLink_StripsEventHandlerExtraAttrs, href by the contract
+	// test, wiring pass-through by TestLinkExtraAttrsCarriesWiring.
 	href := urlsafe.CleanAnchor(cfg.Href)
 	if href == "" {
 		href = "#"
@@ -73,7 +86,7 @@ func Link(cfg LinkConfig) render.HTML {
 		Text:       cfg.Text,
 		Class:      cls,
 		ID:         cfg.ID,
-		ExtraAttrs: scrubAttrs(cfg.ExtraAttrs),
+		ExtraAttrs: html.SafeCarrierAttrs(scrubAttrs(cfg.ExtraAttrs), "href"),
 	}))
 }
 

--- a/framework/ui/link_test.go
+++ b/framework/ui/link_test.go
@@ -82,3 +82,33 @@ func TestLinkActionEmitsCompMarker(t *testing.T) {
 		t.Errorf("Link should emit data-fui-comp=ui-link:\n%s", h)
 	}
 }
+
+func TestLinkExtraAttrsCarriesWiring(t *testing.T) {
+	// Link is a wiring carrier: uinoderender's ActionRef links ship an
+	// href fallback plus a data-fui-rpc upgrade through ExtraAttrs.
+	h := Link(LinkConfig{Href: "/m/mod/act", Text: "Act", ExtraAttrs: map[string]string{
+		"data-fui-rpc": "/m/mod/act",
+	}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-fui-rpc="/m/mod/act"`) {
+		t.Errorf("wiring attr dropped from carrier link:\n%s", root)
+	}
+}
+
+func TestLinkExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := Link(LinkConfig{Href: "/real", Text: "Edit", ExtraAttrs: map[string]string{
+		"data-test": "hook", "href": "javascript:alert(1)", "Class": "evil", "onclick": "evil()",
+	}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `href="/real"`) {
+		t.Errorf("sanitized framework href lost:\n%s", root)
+	}
+	for _, banned := range []string{"evil", "javascript:"} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+}

--- a/framework/ui/markdown.go
+++ b/framework/ui/markdown.go
@@ -25,9 +25,13 @@ type MarkdownConfig struct {
 	Source string
 	// Compact tightens spacing, useful for inline previews where
 	// hero-page paragraph rhythm would feel wrong.
-	Compact    bool
-	ID         string
-	Class      string
+	Compact bool
+	ID      string
+	Class   string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the prose container's
+	// root <div>. Keys the component owns are dropped: class and id
+	// (use Class / ID) and data-fui-*.
 	ExtraAttrs html.Attrs
 }
 
@@ -47,7 +51,7 @@ func Markdown(cfg MarkdownConfig) render.HTML {
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}
-	maps.Copy(attrs, cfg.ExtraAttrs)
+	maps.Copy(attrs, html.SafeExtraAttrs(cfg.ExtraAttrs))
 	body := enrichCodeBlocks(string(markdown.RenderHTML(cfg.Source)))
 	return markdownStyle.WrapHTML(render.Tag("div", attrs, render.HTML(body)))
 }

--- a/framework/ui/markdown_test.go
+++ b/framework/ui/markdown_test.go
@@ -44,3 +44,22 @@ func TestMarkdownDataFuiComp(t *testing.T) {
 		t.Errorf("Markdown should emit data-fui-comp marker:\n%s", h)
 	}
 }
+
+func TestMarkdownExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := Markdown(MarkdownConfig{Source: "hi", ID: "real", ExtraAttrs: map[string]string{
+		"data-test": "hook", "id": "evil", "Class": "evil",
+	}})
+	root := string(h)[:strings.Index(string(h), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("root missing data-test:\n%s", root)
+	}
+	if !strings.Contains(root, `id="real"`) {
+		t.Errorf("framework id lost:\n%s", root)
+	}
+	if !strings.Contains(root, "ui-markdown") {
+		t.Errorf("framework class lost:\n%s", root)
+	}
+	if strings.Contains(root, "evil") {
+		t.Errorf("owned attr overridden by ExtraAttrs:\n%s", root)
+	}
+}

--- a/framework/ui/menu.go
+++ b/framework/ui/menu.go
@@ -1,8 +1,6 @@
 package ui
 
 import (
-	"maps"
-	"slices"
 	"strings"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
@@ -41,12 +39,17 @@ type MenuItem struct {
 	// menu items.
 	RPC, RPCMethod string
 
+	// Confirm asks the user to confirm before the RPC fires. Maps to
+	// data-fui-confirm; only meaningful with RPC (the runtime reads it
+	// on rpc dispatch), ignored otherwise.
+	Confirm string
+
 	// Icon is rendered to the left of Label. Inline HTML; caller
 	// supplies an <svg>, character, or render.Text("⚙").
 	Icon render.HTML
 
 	// Variant tints destructive items (red), purely a visual hint;
-	// the actual confirm step belongs on the RPC via data-fui-confirm.
+	// the actual confirm step is Confirm above.
 	Danger bool
 
 	// Disabled greys the item out and removes it from keyboard
@@ -61,7 +64,11 @@ type MenuItem struct {
 	// for testing or one-off hooks).
 	Class string
 
-	// Attrs sprinkles extra attributes onto the rendered element.
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) onto the rendered item
+	// element. Keys the item owns are dropped: class (use Class), id,
+	// data-fui-* (the disclosure / rpc wiring), and the menuitem
+	// contract (type, href, tabindex, role, aria-disabled, disabled).
 	ExtraAttrs map[string]string
 }
 
@@ -211,20 +218,18 @@ func writeMenuItem(b *strings.Builder, it MenuItem) {
 			method = "POST"
 		}
 		rpcAttr = ` data-fui-rpc="` + render.Escape(it.RPC) + `" data-fui-rpc-method="` + render.Escape(method) + `"`
-	}
-	var extra strings.Builder
-	for _, k := range slices.Sorted(maps.Keys(it.ExtraAttrs)) {
-		// render.Attr validates the key against the same allow-list as
-		// every other ExtraAttrs consumer: render.Escape alone doesn't
-		// touch spaces, so a key like `x onclick` would smuggle a live
-		// event handler into the tag. Unsafe keys are dropped. Sorted
-		// so SSR output is deterministic across renders.
-		if a := render.Attr(k, it.ExtraAttrs[k]); a != "" {
-			extra.WriteString(` ` + a)
+		if it.Confirm != "" {
+			rpcAttr += ` data-fui-confirm="` + render.Escape(it.Confirm) + `"`
 		}
 	}
+	// ExtraAttrs join the SafeExtraAttrs contract: the item owns
+	// type/href/tabindex/role/aria-disabled/disabled plus the rpc
+	// data-fui-* wiring. serializeExtraAttrs sorts the survivors and
+	// validates each key via render.Attr (unsafe keys drop).
+	extra := serializeExtraAttrs(html.SafeExtraAttrs(it.ExtraAttrs,
+		"type", "href", "tabindex", "role", "aria-disabled", "disabled"))
 	b.WriteString(`<` + tag + ` class="` + render.Escape(cls) + `" ` + openExtra +
-		` role="menuitem" tabindex="` + tabindex + `"` + disabledAttr + rpcAttr + extra.String() + `>`)
+		` role="menuitem" tabindex="` + tabindex + `"` + disabledAttr + rpcAttr + extra + `>`)
 	if it.Icon != "" {
 		b.WriteString(`<span class="ui-menu__icon" aria-hidden="true">` + string(it.Icon) + `</span>`)
 	}

--- a/framework/ui/menu_test.go
+++ b/framework/ui/menu_test.go
@@ -155,3 +155,45 @@ func TestMenuExtraAttrsOnRoot(t *testing.T) {
 		t.Errorf("menu root missing data-test:\n%s", root)
 	}
 }
+
+func TestMenuItemConfirmEmitsOnRPCItems(t *testing.T) {
+	out := string(ui.Menu(ui.MenuConfig{
+		Label: "Actions",
+		Items: []ui.MenuItem{
+			{Label: "Delete", RPC: "/api/items/1", RPCMethod: "DELETE",
+				Confirm: "Delete this item?", Danger: true},
+			{Label: "Open", Href: "/x", Confirm: "ignored without RPC"},
+		},
+	}))
+	if !strings.Contains(out, `data-fui-confirm="Delete this item?"`) {
+		t.Errorf("rpc item missing data-fui-confirm:\n%s", out)
+	}
+	if strings.Contains(out, "ignored without RPC") {
+		t.Errorf("Confirm must be inert on non-RPC items:\n%s", out)
+	}
+}
+
+func TestMenuItemExtraAttrsCannotOverrideOwned(t *testing.T) {
+	out := string(ui.Menu(ui.MenuConfig{
+		Label: "Actions",
+		Items: []ui.MenuItem{
+			{Label: "Open", Href: "/x", ExtraAttrs: map[string]string{
+				"data-test": "hook-a", "href": "javascript:evil()", "Class": "evil",
+			}},
+			{Label: "Delete", ExtraAttrs: map[string]string{
+				"data-test": "hook-b", "role": "evil", "tabindex": "evil",
+			}},
+		},
+	}))
+	for _, want := range []string{
+		`data-test="hook-a"`, `data-test="hook-b"`,
+		`href="/x"`, `role="menuitem"`, `tabindex="-1"`, `type="button"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("item output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "evil") {
+		t.Errorf("owned item attr overridden by ExtraAttrs:\n%s", out)
+	}
+}

--- a/framework/ui/notificationbell.go
+++ b/framework/ui/notificationbell.go
@@ -76,8 +76,13 @@ type NotificationBellConfig struct {
 	// empty-state text. When nil, English fallbacks apply.
 	Ctx context.Context
 
-	ID         string
-	Class      string
+	ID    string
+	Class string
+	// ExtraAttrs forwards additional attributes (data-* test hooks,
+	// analytics markers, ARIA overrides) to the bell's root <button>.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-* (the popover wiring), type, aria-label (use
+	// Label), and aria-describedby (the unread-count announcement).
 	ExtraAttrs html.Attrs
 }
 
@@ -118,7 +123,7 @@ func NotificationBell(cfg NotificationBellConfig) (render.HTML, *widget.Builder)
 	if cfg.ID != "" {
 		btnAttrs["id"] = cfg.ID
 	}
-	maps.Copy(btnAttrs, cfg.ExtraAttrs)
+	maps.Copy(btnAttrs, html.SafeExtraAttrs(cfg.ExtraAttrs, "type", "aria-label", "aria-describedby"))
 
 	// Badge: server-rendered count + optional signal-bound override.
 	badgeAttrs := html.Attrs{"class": "ui-notification-bell__badge", "aria-hidden": "true"}

--- a/framework/ui/notificationbell_test.go
+++ b/framework/ui/notificationbell_test.go
@@ -120,3 +120,24 @@ func TestNotificationBellReturnsPopoverBuilder(t *testing.T) {
 		t.Errorf("popover name should match bell name, got %q", def.Name)
 	}
 }
+
+func TestNotificationBellExtraAttrsCannotOverrideOwned(t *testing.T) {
+	trigger, _ := NotificationBell(NotificationBellConfig{
+		Name: "nb", Label: "Notifications", UnreadCount: 3,
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "type": "evil", "Class": "evil",
+		},
+	})
+	root := string(trigger)[:strings.Index(string(trigger), ">")+1]
+	if !strings.Contains(root, `data-test="hook"`) {
+		t.Errorf("bell button missing data-test:\n%s", root)
+	}
+	for _, want := range []string{`type="button"`, `aria-label="Notifications"`, `aria-describedby="nb-count"`} {
+		if !strings.Contains(root, want) {
+			t.Errorf("owned attr lost its framework value (%q):\n%s", want, root)
+		}
+	}
+	if strings.Contains(root, "evil") {
+		t.Errorf("owned attr overridden by ExtraAttrs:\n%s", root)
+	}
+}

--- a/framework/ui/notificationbell_test.go
+++ b/framework/ui/notificationbell_test.go
@@ -141,3 +141,17 @@ func TestNotificationBellExtraAttrsCannotOverrideOwned(t *testing.T) {
 		t.Errorf("owned attr overridden by ExtraAttrs:\n%s", root)
 	}
 }
+
+func TestNotificationBellZeroUnreadDropsDescribedbyVariant(t *testing.T) {
+	// With no unread count the component never re-asserts
+	// aria-describedby after the merge, so this state proves the
+	// sanitizer's case-insensitive drop alone keeps the attr out.
+	trigger, _ := NotificationBell(NotificationBellConfig{
+		Name: "nb", Label: "Notifications",
+		ExtraAttrs: map[string]string{"ARIA-DESCRIBEDBY": "evil"},
+	})
+	root := string(trigger)[:strings.Index(string(trigger), ">")+1]
+	if strings.Contains(strings.ToLower(root), "aria-describedby") {
+		t.Errorf("zero-unread bell must carry no aria-describedby:\n%s", root)
+	}
+}

--- a/framework/ui/numberinput.go
+++ b/framework/ui/numberinput.go
@@ -43,9 +43,13 @@ type NumberInputConfig struct {
 	// Help renders supporting text under the field.
 	Help string
 	// Error overrides Help with an error message.
-	Error      string
-	ID         string
-	Class      string
+	Error string
+	ID    string
+	Class string
+	// ExtraAttrs forwards additional attributes to the <input> element.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, type, name, step, value, min, max, disabled,
+	// required, aria-invalid, and aria-describedby.
 	ExtraAttrs html.Attrs
 	// Ctx carries the per-request context used to resolve the Decrement and
 	// Increment aria labels. When nil, English fallbacks apply.
@@ -109,7 +113,9 @@ func NumberInput(cfg NumberInputConfig) render.HTML {
 	} else if cfg.Help != "" {
 		inputAttrs["aria-describedby"] = id + "-help"
 	}
-	maps.Copy(inputAttrs, cfg.ExtraAttrs)
+	maps.Copy(inputAttrs, html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"type", "name", "step", "value", "min", "max",
+		"disabled", "required", "aria-invalid", "aria-describedby"))
 
 	minusAttrs := map[string]string{
 		"type":                 "button",

--- a/framework/ui/numberinput_test.go
+++ b/framework/ui/numberinput_test.go
@@ -80,3 +80,49 @@ func TestNumberInputAccessibleLabelOnButtons(t *testing.T) {
 		t.Errorf("+ button should have aria-label=Increment <Label>:\n%s", h)
 	}
 }
+
+// extraAttrsOpeningTag returns the opening tag of the first <tag>
+// element in h, attributes included. ExtraAttrs-contract tests pin
+// where extras land by inspecting that element.
+func extraAttrsOpeningTag(t *testing.T, h string, tag string) string {
+	t.Helper()
+	i := strings.Index(h, "<"+tag)
+	if i < 0 {
+		t.Fatalf("no <%s> element in output:\n%s", tag, h)
+	}
+	end := strings.Index(h[i:], ">")
+	if end < 0 {
+		t.Fatalf("unterminated <%s> element:\n%s", tag, h)
+	}
+	return h[i : i+end+1]
+}
+
+// ExtraAttrs land on the <input> but never override what the component
+// owns (#262): step/value/min/max (and the other owned keys) keep their
+// framework values; class/id/data-fui-* case-variants are dropped.
+func TestNumberInputExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := string(NumberInput(NumberInputConfig{
+		Name: "qty", Label: "Quantity", Min: 1, Max: 9, Step: 2, Value: 4, Class: "mine",
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "step": "evil", "Class": "evil", "data-fui-comp": "spoof",
+		},
+	}))
+	input := extraAttrsOpeningTag(t, h, "input")
+	for _, banned := range []string{"evil", "spoof"} {
+		if strings.Contains(input, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, input)
+		}
+	}
+	for _, want := range []string{
+		`data-test="hook"`, `type="number"`, `name="qty"`, `step="2"`, `value="4"`,
+		`min="1"`, `max="9"`, `class="ui-number-input__input`,
+	} {
+		if !strings.Contains(input, want) {
+			t.Errorf("input missing %q:\n%s", want, input)
+		}
+	}
+	root := h[:strings.Index(h, ">")+1]
+	if !strings.Contains(root, `class="ui-number-input mine"`) {
+		t.Errorf("wrapper class should stay framework+caller:\n%s", root)
+	}
+}

--- a/framework/ui/passwordinput.go
+++ b/framework/ui/passwordinput.go
@@ -34,7 +34,10 @@ type PasswordInputConfig struct {
 	Error string
 	// Class adds extra CSS classes to the wrapper.
 	Class string
-	// Attrs lets callers attach additional attributes.
+	// ExtraAttrs forwards additional attributes to the <input> element.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, type, name, placeholder, required, autocomplete,
+	// aria-invalid, and aria-describedby.
 	ExtraAttrs map[string]string
 
 	// Ctx carries the per-request context used to resolve i18n strings
@@ -83,11 +86,9 @@ func PasswordInput(cfg PasswordInputConfig) render.HTML {
 		inputAttrs["aria-invalid"] = "true"
 		inputAttrs["aria-describedby"] = cfg.ID + "-error"
 	}
-	maps.Copy(inputAttrs, cfg.ExtraAttrs)
-	// Protect critical attrs from Attrs override.
-	inputAttrs["type"] = "password"
-	inputAttrs["name"] = cfg.Name
-	inputAttrs["id"] = cfg.ID
+	maps.Copy(inputAttrs, html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"type", "name", "placeholder", "required", "autocomplete",
+		"aria-invalid", "aria-describedby"))
 
 	toggleAttrs := map[string]string{
 		"type":         "button",

--- a/framework/ui/passwordinput_test.go
+++ b/framework/ui/passwordinput_test.go
@@ -148,3 +148,33 @@ func TestPasswordInputRequired(t *testing.T) {
 		t.Errorf("expected required attribute:\n%s", h)
 	}
 }
+
+// ExtraAttrs land on the <input> but never override what the component
+// owns (#262). The old maps.Copy + re-assert left case-variant holes
+// ("Type" folded back onto type in the parser); the SafeExtraAttrs
+// route closes them.
+func TestPasswordInputExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := string(PasswordInput(PasswordInputConfig{
+		Name: "pw", ID: "pw", Placeholder: "Enter password",
+		Autocomplete: "new-password", Class: "mine",
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "type": "text", "Type": "text", "Class": "evil",
+			"data-fui-comp": "spoof",
+		},
+	}))
+	input := extraAttrsOpeningTag(t, h, "input")
+	for _, banned := range []string{"evil", "spoof", `type="text"`} {
+		if strings.Contains(input, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, input)
+		}
+	}
+	for _, want := range []string{
+		`data-test="hook"`, `type="password"`, `name="pw"`, `id="pw"`,
+		`placeholder="Enter password"`, `autocomplete="new-password"`,
+		`class="ui-password-input__input`,
+	} {
+		if !strings.Contains(input, want) {
+			t.Errorf("input missing %q:\n%s", want, input)
+		}
+	}
+}

--- a/framework/ui/progresssteps.go
+++ b/framework/ui/progresssteps.go
@@ -68,8 +68,11 @@ type ProgressStepsConfig struct {
 	// aria-label. When nil, English fallbacks apply.
 	Ctx context.Context
 
-	ID         string
-	Class      string
+	ID    string
+	Class string
+	// ExtraAttrs forwards additional attributes to the <nav> root.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, and aria-label (use Label).
 	ExtraAttrs html.Attrs
 }
 
@@ -103,7 +106,7 @@ func ProgressSteps(cfg ProgressStepsConfig) render.HTML {
 	if cfg.ID != "" {
 		navAttrs["id"] = cfg.ID
 	}
-	maps.Copy(navAttrs, cfg.ExtraAttrs)
+	maps.Copy(navAttrs, html.SafeExtraAttrs(cfg.ExtraAttrs, "aria-label"))
 
 	items := make([]render.HTML, 0, len(cfg.Steps))
 	for i, s := range cfg.Steps {

--- a/framework/ui/progresssteps_test.go
+++ b/framework/ui/progresssteps_test.go
@@ -80,3 +80,29 @@ func TestProgressStepsRejectsUnknownStatus(t *testing.T) {
 		Steps: []ProgressStep{{Label: "x", Status: ProgressStepStatus("bogus")}},
 	})
 }
+
+// ExtraAttrs land on the <nav> root but never override what the
+// component owns (#262): aria-label keeps its framework value; class
+// and data-fui-* case-variants are dropped.
+func TestProgressStepsExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := string(ProgressSteps(ProgressStepsConfig{
+		Label: "Checkout", Class: "mine",
+		Steps: []ProgressStep{{Label: "A"}},
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "aria-label": "evil", "Class": "evil", "data-fui-comp": "spoof",
+		},
+	}))
+	root := h[:strings.Index(h, ">")+1]
+	for _, banned := range []string{"evil", "spoof"} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+	for _, want := range []string{
+		`data-test="hook"`, `aria-label="Checkout"`, `class="ui-progress-steps mine"`,
+	} {
+		if !strings.Contains(root, want) {
+			t.Errorf("nav missing %q:\n%s", want, root)
+		}
+	}
+}

--- a/framework/ui/rangeslider.go
+++ b/framework/ui/rangeslider.go
@@ -41,9 +41,12 @@ type RangeSliderConfig struct {
 	// ShowValue renders a live "lo – hi" text alongside the label.
 	ShowValue bool
 	// Disabled disables both thumbs.
-	Disabled   bool
-	ID         string
-	Class      string
+	Disabled bool
+	ID       string
+	Class    string
+	// ExtraAttrs forwards additional attributes to the root element.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, role, and aria-label (use Label).
 	ExtraAttrs html.Attrs
 }
 
@@ -144,7 +147,7 @@ func RangeSlider(cfg RangeSliderConfig) render.HTML {
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}
-	maps.Copy(attrs, cfg.ExtraAttrs)
+	maps.Copy(attrs, html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-label"))
 	return rangeSliderStyle.WrapHTML(render.Tag("div", attrs, children...))
 }
 

--- a/framework/ui/rangeslider_test.go
+++ b/framework/ui/rangeslider_test.go
@@ -78,3 +78,29 @@ func TestRangeSliderModuleMarkersPaired(t *testing.T) {
 		t.Errorf("both inputs should share data-fui-range-slider=<id>, got %d:\n%s", c, h)
 	}
 }
+
+// ExtraAttrs land on the root element but never override what the
+// component owns (#262): role and aria-label keep framework values, and
+// a spoofed data-fui-range-slider wiring key is dropped.
+func TestRangeSliderExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := string(RangeSlider(RangeSliderConfig{
+		Name: "price", Label: "Price", Class: "mine",
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "role": "evil", "aria-label": "evil", "Class": "evil",
+			"data-fui-range-slider": "spoof",
+		},
+	}))
+	root := h[:strings.Index(h, ">")+1]
+	for _, banned := range []string{"evil", "spoof"} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+	for _, want := range []string{
+		`data-test="hook"`, `role="group"`, `aria-label="Price"`, `class="ui-range-slider mine"`,
+	} {
+		if !strings.Contains(root, want) {
+			t.Errorf("root missing %q:\n%s", want, root)
+		}
+	}
+}

--- a/framework/ui/searchinput.go
+++ b/framework/ui/searchinput.go
@@ -2,7 +2,7 @@ package ui
 
 import (
 	"context"
-	"strings"
+	"maps"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
 	"github.com/DonaldMurillo/gofastr/core-ui/registry"
@@ -33,7 +33,10 @@ type SearchInputConfig struct {
 	Method string
 	// Class adds extra CSS classes to the wrapper.
 	Class string
-	// Attrs lets callers attach additional attributes.
+	// ExtraAttrs forwards additional attributes to the <input> element.
+	// Keys the component owns are dropped: class and id, data-fui-*,
+	// type, and name. "value" is deliberately NOT owned: the resource
+	// UI prefills the current search term through it.
 	ExtraAttrs map[string]string
 	// Ctx carries the per-request context used to resolve i18n labels
 	// (placeholder, aria-labels). When nil, English fallbacks apply.
@@ -79,22 +82,11 @@ func SearchInput(cfg SearchInputConfig) render.HTML {
 		"placeholder": placeholder,
 		"aria-label":  i18nui.T(ctx, i18nui.KeySearchLabel),
 	}
-	for k, v := range cfg.ExtraAttrs {
-		// HTML attribute names are case-insensitive: a case-variant key
-		// ("Type"/"Name"/"ID") survives a lowercase-only re-assert as a
-		// distinct entry, renders as a second attribute, and folds back onto
-		// the protected one in the parser (e.g. "Type" can flip the search
-		// box to a hidden/submit input, "Name" can clobber the submitted
-		// field). Drop every case-variant of the re-asserted keys here.
-		if strings.EqualFold(k, "type") || strings.EqualFold(k, "name") || strings.EqualFold(k, "id") {
-			continue
-		}
-		inputAttrs[k] = v
-	}
-	// Protect critical attrs from Attrs override.
-	inputAttrs["type"] = "search"
-	inputAttrs["name"] = cfg.Name
-	inputAttrs["id"] = cfg.ID
+	// Extras land on the <input>: SafeExtraAttrs drops every
+	// case-variant of type/name (and id/class/data-fui-*), so a caller
+	// cannot flip the box to a hidden input or clobber the submitted
+	// field name. value survives — see the config comment.
+	maps.Copy(inputAttrs, html.SafeExtraAttrs(cfg.ExtraAttrs, "type", "name"))
 
 	inner := []render.HTML{
 		html.Span(html.TextConfig{

--- a/framework/ui/searchinput_test.go
+++ b/framework/ui/searchinput_test.go
@@ -154,3 +154,28 @@ func TestSearchInputPanicOnInvalidMethod(t *testing.T) {
 	}()
 	SearchInput(SearchInputConfig{Name: "q", ID: "q", Action: "/s", Method: "DELETE"})
 }
+
+// ExtraAttrs land on the <input>, sanitized (#262): type/name keep
+// framework values, but "value" must stay caller-settable — the
+// resource UI prefills the current search term through it.
+func TestSearchInputExtraAttrsSanitizedValuePasses(t *testing.T) {
+	h := SearchInput(SearchInputConfig{
+		Name: "q", ID: "q", Class: "mine",
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "value": "needle", "type": "hidden", "Name": "evil",
+		},
+	})
+	input := extraAttrsOpeningTag(t, string(h), "input")
+	for _, banned := range []string{"hidden", "evil"} {
+		if strings.Contains(input, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, input)
+		}
+	}
+	for _, want := range []string{
+		`data-test="hook"`, `value="needle"`, `type="search"`, `name="q"`, `id="q"`,
+	} {
+		if !strings.Contains(input, want) {
+			t.Errorf("input missing %q:\n%s", want, input)
+		}
+	}
+}

--- a/framework/ui/select.go
+++ b/framework/ui/select.go
@@ -40,9 +40,13 @@ type SelectConfig struct {
 	// Help renders supporting text under the field.
 	Help string
 	// Error overrides Help with an error message + aria-invalid.
-	Error      string
-	ID         string
-	Class      string
+	Error string
+	ID    string
+	Class string
+	// ExtraAttrs forwards additional attributes to the <select>
+	// element. Keys the component owns are dropped: class and id (use
+	// Class / ID), data-fui-*, name, disabled, required, aria-invalid,
+	// and aria-describedby.
 	ExtraAttrs html.Attrs
 }
 
@@ -104,7 +108,8 @@ func Select(cfg SelectConfig) render.HTML {
 	} else if cfg.Help != "" {
 		selAttrs["aria-describedby"] = id + "-help"
 	}
-	maps.Copy(selAttrs, cfg.ExtraAttrs)
+	maps.Copy(selAttrs, html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"name", "disabled", "required", "aria-invalid", "aria-describedby"))
 
 	// The marker lives INSIDE the <label>: the component root is a grid,
 	// so a sibling span would become its own row under the label text.

--- a/framework/ui/select_test.go
+++ b/framework/ui/select_test.go
@@ -39,3 +39,28 @@ func TestSelectCSSStylesTheMarker(t *testing.T) {
 		t.Fatal("selectCSS has no rule for .ui-form-field__required — the marker is unstyled unless ui-form-field happens to be on the page")
 	}
 }
+
+// ExtraAttrs land on the <select> but never override what the component
+// owns (#262): name and required keep their framework values.
+func TestSelectExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := string(Select(SelectConfig{
+		Name: "country", Label: "Country", Class: "mine", Required: true,
+		Options: []SelectOption{{Value: "fr", Text: "France"}},
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "name": "evil", "Class": "evil", "data-fui-comp": "spoof",
+		},
+	}))
+	sel := extraAttrsOpeningTag(t, h, "select")
+	for _, banned := range []string{"evil", "spoof"} {
+		if strings.Contains(sel, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, sel)
+		}
+	}
+	for _, want := range []string{
+		`data-test="hook"`, `name="country"`, `class="ui-select__input"`, `required=""`,
+	} {
+		if !strings.Contains(sel, want) {
+			t.Errorf("select missing %q:\n%s", want, sel)
+		}
+	}
+}

--- a/framework/ui/slider.go
+++ b/framework/ui/slider.go
@@ -39,9 +39,13 @@ type SliderConfig struct {
 	// ShowEdgeLabels renders the Min and Max values under the track.
 	ShowEdgeLabels bool
 	// Disabled disables interaction.
-	Disabled   bool
-	ID         string
-	Class      string
+	Disabled bool
+	ID       string
+	Class    string
+	// ExtraAttrs forwards additional attributes to the <input> element.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-* (incl. the slider-mirror wiring), type, name,
+	// min, max, step, value, aria-label, and disabled.
 	ExtraAttrs html.Attrs
 }
 
@@ -103,7 +107,8 @@ func Slider(cfg SliderConfig) render.HTML {
 	if cfg.Disabled {
 		inputAttrs["disabled"] = ""
 	}
-	maps.Copy(inputAttrs, cfg.ExtraAttrs)
+	maps.Copy(inputAttrs, html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"type", "name", "min", "max", "step", "value", "aria-label", "disabled"))
 
 	header := []render.HTML{
 		render.Tag("label", map[string]string{"for": id, "class": "ui-slider__label"},

--- a/framework/ui/slider_test.go
+++ b/framework/ui/slider_test.go
@@ -81,3 +81,30 @@ func TestSliderHasAriaLabel(t *testing.T) {
 		t.Errorf("Slider input should carry aria-label=Label:\n%s", h)
 	}
 }
+
+// ExtraAttrs land on the <input> but never override what the component
+// owns (#262): min/value (and the other owned keys) keep framework
+// values; the data-fui-slider-mirror wiring cannot be spoofed.
+func TestSliderExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := string(Slider(SliderConfig{
+		Name: "vol", Label: "Volume", Min: 0, Max: 100, Step: 5, Value: 25, Class: "mine",
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "min": "evil", "value": "evil", "Class": "evil",
+			"data-fui-slider-mirror": "spoof",
+		},
+	}))
+	input := extraAttrsOpeningTag(t, h, "input")
+	for _, banned := range []string{"evil", "spoof"} {
+		if strings.Contains(input, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, input)
+		}
+	}
+	for _, want := range []string{
+		`data-test="hook"`, `type="range"`, `name="vol"`, `min="0"`, `max="100"`,
+		`step="5"`, `value="25"`, `aria-label="Volume"`, `class="ui-slider__input"`,
+	} {
+		if !strings.Contains(input, want) {
+			t.Errorf("input missing %q:\n%s", want, input)
+		}
+	}
+}

--- a/framework/ui/textarea.go
+++ b/framework/ui/textarea.go
@@ -41,9 +41,14 @@ type TextAreaConfig struct {
 	// Error overrides Help with an error message + aria-invalid.
 	Error string
 	// MaxLength applies the native maxlength attribute.
-	MaxLength  int
-	ID         string
-	Class      string
+	MaxLength int
+	ID        string
+	Class     string
+	// ExtraAttrs forwards additional attributes to the <textarea>
+	// element. Keys the component owns are dropped: class and id (use
+	// Class / ID), data-fui-* (incl. the autogrow wiring), name, rows,
+	// placeholder, disabled, required, maxlength, aria-invalid, and
+	// aria-describedby.
 	ExtraAttrs html.Attrs
 }
 
@@ -102,7 +107,9 @@ func TextArea(cfg TextAreaConfig) render.HTML {
 	} else if cfg.Help != "" {
 		taAttrs["aria-describedby"] = id + "-help"
 	}
-	maps.Copy(taAttrs, cfg.ExtraAttrs)
+	maps.Copy(taAttrs, html.SafeExtraAttrs(cfg.ExtraAttrs,
+		"name", "rows", "placeholder", "disabled", "required", "maxlength",
+		"aria-invalid", "aria-describedby"))
 
 	children := []render.HTML{
 		render.Tag("label", map[string]string{"for": id, "class": "ui-textarea__label"},

--- a/framework/ui/textarea_test.go
+++ b/framework/ui/textarea_test.go
@@ -66,3 +66,29 @@ func TestTextAreaLabelForMatchesID(t *testing.T) {
 		t.Errorf("textarea[id] should default to Name:\n%s", h)
 	}
 }
+
+// ExtraAttrs land on the <textarea> but never override what the
+// component owns (#262): rows keeps its framework value; the
+// data-fui-autogrow wiring cannot be spoofed.
+func TestTextAreaExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := string(TextArea(TextAreaConfig{
+		Name: "bio", Label: "Bio", Class: "mine", Placeholder: "Tell us",
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "rows": "evil", "Class": "evil", "data-fui-autogrow": "spoof",
+		},
+	}))
+	ta := extraAttrsOpeningTag(t, h, "textarea")
+	for _, banned := range []string{"evil", "spoof"} {
+		if strings.Contains(ta, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, ta)
+		}
+	}
+	for _, want := range []string{
+		`data-test="hook"`, `name="bio"`, `rows="3"`, `placeholder="Tell us"`,
+		`class="ui-textarea__input"`,
+	} {
+		if !strings.Contains(ta, want) {
+			t.Errorf("textarea missing %q:\n%s", want, ta)
+		}
+	}
+}

--- a/framework/ui/timeline.go
+++ b/framework/ui/timeline.go
@@ -45,9 +45,12 @@ type TimelineEvent struct {
 
 // TimelineConfig configures a Timeline.
 type TimelineConfig struct {
-	Events     []TimelineEvent
-	ID         string
-	Class      string
+	Events []TimelineEvent
+	ID     string
+	Class  string
+	// ExtraAttrs forwards additional attributes to the <ol> root.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID) and data-fui-*.
 	ExtraAttrs html.Attrs
 }
 
@@ -64,7 +67,7 @@ func Timeline(cfg TimelineConfig) render.HTML {
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}
-	maps.Copy(attrs, cfg.ExtraAttrs)
+	maps.Copy(attrs, html.SafeExtraAttrs(cfg.ExtraAttrs))
 
 	items := make([]render.HTML, 0, len(cfg.Events))
 	for _, e := range cfg.Events {

--- a/framework/ui/timeline_test.go
+++ b/framework/ui/timeline_test.go
@@ -62,3 +62,29 @@ func TestTimelineRejectsUnknownVariant(t *testing.T) {
 		Events: []TimelineEvent{{Title: "x", Variant: TimelineEventVariant("bogus")}},
 	})
 }
+
+// ExtraAttrs land on the <ol> root but never override what the
+// component owns (#262): class and data-fui-* variants are dropped
+// (there are no other owned attributes on the root).
+func TestTimelineExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := string(Timeline(TimelineConfig{
+		Class:  "mine",
+		Events: []TimelineEvent{{Title: "First"}},
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "Class": "evil", "data-fui-comp": "spoof",
+		},
+	}))
+	root := h[:strings.Index(h, ">")+1]
+	for _, banned := range []string{"evil", "spoof"} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+	for _, want := range []string{
+		`data-test="hook"`, `class="ui-timeline mine"`,
+	} {
+		if !strings.Contains(root, want) {
+			t.Errorf("root missing %q:\n%s", want, root)
+		}
+	}
+}

--- a/framework/ui/toc.go
+++ b/framework/ui/toc.go
@@ -32,9 +32,13 @@ type TOCConfig struct {
 	Levels int
 	// Sticky toggles the position: sticky behaviour. Default true.
 	// When false the nav scrolls with the content.
-	Sticky     bool
-	ID         string
-	Class      string
+	Sticky bool
+	ID     string
+	Class  string
+	// ExtraAttrs forwards additional attributes to the <nav> root.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-* (incl. the toc/levels runtime wiring), and
+	// aria-label (use Label).
 	ExtraAttrs html.Attrs
 }
 
@@ -68,7 +72,7 @@ func TableOfContents(cfg TOCConfig) render.HTML {
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}
-	maps.Copy(attrs, cfg.ExtraAttrs)
+	maps.Copy(attrs, html.SafeExtraAttrs(cfg.ExtraAttrs, "aria-label"))
 	return tocStyle.WrapHTML(render.Tag("nav", attrs,
 		// Empty <ol> the runtime fills.
 		render.Tag("ol", map[string]string{"class": "ui-toc__list"}),

--- a/framework/ui/toc_test.go
+++ b/framework/ui/toc_test.go
@@ -50,3 +50,30 @@ func TestTOCStickyClass(t *testing.T) {
 		t.Errorf("Sticky=true should add modifier class:\n%s", on)
 	}
 }
+
+// ExtraAttrs land on the <nav> root but never override what the
+// component owns (#262): aria-label keeps its framework value and the
+// data-fui-toc / data-fui-toc-levels runtime wiring cannot be spoofed.
+func TestTOCExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := string(TableOfContents(TOCConfig{
+		Target: "main", Label: "Contents", Sticky: true, Class: "mine",
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "aria-label": "evil", "Class": "evil",
+			"data-fui-toc": "spoof", "data-fui-toc-levels": "spoof",
+		},
+	}))
+	root := h[:strings.Index(h, ">")+1]
+	for _, banned := range []string{"evil", "spoof"} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+	for _, want := range []string{
+		`data-test="hook"`, `aria-label="Contents"`, `data-fui-toc="main"`,
+		`data-fui-toc-levels="2,3"`, `class="ui-toc ui-toc--sticky mine"`,
+	} {
+		if !strings.Contains(root, want) {
+			t.Errorf("nav missing %q:\n%s", want, root)
+		}
+	}
+}

--- a/framework/ui/toolbar.go
+++ b/framework/ui/toolbar.go
@@ -37,9 +37,12 @@ type ToolbarConfig struct {
 	Groups []ToolbarGroup
 	// Align picks justify-content. Default is "start". Options:
 	// "start", "center", "end", "between".
-	Align      string
-	ID         string
-	Class      string
+	Align string
+	ID    string
+	Class string
+	// ExtraAttrs forwards additional attributes to the root element.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, role, and aria-label (use Label).
 	ExtraAttrs html.Attrs
 }
 
@@ -72,7 +75,7 @@ func Toolbar(cfg ToolbarConfig) render.HTML {
 	if cfg.ID != "" {
 		attrs["id"] = cfg.ID
 	}
-	maps.Copy(attrs, cfg.ExtraAttrs)
+	maps.Copy(attrs, html.SafeExtraAttrs(cfg.ExtraAttrs, "role", "aria-label"))
 
 	parts := make([]render.HTML, 0, len(cfg.Groups))
 	for _, g := range cfg.Groups {

--- a/framework/ui/toolbar_test.go
+++ b/framework/ui/toolbar_test.go
@@ -86,3 +86,29 @@ func TestToolbarRejectsUnknownAlign(t *testing.T) {
 		Groups: []ToolbarGroup{{Children: []render.HTML{Button(ButtonConfig{Label: "Z"})}}},
 	})
 }
+
+// ExtraAttrs land on the root element but never override what the
+// component owns (#262): role and aria-label keep framework values.
+func TestToolbarExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := string(Toolbar(ToolbarConfig{
+		Label: "Format", Class: "mine",
+		Groups: []ToolbarGroup{{Children: []render.HTML{Button(ButtonConfig{Label: "B"})}}},
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "role": "evil", "aria-label": "evil", "Class": "evil",
+			"data-fui-comp": "spoof",
+		},
+	}))
+	root := h[:strings.Index(h, ">")+1]
+	for _, banned := range []string{"evil", "spoof"} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+	for _, want := range []string{
+		`data-test="hook"`, `role="toolbar"`, `aria-label="Format"`, `class="ui-toolbar mine"`,
+	} {
+		if !strings.Contains(root, want) {
+			t.Errorf("root missing %q:\n%s", want, root)
+		}
+	}
+}

--- a/framework/ui/workbench.go
+++ b/framework/ui/workbench.go
@@ -38,8 +38,12 @@ type WorkbenchConfig struct {
 	// case that motivated the component.
 	Pane render.HTML
 
-	ID         string
-	Class      string
+	ID    string
+	Class string
+	// ExtraAttrs forwards additional attributes to the root element.
+	// Keys the component owns are dropped: class and id (use Class /
+	// ID), data-fui-*, and style (RailWidth owns the inline custom
+	// property).
 	ExtraAttrs html.Attrs
 }
 
@@ -60,7 +64,7 @@ func Workbench(cfg WorkbenchConfig) render.HTML {
 		// to allow. See core-ui/check/noinlinescripts.go.
 		attrs["style"] = "--ui-workbench-rail: " + cfg.RailWidth
 	}
-	maps.Copy(attrs, cfg.ExtraAttrs)
+	maps.Copy(attrs, html.SafeExtraAttrs(cfg.ExtraAttrs, "style"))
 	return workbenchStyle.WrapHTML(render.Tag("div", attrs,
 		render.Tag("div", html.Attrs{"class": "ui-workbench__rail"}, cfg.Rail),
 		render.Tag("div", html.Attrs{"class": "ui-workbench__pane"}, cfg.Pane),

--- a/framework/ui/workbench_test.go
+++ b/framework/ui/workbench_test.go
@@ -108,3 +108,30 @@ func sectionOf(t *testing.T, css, selector string) string {
 	}
 	return rest[:end]
 }
+
+// ExtraAttrs land on the root element but never override what the
+// component owns (#262): the style attribute belongs to RailWidth
+// (a CSP-safe custom property), so callers cannot swap in arbitrary
+// inline styles.
+func TestWorkbenchExtraAttrsCannotOverrideOwned(t *testing.T) {
+	h := string(Workbench(WorkbenchConfig{
+		RailWidth: "480px", Class: "mine",
+		Rail: render.Text("rail"), Pane: render.Text("pane"),
+		ExtraAttrs: map[string]string{
+			"data-test": "hook", "style": "evil", "Class": "evil", "data-fui-comp": "spoof",
+		},
+	}))
+	root := h[:strings.Index(h, ">")+1]
+	for _, banned := range []string{"evil", "spoof"} {
+		if strings.Contains(root, banned) {
+			t.Errorf("owned attr overridden by ExtraAttrs (%q):\n%s", banned, root)
+		}
+	}
+	for _, want := range []string{
+		`data-test="hook"`, `style="--ui-workbench-rail: 480px"`, `class="ui-workbench mine"`,
+	} {
+		if !strings.Contains(root, want) {
+			t.Errorf("root missing %q:\n%s", want, root)
+		}
+	}
+}


### PR DESCRIPTION
Closes #262.

Migrates the last 23 `framework/ui` components off raw ExtraAttrs forwarding: AnimatedCounter, Banner, Button, Carousel, Container, FilterToolbar, Gallery, Link, LinkButton, Markdown, Menu items, NotificationBell, NumberInput, PasswordInput, ProgressSteps, RangeSlider, SearchInput, Select, Slider, TextArea, Timeline, TableOfContents, Toolbar, Workbench. Each site now routes extras through `html.SafeExtraAttrs` with that element's owned attributes protected, and each gets a cannot-override test. `extraAttrsRawLegacy` shrinks to `form.go`, the documented exception.

## The design call: ui.Button and ui.Link are wiring carriers

The sweep exposed a conflict: `interactive-patterns.md` documents (and recommends) attaching RPC wiring via `ui.Button{ExtraAttrs: action.Attrs()}`, and the framework itself does it in `framework/ui/resource` (every transition + Delete button), `battery/admin` entity rows, `examples/site` (workspace pane trigger, catalog drawer close), and the gallery demos. `uinoderender`'s ActionRef links do the same through `ui.Link` (href fallback + `data-fui-rpc` upgrade) — its test suite caught that one in the pre-push sweep. A blanket `data-fui-*` drop on these two breaks all of it silently, and any user app on the documented pattern.

Resolution: new `html.SafeCarrierAttrs` — like `SafeExtraAttrs` but `data-fui-*` passes through (the `data-fui-comp` style-scope marker still drops) — used by Button and Link, which emit no wiring of their own. Components that do own wiring (RangeSlider's mirror, TextArea autogrow, TOC, menu items' rpc attrs) keep the strict drop. `TestButtonExtraAttrsCarriesWiring` / `TestLinkExtraAttrsCarriesWiring` pin it; the contract gate recognizes both sanitizers. Documented in `ui-getting-started.md`.

## Also in here

- `ui.MenuItem.Confirm` (→ `data-fui-confirm` on RPC items): the Danger field's doc pointed at an attribute that sanitized item extras left no way to set.
- Case-variant spoofing (`"Type"` flipping a search box to a hidden input) closed in SearchInput/PasswordInput/FilterToolbar — the hand-rolled lowercase-only guards missed it.
- Changelog under Changed/Added; behavior changes named per component.

## Found and filed, not fixed here

#279 — `battery/admin`'s destructive module actions carry a `data-fui-confirm` that has never fired (plain POST forms; the runtime reads the attribute only on rpc dispatch).

## Verification

- The new guards mutation-tested red→green: Button reverted to `SafeExtraAttrs` fails the carrier test; removing the Confirm emission fails the menu test; a raw ExtraAttrs read in a migrated file trips the shrunk gate; the Link carrier flipped uinoderender's `TestRenderLinkActionRefResolvedToRpcURL` from observed-failing back to green.
- `go build ./...` (examples + cmds included), `go vet`, repo analyzers, contracts, and the `core-ui`/`framework/ui`/`battery` test sweeps all pass locally; the resource UI's search-prefill (`value` deliberately unprotected on SearchInput) verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation messages for RPC menu items before actions are performed.
  * Expanded support for safely adding custom HTML attributes across UI components.

* **Bug Fixes**
  * Prevented custom attributes from overriding component-controlled values such as IDs, classes, links, form actions, accessibility attributes, styles, and input settings.
  * Preserved safe interaction and RPC wiring attributes for buttons and links.
  * Improved filtering of case-variant and framework-reserved attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->