### PR TITLE
test(site): harden the toast-fallback e2e wait against runner starvation

### DIFF
--- a/examples/site/e2e_runtime_modules_test.go
+++ b/examples/site/e2e_runtime_modules_test.go
@@ -305,7 +305,7 @@ func TestE2E_RuntimeSplit_ToastModuleFailureShowsFallback(t *testing.T) {
 	base := srv.URL
 	ctx := newE2EBrowserCtx(t)
 
-	var fallbackVisible bool
+	var fallbackResult string
 	// Navigate to a page that doesn't pre-load the toast module so
 	// toasts.js isn't already cached, then manually trigger the
 	// toast push path to exercise the fallback when the module 500s.
@@ -355,24 +355,42 @@ func TestE2E_RuntimeSplit_ToastModuleFailureShowsFallback(t *testing.T) {
 		// delays the toasts.js onerror → fallback render past the
 		// sample point. The fallback is delayed, never lost, so wait
 		// on the real signal with a generous budget.
-		chromedp.Evaluate(`new Promise((resolve) => {
+		// Issue #278: a starved CI runner once let that in-order
+		// chain outlive 10s, so the budget is now 30s (the per-test
+		// tab context is 45s) and the timeout path resolves a
+		// diagnostic snapshot (fallback node state, runtime script
+		// srcs, loaded modules) instead of a bare false.
+		// Pin the poll promise on window: CDP holds only a weak
+		// reference to an awaited promise, and once the tick chain
+		// stops at resolve nothing else pins it — GC then reports
+		// "Promise was collected" (-32000) and the diagnostic is
+		// lost instead of delivered.
+		chromedp.Evaluate(`window.__toastFallbackPoll = new Promise((resolve) => {
             const t0 = performance.now();
             const tick = () => {
                 const fallback = document.querySelector('[data-fui-toast-fallback]');
-                if (fallback && fallback.textContent.includes('Saved')) { resolve(true); return; }
-                if (performance.now() - t0 > 10000) { resolve(false); return; }
+                if (fallback && fallback.textContent.includes('Saved')) { resolve('ok'); return; }
+                if (performance.now() - t0 > 30000) {
+                    resolve(JSON.stringify({
+                        fallbackPresent: !!fallback,
+                        fallbackText: fallback ? fallback.textContent : null,
+                        runtimeScripts: Array.from(document.querySelectorAll('script[src*="/__gofastr/runtime/"]')).map(s => s.src),
+                        loadedModules: Object.keys((window.__gofastr && window.__gofastr.loadedModules) || {}),
+                    }));
+                    return;
+                }
                 setTimeout(tick, 100);
             };
             tick();
-        })`, &fallbackVisible, func(p *cdruntime.EvaluateParams) *cdruntime.EvaluateParams {
+		})`, &fallbackResult, func(p *cdruntime.EvaluateParams) *cdruntime.EvaluateParams {
 			return p.WithAwaitPromise(true)
 		}),
 	); err != nil {
 		t.Fatalf("chromedp: %v", err)
 	}
-	if !fallbackVisible {
-		t.Errorf("X-Gofastr-Toast header fired with toasts.js returning 500 should render a fallback " +
-			"notice carrying the server-sent title; nothing visible was found.")
+	if fallbackResult != "ok" {
+		t.Errorf("X-Gofastr-Toast header fired with toasts.js returning 500 should render a fallback "+
+			"notice carrying the server-sent title; nothing visible was found. Diagnostic: %s", fallbackResult)
 	}
 }
 


### PR DESCRIPTION
Hardens the wait in `TestE2E_RuntimeSplit_ToastModuleFailureShowsFallback` per #278. Not marked as closing the issue: it stays open until the flake stops recurring, per its own filing note.

## What changed

- The fallback-visibility poll budget goes from 10s to 30s. The failed CI attempt ran 10.66s — the poll expired rather than erroring. Module scripts load with `async=false`, so the toasts.js error event that triggers the fallback queues behind every earlier in-order boot script; under runner starvation that chain can outlive 10s. The per-test tab context is 45s, so 30s fits.
- A timeout now resolves a diagnostic snapshot (fallback node state, runtime script srcs, loaded modules) instead of a bare `false`, so a recurrence reports what the page looked like instead of "nothing visible was found".
- The poll promise is pinned as `window.__toastFallbackPoll`. At the longer budget Chrome GC collected the awaited promise (`Promise was collected` -32000) because CDP holds it only weakly once the tick chain stops; the pin keeps the diagnostic deliverable. (This GC failure can't be the original CI flake — a collected promise fails the test via `chromedp:` fatal, not the observed `t.Errorf`.)

## Verification

- `go vet ./examples/site/` clean; the test passes at `-count=3` (~1–2s per run).
- The timeout path was proven by mutation: predicate broken, run observed failing with the diagnostic JSON delivered intact, predicate restored. The captured diagnostic also confirmed the in-order-queue analysis — toasts.js sat behind 8 other boot-queued modules.

No runtime or framework code changed; test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnA5y1Dynm4T1AGvAMbPMe
