### PR TITLE
docs: porting guide — the foreign-DOM escape hatch (#245 item 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   the drawer, so no duplicate control exists at any width. Meridian's
   guest marketing header now keeps Sign in visible at 390px.
 
+- **Porting guide** (#245 item 1, decided: escape hatch, not a
+  supported use case): a new docs page, `porting.md`, shows how to move
+  an app with a foreign DOM contract onto GoFastr — html/template
+  screens rendered as `render.HTML`, the compiled design system served
+  via `static.Mount` — and states plainly that markup and stylesheets
+  brought this way are outside the one-styling-surface contract: the
+  app owns the drift.
+
 - **`ui.MenuItem.Confirm`**: pre-flight confirmation for RPC menu
   items, emitted as `data-fui-confirm` alongside the item's
   `data-fui-rpc` wiring. Previously the Danger field's doc pointed at

--- a/examples/site/docs_catalog.go
+++ b/examples/site/docs_catalog.go
@@ -122,6 +122,7 @@ var docIntents = []docIntent{
 			{"pwa", "PWA", "uihost.WithPWA: installable manifest, versioned offline shell, and a safe service worker."},
 			{"seo", "SEO", "Meta tags, Open Graph, JSON-LD, sitemap, robots, and the one-image icon surface."},
 			{"accessibility", "Accessibility", "Built-in ARIA guarantees, the guided audit command, and the build gate."},
+			{"porting", "Porting an existing frontend", "The escape hatch for a foreign DOM contract: html/template screens + static.Mount, deliberately unsupported."},
 			{"strict-mode", "Strict mode", "WithStrict: missing SEO and missing per-screen axe tests fail boot instead of shipping."},
 			{"reactivity", "Reactivity model", "The four-rung ladder of client signals, RPC, polling, and SSE push, plus the stateless-interactive-layer contract."},
 			{"interactive-patterns", "Interactive patterns", "The data-fui-* vocabulary: RPC islands, signals, open-widget, optimistic actions, polling."},

--- a/framework/docs/content/overview.md
+++ b/framework/docs/content/overview.md
@@ -133,6 +133,10 @@ re-render.
   **[Runtime modules](/docs/runtime-minification)**: split per feature, so a
   page ships only the JS it uses.
 - Browse every component live in the **[gallery](/components/)**.
+- **[Porting an app with an existing frontend](/docs/porting)**: the escape
+  hatch for a foreign DOM contract — html/template screens plus
+  `static.Mount` for a compiled design system. Possible, deliberately
+  unsupported; the page says exactly where the line is.
 
 ## Persisting & migrating
 

--- a/framework/docs/content/porting.md
+++ b/framework/docs/content/porting.md
@@ -35,11 +35,24 @@ if err := page.Execute(&buf, struct{ Title string }{"March"}); err != nil {
 // buf.String() is the screen's markup, verbatim.
 ```
 
-Embed `.tmpl` files with `//go:embed templates/*.tmpl` and
-`template.ParseFS` instead of inline strings — the markup stays reviewable
-as markup, and designers can edit it without touching Go. The executed
-HTML renders inside the App layout like any other screen, so navigation,
-sessions, and auth all still work.
+Embed `.tmpl` files instead of inline strings — the markup stays
+reviewable as markup, and designers can edit it without touching Go:
+
+```go
+import (
+	"embed"
+	"html/template"
+)
+
+//go:embed templates/*.tmpl
+var templatesFS embed.FS
+
+var pages = template.Must(template.ParseFS(templatesFS, "templates/*.tmpl"))
+// pages.ExecuteTemplate(&buf, "invoice.tmpl", data) as above.
+```
+
+The executed HTML renders inside the App layout like any other screen,
+so navigation, sessions, and auth all still work.
 
 `html/template` escapes interpolated data contextually; that part of the
 safety story survives the port. What does not survive: none of the

--- a/framework/docs/content/porting.md
+++ b/framework/docs/content/porting.md
@@ -1,0 +1,96 @@
+# Porting an app with an existing frontend
+
+Sometimes the job is not "build a GoFastr app" but "move an existing app
+onto GoFastr without breaking its DOM contract" — a frontend whose tests
+pin attributes like `data-slot="card-title"`, whose CSS is a compiled
+design system, whose markup the framework's components will never emit.
+
+That is possible today, and this page shows the pieces. It is also
+**deliberately not a supported use case**: the framework has one styling
+surface (`framework/ui` + the theme tokens), and everything on this page
+steps outside it. The contracts pipeline, the design system, and the
+upgrade notes make no promises about markup and stylesheets you bring
+yourself. You own the drift.
+
+## A screen is anything that returns render.HTML
+
+There is no special template feature to enable. A screen component's
+render is a `render.HTML` string; executing an `html/template` into one
+is plain Go:
+
+<!-- gofastr:compile
+stmt: _ = render.HTML(buf.String())
+import "bytes"
+import "html/template"
+import "github.com/DonaldMurillo/gofastr/core/render"
+-->
+```go
+var page = template.Must(template.New("invoice").Parse(
+	`<article data-slot="invoice"><h1>{{.Title}}</h1></article>`))
+
+var buf bytes.Buffer
+if err := page.Execute(&buf, struct{ Title string }{"March"}); err != nil {
+	panic(err)
+}
+// buf.String() is the screen's markup, verbatim.
+```
+
+Embed `.tmpl` files with `//go:embed templates/*.tmpl` and
+`template.ParseFS` instead of inline strings — the markup stays reviewable
+as markup, and designers can edit it without touching Go. The executed
+HTML renders inside the App layout like any other screen, so navigation,
+sessions, and auth all still work.
+
+`html/template` escapes interpolated data contextually; that part of the
+safety story survives the port. What does not survive: none of the
+framework's UI guarantees (theming, dark mode, a11y patterns, the
+runtime's island wiring) apply to markup it did not emit.
+
+## Serving the foreign design system
+
+A compiled stylesheet, fonts, and static JS mount without adopting any
+of `uihost`:
+
+```go
+static.Mount(app.Router(), static.Config{FS: assets, Prefix: "/static"})
+```
+
+Reference them from your templates like any static asset. See
+[core packages](core-packages.md) for `core/static`'s cache headers and
+fingerprinting.
+
+## Where the line is
+
+- Data layer, auth, routing, jobs, CRUD APIs: fully supported — nothing
+  on this page changes how the backend works.
+- Attributes on framework components: supported. If you only need extra
+  `data-*` / ARIA attributes on components you otherwise adopt, use
+  `ExtraAttrs` (see [UI getting started](ui-getting-started.md)) — that
+  path IS covered by the contract and its tests.
+- Bespoke markup + bespoke CSS via this page: possible, unsupported.
+  `gofastr verify` will flag bespoke-CSS and inline-style patterns in
+  app code; keep ported surfaces in clearly separated packages so the
+  findings stay legible, and expect to re-verify the frontend yourself
+  on every framework upgrade.
+
+If a port later migrates surfaces onto `framework/ui`, each migrated
+screen rejoins the supported world one at a time — the two styles can
+coexist during the transition because both are just `render.HTML`.
+
+## Common mistakes
+
+- **Inline `template.Must` strings scattered through Go files.** Embed
+  `.tmpl` files with `go:embed` + `template.ParseFS`. One real port
+  accumulated 40 files of inline strings; the markup became invisible
+  to every markup tool.
+- **Expecting framework/ui components to emit a foreign DOM.** They
+  emit their own DOM and always will; `ExtraAttrs` attaches attributes,
+  it does not reshape markup. If the test suite pins someone else's
+  structure, render that structure from templates instead.
+- **Adopting half of `uihost` for the styling.** If the port brings its
+  own design system, serve it with `static.Mount` and skip the
+  framework's styling surface entirely on those screens — mixing the
+  two on one surface means neither owns the result.
+- **Treating this page as the recommended path.** It is the escape
+  hatch. A new app, or a port free to change its DOM, should build on
+  `framework/ui` and get theming, dark mode, and a11y for free.


### PR DESCRIPTION
Records the #245 item 1 decision (documented escape hatch, not a supported use case) as a docs page.

`porting.md` shows the two pieces that already exist — `html/template` executed into `render.HTML` screens (compile-checked snippet) and `static.Mount` for a compiled design system — and draws the line explicitly: backend fully supported, `ExtraAttrs` on adopted components supported, bespoke markup/CSS possible but outside the one-styling-surface contract, drift owned by the app. Includes the Common-mistakes section the docs gate requires (the 40-file inline-`template.Must` pattern from the motivating port is mistake #1), an overview row, and a changelog entry naming the decision.

Docs-only diff; `go test ./framework/docs/` green (link check caught one bad cross-reference during authoring, fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a porting guide for integrating existing frontend screens with GoFastr.
  * Documented how to reuse existing markup, templates, and styles while retaining framework features such as routing, authentication, jobs, and CRUD APIs.
  * Clarified supported and unsupported integration boundaries, including bespoke markup and CSS.
  * Added a link to the new guide from the “Building UI” overview section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->