### PR TITLE
feat(pluginhost): bidirectional request channel + shipped frame client (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+
+- **Pluginhost bidirectional request channel** (#252, first of the
+  three framed-runtime PRs): frame → host requests are now
+  platform-owned, mirroring the host's existing `request()`. GoFastr
+  ships the frame-side client for the first time —
+  `frame/frameclient.js` (`window.__gofastrPluginFrame` with
+  `ready`/`sendEvent`/`sendRequest`/`onEvent`/`onRequest`), served via
+  `pluginhost.RegisterFrameClientRoute` with the framed CORP
+  relaxation, or bundled via `pluginhost.FrameClientJS()`. Host
+  adapters answer with `api.onRequest(method, handler)` or a static
+  `registration.onRequest` fallback. One contract in both directions:
+  every request is answered (`E_NO_HANDLER` / `E_HANDLER`, never
+  silence), the in-flight map is bounded at 64 (`E_SATURATED`),
+  invalid timeouts fall back to 5s, and teardown rejects outstanding
+  requests with `E_TEARDOWN` instead of leaking hung promises — the
+  host broker previously cleared its timers without rejecting, and
+  plugins (richtext, datagrid) each hand-rolled their own correlation.
+
 ### Changed
 
 - **The last 23 legacy `framework/ui` files (24 components) join the

--- a/framework/docs/content/plugin-platform.md
+++ b/framework/docs/content/plugin-platform.md
@@ -54,11 +54,13 @@ One versioned envelope in both directions:
 
 - Handshake: the frame speaks first (`ready`), the host answers `init`
   with the document, theme tokens, and the capability grant set.
-- host→plugin: `init`, `themeChanged`, `requestSave`, `uploadResult`,
-  `teardown`, `hostPointerdown` (interaction-outside relay so in-frame
-  overlays can dismiss).
-- plugin→host: `ready`, `docChanged`, `save`, `requestUpload`, `resize`,
-  `focusChanged`, `metric`, `themeApplied`, `bootError`.
+- host→plugin: `init`, `themeChanged`, `teardown`, `hostPointerdown`
+  (interaction-outside relay so in-frame overlays can dismiss).
+- plugin→host: `ready`, `docChanged`, `save`, `resize`, `focusChanged`,
+  `metric`, `themeApplied`, `bootError`.
+- Legacy correlated-event pairs (`requestSave`/`uploadResult`,
+  `requestUpload`) predate the request channel below; new plugins use
+  `sendRequest`/`onRequest` instead of inventing paired events.
 - **Source validation:** `event.source === iframe.contentWindow`, never
   `event.origin`; an opaque frame's origin is the literal string
   `"null"`, so origin-string checks are a trap.
@@ -98,6 +100,9 @@ One contract, both directions:
   `{code: "E_HANDLER"}`. Silence is not a protocol state.
 - The in-flight map is bounded (64); a saturated sender gets an
   immediate `{code: "E_SATURATED"}` rejection and nothing is posted.
+  The bound is sender-side: inbound dispatch is uncapped, the same
+  trust posture as the event path, so host-side request handlers must
+  stay cheap or debounce, exactly like `onEvent` handlers.
 - Invalid timeouts fall back to the 5s default; a timed-out request
   rejects `{code: "E_TIMEOUT"}` and its late response is dropped by id.
 - Teardown rejects every outstanding request with

--- a/framework/docs/content/plugin-platform.md
+++ b/framework/docs/content/plugin-platform.md
@@ -69,6 +69,41 @@ its own route (`pluginhost.RegisterBrokerRoute`, idempotent across
 plugins). It is **not** part of `runtime.js`; pages without plugins
 ship zero extra bytes and the core payload budgets are untouched.
 
+### Requests, both directions
+
+`request`/`response` correlation is platform-owned in both directions —
+plugins never hand-roll a request id, a pending map, or a timeout.
+
+The frame side is `framework/pluginhost/frame/frameclient.js`
+(`pluginhost.RegisterFrameClientRoute`, served with the framed CORP
+relaxation so opaque-origin frame documents can load it; or bundle
+`pluginhost.FrameClientJS()`). Inside the frame:
+
+```js
+var client = window.__gofastrPluginFrame;
+client.onEvent("init", function (params) { /* theme, doc, caps */ });
+client.onRequest("getState", function (params) { return state; });
+client.ready({ domReady: true }).then(function (init) { /* … */ });
+client.sendRequest("rows", { page: 2 }, 5000).then(render, showError);
+```
+
+On the host, an adapter answers frame requests with per-instance
+handlers (`api.onRequest(method, handler)`) or a static
+`registration.onRequest(method, params, api)` fallback.
+
+One contract, both directions:
+
+- A request is **always answered**: no handler → an
+  `{code: "E_NO_HANDLER"}` error response; a handler throw/rejection →
+  `{code: "E_HANDLER"}`. Silence is not a protocol state.
+- The in-flight map is bounded (64); a saturated sender gets an
+  immediate `{code: "E_SATURATED"}` rejection and nothing is posted.
+- Invalid timeouts fall back to the 5s default; a timed-out request
+  rejects `{code: "E_TIMEOUT"}` and its late response is dropped by id.
+- Teardown rejects every outstanding request with
+  `{code: "E_TEARDOWN"}` on both sides (the frame also fails
+  outstanding requests on `pagehide`), so no promise ever hangs.
+
 ## Capabilities: reuse the scope registry, don't invent one
 
 Grants use the **same `resource:verb` grammar as battery/auth token

--- a/framework/pluginhost/broker.go
+++ b/framework/pluginhost/broker.go
@@ -78,6 +78,11 @@ func UIHostOption() uihost.Option {
 //	    // api = { request, sendEvent, iframe, marker, form }
 //	    // handle plugin-specific events: docChanged, save, requestUpload, …
 //	    // and mirror the generic hooks if the e2e depends on plugin-named ones.
+//	  },
+//	  onRequest: function (method, params, api) {
+//	    // static fallback for frame → host requests with no explicit
+//	    // api.onRequest handler; return a value or a Promise (a throw
+//	    // becomes an E_HANDLER response). Neither exists → E_NO_HANDLER.
 //	  }
 //	});
 //
@@ -87,7 +92,9 @@ func UIHostOption() uihost.Option {
 // (iframe.__pluginReady / __pluginProbes / __pluginTheme / __pluginLastMetric).
 // It calls registration.onEvent for EVERY inbound event after its own handling,
 // so an adapter can both handle its own methods and mirror the generic hooks
-// under plugin-specific names the tests read.
+// under plugin-specific names the tests read. Inbound frame → host requests
+// dispatch to a per-method api.onRequest handler first, with
+// registration.onRequest as the fallback, and are ALWAYS answered.
 type BrokerRegistration struct {
 	Manifest Manifest                                 `json:"manifest"`
 	Config   any                                      `json:"config,omitempty"`

--- a/framework/pluginhost/clientcore_test.go
+++ b/framework/pluginhost/clientcore_test.go
@@ -16,15 +16,18 @@ import (
 // mounted frame's contentWindow, and event.origin is deliberately NOT trusted
 // (opaque frames report origin "null").
 func TestBrokerJS_ValidatesMessageSource(t *testing.T) {
-	js := string(brokerJSBytes)
-	if !strings.Contains(js, "contentWindow === event.source") {
+	// Code lines only (nonCommentJS): the header comment states the same
+	// invariants in prose, and a whole-file Contains could go vacuous the
+	// day the comment happens to use the code's operand order.
+	code := nonCommentJS(string(brokerJSBytes))
+	if !strings.Contains(code, "contentWindow === event.source") {
 		t.Error("onMessage must accept only messages whose source is a mounted frame's contentWindow")
 	}
 	// It must reject wrong envelope version and non-plugin source markers.
-	if !strings.Contains(js, "msg.v !== ENVELOPE_VERSION") {
+	if !strings.Contains(code, "msg.v !== ENVELOPE_VERSION") {
 		t.Error("onMessage must reject a wrong envelope version")
 	}
-	if !strings.Contains(js, `msg.src !== "plugin"`) {
+	if !strings.Contains(code, `msg.src !== "plugin"`) {
 		t.Error("onMessage must reject messages not marked src:plugin")
 	}
 }

--- a/framework/pluginhost/frame/frameclient.js
+++ b/framework/pluginhost/frame/frameclient.js
@@ -1,0 +1,249 @@
+/*!
+ * pluginhost/frame/frameclient.js — frame-side channel client for GoFastr
+ * heavy-JS plugins.
+ *
+ * Plain JavaScript (IIFE, no imports, no external URLs). Runs INSIDE the
+ * opaque-origin sandboxed plugin frame and mirrors the host broker
+ * (host/pluginhost.js): same envelope, same source check, same
+ * request/response semantics, so both directions of the plugin channel
+ * share ONE contract.
+ *
+ * Security invariants (mirror of the broker — do NOT weaken):
+ *   - Messages are accepted only when event.source === window.parent.
+ *     Like the broker, we do NOT check event.origin: this frame IS an
+ *     opaque origin (its origin string is literally "null"), so
+ *     origin-string checks are a trap in both directions; the window
+ *     identity is the gate.
+ *   - Posts use targetOrigin "*" — the frame is opaque-origin, so a
+ *     concrete targetOrigin is the wrong tool; the source check is the
+ *     gate, exactly as in the broker's postTo.
+ *
+ * Usage (inside the frame document, after this script loads):
+ *
+ *   var client = window.__gofastrPluginFrame;
+ *   client.onEvent("init", function (params) { … });
+ *   client.onRequest("getState", function (params) { return {…}; });
+ *   client.ready({ domReady: true }).then(function (init) { … });
+ *   client.sendRequest("save", {…}).then(function (result) { … });
+ */
+(function () {
+  'use strict';
+
+  // --- Protocol constants (must match host/pluginhost.js; the pair is
+  //     pinned by TestEnvelopeVersionsAgree) ---------------------------------
+  var ENVELOPE_VERSION = 1;
+  var RESPONSE_TIMEOUT_MS = 5000;  // request → response default
+  var MAX_INFLIGHT = 64;           // pending-request bound, both directions
+
+  // id -> {resolve, reject, timer} for OUR outbound (frame → host) requests.
+  var pending = Object.create(null);
+  // method -> handler, for inbound host → frame traffic.
+  var eventHandlers = Object.create(null);
+  var requestHandlers = Object.create(null);
+  var reqCounter = 0;
+
+  // ready() → init handshake state: every outstanding ready() promise
+  // resolves ONCE with the first init's params; later inits only dispatch
+  // through the onEvent handlers.
+  var initArrived = false;
+  var initParams = null;
+  var initWaiters = [];
+
+  function envelope(type, method, params, id) {
+    var env = { v: ENVELOPE_VERSION, type: type, src: "plugin", result: null, error: null };
+    if (id) env.id = id;
+    if (method) env.method = method;
+    if (params) env.params = params;
+    return env;
+  }
+
+  function postToHost(env) {
+    // The frame is an opaque origin; targetOrigin MUST be "*". The real
+    // gate is the event.source === window.parent check on both sides (§3).
+    window.parent.postMessage(env, "*");
+  }
+
+  // A non-positive / NaN / infinite timeoutMs is not a timeout — fall back
+  // to the protocol default instead of handing garbage to setTimeout.
+  function validTimeout(timeoutMs) {
+    return (typeof timeoutMs === "number" && isFinite(timeoutMs) && timeoutMs > 0)
+      ? timeoutMs
+      : RESPONSE_TIMEOUT_MS;
+  }
+
+  // Fail every outstanding sendRequest (host teardown ack, pagehide) so
+  // nothing hangs; responses arriving after this are dropped by id.
+  function rejectOutstanding(err) {
+    for (var id in pending) {
+      if (Object.prototype.hasOwnProperty.call(pending, id)) {
+        clearTimeout(pending[id].timer);
+        pending[id].reject(err);
+      }
+    }
+    pending = Object.create(null);
+  }
+
+  // --- Inbound dispatch (host → frame) --------------------------------------
+
+  function reply(id, result, err) {
+    var env = envelope("response", null, null, id);
+    if (err) env.error = err;
+    else env.result = result;
+    postToHost(env);
+  }
+
+  function handleRequest(msg) {
+    var handler = requestHandlers[msg.method];
+    if (typeof handler !== "function") {
+      // Never silence: the host holds a pending entry per request id and a
+      // dropped reply would hang it until its own timeout.
+      reply(msg.id, null, { code: "E_NO_HANDLER", message: "no handler for " + msg.method });
+      return;
+    }
+    // Promise.resolve().then(...): a synchronous throw in the handler
+    // becomes a rejection instead of escaping the message dispatch.
+    Promise.resolve().then(function () {
+      return handler(msg.params || {});
+    }).then(
+      function (result) { reply(msg.id, result, null); },
+      function (err) {
+        reply(msg.id, null, { code: "E_HANDLER", message: String(err && err.message || err) });
+      }
+    );
+  }
+
+  function handleEvent(method, params) {
+    params = params || {};
+    if (method === "init") {
+      if (!initArrived) {
+        initArrived = true;
+        initParams = params;
+        var waiters = initWaiters;
+        initWaiters = [];
+        for (var i = 0; i < waiters.length; i++) waiters[i](params);
+      }
+    }
+    var h = eventHandlers[method];
+    if (typeof h === "function") {
+      try { h(params); } catch (e) {
+        if (typeof console !== "undefined" && console.error) {
+          console.error("[pluginframe] onEvent handler threw", e);
+        }
+      }
+    }
+    // No handler registered → unknown events are ignored by protocol
+    // rule (§4: unknown method → ignore).
+  }
+
+  // Host teardown (SPA nav): run the plugin's registered teardown handler
+  // (awaited), ACK the request, THEN fail every outstanding sendRequest —
+  // in that order, so the ACK is on the wire before the host removes us.
+  function handleTeardown(msg) {
+    var handler = requestHandlers["teardown"];
+    var run = (typeof handler === "function")
+      ? function () { return handler(msg.params || {}); }
+      : function () { return null; }; // no plugin teardown hook — still ACK
+    Promise.resolve().then(run).then(
+      function (result) {
+        reply(msg.id, result, null);
+        rejectOutstanding({ code: "E_TEARDOWN", message: "instance torn down" });
+      },
+      function (err) {
+        reply(msg.id, null, { code: "E_HANDLER", message: String(err && err.message || err) });
+        rejectOutstanding({ code: "E_TEARDOWN", message: "instance torn down" });
+      }
+    );
+  }
+
+  function onMessage(event) {
+    // Security mirror of the broker: accept ONLY the parent window — NOT
+    // event.origin (opaque origins report "null"; source identity is the
+    // gate, §3).
+    var fromParent = event.source === window.parent;
+    if (!fromParent) return;
+    var msg = event.data;
+    if (!msg || typeof msg !== "object") return;
+    if (msg.v !== ENVELOPE_VERSION) return;
+    if (msg.src !== "host") return;
+
+    if (msg.type === "response") {
+      var p = pending[msg.id];
+      if (!p) return; // late (post-timeout / post-teardown): dropped by id
+      clearTimeout(p.timer);
+      delete pending[msg.id];
+      if (msg.error) p.reject(msg.error);
+      else p.resolve(msg.result);
+      return;
+    }
+    if (msg.type === "request") {
+      if (msg.method === "teardown") handleTeardown(msg);
+      else handleRequest(msg);
+      return;
+    }
+    if (msg.type === "event") {
+      handleEvent(msg.method, msg.params);
+    }
+  }
+
+  // --- Public client ----------------------------------------------------------
+
+  window.__gofastrPluginFrame = {
+    // ready → init handshake. Sends the ready event (with probes) to the
+    // host and resolves with the init event's params. Resolves once; a
+    // repeat init re-resolves nothing but still fires onEvent("init").
+    ready: function (probes) {
+      postToHost(envelope("event", "ready", { probes: probes || null }));
+      return new Promise(function (resolve) {
+        if (initArrived) { resolve(initParams); return; }
+        initWaiters.push(resolve);
+      });
+    },
+    // Frame → host event (fire-and-forget).
+    sendEvent: function (method, params) {
+      postToHost(envelope("event", method, params || {}));
+    },
+    // Frame → host request → Promise (default 5s timeout). SAME contract as
+    // the host side: bounded in-flight map (immediate E_SATURATED reject
+    // without posting), validated timeout, late responses dropped by id.
+    // Our ids are prefixed "p-…" where the host's own requests are "h-…".
+    sendRequest: function (method, params, timeoutMs) {
+      if (Object.keys(pending).length >= MAX_INFLIGHT) {
+        return Promise.reject({
+          code: "E_SATURATED",
+          message: "request map saturated at " + MAX_INFLIGHT + " in flight: " + method
+        });
+      }
+      timeoutMs = validTimeout(timeoutMs);
+      return new Promise(function (resolve, reject) {
+        var id = "p-" + (++reqCounter);
+        var timer = setTimeout(function () {
+          if (pending[id]) {
+            delete pending[id];
+            reject({ code: "E_TIMEOUT", message: "request " + method + " timed out" });
+          }
+        }, timeoutMs);
+        pending[id] = { resolve: resolve, reject: reject, timer: timer };
+        postToHost(envelope("request", method, params || {}, id));
+      });
+    },
+    // Host → frame event handler (method → handler); re-registering a
+    // method overwrites. Events with no registered handler are ignored.
+    onEvent: function (method, handler) {
+      eventHandlers[method] = handler;
+    },
+    // Host → frame request handler (method → handler); re-registering a
+    // method overwrites. The handler receives (params) and may return a
+    // value or a Promise; a method with no handler gets an E_NO_HANDLER
+    // response, a throw an E_HANDLER response.
+    onRequest: function (method, handler) {
+      requestHandlers[method] = handler;
+    }
+  };
+
+  window.addEventListener("message", onMessage);
+  // The frame document is going away — outstanding sendRequests can never
+  // get a response; fail them now instead of leaking until timeout.
+  window.addEventListener("pagehide", function () {
+    rejectOutstanding({ code: "E_TEARDOWN", message: "page hidden" });
+  });
+})();

--- a/framework/pluginhost/frame/frameclient.js
+++ b/framework/pluginhost/frame/frameclient.js
@@ -89,7 +89,22 @@
     var env = envelope("response", null, null, id);
     if (err) env.error = err;
     else env.result = result;
-    postToHost(env);
+    try {
+      postToHost(env);
+    } catch (e) {
+      // A non-structured-cloneable result (function, DOM node) throws
+      // DataCloneError here; without this guard the host waits out its
+      // full timeout instead of learning the handler misbehaved. Error
+      // envelopes are plain strings, so the fallback always clones.
+      var fallback = envelope("response", null, null, id);
+      fallback.error = {
+        code: "E_HANDLER",
+        message: "response not cloneable: " + String(e && e.message || e)
+      };
+      try {
+        postToHost(fallback);
+      } catch (ignored) { /* parent gone — nothing left to deliver to */ }
+    }
   }
 
   function handleRequest(msg) {

--- a/framework/pluginhost/frameclient.go
+++ b/framework/pluginhost/frameclient.go
@@ -1,0 +1,52 @@
+package pluginhost
+
+import (
+	_ "embed"
+	"net/http"
+
+	"github.com/DonaldMurillo/gofastr/core/router"
+)
+
+// FrameClientScriptURL is the platform route serving the frame-side channel
+// client (frame/frameclient.js), the mirror of the host broker. Plugin frame
+// documents hot-link it to get the same envelope, source check, and
+// request/response semantics as the host side without hand-rolling a
+// postMessage RPC per plugin.
+const FrameClientScriptURL = "/__gofastr/plugin/frame/frameclient.js"
+
+//go:embed frame/frameclient.js
+var frameClientJSBytes []byte
+
+// FrameClientRouteMethod is the router method the frame client route is
+// registered under.
+const FrameClientRouteMethod = "GET"
+
+// RegisterFrameClientRoute serves the frame client at [FrameClientScriptURL]
+// on the given router. Like [RegisterBrokerRoute] it is IDEMPOTENT: multiple
+// plugins may call it from their Init and only the first registration lands.
+//
+// Unlike the broker (a HOST-page script served same-origin, framed=false),
+// this script is fetched BY opaque-origin frame documents: the global
+// security middleware's Cross-Origin-Resource-Policy: same-origin would
+// refuse the "null"-origin frame's <script src>, so it is served with
+// framed=true to apply exactly that CORP relaxation. The framedCSP header
+// writeAsset also emits is inert on a script response (CSP governs
+// documents, not script bytes) — harmless there; the CORP relaxation is the
+// point.
+func RegisterFrameClientRoute(rt *router.Router) {
+	if routeRegistered(rt, FrameClientRouteMethod, FrameClientScriptURL) {
+		return
+	}
+	rt.Get(FrameClientScriptURL, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeAsset(w, r, frameClientJSBytes, "text/javascript; charset=utf-8", true)
+	}))
+}
+
+// FrameClientJS returns a copy of the embedded frame client, for plugins
+// that bundle the script into their own frame document instead of
+// hot-linking [FrameClientScriptURL].
+func FrameClientJS() []byte {
+	b := make([]byte, len(frameClientJSBytes))
+	copy(b, frameClientJSBytes)
+	return b
+}

--- a/framework/pluginhost/frameclient.go
+++ b/framework/pluginhost/frameclient.go
@@ -30,7 +30,7 @@ const FrameClientRouteMethod = "GET"
 // security middleware's Cross-Origin-Resource-Policy: same-origin would
 // refuse the "null"-origin frame's <script src>, so it is served with
 // framed=true to apply exactly that CORP relaxation. The framedCSP header
-// writeAsset also emits is inert on a script response (CSP governs
+// that writeAsset also emits is inert on a script response (CSP governs
 // documents, not script bytes) — harmless there; the CORP relaxation is the
 // point.
 func RegisterFrameClientRoute(rt *router.Router) {

--- a/framework/pluginhost/frameclient_test.go
+++ b/framework/pluginhost/frameclient_test.go
@@ -74,14 +74,19 @@ func TestFrameClientJS_PostsWithWildcardTargetOrigin(t *testing.T) {
 // home would defeat the point of the isolation. Scan non-comment lines
 // (same comment-stripping approach as TestBrokerJS_NeverEmitsAllowSameOrigin).
 func TestFrameClientJS_NoExternalURLs(t *testing.T) {
+	// Deliberately NO trailing-comment strip here: a URL's own "//"
+	// would be read as a comment start and the scheme destroyed before
+	// the check, leaving the pin unable to fire on the exact thing it
+	// exists for (found by mutation: an injected fetch("https://…")
+	// stayed green). Whole comment lines are skipped; a URL in a
+	// trailing comment flags as a false positive, which is the safe
+	// direction — keep URLs out of trailing comments in this file.
 	js := string(frameClientJSBytes)
 	for line := range strings.SplitSeq(js, "\n") {
 		code := strings.TrimSpace(line)
-		if strings.HasPrefix(code, "//") {
+		if strings.HasPrefix(code, "//") || strings.HasPrefix(code, "*") ||
+			strings.HasPrefix(code, "/*") {
 			continue // whole-line comment
-		}
-		if idx := strings.Index(code, "//"); idx >= 0 {
-			code = strings.TrimSpace(code[:idx]) // strip trailing comment
 		}
 		if strings.Contains(code, "http://") || strings.Contains(code, "https://") {
 			t.Errorf("external URL in executable code: %q", strings.TrimSpace(line))
@@ -128,8 +133,25 @@ func TestChannelContractPins(t *testing.T) {
 			t.Errorf("frame client missing channel contract literal %s", s)
 		}
 	}
-	if !strings.Contains(broker, "onRequest") {
-		t.Error("broker must expose onRequest handler registration")
+	// Pin the CODE shapes, not the word: "onRequest" appears in the
+	// broker's header comment, so a bare Contains would survive deleting
+	// the registration API entirely.
+	if !strings.Contains(broker, "st.requestHandlers[msg.method]") {
+		t.Error("broker must dispatch inbound requests via st.requestHandlers")
+	}
+	if !strings.Contains(broker, "onRequest: function (method, handler)") {
+		t.Error("broker api must expose onRequest handler registration")
+	}
+
+	// The frame controls msg.id on the broker's response path: the
+	// pending maps must be null-proto so "__proto__"/"constructor"
+	// lookups are undefined instead of truthy Object.prototype members
+	// (which pass the not-pending guard and throw in the host page).
+	if !strings.Contains(broker, "pending: Object.create(null)") {
+		t.Error("broker per-instance pending map must be Object.create(null)")
+	}
+	if !strings.Contains(broker, "st.pending = Object.create(null)") {
+		t.Error("broker cleanup must reset pending to Object.create(null), not {}")
 	}
 
 	// The bound must be ENFORCED, not just declared: pin the saturation

--- a/framework/pluginhost/frameclient_test.go
+++ b/framework/pluginhost/frameclient_test.go
@@ -1,0 +1,210 @@
+package pluginhost
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/router"
+)
+
+// The frame-side channel client lives in frame/frameclient.js and mirrors
+// the host broker (host/pluginhost.js). Like the broker, its invariants
+// can't be Go-typed away, so the dangerous regressions are pinned at the
+// source level (deterministic, no browser), and the channel contract BOTH
+// files must share is pinned symmetrically.
+
+// (1) postMessage source validation, mirror of the broker: messages are
+// accepted ONLY from the parent window, the envelope version is checked,
+// and only src:"host" traffic is dispatched.
+func TestFrameClientJS_ValidatesMessageSource(t *testing.T) {
+	js := string(frameClientJSBytes)
+	// Scan CODE lines only: the header comment states the invariant in the
+	// same words, so a whole-file Contains would stay green with the actual
+	// check deleted (caught by mutation during review).
+	code := nonCommentJS(js)
+	if !strings.Contains(code, "event.source === window.parent") &&
+		!strings.Contains(code, "window.parent === event.source") {
+		t.Error("onMessage must accept only messages whose source is the parent window (in code, not prose)")
+	}
+	if !strings.Contains(code, "msg.v !== ENVELOPE_VERSION") {
+		t.Error("onMessage must reject a wrong envelope version")
+	}
+	if !strings.Contains(code, `msg.src !== "host"`) {
+		t.Error("onMessage must reject messages not marked src:host")
+	}
+}
+
+// nonCommentJS strips whole-line and trailing // comments, returning the
+// executable lines joined — the same approach as the NoExternalURLs scan,
+// shared so security pins can't be satisfied by prose.
+func nonCommentJS(js string) string {
+	var b strings.Builder
+	for line := range strings.SplitSeq(js, "\n") {
+		code := strings.TrimSpace(line)
+		if strings.HasPrefix(code, "//") || strings.HasPrefix(code, "*") ||
+			strings.HasPrefix(code, "/*") {
+			continue
+		}
+		if idx := strings.Index(code, "//"); idx >= 0 {
+			code = strings.TrimSpace(code[:idx])
+		}
+		b.WriteString(code)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// (2) The frame→host post uses targetOrigin "*" (the frame is opaque, a
+// concrete targetOrigin is the wrong tool); the source check, not an
+// origin string, is the gate. Mirror of the broker pin so nobody
+// "hardens" it into an origin that silently drops every message.
+func TestFrameClientJS_PostsWithWildcardTargetOrigin(t *testing.T) {
+	js := string(frameClientJSBytes)
+	if !strings.Contains(js, `postMessage(env, "*")`) {
+		t.Error("postToHost must use targetOrigin \"*\" (source check is the gate)")
+	}
+}
+
+// (3) No external URLs: the client runs inside the sandboxed frame with
+// connect-src 'none' as the exfiltration guard, and a script that phones
+// home would defeat the point of the isolation. Scan non-comment lines
+// (same comment-stripping approach as TestBrokerJS_NeverEmitsAllowSameOrigin).
+func TestFrameClientJS_NoExternalURLs(t *testing.T) {
+	js := string(frameClientJSBytes)
+	for line := range strings.SplitSeq(js, "\n") {
+		code := strings.TrimSpace(line)
+		if strings.HasPrefix(code, "//") {
+			continue // whole-line comment
+		}
+		if idx := strings.Index(code, "//"); idx >= 0 {
+			code = strings.TrimSpace(code[:idx]) // strip trailing comment
+		}
+		if strings.Contains(code, "http://") || strings.Contains(code, "https://") {
+			t.Errorf("external URL in executable code: %q", strings.TrimSpace(line))
+		}
+	}
+}
+
+// The envelope version is a wire contract between the two scripts: if they
+// drift, every message is silently dropped by the version check on both
+// sides. Pin them equal.
+func TestEnvelopeVersionsAgree(t *testing.T) {
+	re := regexp.MustCompile(`ENVELOPE_VERSION = (\d+)`)
+	broker := re.FindStringSubmatch(string(brokerJSBytes))
+	client := re.FindStringSubmatch(string(frameClientJSBytes))
+	if broker == nil {
+		t.Fatal("brokerJSBytes: ENVELOPE_VERSION declaration not found")
+	}
+	if client == nil {
+		t.Fatal("frameClientJSBytes: ENVELOPE_VERSION declaration not found")
+	}
+	if broker[1] != client[1] {
+		t.Errorf("envelope versions disagree: broker v%s, frame client v%s", broker[1], client[1])
+	}
+}
+
+// The bidirectional channel contract is shared by both files: bounded
+// in-flight map, the four error codes, and handler registration. Pin the
+// literals (quoted forms — comments mention the codes unquoted, so a pin
+// only passes on executable code).
+func TestChannelContractPins(t *testing.T) {
+	broker := string(brokerJSBytes)
+	client := string(frameClientJSBytes)
+	for _, s := range []string{
+		"MAX_INFLIGHT = 64",
+		`"E_SATURATED"`,
+		`"E_TEARDOWN"`,
+		`"E_NO_HANDLER"`,
+		`"E_HANDLER"`,
+	} {
+		if !strings.Contains(broker, s) {
+			t.Errorf("broker missing channel contract literal %s", s)
+		}
+		if !strings.Contains(client, s) {
+			t.Errorf("frame client missing channel contract literal %s", s)
+		}
+	}
+	if !strings.Contains(broker, "onRequest") {
+		t.Error("broker must expose onRequest handler registration")
+	}
+
+	// The bound must be ENFORCED, not just declared: pin the saturation
+	// checks that reject before posting.
+	if !strings.Contains(broker, "Object.keys(st.pending).length >= MAX_INFLIGHT") {
+		t.Error("broker request() must reject when the pending map is full")
+	}
+	if !strings.Contains(client, "Object.keys(pending).length >= MAX_INFLIGHT") {
+		t.Error("frame client sendRequest() must reject when the pending map is full")
+	}
+
+	// cleanup() must REJECT pending entries with E_TEARDOWN, not just clear
+	// their timers — otherwise teardown leaks unresolved promises forever.
+	ci := strings.Index(broker, "function cleanup(")
+	if ci < 0 {
+		t.Fatal("broker: cleanup() not found")
+	}
+	end := strings.Index(broker[ci:], "\n  }")
+	if end < 0 {
+		t.Fatal("broker: cleanup() end not found")
+	}
+	if !strings.Contains(broker[ci:ci+end], `"E_TEARDOWN"`) {
+		t.Error("broker cleanup() must reject pending requests with E_TEARDOWN before clearing")
+	}
+}
+
+// RegisterFrameClientRoute is idempotent: many plugins may call it from
+// Init, but only the first registration lands (a duplicate router pattern
+// panics). Mirror of TestRegisterBrokerRoute_Idempotent.
+func TestRegisterFrameClientRoute_Idempotent(t *testing.T) {
+	rt := router.New()
+	RegisterFrameClientRoute(rt)
+	RegisterFrameClientRoute(rt) // must NOT panic
+	RegisterFrameClientRoute(rt)
+
+	n := 0
+	for _, rr := range rt.Routes() {
+		if rr.Method == FrameClientRouteMethod && rr.Pattern == FrameClientScriptURL {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("frame client route registered %d times, want exactly 1", n)
+	}
+}
+
+// The frame client route is a FRAMED asset, unlike the broker route: it is
+// fetched by opaque-origin frame documents, so it must carry the CORP
+// cross-origin relaxation (the global same-origin default would block the
+// frame's script fetch), plus the nosniff every asset carries.
+func TestFrameClientRouteServedFramed(t *testing.T) {
+	rt := router.New()
+	RegisterFrameClientRoute(rt)
+
+	srv := httptest.NewServer(rt)
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + FrameClientScriptURL)
+	if err != nil {
+		t.Fatalf("GET frame client: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("frame client status=%d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/javascript") {
+		t.Errorf("frame client Content-Type=%q", ct)
+	}
+	if got := resp.Header.Get("Cross-Origin-Resource-Policy"); got != "cross-origin" {
+		t.Errorf("frame client CORP=%q, want cross-origin (opaque-origin fetcher)", got)
+	}
+	if resp.Header.Get("X-Content-Type-Options") != "nosniff" {
+		t.Error("frame client must carry nosniff")
+	}
+	if len(body) == 0 {
+		t.Error("frame client body empty")
+	}
+}

--- a/framework/pluginhost/host/pluginhost.js
+++ b/framework/pluginhost/host/pluginhost.js
@@ -292,9 +292,16 @@
       adapter: adapter,
       capabilities: parseCaps(marker, adapter.manifest),
       docId: marker.getAttribute("data-fui-plugin-docid") || "demo",
-      pending: {},            // id -> {resolve, reject, timer}
+      // id -> {resolve, reject, timer}. NULL-PROTO, not {}: the frame
+      // controls msg.id on the response path, and a {} lookup of
+      // "__proto__"/"constructor" returns an Object.prototype member —
+      // truthy, so the not-pending guard passes and p.resolve throws an
+      // uncaught TypeError in the host page, on demand, from a hostile
+      // frame. Object.create(null) makes unknown ids uniformly undefined.
+      pending: Object.create(null),
       requestHandlers: Object.create(null), // method -> frame→host handler
       ready: false,
+      tearingDown: false,
       focused: false,
       lastMetric: null,
       theme: null,
@@ -543,10 +550,15 @@
         st.pending[id].reject({ code: "E_TEARDOWN", message: "instance torn down" });
       }
     }
-    st.pending = {};
+    st.pending = Object.create(null);
   }
 
   function teardownInstance(st) {
+    // Idempotent: a second gofastr:navigate inside the teardown-ack
+    // window would otherwise send a second teardown request and run the
+    // plugin's teardown handler twice.
+    if (st.tearingDown) return;
+    st.tearingDown = true;
     if (!st.ready) { cleanup(st); return; }
     request(st, "teardown", {}, TEARDOWN_TIMEOUT_MS).then(function () {
       cleanup(st);

--- a/framework/pluginhost/host/pluginhost.js
+++ b/framework/pluginhost/host/pluginhost.js
@@ -20,12 +20,25 @@
  * and the ready→init handshake are EXACTLY as the wysiwyg broker shipped them
  * in Phase 0.
  *
+ * Frame → host requests (envelope type "request" from the frame) share that
+ * one contract, both directions: the broker dispatches them to a per-method
+ * handler registered via api.onRequest, with the adapter's static
+ * registration.onRequest as fallback, and ALWAYS replies — result,
+ * E_NO_HANDLER, or E_HANDLER. The pending map is bounded (MAX_INFLIGHT) and
+ * teardown rejects stragglers with E_TEARDOWN. The frame-side counterpart is
+ * frame/frameclient.js (window.__gofastrPluginFrame).
+ *
  * Adapter contract (see pluginhost.BrokerRegistration in Go):
  *
  *   window.__gofastrPluginHost.register(name, {
  *     manifest: { entry, isolation, sandbox, capabilities, minHeight, schema, title },
  *     config:   { …plugin blob… },
- *     onEvent:  function (method, params, api) { … }
+ *     onEvent:  function (method, params, api) { … },
+ *     onRequest: function (method, params, api) {
+ *       // static fallback for frame → host requests with no explicit
+ *       // api.onRequest handler; return a value or a Promise (a throw
+ *       // becomes E_HANDLER). Neither handler exists → E_NO_HANDLER.
+ *     }
  *   });
  *
  * The generic broker handles the protocol-level events itself (ready, resize,
@@ -40,6 +53,7 @@
   var ENVELOPE_VERSION = 1;
   var RESPONSE_TIMEOUT_MS = 5000;  // request → response (§3)
   var TEARDOWN_TIMEOUT_MS = 200;   // SPA teardown ack budget (§6.9)
+  var MAX_INFLIGHT = 64;           // pending-request bound, both directions
 
   var DEFAULT_CAPS = ["document:read", "document:write", "upload:images", "theme:read"];
   var DEFAULT_MIN_HEIGHT = "240px";
@@ -279,6 +293,7 @@
       capabilities: parseCaps(marker, adapter.manifest),
       docId: marker.getAttribute("data-fui-plugin-docid") || "demo",
       pending: {},            // id -> {resolve, reject, timer}
+      requestHandlers: Object.create(null), // method -> frame→host handler
       ready: false,
       focused: false,
       lastMetric: null,
@@ -288,8 +303,26 @@
     };
   }
 
+  // A non-positive / NaN / infinite timeoutMs is not a timeout — fall back
+  // to the protocol default instead of handing garbage to setTimeout (a
+  // negative value fires "immediately", NaN never fires at all).
+  function validTimeout(timeoutMs) {
+    return (typeof timeoutMs === "number" && isFinite(timeoutMs) && timeoutMs > 0)
+      ? timeoutMs
+      : RESPONSE_TIMEOUT_MS;
+  }
+
   // Host → frame request expecting a response (resolves on matched id).
+  // The pending map is BOUNDED: a wedged frame that never responds would
+  // otherwise grow it without limit (one timer + closure per request).
   function request(st, method, params, timeoutMs) {
+    if (Object.keys(st.pending).length >= MAX_INFLIGHT) {
+      return Promise.reject({
+        code: "E_SATURATED",
+        message: "request map saturated at " + MAX_INFLIGHT + " in flight: " + method
+      });
+    }
+    timeoutMs = validTimeout(timeoutMs);
     return new Promise(function (resolve, reject) {
       var id = "h-" + (++reqCounter);
       var timer = setTimeout(function () {
@@ -297,7 +330,7 @@
           delete st.pending[id];
           reject({ code: "E_TIMEOUT", message: "request " + method + " timed out" });
         }
-      }, timeoutMs || RESPONSE_TIMEOUT_MS);
+      }, timeoutMs);
       st.pending[id] = { resolve: resolve, reject: reject, timer: timer };
       postTo(st.frame, envelope("request", method, params || {}, id));
     });
@@ -314,9 +347,15 @@
       sendEvent: function (method, params) {
         postTo(st.frame, envelope("event", method, params || {}));
       },
-      // Host → frame request → Promise (5s timeout).
+      // Host → frame request → Promise (5s timeout, bounded in flight).
       request: function (method, params, timeoutMs) {
         return request(st, method, params, timeoutMs);
+      },
+      // Frame → host request handler registration (method → handler);
+      // re-registering a method overwrites. The handler receives
+      // (params, api) and may return a value or a Promise.
+      onRequest: function (method, handler) {
+        st.requestHandlers[method] = handler;
       }
     };
   }
@@ -389,6 +428,55 @@
     }
   }
 
+  // Frame → host request dispatch. An explicit handler (api.onRequest) wins;
+  // the adapter's static registration.onRequest(method, params, api) is the
+  // fallback for methods with no explicit handler. NEITHER exists → error
+  // response, never silence: the frame holds a pending entry per request id
+  // and a dropped reply would hang it until its own timeout.
+  function reply(st, id, result, err) {
+    // The frame may have been torn down while a handler's Promise was in
+    // flight — send the response anyway so its pending map can settle. A
+    // DETACHED frame has a null contentWindow: nobody can receive the reply,
+    // so drop silently in exactly that case.
+    if (!st.frame.contentWindow) return;
+    var env = envelope("response", null, null, id);
+    if (err) env.error = err;
+    else env.result = result;
+    try {
+      postTo(st.frame, env);
+    } catch (e) {
+      // Detached between the liveness check and the post — nothing left to
+      // deliver to.
+    }
+  }
+
+  function handleRequest(st, msg) {
+    var handler = st.requestHandlers[msg.method];
+    var run;
+    if (typeof handler === "function") {
+      run = function () { return handler(msg.params || {}, st.api); };
+    } else if (st.adapter && typeof st.adapter.onRequest === "function") {
+      run = function () { return st.adapter.onRequest(msg.method, msg.params || {}, st.api); };
+    } else {
+      reply(st, msg.id, null, {
+        code: "E_NO_HANDLER",
+        message: "no handler for " + msg.method
+      });
+      return;
+    }
+    // Promise.resolve().then(run): a synchronous throw in the handler
+    // becomes a rejection instead of escaping the message dispatch.
+    Promise.resolve().then(run).then(
+      function (result) { reply(st, msg.id, result, null); },
+      function (err) {
+        reply(st, msg.id, null, {
+          code: "E_HANDLER",
+          message: String(err && err.message || err)
+        });
+      }
+    );
+  }
+
   function onMessage(event) {
     // Find the instance this message came from. We accept ONLY messages whose
     // source is one of our iframe contentWindows — NOT event.origin (§3).
@@ -409,6 +497,10 @@
       delete st.pending[msg.id];
       if (msg.error) p.reject(msg.error);
       else p.resolve(msg.result);
+      return;
+    }
+    if (msg.type === "request") {
+      handleRequest(st, msg);
       return;
     }
     if (msg.type === "event") {
@@ -443,10 +535,12 @@
     var i = live.indexOf(st);
     if (i !== -1) live.splice(i, 1);
     states["delete"](st.frame);
-    // Clear any pending requests so nothing leaks.
+    // Reject any pending requests so no promise leaks unresolved forever,
+    // then clear the map — callers get E_TEARDOWN, not a hang.
     for (var id in st.pending) {
       if (Object.prototype.hasOwnProperty.call(st.pending, id)) {
         clearTimeout(st.pending[id].timer);
+        st.pending[id].reject({ code: "E_TEARDOWN", message: "instance torn down" });
       }
     }
     st.pending = {};


### PR DESCRIPTION
First of the three framed-runtime PRs from the approved design on #252 (sequencing: channel → #253 marker fallback → #255 wasm profile).

## What changes

**Host broker** (`host/pluginhost.js`): inbound `type:"request"` envelopes dispatch to handlers registered via `api.onRequest(method, handler)` or the adapter's static `registration.onRequest` fallback, and are **always answered** — `E_NO_HANDLER` when nothing is registered, `E_HANDLER` on a throw/rejection. A silent drop would hang the frame's pending entry until its own timeout.

**Frame client** (new, first frame-side artifact GoFastr ships): `frame/frameclient.js` exposes `window.__gofastrPluginFrame` — `ready`/`sendEvent`/`sendRequest`/`onEvent`/`onRequest`. Served by `RegisterFrameClientRoute` with the framed CORP relaxation (opaque-origin frame documents fetch it; CSP on a script response is inert), or bundled via `FrameClientJS()`. Security mirrors the broker exactly: parent-window source identity is the gate (never `event.origin`), wildcard targetOrigin, envelope v1 pinned equal across both files by test.

**One correlation contract, both directions** — and it fixes two pre-existing host-side gaps the design review found: bounded in-flight map (64, immediate `E_SATURATED`), validated timeouts (5s fallback), late responses dropped by id, and teardown now **rejects** outstanding promises with `E_TEARDOWN` (`cleanup()` previously cleared timers and leaked the promises unresolved forever). The frame also fails outstanding requests on `pagehide`.

This deletes the reqId+pending+timeout code richtext and datagrid each hand-rolled (their migration lands in gofastr-plugins after release) and unblocks datagrid's paging plus the host-mediated capture pattern behind #273's close.

## Verification

- `go test ./framework/pluginhost/ -count=1` green; 7 new tests (source-level pins + behavioral route/header tests, no browser).
- Guards mutation-proven red→green on both sides: silenced `E_NO_HANDLER`, removed both saturation checks, dropped the cleanup rejection, gutted the frame's source check. That last mutation exposed a vacuous pin (a whole-file `Contains` satisfied by the header comment) — the source-validation pins for **both** JS files now scan non-comment lines only.
- `plugin-platform.md` protocol section documents the channel in the same commit; changelog under Added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9