### PR TITLE
feat(ui): SiteHeader PersistentActions slot (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Added
 
+- **`ui.SiteHeaderConfig.PersistentActions`** (#256): a slot for the
+  one journey-critical control (sign-in link, primary CTA) that stays
+  in the bar at every viewport width instead of collapsing into the
+  mobile drawer with the rest of `Actions`. It is never copied into
+  the drawer, so no duplicate control exists at any width. Meridian's
+  guest marketing header now keeps Sign in visible at 390px.
+
 - **`ui.MenuItem.Confirm`**: pre-flight confirmation for RPC menu
   items, emitted as `data-fui-confirm` alongside the item's
   `data-fui-rpc` wiring. Previously the Danger field's doc pointed at

--- a/examples/meridian/app.go
+++ b/examples/meridian/app.go
@@ -81,18 +81,22 @@ func guestPolicy(appHome string) app.Policy {
 // marketingHeader / Footer wrap the public marketing layout.
 func marketingHeader(ctx context.Context) render.HTML {
 	nav := []ui.SiteHeaderLink{{Label: "Pricing", Href: "/pricing"}, {Label: "About", Href: "/about"}}
-	var actions render.HTML
+	var actions, persistent render.HTML
 	if u, ok := handler.GetUser(ctx); ok && u != nil {
 		nav = append(nav, ui.SiteHeaderLink{Label: "Dashboard", Href: "/app"})
 		actions = ui.Cluster(ui.ClusterConfig{Gap: ui.GapSM, Align: ui.AlignCenter, NoWrap: true}, ui.SignOut(ui.SignOutConfig{Next: "/"}), ui.ThemeToggle(ui.ThemeToggleConfig{Variant: ui.ThemeToggleIcon}))
 	} else {
-		actions = ui.Cluster(ui.ClusterConfig{Gap: ui.GapSM, Align: ui.AlignCenter, NoWrap: true}, ui.LinkButton(ui.LinkButtonConfig{Label: "Sign in", Href: "/login", Variant: ui.ButtonSecondary, Size: ui.ButtonSizeSmall}), ui.ThemeToggle(ui.ThemeToggleConfig{Variant: ui.ThemeToggleIcon}))
+		// Sign in is the journey-critical CTA: it stays in the bar on
+		// phones instead of collapsing into the drawer.
+		persistent = ui.LinkButton(ui.LinkButtonConfig{Label: "Sign in", Href: "/login", Variant: ui.ButtonSecondary, Size: ui.ButtonSizeSmall})
+		actions = ui.ThemeToggle(ui.ThemeToggleConfig{Variant: ui.ThemeToggleIcon})
 	}
 	return ui.SiteHeader(ui.SiteHeaderConfig{
-		Brand:    ui.Link(ui.LinkConfig{Href: "/", Text: appName}),
-		NavItems: nav,
-		Drawer:   ui.SiteHeaderDrawerSheet,
-		Actions:  actions,
+		Brand:             ui.Link(ui.LinkConfig{Href: "/", Text: appName}),
+		NavItems:          nav,
+		Drawer:            ui.SiteHeaderDrawerSheet,
+		Actions:           actions,
+		PersistentActions: persistent,
 	})
 }
 

--- a/examples/meridian/e2e_header_persistent_test.go
+++ b/examples/meridian/e2e_header_persistent_test.go
@@ -34,13 +34,20 @@ func TestE2E_SignInStaysInBarAt390(t *testing.T) {
 		})()`
 	}
 
-	var signIn, toggle rect
+	var signIn, toggle, drawerToggle, drawerSignIn rect
 	if err := chromedp.Run(ctx,
 		chromedp.EmulateViewport(390, 844),
 		chromedp.Navigate(base+"/"),
 		chromedp.WaitReady("body", chromedp.ByQuery),
 		chromedp.Evaluate(measure(`.ui-site-header__persistent-actions a[href="/login"]`), &signIn),
 		chromedp.Evaluate(measure(`.ui-site-header__bar-actions [data-fui-comp="ui-theme-toggle"]`), &toggle),
+		// Open the drawer: "collapsed into the drawer" must mean the
+		// toggle actually lives there, not that it vanished — and the
+		// persistent Sign in must not have a drawer duplicate.
+		chromedp.Click(`.ui-site-header__mobile-toggle`, chromedp.ByQuery),
+		chromedp.WaitVisible(`.ui-site-header__mobile-links`, chromedp.ByQuery),
+		chromedp.Evaluate(measure(`.ui-site-header__mobile-actions [data-fui-comp="ui-theme-toggle"]`), &drawerToggle),
+		chromedp.Evaluate(measure(`.ui-site-header__mobile-links a[href="/login"]`), &drawerSignIn),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -52,5 +59,11 @@ func TestE2E_SignInStaysInBarAt390(t *testing.T) {
 	}
 	if toggle.Present && toggle.Visible {
 		t.Errorf("regular Actions must collapse into the drawer at 390px: %+v", toggle)
+	}
+	if !drawerToggle.Present || !drawerToggle.Visible {
+		t.Errorf("theme toggle must be reachable in the open drawer: %+v", drawerToggle)
+	}
+	if drawerSignIn.Present {
+		t.Errorf("persistent Sign in must have no drawer duplicate: %+v", drawerSignIn)
 	}
 }

--- a/examples/meridian/e2e_header_persistent_test.go
+++ b/examples/meridian/e2e_header_persistent_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/chromedp/chromedp"
+)
+
+// Pins #256: the guest header's Sign in CTA rides PersistentActions, so
+// at 390px it stays visible in the bar while the regular Actions cluster
+// (theme toggle) collapses into the drawer. Measured, not probed: the
+// assertions are on rendered bounding boxes inside the viewport.
+func TestE2E_SignInStaysInBarAt390(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds + boots the binary")
+	}
+	base := e2eBootApp(t)
+	ctx := e2eBrowser(t)
+
+	type rect struct {
+		Present bool    `json:"present"`
+		Visible bool    `json:"visible"`
+		Width   float64 `json:"width"`
+		Right   float64 `json:"right"`
+	}
+	measure := func(sel string) string {
+		return `(() => {
+			const el = document.querySelector(` + "`" + sel + "`" + `);
+			if (!el) return {present: false};
+			const r = el.getBoundingClientRect();
+			const visible = r.width > 0 && r.height > 0 &&
+				getComputedStyle(el).visibility !== "hidden";
+			return {present: true, visible, width: r.width, right: r.right};
+		})()`
+	}
+
+	var signIn, toggle rect
+	if err := chromedp.Run(ctx,
+		chromedp.EmulateViewport(390, 844),
+		chromedp.Navigate(base+"/"),
+		chromedp.WaitReady("body", chromedp.ByQuery),
+		chromedp.Evaluate(measure(`.ui-site-header__persistent-actions a[href="/login"]`), &signIn),
+		chromedp.Evaluate(measure(`.ui-site-header__bar-actions [data-fui-comp="ui-theme-toggle"]`), &toggle),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if !signIn.Present || !signIn.Visible {
+		t.Fatalf("Sign in must be visible in the bar at 390px: %+v", signIn)
+	}
+	if signIn.Right > 390 {
+		t.Errorf("Sign in overflows the 390px viewport: %+v", signIn)
+	}
+	if toggle.Present && toggle.Visible {
+		t.Errorf("regular Actions must collapse into the drawer at 390px: %+v", toggle)
+	}
+}

--- a/framework/docs/content/ui-getting-started.md
+++ b/framework/docs/content/ui-getting-started.md
@@ -484,7 +484,10 @@ Choose the navigation primitive that matches the product shell:
 
 - `ui.SiteHeader` provides brand, desktop navigation, actions, and its mobile
   drawer as one component. Set `MobileBrand` when the desktop identity is too
-  long for the phone row.
+  long for the phone row. `Actions` collapse into the drawer on phones; put
+  the one journey-critical control (a sign-in link, a primary CTA) in
+  `PersistentActions` and it stays in the bar at every width, with no drawer
+  copy.
 - `ui.Sidebar` provides the desktop rail; pair the same `SidebarConfig` with
   `ui.MountSidebar` for the framework-owned mobile drawer.
 - `ui.Responsive` is for cases where mobile needs a genuinely different

--- a/framework/docs/content/ui-new-components.md
+++ b/framework/docs/content/ui-new-components.md
@@ -109,7 +109,7 @@ raw (enumerated in `framework/ui/extraattrs_contract_test.go`). See
 - **recordsummary**: `framework/ui.RecordSummary`, compact dominant record or event summary with status, next-decision, balanced phone metrics, a bounded support rail, ownership, and a lead-region natural-width action that stays early on phones
 - **skiplink**: `framework/ui.SkipLink`, focus-visible bypass link for jumping to main content
 - **pageheader**: `framework/ui.PageHeader`, top-of-page header with title / eyebrow / subtitle / actions
-- **siteheader**: `framework/ui.SiteHeader`, top bar with brand + nav + actions + mobile drawer; `MobileBrand` swaps in a concise phone identity
+- **siteheader**: `framework/ui.SiteHeader`, top bar with brand + nav + actions + mobile drawer; `MobileBrand` swaps in a concise phone identity; `PersistentActions` keeps one journey-critical control in the bar at every width (no drawer copy)
 - **sitefooter**: `framework/ui.SiteFooter`, multi-column footer grid + bottom strip
 - **anchoredrail**: `framework/ui.AnchoredRail`, sticky in-page nav rail with scrollspy-tracked active state
 - **doclayout**: `framework/ui.DocLayout` / `DocPrevNext`, documentation page skeleton (nav rail + article + prev/next pager)

--- a/framework/ui/site_header.go
+++ b/framework/ui/site_header.go
@@ -63,7 +63,9 @@ type SiteHeaderConfig struct {
 	// journey depends on here — a sign-in link, a primary CTA — and
 	// leave the rest in Actions, which collapses into the drawer on
 	// phones. Keep it to a single compact control: it shares the
-	// ≤720px bar with brand + hamburger.
+	// ≤720px bar with brand + hamburger. The wrapper is
+	// layout-transparent (display: contents) — style the control, not
+	// the wrapper.
 	PersistentActions render.HTML
 	// MobileExtraLinks are appended only to the mobile drawer list
 	// (e.g., "Home", "GitHub ↗"). Lets the consumer surface secondary

--- a/framework/ui/site_header.go
+++ b/framework/ui/site_header.go
@@ -57,6 +57,14 @@ type SiteHeaderConfig struct {
 	// icon links, etc. Rendered before the mobile drawer trigger so
 	// the trigram glyph sits at the far right.
 	Actions render.HTML
+	// PersistentActions stays visible in the bar at every viewport
+	// width, rendered after Actions and before the drawer trigger. It
+	// is never copied into the drawer. Put the one control the page's
+	// journey depends on here — a sign-in link, a primary CTA — and
+	// leave the rest in Actions, which collapses into the drawer on
+	// phones. Keep it to a single compact control: it shares the
+	// ≤720px bar with brand + hamburger.
+	PersistentActions render.HTML
 	// MobileExtraLinks are appended only to the mobile drawer list
 	// (e.g., "Home", "GitHub ↗"). Lets the consumer surface secondary
 	// destinations on phones without cluttering the desktop bar.
@@ -187,6 +195,12 @@ func SiteHeader(cfg SiteHeaderConfig) render.HTML {
 		// also render inside the drawer).
 		rightChildren = append(rightChildren,
 			html.Div(html.DivConfig{Class: "ui-site-header__bar-actions"}, cfg.Actions))
+	}
+	if cfg.PersistentActions != "" {
+		// Bar-only, all widths: no drawer copy exists, so the ≤720px
+		// block must never hide this wrapper.
+		rightChildren = append(rightChildren,
+			html.Div(html.DivConfig{Class: "ui-site-header__persistent-actions"}, cfg.PersistentActions))
 	}
 	rightChildren = append(rightChildren, mobile)
 	right := html.Div(html.DivConfig{Class: "ui-site-header__right"}, rightChildren...)
@@ -365,8 +379,11 @@ func siteHeaderCSS(_ style.Theme) string {
 }
 
 /* Bar actions are layout-transparent on desktop (their cluster participates in
-   the right group directly); the foot-of-drawer copy is hidden until ≤720px. */
+   the right group directly); the foot-of-drawer copy is hidden until ≤720px.
+   Persistent actions get the same transparency but no breakpoint rule: they
+   stay in the bar at every width and have no drawer copy. */
 [data-fui-comp="ui-site-header"] .ui-site-header__bar-actions { display: contents; }
+[data-fui-comp="ui-site-header"] .ui-site-header__persistent-actions { display: contents; }
 [data-fui-comp="ui-site-header"] .ui-site-header__mobile-actions {
   display: flex;
   flex-direction: column;

--- a/framework/ui/site_header_test.go
+++ b/framework/ui/site_header_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -235,12 +236,13 @@ func TestSiteHeaderPersistentActionsStayInBar(t *testing.T) {
 		t.Error("persistent action must not be copied into the mobile drawer")
 	}
 	// The stylesheet must never hide the persistent wrapper: the only
-	// rule that may mention it is the layout-transparency one.
+	// rule that may mention it is the layout-transparency one. Scan
+	// whole declaration blocks, not lines, so a multi-line rule can't
+	// slip past; visibility:hidden is as much a hide as display:none.
 	css := siteHeaderCSS(style.Theme{})
-	for _, line := range strings.Split(css, "\n") {
-		if strings.Contains(line, "persistent-actions") && strings.Contains(line, "display: none") {
-			t.Errorf("persistent-actions must not be display:none at any width: %s", line)
-		}
+	hideRe := regexp.MustCompile(`persistent-actions[^{]*\{[^}]*(display:\s*none|visibility:\s*hidden)`)
+	if m := hideRe.FindString(css); m != "" {
+		t.Errorf("persistent-actions must stay visible at every width, found: %s", m)
 	}
 	if !strings.Contains(css, ".ui-site-header__persistent-actions { display: contents; }") {
 		t.Error("persistent-actions should be layout-transparent like bar-actions")

--- a/framework/ui/site_header_test.go
+++ b/framework/ui/site_header_test.go
@@ -214,6 +214,39 @@ func TestSiteHeaderActionsCollapseIntoDrawer(t *testing.T) {
 	}
 }
 
+func TestSiteHeaderPersistentActionsStayInBar(t *testing.T) {
+	// PersistentActions render once, in the bar, and are never copied
+	// into the drawer — unlike Actions, whose bar copy CSS-hides ≤720px
+	// while the drawer copy takes over.
+	h := string(SiteHeader(SiteHeaderConfig{
+		Brand:             render.Raw(`<a>x</a>`),
+		NavItems:          []SiteHeaderLink{{Label: "Pricing", Href: "/pricing"}},
+		Actions:           render.Raw(`<button id="act">Theme</button>`),
+		PersistentActions: render.Raw(`<a id="cta">Sign in</a>`),
+	}))
+	if !strings.Contains(h, "ui-site-header__persistent-actions") {
+		t.Fatal("missing persistent-actions wrapper")
+	}
+	if n := strings.Count(h, `id="cta"`); n != 1 {
+		t.Errorf("persistent action must render exactly once, got %d:\n%s", n, h)
+	}
+	idx := strings.Index(h, `data-fui-disclosure`)
+	if idx == -1 || strings.Contains(h[idx:], `id="cta"`) {
+		t.Error("persistent action must not be copied into the mobile drawer")
+	}
+	// The stylesheet must never hide the persistent wrapper: the only
+	// rule that may mention it is the layout-transparency one.
+	css := siteHeaderCSS(style.Theme{})
+	for _, line := range strings.Split(css, "\n") {
+		if strings.Contains(line, "persistent-actions") && strings.Contains(line, "display: none") {
+			t.Errorf("persistent-actions must not be display:none at any width: %s", line)
+		}
+	}
+	if !strings.Contains(css, ".ui-site-header__persistent-actions { display: contents; }") {
+		t.Error("persistent-actions should be layout-transparent like bar-actions")
+	}
+}
+
 func TestSiteHeaderNavUnderlineVariantIsOptIn(t *testing.T) {
 	items := []SiteHeaderLink{{Label: "Docs", Href: "/docs"}}
 	on := string(SiteHeader(SiteHeaderConfig{NavUnderline: true, NavItems: items}))


### PR DESCRIPTION
Closes #256.

The ticket proposed `PersistentActionsOnMobile bool` — keep the whole Actions cluster in the phone bar. Shipped a slot instead:

```go
// SiteHeaderConfig
PersistentActions render.HTML
```

Rationale: a 390px bar has room for exactly one control next to brand + hamburger, so the caller should pick which — a sign-in link, a primary CTA — while the rest of `Actions` keeps today's collapse-into-drawer behavior. The slot renders after `Actions`, before the drawer trigger, at every width, and is **never copied into the drawer**, which settles the duplicate-control question the ticket flagged: no duplicate exists at any width.

CSS is one layout-transparency rule (`display: contents`, same as bar-actions); the ≤720px block never touches the wrapper, and the unit test scans the stylesheet to keep it that way.

## Verification

- Guards mutation-proven red→green: copying the slot into the drawer, and adding a `display:none` for it in the mobile block, each fail `TestSiteHeaderPersistentActionsStayInBar`.
- Meridian dogfoods it (the motivating case): the guest marketing header's Sign in CTA now stays in the bar at 390px while the theme toggle collapses into the drawer. Pinned by a bounding-box e2e (`TestE2E_SignInStaysInBarAt390`: Sign in visible and inside the 390px viewport, toggle hidden) and verified on rendered screenshots — light + dark, 390px + 1440px, no overflow (`TestE2EVisualSurfaces` marketing captures pass).
- Docs updated in the same commit (`ui-getting-started.md`, `ui-new-components.md`); changelog Added entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent header actions that remain visible at all viewport widths and are not duplicated in the mobile navigation drawer.
  * Updated the guest marketing header to keep the “Sign in” link visible on small screens.

* **Bug Fixes**
  * Prevented important header controls from being hidden or duplicated in responsive layouts.

* **Documentation**
  * Documented persistent header actions and their responsive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->