### PR TITLE
feat(mcp): server-initiated notifications and resource subscriptions (#287)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,9 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Added
 
-- **MCP server-initiated notifications** (#287): `notifications/tools/
-  list_changed`, `notifications/resources/list_changed`,
+- **MCP server-initiated notifications** (#287):
+  `notifications/tools/list_changed`,
+  `notifications/resources/list_changed`,
   `notifications/prompts/list_changed` and `notifications/resources/updated`,
   plus `resources/subscribe` / `resources/unsubscribe`. `initialize` now
   advertises `listChanged` and `subscribe` truthfully; both were hardcoded
@@ -72,15 +73,20 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   returned, so there was no subscriber machinery at all — it now holds the
   connection and streams.
 
-  Notifications are filtered **per subscriber, at delivery time**, through the
-  same gates the list methods use. A gated resource's `updated` notification
-  carries its URI, so broadcasting it would disclose the existence and URI of a
-  resource the caller cannot read — undoing the property that hides gated items
-  from list methods and pages the post-gate set. Payload-free `list_changed`
+  Notifications are filtered **per subscriber, at delivery time**. A gated
+  resource's `updated` notification carries its URI, so it reaches only
+  streams whose caller passes the resource's own `WithResourceGate` — the
+  same gate that refuses the read. That does not hide the resource from
+  `resources/list`, whose metadata stays listed by design (the gate guards
+  contents); it keeps update notices from callers who cannot read the
+  result. Tools, prompts and resource templates are the other shape: those
+  gates hide the item from its list method and page the post-gate set, and
+  the `list_changed` a gated tool or resource template registration fires
+  is withheld from callers the gate refuses. Payload-free `list_changed`
   still requires passing the server-wide gate, because a caller refused
-  wholesale should not learn that something changed. Delivery-time evaluation
-  means a session revoked mid-stream stops receiving immediately, and app gate
-  code never runs on the publisher's goroutine.
+  wholesale should not learn that something changed. Delivery-time
+  evaluation means a session revoked mid-stream stops receiving
+  immediately, and app gate code never runs on the publisher's goroutine.
 
   A subscriber that falls behind is dropped and its stream closed rather than
   blocking the publisher: `list_changed` is idempotent, so a reconnecting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,36 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Added
 
+- **MCP server-initiated notifications** (#287): `notifications/tools/
+  list_changed`, `notifications/resources/list_changed`,
+  `notifications/prompts/list_changed` and `notifications/resources/updated`,
+  plus `resources/subscribe` / `resources/unsubscribe`. `initialize` now
+  advertises `listChanged` and `subscribe` truthfully; both were hardcoded
+  `false`. The SSE GET stream previously wrote one static `endpoint` event and
+  returned, so there was no subscriber machinery at all — it now holds the
+  connection and streams.
+
+  Notifications are filtered **per subscriber, at delivery time**, through the
+  same gates the list methods use. A gated resource's `updated` notification
+  carries its URI, so broadcasting it would disclose the existence and URI of a
+  resource the caller cannot read — undoing the property that hides gated items
+  from list methods and pages the post-gate set. Payload-free `list_changed`
+  still requires passing the server-wide gate, because a caller refused
+  wholesale should not learn that something changed. Delivery-time evaluation
+  means a session revoked mid-stream stops receiving immediately, and app gate
+  code never runs on the publisher's goroutine.
+
+  A subscriber that falls behind is dropped and its stream closed rather than
+  blocking the publisher: `list_changed` is idempotent, so a reconnecting
+  client re-lists and is correct again, whereas a blocked publisher would stall
+  every other subscriber and the code that raised the notification.
+
+  Two limits documented rather than solved: subscriptions are refcounted per
+  URI rather than per stream, because this transport has no session id linking
+  a POST to a GET stream (the per-subscriber gates remain the boundary), and a
+  notification raised on one replica does not reach clients connected to
+  another — the same class of limit as the per-process cursor signing key.
+
 - **MCP prompts, pagination and resource templates** (#287): `core/mcp`
   spoke tools and resources only. It now serves `prompts/list` and
   `prompts/get` (registered with `RegisterPrompt` and the same option

--- a/core/mcp/notifications.go
+++ b/core/mcp/notifications.go
@@ -1,0 +1,267 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// sseSubBufferSize is the bounded per-subscriber notification buffer. A
+// subscriber whose stream loop stops draining it for this many
+// notifications is dropped (see notifySubscribers): the publisher is
+// never blocked and the buffer is never grown.
+const sseSubBufferSize = 16
+
+// sseNotification is one server-initiated MCP notification queued for
+// delivery to the SSE subscriber streams.
+type sseNotification struct {
+	// method is the JSON-RPC notification method, e.g.
+	// "notifications/tools/list_changed".
+	method string
+	// params is the optional params object; nil for the list_changed
+	// notifications, which carry no payload.
+	params any
+	// itemGate, when non-nil, is the per-item gate a subscriber's
+	// caller must pass to receive this notification — for
+	// notifications/resources/updated, the resource's own
+	// WithResourceGate. It is evaluated per subscriber, at delivery
+	// time, against the identity the subscriber's GET request
+	// presented. See subscriberMayReceive for why delivery time and
+	// not subscribe time.
+	itemGate func(ctx context.Context) error
+}
+
+// sseSubscriber is one held-open GET stream. The channel is written only
+// by notifySubscribers (under s.sseMu, never blocking) and read only by
+// the stream's own write loop in sseGetHandler.
+type sseSubscriber struct {
+	ch chan sseNotification
+	// ctx carries the caller identity from the subscriber's GET
+	// request: the request context, enriched the same way the POST
+	// path enriches it, with the inbound *http.Request stashed via
+	// WithRequest. Gates are evaluated against it at delivery time.
+	ctx context.Context
+}
+
+// addSSESubscriber registers a stream for notification delivery and
+// returns it. Called from sseGetHandler after the origin/Host gate.
+func (s *Server) addSSESubscriber(ctx context.Context) *sseSubscriber {
+	sub := &sseSubscriber{
+		ch:  make(chan sseNotification, sseSubBufferSize),
+		ctx: ctx,
+	}
+	s.sseMu.Lock()
+	if s.sseSubs == nil {
+		s.sseSubs = make(map[*sseSubscriber]struct{})
+	}
+	s.sseSubs[sub] = struct{}{}
+	s.sseMu.Unlock()
+	return sub
+}
+
+// removeSSESubscriber unregisters a stream. Called from sseGetHandler's
+// exit path (client disconnect or dropped-for-backpressure). It does not
+// close sub.ch: only notifySubscribers closes channels, and only under
+// sseMu, so a fan-out holding the registry can never race a send onto a
+// closed channel. An unregistered, unclosed channel is simply garbage.
+func (s *Server) removeSSESubscriber(sub *sseSubscriber) {
+	s.sseMu.Lock()
+	delete(s.sseSubs, sub)
+	s.sseMu.Unlock()
+}
+
+// notifySubscribers fans a notification out to every live subscriber.
+// It never blocks and never runs a gate: enqueueing is a non-blocking
+// channel send, and the gates run in each subscriber's own write loop
+// (subscriberMayReceive), so a slow or panicking gate can stall only
+// that subscriber's stream, not the publisher and not the other
+// subscribers.
+func (s *Server) notifySubscribers(n sseNotification) {
+	s.sseMu.Lock()
+	defer s.sseMu.Unlock()
+	for sub := range s.sseSubs {
+		select {
+		case sub.ch <- n:
+		default:
+			// Backpressure: this subscriber's buffer is full, which
+			// means its write loop has stopped draining — a stalled or
+			// slow client. Do NOT block (the caller is whatever server
+			// code raised the notification, and blocking it would stall
+			// every other subscriber too) and do NOT grow the buffer:
+			// drop the subscriber and close its stream. list_changed is
+			// idempotent and resources/updated sends the client back to
+			// resources/read for current state, so a client that
+			// reconnects is correct again after re-listing.
+			delete(s.sseSubs, sub)
+			close(sub.ch)
+		}
+	}
+}
+
+// subscriberMayReceive decides whether one stream may see one
+// notification. Both gates are evaluated HERE, in the subscriber's
+// write loop at delivery time, against the identity stored at subscribe
+// time — never once at subscribe time — because a gate can depend on
+// state that changes during a long-lived connection (a session revoked
+// mid-stream must stop receiving).
+//
+// The two gates, in order:
+//
+//   - the server-wide gate (SetGate): a caller refused wholesale learns
+//     nothing, not even that something changed. list_changed carries no
+//     payload, so it is safe to broadcast — but only past this gate.
+//   - the notification's item gate (a resource's WithResourceGate):
+//     notifications/resources/updated carries a URI, so it must reach
+//     only subscribers whose gate would let them read that resource.
+//     Pushing it past a refusing gate would disclose the existence and
+//     URI of a gated resource — the same disclosure the list methods
+//     prevent by hiding gated items and paging the post-gate set.
+func (s *Server) subscriberMayReceive(sub *sseSubscriber, n sseNotification) bool {
+	if !gateAllows(s.checkServerGate, sub.ctx) {
+		return false
+	}
+	if n.itemGate != nil && !gateAllows(n.itemGate, sub.ctx) {
+		return false
+	}
+	return true
+}
+
+// gateAllows runs a gate under a recover guard, failing CLOSED: a
+// panicking gate refuses the notification instead of unwinding the
+// subscriber's stream loop. Same contract as checkPromptGate — a panic
+// in app-supplied gate code must never kill a transport loop.
+func gateAllows(gate func(ctx context.Context) error, ctx context.Context) (ok bool) {
+	defer func() {
+		if recover() != nil {
+			ok = false
+		}
+	}()
+	return gate(ctx) == nil
+}
+
+// jsonrpcNotification is a server-initiated JSON-RPC message: a method
+// with optional params and no id. Notifications never get a response.
+type jsonrpcNotification struct {
+	JSONRPC string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+// resourceUpdatedParams is the params object for
+// notifications/resources/updated: the uri that changed.
+type resourceUpdatedParams struct {
+	URI string `json:"uri"`
+}
+
+// NotifyToolsListChanged raises notifications/tools/list_changed on
+// every eligible subscriber stream: any connected client whose
+// server-wide gate allows it should re-issue tools/list.
+//
+// RegisterTool fires this automatically, so app code needs it only
+// after mutating tool visibility some other way.
+func (s *Server) NotifyToolsListChanged() {
+	s.notifySubscribers(sseNotification{method: "notifications/tools/list_changed"})
+}
+
+// NotifyResourcesListChanged raises notifications/resources/list_changed
+// on every eligible subscriber stream. RegisterResource and
+// RegisterResourceTemplate fire it automatically (the spec folds
+// templates under the one `resources` capability, and has no separate
+// template list_changed).
+func (s *Server) NotifyResourcesListChanged() {
+	s.notifySubscribers(sseNotification{method: "notifications/resources/list_changed"})
+}
+
+// NotifyPromptsListChanged raises notifications/prompts/list_changed on
+// every eligible subscriber stream. RegisterPrompt fires it
+// automatically.
+func (s *Server) NotifyPromptsListChanged() {
+	s.notifySubscribers(sseNotification{method: "notifications/prompts/list_changed"})
+}
+
+// NotifyResourceUpdated raises notifications/resources/updated for uri
+// on the streams whose caller passes the resource's own gate
+// (WithResourceGate) and the server-wide gate, both evaluated at
+// delivery time. A uri with no registered resource carries no item gate
+// and reaches every server-gate-passing subscriber — the spec allows
+// update notices for resources a client subscribed to before they were
+// registered.
+//
+// It is a no-op unless at least one resources/subscribe is active for
+// uri: the spec has servers sending updates only for subscribed
+// resources. Subscribe first (an MCP client does this itself via
+// resources/subscribe).
+func (s *Server) NotifyResourceUpdated(uri string) {
+	s.sseMu.Lock()
+	n := s.resourceSubs[uri]
+	s.sseMu.Unlock()
+	if n == 0 {
+		return
+	}
+	var gate func(ctx context.Context) error
+	s.mu.RLock()
+	if res, ok := s.resources[uri]; ok {
+		gate = res.gate
+	}
+	s.mu.RUnlock()
+	s.notifySubscribers(sseNotification{
+		method:   "notifications/resources/updated",
+		params:   resourceUpdatedParams{URI: uri},
+		itemGate: gate,
+	})
+}
+
+// handleResourcesSubscribe records a resources/subscribe request: from
+// here on, NotifyResourceUpdated(uri) delivers to the eligible streams.
+//
+// Transport limit, on purpose: this HTTP transport has no session id
+// linking a POST to a particular GET stream, so the subscription is
+// connection-agnostic — a per-uri count, not a per-stream set. A uri
+// any client subscribed to gets updates on every eligible stream. The
+// per-subscriber gates remain the security boundary; this is the same
+// class of limit the multi-replica deployment already has (see the
+// notifications section of framework/docs/content/mcp.md). The server
+// may subscribe to a uri before it is registered, per spec.
+func (s *Server) handleResourcesSubscribe(_ context.Context, req Request) Response {
+	if req.Params == nil {
+		return newErrorResponse(req.ID, ErrInvalidParams, "missing params")
+	}
+	var params resourcesReadParams // same {"uri"} shape
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return newErrorResponse(req.ID, ErrInvalidParams, "invalid params: "+err.Error())
+	}
+	if params.URI == "" {
+		return newErrorResponse(req.ID, ErrInvalidParams, "missing resource uri")
+	}
+	s.sseMu.Lock()
+	if s.resourceSubs == nil {
+		s.resourceSubs = make(map[string]int)
+	}
+	s.resourceSubs[params.URI]++
+	s.sseMu.Unlock()
+	return newSuccessResponse(req.ID, map[string]any{})
+}
+
+// handleResourcesUnsubscribe releases one resources/subscribe. The count
+// per uri is decremented; at zero the uri stops receiving updates.
+// Unsubscribing a uri nobody subscribed to is a no-op, not an error, per
+// spec.
+func (s *Server) handleResourcesUnsubscribe(_ context.Context, req Request) Response {
+	if req.Params == nil {
+		return newErrorResponse(req.ID, ErrInvalidParams, "missing params")
+	}
+	var params resourcesReadParams // same {"uri"} shape
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return newErrorResponse(req.ID, ErrInvalidParams, "invalid params: "+err.Error())
+	}
+	if params.URI == "" {
+		return newErrorResponse(req.ID, ErrInvalidParams, "missing resource uri")
+	}
+	s.sseMu.Lock()
+	if n := s.resourceSubs[params.URI]; n <= 1 {
+		delete(s.resourceSubs, params.URI)
+	} else {
+		s.resourceSubs[params.URI] = n - 1
+	}
+	s.sseMu.Unlock()
+	return newSuccessResponse(req.ID, map[string]any{})
+}

--- a/core/mcp/notifications.go
+++ b/core/mcp/notifications.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 )
 
 // sseSubBufferSize is the bounded per-subscriber notification buffer. A
@@ -10,6 +11,23 @@ import (
 // notifications is dropped (see notifySubscribers): the publisher is
 // never blocked and the buffer is never grown.
 const sseSubBufferSize = 16
+
+// maxResourceURIBytes caps the uri one resources/subscribe may pin in
+// the subscription map. The map holds caller-controlled strings, and a
+// POST subscribe is not tied to any GET stream (see
+// handleResourcesSubscribe), so without the cap a caller could pin
+// arbitrarily long uris for the process lifetime. A longer uri is an
+// invalid-params error, never a silent truncation: the uri is a map
+// key, and truncating it would arm updates for a different, wrong uri.
+const maxResourceURIBytes = 2048
+
+// maxResourceSubscriptions caps how many distinct uris the
+// subscription map retains. Refcounts do not count toward it — only
+// distinct entries do — so a second subscriber to an already-subscribed
+// uri always works. Over the cap, resources/subscribe fails rather
+// than growing the map; unsubscribing or the idle expiry
+// (expireResourceSubsIfIdleLocked) frees room.
+const maxResourceSubscriptions = 1024
 
 // sseNotification is one server-initiated MCP notification queued for
 // delivery to the SSE subscriber streams.
@@ -21,12 +39,15 @@ type sseNotification struct {
 	// notifications, which carry no payload.
 	params any
 	// itemGate, when non-nil, is the per-item gate a subscriber's
-	// caller must pass to receive this notification — for
+	// caller must pass to receive this notification. It carries: for
 	// notifications/resources/updated, the resource's own
-	// WithResourceGate. It is evaluated per subscriber, at delivery
-	// time, against the identity the subscriber's GET request
-	// presented. See subscriberMayReceive for why delivery time and
-	// not subscribe time.
+	// WithResourceGate; for the list_changed that RegisterTool and
+	// RegisterResourceTemplate fire, the registered item's gate — a
+	// caller the gate refuses cannot see the item in its list method
+	// and must not be told it appeared. It is evaluated per
+	// subscriber, at delivery time, against the identity the
+	// subscriber's GET request presented. See subscriberMayReceive for
+	// why delivery time and not subscribe time.
 	itemGate func(ctx context.Context) error
 }
 
@@ -59,14 +80,33 @@ func (s *Server) addSSESubscriber(ctx context.Context) *sseSubscriber {
 }
 
 // removeSSESubscriber unregisters a stream. Called from sseGetHandler's
-// exit path (client disconnect or dropped-for-backpressure). It does not
-// close sub.ch: only notifySubscribers closes channels, and only under
-// sseMu, so a fan-out holding the registry can never race a send onto a
-// closed channel. An unregistered, unclosed channel is simply garbage.
+// exit path (client disconnect, blocked write, or dropped-for-
+// backpressure). It does not close sub.ch: only notifySubscribers
+// closes channels, and only under sseMu, so a fan-out holding the
+// registry can never race a send onto a closed channel. An
+// unregistered, unclosed channel is simply garbage. If this was the
+// last stream, the idle expiry drops the retained resource
+// subscriptions (see expireResourceSubsIfIdleLocked).
 func (s *Server) removeSSESubscriber(sub *sseSubscriber) {
 	s.sseMu.Lock()
 	delete(s.sseSubs, sub)
+	s.expireResourceSubsIfIdleLocked()
 	s.sseMu.Unlock()
+}
+
+// expireResourceSubsIfIdleLocked clears the per-uri subscription counts
+// when the subscriber registry has just become empty; the caller holds
+// sseMu. With no stream left there is nobody to deliver an update to,
+// so the retained counts are abandoned state — and because the counts
+// are refcounted per uri across connections (this transport has no
+// session id linking a POST subscribe to a GET stream, so a departing
+// stream cannot attribute its own counts), the only sound lifetime
+// bound is the whole map. A client that reconnects re-subscribes, which
+// is the spec's own recovery after a dropped connection anyway.
+func (s *Server) expireResourceSubsIfIdleLocked() {
+	if len(s.sseSubs) == 0 {
+		clear(s.resourceSubs)
+	}
 }
 
 // notifySubscribers fans a notification out to every live subscriber.
@@ -90,9 +130,12 @@ func (s *Server) notifySubscribers(n sseNotification) {
 			// drop the subscriber and close its stream. list_changed is
 			// idempotent and resources/updated sends the client back to
 			// resources/read for current state, so a client that
-			// reconnects is correct again after re-listing.
+			// reconnects is correct again after re-listing. A dropped
+			// stream is also a departure: if it was the last one, the
+			// idle expiry applies here too.
 			delete(s.sseSubs, sub)
 			close(sub.ch)
+			s.expireResourceSubsIfIdleLocked()
 		}
 	}
 }
@@ -109,12 +152,18 @@ func (s *Server) notifySubscribers(n sseNotification) {
 //   - the server-wide gate (SetGate): a caller refused wholesale learns
 //     nothing, not even that something changed. list_changed carries no
 //     payload, so it is safe to broadcast — but only past this gate.
-//   - the notification's item gate (a resource's WithResourceGate):
-//     notifications/resources/updated carries a URI, so it must reach
-//     only subscribers whose gate would let them read that resource.
-//     Pushing it past a refusing gate would disclose the existence and
-//     URI of a gated resource — the same disclosure the list methods
-//     prevent by hiding gated items and paging the post-gate set.
+//   - the notification's item gate: notifications/resources/updated
+//     carries the resource's own WithResourceGate, and the list_changed
+//     that a gated RegisterTool or RegisterResourceTemplate fires
+//     carries the item's own gate. list_changed is payload-free, so it
+//     names no item — but firing it past a refusing gate would still
+//     tell that caller that something they cannot see just appeared.
+//     An updated notification past a refusing gate would tell a caller
+//     who can never read the contents that they just changed.
+//     (Concrete resources are the deliberate asymmetry: their
+//     metadata stays listed — the gate guards the read and the update
+//     notice, not the listing — while tools, prompts and resource
+//     templates ARE hidden from their list methods.)
 func (s *Server) subscriberMayReceive(sub *sseSubscriber, n sseNotification) bool {
 	if !gateAllows(s.checkServerGate, sub.ctx) {
 		return false
@@ -156,17 +205,22 @@ type resourceUpdatedParams struct {
 // every eligible subscriber stream: any connected client whose
 // server-wide gate allows it should re-issue tools/list.
 //
-// RegisterTool fires this automatically, so app code needs it only
-// after mutating tool visibility some other way.
+// RegisterTool fires the gated internal form automatically — its
+// notification carries the registered tool's own gate, so a caller the
+// gate refuses is not told something appeared. App code needs this
+// exported, gate-less form only after mutating tool visibility some
+// other way, where no item gate can be known.
 func (s *Server) NotifyToolsListChanged() {
 	s.notifySubscribers(sseNotification{method: "notifications/tools/list_changed"})
 }
 
 // NotifyResourcesListChanged raises notifications/resources/list_changed
-// on every eligible subscriber stream. RegisterResource and
-// RegisterResourceTemplate fire it automatically (the spec folds
-// templates under the one `resources` capability, and has no separate
-// template list_changed).
+// on every eligible subscriber stream. RegisterResource fires it
+// directly — a concrete resource's metadata stays listed by design, so
+// there is no item gate to carry — and RegisterResourceTemplate fires
+// the gated internal form, carrying the template's own gate (the spec
+// folds templates under the one `resources` capability, and has no
+// separate template list_changed).
 func (s *Server) NotifyResourcesListChanged() {
 	s.notifySubscribers(sseNotification{method: "notifications/resources/list_changed"})
 }
@@ -216,11 +270,17 @@ func (s *Server) NotifyResourceUpdated(uri string) {
 // Transport limit, on purpose: this HTTP transport has no session id
 // linking a POST to a particular GET stream, so the subscription is
 // connection-agnostic — a per-uri count, not a per-stream set. A uri
-// any client subscribed to gets updates on every eligible stream. The
-// per-subscriber gates remain the security boundary; this is the same
-// class of limit the multi-replica deployment already has (see the
-// notifications section of framework/docs/content/mcp.md). The server
-// may subscribe to a uri before it is registered, per spec.
+// any client subscribed to gets updates on every eligible stream. DO
+// NOT "fix" this into per-stream bookkeeping: the POST that subscribes
+// and the GET stream that receives are separate connections, so tying
+// the count to either would break delivery to the other. The
+// per-subscriber gates remain the security boundary; the retained
+// state is bounded (maxResourceURIBytes, maxResourceSubscriptions) and
+// expired when the last stream disconnects
+// (expireResourceSubsIfIdleLocked). This is the same class of limit
+// the multi-replica deployment already has (see the notifications
+// section of framework/docs/content/mcp.md). The server may subscribe
+// to a uri before it is registered, per spec.
 func (s *Server) handleResourcesSubscribe(_ context.Context, req Request) Response {
 	if req.Params == nil {
 		return newErrorResponse(req.ID, ErrInvalidParams, "missing params")
@@ -232,9 +292,21 @@ func (s *Server) handleResourcesSubscribe(_ context.Context, req Request) Respon
 	if params.URI == "" {
 		return newErrorResponse(req.ID, ErrInvalidParams, "missing resource uri")
 	}
+	if len(params.URI) > maxResourceURIBytes {
+		return newErrorResponse(req.ID, ErrInvalidParams,
+			fmt.Sprintf("resource uri exceeds %d bytes", maxResourceURIBytes))
+	}
 	s.sseMu.Lock()
 	if s.resourceSubs == nil {
 		s.resourceSubs = make(map[string]int)
+	}
+	// The cap counts distinct uris, not refcounts: a further subscriber
+	// to an already-subscribed uri must keep working at the cap — only
+	// growth of the map is bounded.
+	if _, exists := s.resourceSubs[params.URI]; !exists && len(s.resourceSubs) >= maxResourceSubscriptions {
+		s.sseMu.Unlock()
+		return newErrorResponse(req.ID, ErrInvalidParams,
+			fmt.Sprintf("too many distinct subscribed resource uris (max %d)", maxResourceSubscriptions))
 	}
 	s.resourceSubs[params.URI]++
 	s.sseMu.Unlock()

--- a/core/mcp/notifications_test.go
+++ b/core/mcp/notifications_test.go
@@ -1,0 +1,513 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// streamSSEEvents parses an SSE response body as it arrives and yields
+// dispatched events on the returned channel (the streaming counterpart
+// of parseSSEEvents). The channel closes when the body does.
+func streamSSEEvents(t *testing.T, body io.Reader) <-chan sseEvent {
+	t.Helper()
+	out := make(chan sseEvent, 8)
+	go func() {
+		defer close(out)
+		br := bufio.NewReader(body)
+		var ev sseEvent
+		var data []string
+		dispatch := func() {
+			if ev.event != "" || len(data) > 0 {
+				out <- sseEvent{event: ev.event, data: strings.Join(data, "\n")}
+			}
+			ev, data = sseEvent{}, nil
+		}
+		for {
+			line, err := br.ReadString('\n')
+			trimmed := strings.TrimRight(line, "\r\n")
+			switch {
+			case trimmed == "":
+				dispatch()
+			case strings.HasPrefix(trimmed, "event:"):
+				ev.event = strings.TrimSpace(strings.TrimPrefix(trimmed, "event:"))
+			case strings.HasPrefix(trimmed, "data:"):
+				data = append(data, strings.TrimPrefix(strings.TrimPrefix(trimmed, "data:"), " "))
+			}
+			if err != nil {
+				dispatch()
+				return
+			}
+		}
+	}()
+	return out
+}
+
+// awaitSSE waits for the next dispatched event, failing the test on
+// stream close or timeout.
+func awaitSSE(t *testing.T, events <-chan sseEvent, what string) sseEvent {
+	t.Helper()
+	select {
+	case ev, ok := <-events:
+		if !ok {
+			t.Fatalf("stream closed while waiting for %s", what)
+		}
+		return ev
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for %s", what)
+		return sseEvent{}
+	}
+}
+
+// expectNoSSE asserts that nothing arrives on the stream within the
+// window. The window only guards against a would-be delivery racing the
+// assertion; the property itself (nothing was ever written) is
+// deterministic.
+func expectNoSSE(t *testing.T, events <-chan sseEvent, what string) {
+	t.Helper()
+	select {
+	case ev, ok := <-events:
+		if ok {
+			t.Errorf("SECURITY: [disclosure] unexpected %s: %+v", what, ev)
+		}
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+// openStream opens one GET notification stream against ts and returns
+// its event channel after swallowing the initial endpoint event. When
+// auth is set the request carries an Authorization header, which the
+// wrapped test server resolves into the principal the gates check.
+func openStream(t *testing.T, ts *httptest.Server, auth bool) <-chan sseEvent {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/mcp", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	if auth {
+		req.Header.Set("Authorization", "Bearer t")
+	}
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		t.Fatalf("GET stream status = %d", resp.StatusCode)
+	}
+	// Cleanup order matters: t.Cleanup runs LIFO, so the body closes
+	// before the test server does (registered first by the caller) —
+	// ts.Close would otherwise wait forever on the held connection.
+	t.Cleanup(func() { resp.Body.Close() })
+	events := streamSSEEvents(t, resp.Body)
+	ev := awaitSSE(t, events, "initial endpoint event")
+	if ev.event != "endpoint" {
+		t.Errorf("first event = %q, want endpoint", ev.event)
+	}
+	return events
+}
+
+// postMCP sends one JSON-RPC POST and decodes the response. auth sets
+// the Authorization header the wrapped test server resolves.
+func postMCP(t *testing.T, ts *httptest.Server, auth bool, body string) Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/mcp", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if auth {
+		req.Header.Set("Authorization", "Bearer t")
+	}
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var out Response
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decoding POST response: %v", err)
+	}
+	return out
+}
+
+// decodeNotification unpacks a message event into its JSON-RPC method
+// and, when present, its params uri.
+func decodeNotification(t *testing.T, ev sseEvent) (method, uri string) {
+	t.Helper()
+	if ev.event != "message" {
+		t.Fatalf("event name = %q, want message", ev.event)
+	}
+	var msg struct {
+		Method string `json:"method"`
+		Params struct {
+			URI string `json:"uri"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal([]byte(ev.data), &msg); err != nil {
+		t.Fatalf("data is not a JSON-RPC notification: %v (%q)", err, ev.data)
+	}
+	return msg.Method, msg.Params.URI
+}
+
+// sseRegistryCount snapshots the live subscriber count.
+func sseRegistryCount(s *Server) int {
+	s.sseMu.Lock()
+	defer s.sseMu.Unlock()
+	return len(s.sseSubs)
+}
+
+// waitForSubscribers polls until the registry holds want streams.
+func waitForSubscribers(t *testing.T, s *Server, want int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if sseRegistryCount(s) == want {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("subscriber count never reached %d", want)
+}
+
+// newNotificationServer wraps an MCP SSE handler in the middleware a
+// real app has: an Authorization header resolves into the caller
+// identity the gates evaluate. Streams and POSTs sent without the
+// header stay anonymous.
+func newNotificationServer(t *testing.T, s *Server) *httptest.Server {
+	t.Helper()
+	h := s.ServeSSE("/mcp")
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			r = r.WithContext(authed(r.Context()))
+		}
+		h.ServeHTTP(w, r)
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// A registration after a stream connected must reach it as a
+// list_changed notification, for every registry that fires one.
+func TestRegisterFiresListChangedOnStream(t *testing.T) {
+	s := NewServer()
+	ts := newNotificationServer(t, s)
+	events := openStream(t, ts, false)
+	waitForSubscribers(t, s, 1)
+
+	steps := []struct {
+		name     string
+		register func()
+		method   string
+	}{
+		{
+			name:     "tool",
+			register: func() { mustRegisterOpen(t, s, "late_tool") },
+			method:   "notifications/tools/list_changed",
+		},
+		{
+			name: "resource",
+			register: func() {
+				if err := s.RegisterResource("docs://late", "Late", "text/plain",
+					func(context.Context) (ResourceContents, error) {
+						return ResourceContents{Text: "x"}, nil
+					}); err != nil {
+					t.Errorf("register resource: %v", err)
+				}
+			},
+			method: "notifications/resources/list_changed",
+		},
+		{
+			name: "prompt",
+			register: func() {
+				if err := s.RegisterPrompt("late_prompt",
+					func(context.Context, map[string]string) ([]PromptMessage, error) {
+						return nil, nil
+					}); err != nil {
+					t.Errorf("register prompt: %v", err)
+				}
+			},
+			method: "notifications/prompts/list_changed",
+		},
+		{
+			// The spec folds templates under the `resources`
+			// capability: a template registration fires the resources
+			// list_changed, the only one that exists for that surface.
+			name: "template",
+			register: func() {
+				if err := s.RegisterResourceTemplate("docs://late/{id}", "Late", "text/plain"); err != nil {
+					t.Errorf("register template: %v", err)
+				}
+			},
+			method: "notifications/resources/list_changed",
+		},
+	}
+	for _, step := range steps {
+		step.register()
+		method, uri := decodeNotification(t, awaitSSE(t, events, step.name+" list_changed"))
+		if method != step.method {
+			t.Errorf("%s registration fired %q, want %q", step.name, method, step.method)
+		}
+		if uri != "" {
+			t.Errorf("%s list_changed carried a uri payload (%q); list_changed is payload-free", step.name, uri)
+		}
+	}
+}
+
+// THE headline property. notifications/resources/updated carries a
+// gated resource's URI: it must reach only the streams whose gate
+// would let them read the resource. Broadcasting it would disclose the
+// existence and URI of a gated resource — the same disclosure the list
+// methods prevent by hiding gated items and paging the post-gate set.
+func TestGatedResourceUpdatedRespectsGate(t *testing.T) {
+	s := NewServer()
+	if err := s.RegisterResource("secret://books", "Books", "text/csv",
+		func(context.Context) (ResourceContents, error) {
+			return ResourceContents{Text: "id,amount\n1,49.00"}, nil
+		},
+		WithResourceGate(requireUser)); err != nil {
+		t.Fatal(err)
+	}
+	ts := newNotificationServer(t, s)
+
+	authedEvents := openStream(t, ts, true)
+	anonEvents := openStream(t, ts, false)
+	waitForSubscribers(t, s, 2)
+
+	// Arm updates for the uri as the caller allowed to read it.
+	if resp := postMCP(t, ts, true, `{"jsonrpc":"2.0","id":1,"method":"resources/subscribe","params":{"uri":"secret://books"}}`); resp.Error != nil {
+		t.Fatalf("resources/subscribe errored: %v", resp.Error)
+	}
+
+	s.NotifyResourceUpdated("secret://books")
+
+	method, uri := decodeNotification(t, awaitSSE(t, authedEvents, "gated update on the allowed stream"))
+	if method != "notifications/resources/updated" {
+		t.Errorf("allowed stream got %q, want notifications/resources/updated", method)
+	}
+	if uri != "secret://books" {
+		t.Errorf("updated uri = %q, want secret://books", uri)
+	}
+
+	expectNoSSE(t, anonEvents, "gated resource update on a gate-refusing stream")
+}
+
+// A caller the server-wide gate refuses learns nothing at all — not
+// even a payload-free list_changed, which is otherwise safe to
+// broadcast. The stream may exist; it must stay silent.
+func TestServerGateRefusedGetsNoNotifications(t *testing.T) {
+	s := NewServer()
+	s.SetGate(requireUser)
+	ts := newNotificationServer(t, s)
+	events := openStream(t, ts, false) // anonymous: the gate refuses it
+	waitForSubscribers(t, s, 1)
+
+	mustRegisterOpen(t, s, "public_tool") // fires NotifyToolsListChanged
+	s.NotifyToolsListChanged()            // and again, explicitly
+
+	expectNoSSE(t, events, "any notification for a server-gate-refused caller")
+}
+
+// A subscriber whose buffer stays full is dropped and its stream
+// closed; the publisher never blocks and every other subscriber still
+// receives everything.
+func TestStalledSubscriberDroppedNotBlocking(t *testing.T) {
+	s := NewServer()
+	stalled := s.addSSESubscriber(context.Background()) // never drained
+	live := s.addSSESubscriber(context.Background())
+
+	const sends = sseSubBufferSize + 5
+	received := 0
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range sends {
+			s.NotifyToolsListChanged()
+			// Keep live's buffer drained non-blockingly so only the
+			// genuinely stalled subscriber can hit the full-buffer
+			// branch, deterministically.
+			for {
+				select {
+				case <-live.ch:
+					received++
+					continue
+				default:
+				}
+				break
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("SECURITY: [liveness] publisher blocked on a stalled subscriber")
+	}
+	// The drop closes the channel with the sseSubBufferSize
+	// notifications already buffered: drain exactly those, then the
+	// channel must read closed. A still-open (or still-delivering)
+	// channel means no drop happened.
+	for range sseSubBufferSize {
+		select {
+		case _, ok := <-stalled.ch:
+			if !ok {
+				t.Fatal("stalled channel closed before draining its buffer")
+			}
+		default:
+			t.Fatal("stalled channel drained early; expected the full buffer")
+		}
+	}
+	select {
+	case _, ok := <-stalled.ch:
+		if ok {
+			t.Error("stalled subscriber kept receiving after the drop")
+		}
+	default:
+		t.Error("stalled subscriber's stream was not closed")
+	}
+	// Drain the remainder and count: live got every notification.
+	for {
+		select {
+		case <-live.ch:
+			received++
+			continue
+		default:
+		}
+		break
+	}
+	if received != sends {
+		t.Errorf("live subscriber received %d of %d notifications", received, sends)
+	}
+}
+
+// The client going away unregisters its stream: no map entry, no
+// leaked goroutine blocked on a dead connection.
+func TestDisconnectUnregistersSubscriber(t *testing.T) {
+	s := NewServer()
+	ts := newNotificationServer(t, s)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/mcp", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForSubscribers(t, s, 1)
+
+	resp.Body.Close() // the client goes away
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if sseRegistryCount(s) == 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Errorf("subscriber registry not empty after disconnect: %d entries (map/goroutine leak)", sseRegistryCount(s))
+}
+
+// resources/subscribe and resources/unsubscribe are data methods: the
+// server-wide gate must cover them like every other one, or a caller
+// refused wholesale could still arm update notifications.
+func TestServerGateClosesResourceSubscribe(t *testing.T) {
+	s := NewServer()
+	s.SetGate(requireUser)
+
+	resp := s.HandleRequest(context.Background(), Request{
+		JSONRPC: "2.0", ID: 1, Method: "resources/subscribe",
+		Params: json.RawMessage(`{"uri":"x://y"}`),
+	})
+	if resp.Error == nil {
+		t.Error("SECURITY: [authz] server gate did not cover resources/subscribe")
+	}
+	resp = s.HandleRequest(context.Background(), Request{
+		JSONRPC: "2.0", ID: 2, Method: "resources/unsubscribe",
+		Params: json.RawMessage(`{"uri":"x://y"}`),
+	})
+	if resp.Error == nil {
+		t.Error("SECURITY: [authz] server gate did not cover resources/unsubscribe")
+	}
+
+	// The caller the gate allows gets through, and a params-less
+	// subscribe is an invalid-params error, not a panic or a success.
+	resp = s.HandleRequest(authed(context.Background()), Request{
+		JSONRPC: "2.0", ID: 3, Method: "resources/subscribe",
+		Params: json.RawMessage(`{"uri":"x://y"}`),
+	})
+	if resp.Error != nil {
+		t.Errorf("authenticated resources/subscribe refused: %v", resp.Error)
+	}
+	resp = s.HandleRequest(authed(context.Background()), Request{
+		JSONRPC: "2.0", ID: 4, Method: "resources/subscribe",
+	})
+	if resp.Error == nil {
+		t.Error("params-less resources/subscribe succeeded; want invalid params")
+	}
+}
+
+// NotifyResourceUpdated is a no-op until a resources/subscribe is
+// active for the uri, and unsubscribe ends delivery: the spec has
+// servers sending updates only for subscribed resources.
+func TestUpdatedRequiresActiveSubscription(t *testing.T) {
+	s := NewServer()
+	ts := newNotificationServer(t, s)
+	events := openStream(t, ts, false)
+	waitForSubscribers(t, s, 1)
+
+	s.NotifyResourceUpdated("docs://x")
+	expectNoSSE(t, events, "update for a uri nobody subscribed to")
+
+	if resp := postMCP(t, ts, false, `{"jsonrpc":"2.0","id":1,"method":"resources/subscribe","params":{"uri":"docs://x"}}`); resp.Error != nil {
+		t.Fatalf("resources/subscribe errored: %v", resp.Error)
+	}
+	s.NotifyResourceUpdated("docs://x")
+	method, uri := decodeNotification(t, awaitSSE(t, events, "update after subscribe"))
+	if method != "notifications/resources/updated" || uri != "docs://x" {
+		t.Errorf("got %q uri %q, want notifications/resources/updated uri docs://x", method, uri)
+	}
+
+	if resp := postMCP(t, ts, false, `{"jsonrpc":"2.0","id":2,"method":"resources/unsubscribe","params":{"uri":"docs://x"}}`); resp.Error != nil {
+		t.Fatalf("resources/unsubscribe errored: %v", resp.Error)
+	}
+	s.NotifyResourceUpdated("docs://x")
+	expectNoSSE(t, events, "update after unsubscribe")
+}
+
+// The handshake must advertise what the server now does: listChanged
+// on every list capability and subscribe on resources.
+func TestInitializeAdvertisesNotifications(t *testing.T) {
+	s := NewServer()
+	if err := s.RegisterResource("x://y", "Y", "text/plain",
+		func(context.Context) (ResourceContents, error) {
+			return ResourceContents{Text: "x"}, nil
+		}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterPrompt("p",
+		func(context.Context, map[string]string) ([]PromptMessage, error) {
+			return nil, nil
+		}); err != nil {
+		t.Fatal(err)
+	}
+	resp := s.HandleRequest(context.Background(), Request{JSONRPC: "2.0", ID: 1, Method: "initialize"})
+	if resp.Error != nil {
+		t.Fatalf("initialize errored: %v", resp.Error)
+	}
+	blob, _ := json.Marshal(resp.Result)
+	for _, want := range []string{`"listChanged":true`, `"subscribe":true`} {
+		if !strings.Contains(string(blob), want) {
+			t.Errorf("capabilities missing %s: %s", want, blob)
+		}
+	}
+	if strings.Contains(string(blob), "false") {
+		t.Errorf("capabilities still advertise a false capability: %s", blob)
+	}
+}

--- a/core/mcp/notifications_test.go
+++ b/core/mcp/notifications_test.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -510,4 +512,227 @@ func TestInitializeAdvertisesNotifications(t *testing.T) {
 	if strings.Contains(string(blob), "false") {
 		t.Errorf("capabilities still advertise a false capability: %s", blob)
 	}
+}
+
+// resourceSubsSnapshot copies the per-uri subscription counts for
+// assertions.
+func resourceSubsSnapshot(s *Server) map[string]int {
+	s.sseMu.Lock()
+	defer s.sseMu.Unlock()
+	out := make(map[string]int, len(s.resourceSubs))
+	for uri, n := range s.resourceSubs {
+		out[uri] = n
+	}
+	return out
+}
+
+// resources/subscribe pins caller-controlled strings in server state.
+// The uri cap keeps that bounded; oversize is invalid params, never a
+// truncation (the uri is a map key — truncating it would arm updates
+// for the wrong uri).
+func TestSubscribeRejectsOversizedURI(t *testing.T) {
+	s := NewServer()
+	oversize := "x://" + strings.Repeat("a", maxResourceURIBytes)
+	resp := s.HandleRequest(context.Background(), Request{
+		JSONRPC: "2.0", ID: 1, Method: "resources/subscribe",
+		Params: json.RawMessage(`{"uri":"` + oversize + `"}`),
+	})
+	if resp.Error == nil {
+		t.Error("SECURITY: [resource-exhaustion] oversize uri accepted; want invalid params")
+	}
+	if got := resourceSubsSnapshot(s); len(got) != 0 {
+		t.Errorf("oversize uri pinned state: %v", got)
+	}
+	// The boundary is inclusive: a uri of exactly maxResourceURIBytes
+	// bytes passes.
+	atCap := "x://" + strings.Repeat("b", maxResourceURIBytes-4)
+	resp = s.HandleRequest(context.Background(), Request{
+		JSONRPC: "2.0", ID: 2, Method: "resources/subscribe",
+		Params: json.RawMessage(`{"uri":"` + atCap + `"}`),
+	})
+	if resp.Error != nil {
+		t.Errorf("uri at the cap refused: %v", resp.Error)
+	}
+}
+
+// The distinct-uri cap bounds the retained subscription map. Refcounts
+// do not count toward it: re-subscribing an existing uri must keep
+// working at the cap, a refused subscribe pins nothing, and
+// unsubscribing a uri to zero frees a slot.
+func TestSubscribeCapsDistinctURIs(t *testing.T) {
+	s := NewServer()
+	for i := range maxResourceSubscriptions {
+		resp := s.HandleRequest(context.Background(), Request{
+			JSONRPC: "2.0", ID: i, Method: "resources/subscribe",
+			Params: json.RawMessage(fmt.Sprintf(`{"uri":"x://%d"}`, i)),
+		})
+		if resp.Error != nil {
+			t.Fatalf("subscribe %d under the cap failed: %v", i, resp.Error)
+		}
+	}
+	subscribe := func(uri string, id int) Response {
+		return s.HandleRequest(context.Background(), Request{
+			JSONRPC: "2.0", ID: id, Method: "resources/subscribe",
+			Params: json.RawMessage(`{"uri":"` + uri + `"}`),
+		})
+	}
+	if resp := subscribe("x://0", maxResourceSubscriptions+1); resp.Error != nil {
+		t.Errorf("re-subscribe to an existing uri refused at the cap: %v", resp.Error)
+	}
+	if resp := subscribe("x://extra", maxResourceSubscriptions+2); resp.Error == nil {
+		t.Error("SECURITY: [resource-exhaustion] distinct-uri cap not enforced")
+	}
+	if _, ok := resourceSubsSnapshot(s)["x://extra"]; ok {
+		t.Error("refused subscribe pinned state anyway")
+	}
+	// x://0 holds two counts (initial + re-subscribe): release both to
+	// free the entry.
+	for id := range 2 {
+		if resp := s.HandleRequest(context.Background(), Request{
+			JSONRPC: "2.0", ID: maxResourceSubscriptions + 10 + id, Method: "resources/unsubscribe",
+			Params: json.RawMessage(`{"uri":"x://0"}`),
+		}); resp.Error != nil {
+			t.Fatalf("unsubscribe errored: %v", resp.Error)
+		}
+	}
+	if resp := subscribe("x://freed", maxResourceSubscriptions+20); resp.Error != nil {
+		t.Errorf("subscribe after unsubscribe refused (slot not freed): %v", resp.Error)
+	}
+}
+
+// The last stream's disconnect drops the retained resource
+// subscriptions: with no stream there is nobody to deliver to, and the
+// per-uri refcount cannot be attributed to the departing connection
+// (this transport has no session correlation), so the whole map goes.
+func TestLastDisconnectClearsResourceSubscriptions(t *testing.T) {
+	s := NewServer()
+	ts := newNotificationServer(t, s)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/mcp", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForSubscribers(t, s, 1)
+
+	for _, uri := range []string{"docs://a", "docs://b"} {
+		if r := postMCP(t, ts, false, `{"jsonrpc":"2.0","id":1,"method":"resources/subscribe","params":{"uri":"`+uri+`"}}`); r.Error != nil {
+			t.Fatalf("resources/subscribe %s errored: %v", uri, r.Error)
+		}
+	}
+	if got := resourceSubsSnapshot(s); len(got) != 2 {
+		t.Fatalf("subscriptions not armed: %v", got)
+	}
+
+	resp.Body.Close() // the last (only) stream goes away
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if sseRegistryCount(s) == 0 {
+			if got := resourceSubsSnapshot(s); len(got) != 0 {
+				t.Errorf("subscriptions survived the last disconnect: %v (unbounded retained state)", got)
+			}
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("subscriber registry never emptied after disconnect")
+}
+
+// blockingWriter simulates a client that stopped reading: the writes
+// of a message event block until the handler has armed a write
+// deadline, then fail as if the deadline had expired. Handshake writes
+// flow so the subscriber registers first, which is what makes the
+// unregistration assertion meaningful. If the handler never arms a
+// deadline, the blocked write never returns and the test's watchdog
+// fires — that hang is the regression the deadline fixes.
+type blockingWriter struct {
+	unblock chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingWriter) Header() http.Header { return http.Header{} }
+func (b *blockingWriter) WriteHeader(int)     {}
+
+func (b *blockingWriter) Write(p []byte) (int, error) {
+	if !strings.Contains(string(p), "event: message") {
+		return len(p), nil // handshake and framing writes flow
+	}
+	<-b.unblock
+	return 0, fmt.Errorf("write: i/o timeout")
+}
+
+func (b *blockingWriter) Flush() {}
+
+func (b *blockingWriter) SetWriteDeadline(deadline time.Time) error {
+	// Not the real 10s: the test proves the mechanism (deadline armed →
+	// blocked write released → write fails → handler returns and
+	// unregisters), not the duration. Release shortly after the arm.
+	b.once.Do(func() {
+		time.AfterFunc(50*time.Millisecond, func() { close(b.unblock) })
+	})
+	return nil
+}
+
+// A client that stops reading pins nothing: each write on the SSE
+// notification stream carries a fresh deadline, so the handler returns
+// instead of hanging on the blocked write, and its exit path
+// unregisters the subscriber.
+func TestBlockedWriteDeadlineReturnsAndUnregisters(t *testing.T) {
+	s := NewServer()
+	w := &blockingWriter{unblock: make(chan struct{})}
+	r := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	r.Header.Set("Accept", "text/event-stream")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.sseGetHandler(w, r)
+	}()
+
+	waitForSubscribers(t, s, 1)
+	s.NotifyToolsListChanged() // a message event: its write blocks
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("SECURITY: [liveness] handler hung on a write the client never reads")
+	}
+	if sseRegistryCount(s) != 0 {
+		t.Errorf("subscriber still registered after the failed write: %d live", sseRegistryCount(s))
+	}
+}
+
+// The list_changed a gated registration fires carries the item's own
+// gate: a caller the gate refuses cannot see the item in its list
+// method and must not be told it appeared. Concrete resources are the
+// documented exception — their metadata stays listed; their gate
+// guards the read, so RegisterResource is not covered here.
+func TestGatedRegistrationWithholdsListChanged(t *testing.T) {
+	s := NewServer()
+	ts := newNotificationServer(t, s)
+	authedEvents := openStream(t, ts, true)
+	anonEvents := openStream(t, ts, false)
+	waitForSubscribers(t, s, 2)
+
+	mustRegisterGated(t, s, "hidden_tool", requireUser)
+	method, uri := decodeNotification(t, awaitSSE(t, authedEvents, "tools list_changed on the allowed stream"))
+	if method != "notifications/tools/list_changed" || uri != "" {
+		t.Errorf("allowed stream got %q (uri %q), want payload-free tools list_changed", method, uri)
+	}
+	expectNoSSE(t, anonEvents, "tools list_changed for a caller the tool gate refuses")
+
+	if err := s.RegisterResourceTemplate("hidden://tpl/{id}", "Hidden", "text/plain",
+		WithResourceTemplateGate(requireUser)); err != nil {
+		t.Fatal(err)
+	}
+	method, uri = decodeNotification(t, awaitSSE(t, authedEvents, "resources list_changed on the allowed stream"))
+	if method != "notifications/resources/list_changed" || uri != "" {
+		t.Errorf("allowed stream got %q (uri %q), want payload-free resources list_changed", method, uri)
+	}
+	expectNoSSE(t, anonEvents, "resources list_changed for a caller the template gate refuses")
 }

--- a/core/mcp/origin_security_test.go
+++ b/core/mcp/origin_security_test.go
@@ -93,10 +93,9 @@ func TestMCPHostPinRejectsRebind(t *testing.T) {
 // transport applies the same origin/Host gate its POST sibling does.
 //
 // sseGetHandler discarded the request entirely (`_ *http.Request`), so
-// it never ran originOK. Nothing is disclosed by the static endpoint
-// event it currently writes, which is why this is low, but it is a
-// guard hole in the pair, and the moment that handler starts streaming
-// anything session-derived it becomes a cross-origin read.
+// it never ran originOK. The handler now holds the connection and
+// streams session-derived notifications, so the gate is load-bearing:
+// without it the stream is a cross-origin read.
 func TestSSEGetHandlerEnforcesOrigin(t *testing.T) {
 	get := func(origin, host string) *httptest.ResponseRecorder {
 		s := NewServer()
@@ -106,9 +105,10 @@ func TestSSEGetHandlerEnforcesOrigin(t *testing.T) {
 			r.Header.Set("Origin", origin)
 		}
 		r.Host = host
-		w := httptest.NewRecorder()
-		h.ServeHTTP(w, r)
-		return w
+		// The handler now HOLDS the connection (it streams
+		// notifications), so run it the held way: goroutine +
+		// cancellable context, joined before the recorder is read.
+		return serveHeldSSEGet(t, s, h, r)
 	}
 
 	if got := get("https://evil.example", "app.example.com").Code; got != 403 {

--- a/core/mcp/prompts.go
+++ b/core/mcp/prompts.go
@@ -101,14 +101,19 @@ func (s *Server) RegisterPrompt(name string, handler PromptHandler, opts ...Prom
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.prompts == nil {
 		s.prompts = make(map[string]Prompt)
 	}
 	if _, exists := s.prompts[name]; exists {
+		s.mu.Unlock()
 		return fmt.Errorf("mcp: prompt %q already registered", name)
 	}
 	s.prompts[name] = p
+	s.mu.Unlock()
+
+	// Connected clients re-list. Before serving has begun this fans out
+	// to zero subscribers, so boot-time registration notifies nobody.
+	s.NotifyPromptsListChanged()
 	return nil
 }
 

--- a/core/mcp/protocol.go
+++ b/core/mcp/protocol.go
@@ -59,9 +59,14 @@ func (s *Server) HandleRequest(ctx context.Context, req Request) Response {
 
 	switch req.Method {
 	case "tools/list", "tools/call", "resources/list", "resources/read",
-		"resources/templates/list", "prompts/list", "prompts/get":
-		// Server-wide gate over the DATA surface. initialize and ping fall
-		// through uncovered on purpose. See Server.serverGate.
+		"resources/templates/list", "resources/subscribe",
+		"resources/unsubscribe", "prompts/list", "prompts/get":
+		// Server-wide gate over the DATA surface. resources/subscribe
+		// and resources/unsubscribe sit here too: they are the doorway
+		// to notifications/resources/updated, itself gated per
+		// subscriber, and a caller refused wholesale must not be able
+		// to arm updates either. initialize and ping fall through
+		// uncovered on purpose. See Server.serverGate.
 		if err := s.checkServerGate(ctx); err != nil {
 			return newErrorResponse(req.ID, ErrInvalidParams, err.Error())
 		}
@@ -76,6 +81,10 @@ func (s *Server) HandleRequest(ctx context.Context, req Request) Response {
 		return s.handleResourcesList(ctx, req)
 	case "resources/read":
 		return s.handleResourcesRead(ctx, req)
+	case "resources/subscribe":
+		return s.handleResourcesSubscribe(ctx, req)
+	case "resources/unsubscribe":
+		return s.handleResourcesUnsubscribe(ctx, req)
 	case "resources/templates/list":
 		return s.handleResourcesTemplatesList(ctx, req)
 	case "prompts/list":
@@ -133,15 +142,15 @@ func (s *Server) handleInitialize(req Request) Response {
 	name, version := s.name, s.version
 	s.mu.RUnlock()
 	capabilities := map[string]any{
-		"tools": map[string]any{"listChanged": false},
+		"tools": map[string]any{"listChanged": true},
 	}
 	if s.hasResources() || s.hasTemplates() {
 		// The spec has one `resources` capability for both resources and
 		// resource templates; a templates-only server still advertises it.
-		capabilities["resources"] = map[string]any{"listChanged": false, "subscribe": false}
+		capabilities["resources"] = map[string]any{"listChanged": true, "subscribe": true}
 	}
 	if s.hasPrompts() {
-		capabilities["prompts"] = map[string]any{"listChanged": false}
+		capabilities["prompts"] = map[string]any{"listChanged": true}
 	}
 	return newSuccessResponse(req.ID, map[string]any{
 		"protocolVersion": "2025-06-18",

--- a/core/mcp/resource_templates.go
+++ b/core/mcp/resource_templates.go
@@ -77,14 +77,20 @@ func (s *Server) RegisterResourceTemplate(uriTemplate, name, mimeType string, op
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.templates == nil {
 		s.templates = make(map[string]ResourceTemplate)
 	}
 	if _, exists := s.templates[uriTemplate]; exists {
+		s.mu.Unlock()
 		return fmt.Errorf("mcp: resource template %q already registered", uriTemplate)
 	}
 	s.templates[uriTemplate] = tpl
+	s.mu.Unlock()
+
+	// The spec folds templates under the one `resources` capability and
+	// has no separate template list_changed, so a template registration
+	// fires the resources one: connected clients re-list both surfaces.
+	s.NotifyResourcesListChanged()
 	return nil
 }
 

--- a/core/mcp/resource_templates.go
+++ b/core/mcp/resource_templates.go
@@ -90,7 +90,13 @@ func (s *Server) RegisterResourceTemplate(uriTemplate, name, mimeType string, op
 	// The spec folds templates under the one `resources` capability and
 	// has no separate template list_changed, so a template registration
 	// fires the resources one: connected clients re-list both surfaces.
-	s.NotifyResourcesListChanged()
+	// The notification carries the template's own gate: a caller the
+	// gate refuses never sees the template in resources/templates/list,
+	// and must not be told it appeared either.
+	s.notifySubscribers(sseNotification{
+		method:   "notifications/resources/list_changed",
+		itemGate: tpl.gate,
+	})
 	return nil
 }
 

--- a/core/mcp/resources.go
+++ b/core/mcp/resources.go
@@ -95,14 +95,19 @@ func (s *Server) RegisterResource(uri, name, mimeType string, contents ResourceC
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.resources == nil {
 		s.resources = make(map[string]Resource)
 	}
 	if _, exists := s.resources[uri]; exists {
+		s.mu.Unlock()
 		return fmt.Errorf("mcp: resource %q already registered", uri)
 	}
 	s.resources[uri] = res
+	s.mu.Unlock()
+
+	// Connected clients re-list. Before serving has begun this fans out
+	// to zero subscribers, so boot-time registration notifies nobody.
+	s.NotifyResourcesListChanged()
 	return nil
 }
 

--- a/core/mcp/server.go
+++ b/core/mcp/server.go
@@ -152,6 +152,24 @@ type Server struct {
 	// auto-enables the mutating control tools; it is the port-agnostic
 	// form of the allowedHosts pin.
 	requireLoopbackHost bool
+
+	// sseMu guards the server-initiated notification machinery: the
+	// SSE subscriber registry and the resources/subscribe counts. It is
+	// deliberately NOT s.mu — notification fan-out happens on every
+	// registration and update, and must never contend with (or nest
+	// inside) the registry lock. The lock order is one-way: registry
+	// methods take s.mu, release it, then notify with sseMu; nothing
+	// takes sseMu while holding s.mu.
+	sseMu sync.Mutex
+	// sseSubs holds the live GET-stream subscribers
+	// (notifications.go). Initialized in NewServer; addSSESubscriber
+	// also grows it lazily for a zero-value Server.
+	sseSubs map[*sseSubscriber]struct{}
+	// resourceSubs counts active resources/subscribe requests per uri;
+	// NotifyResourceUpdated only fans out while a uri's count is
+	// positive. Connection-agnostic by transport necessity: there is no
+	// session id linking a POST to a GET stream.
+	resourceSubs map[string]int
 }
 
 // NewServer creates a new MCP server with an empty tool registry.
@@ -161,6 +179,8 @@ func NewServer() *Server {
 		name:         "GoFastr MCP",
 		version:      "1.0.0",
 		listPageSize: defaultListPageSize,
+		sseSubs:      make(map[*sseSubscriber]struct{}),
+		resourceSubs: make(map[string]int),
 	}
 }
 
@@ -243,6 +263,11 @@ func (s *Server) RegisterTool(name, description string, inputSchema map[string]a
 	if hook != nil {
 		hook(name)
 	}
+	// Registration after serving has begun tells connected clients to
+	// re-list. "After serving has begun" needs no flag: before any
+	// subscriber exists the fan-out is a no-op, and a subscriber can
+	// only exist once serving has begun.
+	s.NotifyToolsListChanged()
 	return nil
 }
 
@@ -333,8 +358,11 @@ func (s *Server) listToolsUnfiltered() []Tool {
 
 // SetGate installs a server-wide precondition over the JSON-RPC data surface
 // (tools/list, tools/call, resources/list, resources/read,
-// resources/templates/list, prompts/list, prompts/get). Pass nil to clear
-// it. See the serverGate field for why initialize and ping stay open.
+// resources/templates/list, resources/subscribe, resources/unsubscribe,
+// prompts/list, prompts/get). Pass nil to clear it. See the serverGate field
+// for why initialize and ping stay open. The gate also filters
+// server-initiated notifications per subscriber: a caller it refuses
+// receives nothing on the SSE stream, not even a list_changed.
 //
 // Use it when the whole /mcp endpoint is private. For a mixed surface,
 // public read tools and gated mutating ones, attach per-tool gates with

--- a/core/mcp/server.go
+++ b/core/mcp/server.go
@@ -266,8 +266,13 @@ func (s *Server) RegisterTool(name, description string, inputSchema map[string]a
 	// Registration after serving has begun tells connected clients to
 	// re-list. "After serving has begun" needs no flag: before any
 	// subscriber exists the fan-out is a no-op, and a subscriber can
-	// only exist once serving has begun.
-	s.NotifyToolsListChanged()
+	// only exist once serving has begun. The notification carries the
+	// tool's own gate: a caller the gate refuses cannot see the tool in
+	// tools/list, and must not be told it appeared either.
+	s.notifySubscribers(sseNotification{
+		method:   "notifications/tools/list_changed",
+		itemGate: tool.Gate,
+	})
 	return nil
 }
 

--- a/core/mcp/transport.go
+++ b/core/mcp/transport.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -11,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/DonaldMurillo/gofastr/core/handler"
 )
@@ -19,6 +21,14 @@ import (
 // this cap a single unauthenticated POST could read an arbitrary
 // payload into memory.
 const maxMCPBodyBytes = 1 << 20
+
+// sseWriteTimeout bounds each individual write on the held-open SSE
+// notification stream. Servers that serve that stream run
+// http.Server.WriteTimeout zero (a global deadline would kill
+// long-lived streams), so without a per-write deadline a client that
+// stops reading pins the handler goroutine forever: closing sub.ch
+// cannot interrupt an in-flight write. Each write arms a fresh one.
+const sseWriteTimeout = 10 * time.Second
 
 // isMCPJSONContentType allows only "application/json" (with optional
 // parameters) and the +json structured-suffix family. The literal
@@ -359,11 +369,44 @@ func (s *Server) sseGetHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 	w.WriteHeader(http.StatusOK)
 
+	// rc carries per-write deadlines down to the connection; ew
+	// surfaces the first write error, which StreamSSE's io.Writer API
+	// cannot return. writeSSEEvent arms a fresh deadline, writes one
+	// event, flushes, and reports whether the stream is still alive.
+	// On failure the handler returns and the deferred
+	// removeSSESubscriber unregisters this stream, so fan-out stops
+	// targeting it.
+	rc := http.NewResponseController(w)
+	ew := &errWriter{w: w}
+	writeSSEEvent := func(event, data string) bool {
+		if err := rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout)); err != nil {
+			// http.ErrNotSupported means the ResponseWriter chain has
+			// no deadline support (a wrapped writer with no connection
+			// underneath — middleware, tests): that is "no deadline
+			// available", not a dead stream, so the write is still
+			// attempted. Any other error means arming the deadline
+			// itself failed; fail the stream rather than risk an
+			// unbounded write.
+			if !errors.Is(err, http.ErrNotSupported) {
+				return false
+			}
+		}
+		StreamSSE(ew, event, data)
+		if ew.err != nil {
+			return false
+		}
+		if err := rc.Flush(); err != nil && !errors.Is(err, http.ErrNotSupported) {
+			// Flush has the same wrapped-writer escape as the
+			// deadline: a chain without a Flusher was always skipped,
+			// never fatal.
+			return false
+		}
+		return true
+	}
+
 	// Send initial connection event
-	StreamSSE(w, "endpoint", "/sse")
-	f, _ := w.(http.Flusher)
-	if f != nil {
-		f.Flush()
+	if !writeSSEEvent("endpoint", "/sse") {
+		return
 	}
 
 	// Register a subscriber carrying this caller's identity (the
@@ -408,9 +451,13 @@ func (s *Server) sseGetHandler(w http.ResponseWriter, r *http.Request) {
 				// marshalling failure must never kill the stream.
 				continue
 			}
-			StreamSSE(w, "message", string(data))
-			if f != nil {
-				f.Flush()
+			if !writeSSEEvent("message", string(data)) {
+				// The write failed — deadline exceeded on a client
+				// that stopped reading, or the connection is gone.
+				// Return: the deferred removeSSESubscriber unregisters
+				// the stream. Closing the connection is the client's
+				// signal to reconnect and re-list, which restores it.
+				return
 			}
 		}
 	}
@@ -441,6 +488,26 @@ func WithRequest(ctx context.Context, r *http.Request) context.Context {
 func RequestFromContext(ctx context.Context) (*http.Request, bool) {
 	r, ok := ctx.Value(contextKey{}).(*http.Request)
 	return r, ok
+}
+
+// errWriter records the first write error, so the SSE stream loop can
+// detect a failed write through StreamSSE — an io.Writer API that
+// cannot return one itself. Once a write fails, every later write
+// short-circuits to the same error without touching w.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (ew *errWriter) Write(p []byte) (int, error) {
+	if ew.err != nil {
+		return 0, ew.err
+	}
+	n, err := ew.w.Write(p)
+	if err != nil {
+		ew.err = err
+	}
+	return n, err
 }
 
 // StreamSSE writes a single SSE event to the writer. It is the hardened

--- a/core/mcp/transport.go
+++ b/core/mcp/transport.go
@@ -332,7 +332,18 @@ func (s *Server) ssePostHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
-// sseGetHandler sets up an SSE connection for streaming.
+// sseGetHandler sets up an SSE connection for streaming and then HOLDS
+// it: the connection stays open for the life of the client, carrying
+// the server-initiated MCP notifications (notifications/*) fanned out
+// to the per-subscriber registry in notifications.go.
+//
+// Hard rule 3 note: SSE here is the MCP transport's own mandated
+// server-push stream (the GET half of the protocol's HTTP transport),
+// not an app surface and not the app's /__gofastr/sse bus. Rule 3
+// ("SSE is push-only, never for responses to user actions") governs
+// app surfaces; this stream carries only protocol notifications the
+// MCP spec requires the server to be able to push. It is not a
+// precedent for app-surface SSE.
 func (s *Server) sseGetHandler(w http.ResponseWriter, r *http.Request) {
 	// Same gate as ssePostHandler. This handler used to discard the
 	// request entirely, so the origin/Host check simply did not run on
@@ -350,8 +361,58 @@ func (s *Server) sseGetHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Send initial connection event
 	StreamSSE(w, "endpoint", "/sse")
-	if f, ok := w.(http.Flusher); ok {
+	f, _ := w.(http.Flusher)
+	if f != nil {
 		f.Flush()
+	}
+
+	// Register a subscriber carrying this caller's identity (the
+	// request context, enriched like the POST path enriches it, with
+	// the inbound request stashed via WithRequest) so per-subscriber
+	// gates can be evaluated against it at delivery time — a
+	// long-lived stream must reflect gate decisions that change
+	// mid-connection, not a snapshot taken now.
+	ctx := context.WithValue(r.Context(), contextKey{}, r)
+	ctx = enrichContext(ctx)
+	sub := s.addSSESubscriber(ctx)
+	defer s.removeSSESubscriber(sub)
+
+	// Hold the connection until the client goes away. Each notification
+	// is filtered per subscriber (server-wide gate + the item's gate,
+	// both evaluated HERE at send time — see subscriberMayReceive) and
+	// flushed as one SSE event.
+	for {
+		select {
+		case <-r.Context().Done():
+			// Client disconnected. The deferred removeSSESubscriber
+			// unregisters; nothing else is needed.
+			return
+		case n, ok := <-sub.ch:
+			if !ok {
+				// The publisher dropped this subscriber for
+				// backpressure (buffer full: a stalled stream loop).
+				// Returning closes the stream — the client's recovery
+				// is to reconnect and re-list. See notifySubscribers.
+				return
+			}
+			if !s.subscriberMayReceive(sub, n) {
+				continue
+			}
+			data, err := json.Marshal(jsonrpcNotification{
+				JSONRPC: "2.0",
+				Method:  n.method,
+				Params:  n.params,
+			})
+			if err != nil {
+				// params are server-built strings; unreachable, but a
+				// marshalling failure must never kill the stream.
+				continue
+			}
+			StreamSSE(w, "message", string(data))
+			if f != nil {
+				f.Flush()
+			}
+		}
 	}
 }
 

--- a/core/mcp/transport_security_test.go
+++ b/core/mcp/transport_security_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func oversizedMCPRequestBody(t *testing.T) *bytes.Reader {
@@ -129,12 +130,47 @@ func TestServeHTTP_SetsNoStore(t *testing.T) {
 	}
 }
 
+// serveHeldSSEGet invokes the SSE GET handler the way it now runs in
+// production: in a goroutine, holding the connection until the request
+// context is cancelled. It waits until the stream is established
+// (headers and endpoint event written, subscriber registered) or the
+// handler has returned (the refused-before-stream path), then cancels
+// and joins. Reading the returned recorder afterwards is race-free.
+func serveHeldSSEGet(t *testing.T, s *Server, h http.Handler, r *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r = r.WithContext(ctx)
+	w := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.ServeHTTP(w, r)
+	}()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for sseRegistryCount(s) == 0 {
+		select {
+		case <-done:
+			// Refused before the stream was held (the 403 path).
+			return w
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("SSE GET handler neither registered a subscriber nor returned")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	cancel()
+	<-done
+	return w
+}
+
 func TestServeSSEGet_SetsNoStore(t *testing.T) {
 	s := newSecurityTestServer(t)
 	handler := s.ServeSSE("/mcp")
 	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
+	rec := serveHeldSSEGet(t, s, handler, req)
 
 	if rec.Header().Get("Cache-Control") != "no-store" {
 		t.Fatalf("SECURITY: [mcp-http] SSE GET missing Cache-Control: no-store, got %q. Attack: cacheable event-stream bootstrap.", rec.Header().Get("Cache-Control"))

--- a/framework/docs/content/mcp.md
+++ b/framework/docs/content/mcp.md
@@ -382,8 +382,14 @@ A client subscribes by GETting the SSE endpoint and keeping it open; a
 `list_changed` tells it to re-issue the corresponding list method. For
 resource updates it must also send `resources/subscribe` with the `uri` —
 `NotifyResourceUpdated` is a no-op until at least one subscription is
-active, and `resources/unsubscribe` ends delivery. Raising one from
-server code:
+active. Subscriptions are refcounted per `uri`: every
+`resources/subscribe` adds one, every `resources/unsubscribe` releases
+one, and delivery stops only when the count for that `uri` reaches
+zero. A `uri` longer than 2048 bytes is refused, the server retains at
+most 1024 distinct subscribed uris (a `resources/subscribe` past that
+fails), and when the last stream disconnects the retained
+subscriptions are dropped — with no stream there is nobody to deliver
+to. Raising one from server code:
 
 <!-- gofastr:compile
 import (
@@ -397,16 +403,23 @@ var srv *mcp.Server
 srv.NotifyResourceUpdated("docs://api/quickstart")
 ```
 
-Notifications are filtered per subscriber through the same gates as the
-list methods, so a stream can never be the leak the listings closed:
+Notifications are filtered per subscriber, so a stream cannot tell a
+caller anything the matching methods would not:
 
 - Every notification passes the server-wide gate (`SetGate`). A caller
   refused wholesale receives nothing at all — not even a payload-free
   `list_changed`, which is otherwise safe to broadcast.
 - `notifications/resources/updated` additionally passes the resource's
-  own `WithResourceGate`. The notification carries the `uri`, so it
-  reaches only streams whose caller may read that resource; pushing it
-  further would disclose the existence and uri of a gated resource.
+  own `WithResourceGate`, so it reaches only streams whose caller may
+  read that resource's contents. This does not hide the resource from
+  `resources/list` — resource metadata stays listed by design, and the
+  gate refuses the read, not the listing; it keeps the update notice
+  from callers who could never read the result. Tools, prompts and
+  resource templates are the other shape: their gates hide the item
+  from its list method, and the `list_changed` a gated tool or
+  resource template registration fires is likewise withheld from
+  callers its gate refuses, who cannot see the item in that listing
+  either.
 - Both gates are evaluated at delivery time against the identity the
   stream's GET request presented, not once when the stream opened. A
   session revoked mid-stream stops receiving immediately.

--- a/framework/docs/content/mcp.md
+++ b/framework/docs/content/mcp.md
@@ -43,6 +43,8 @@ the MCP server card mirrors it.
 | `resources/list` | One page of registered resources, URI order, metadata only. |
 | `resources/read` | A resource's contents by `uri`. |
 | `resources/templates/list` | One page of the templates the caller may see, uriTemplate order. |
+| `resources/subscribe` | Arms `resources/updated` notifications for a `uri`. Empty result. |
+| `resources/unsubscribe` | Releases one `resources/subscribe`. Empty result. |
 | `prompts/list` | One page of the prompts the caller may see, name order. |
 | `prompts/get` | A prompt's messages by name and string `arguments`. |
 
@@ -54,9 +56,9 @@ are exported: `ErrMethodNotFound` (-32601), `ErrInvalidParams` (-32602),
 `initialize` advertises capabilities from the registries: `tools` always;
 `resources` once any resource or template is registered (one capability covers
 both, so a templates-only server advertises it); `prompts` once any prompt is
-registered. All list capabilities report `listChanged: false` and resources
-reports `subscribe: false`: the server emits no change notifications, so a
-client that wants fresh state re-lists.
+registered. Every list capability reports `listChanged: true`, and resources
+reports `subscribe: true`: the server pushes change notifications over the
+SSE stream (see [notifications](#server-initiated-notifications)).
 
 ## Registering a tool
 
@@ -344,12 +346,16 @@ takes only a `ToolHandler`.
 
 `SetGate` installs one server-wide precondition over the data methods
 (`tools/list`, `tools/call`, `resources/list`, `resources/read`,
-`resources/templates/list`, `prompts/list`, `prompts/get`); pass nil to clear
-it. `initialize` and `ping` stay open on purpose: they carry only the protocol
-version, capability booleans, and the server name, and a client that cannot
-complete the handshake cannot present credentials in a way any MCP client
-implements. In a framework app, `framework.WithMCPGate(framework.MCPRequireUser())`
-is this same switch (see [agent-readiness](agent-ready.md)).
+`resources/templates/list`, `resources/subscribe`,
+`resources/unsubscribe`, `prompts/list`, `prompts/get`); pass nil to
+clear it. It also silences notifications for a caller it refuses — see
+[notifications](#server-initiated-notifications). `initialize` and
+`ping` stay open on purpose: they carry only the protocol version,
+capability booleans, and the server name, and a client that cannot
+complete the handshake cannot present credentials in a way any MCP
+client implements. In a framework app,
+`framework.WithMCPGate(framework.MCPRequireUser())` is this same switch
+(see [agent-readiness](agent-ready.md)).
 
 On `tools/call` the checks run in order: resolve the tool (unknown name:
 method-not-found), the framework call gate (disabled module: a generic
@@ -358,6 +364,76 @@ error), then the handler. The handler runs under a recover guard, so a panic
 in handler code becomes an internal error with no detail echoed, instead of
 unwinding the transport loop; the same guard covers resource contents funcs
 and prompt handlers.
+
+## Server-initiated notifications
+
+The GET half of `ServeSSE` holds the connection open and streams
+server-initiated notifications to the client, each as one SSE `message`
+event carrying a JSON-RPC notification (a method, optional params, no id):
+
+| Method | Payload | Raised |
+|---|---|---|
+| `notifications/tools/list_changed` | none | `RegisterTool` |
+| `notifications/resources/list_changed` | none | `RegisterResource`, `RegisterResourceTemplate` |
+| `notifications/prompts/list_changed` | none | `RegisterPrompt` |
+| `notifications/resources/updated` | `{"uri": "..."}` | your code, via `NotifyResourceUpdated(uri)` |
+
+A client subscribes by GETting the SSE endpoint and keeping it open; a
+`list_changed` tells it to re-issue the corresponding list method. For
+resource updates it must also send `resources/subscribe` with the `uri` —
+`NotifyResourceUpdated` is a no-op until at least one subscription is
+active, and `resources/unsubscribe` ends delivery. Raising one from
+server code:
+
+<!-- gofastr:compile
+import (
+	"github.com/DonaldMurillo/gofastr/core/mcp"
+)
+
+var srv *mcp.Server
+-->
+```go
+// the docs resource changed; tell every subscribed, eligible stream
+srv.NotifyResourceUpdated("docs://api/quickstart")
+```
+
+Notifications are filtered per subscriber through the same gates as the
+list methods, so a stream can never be the leak the listings closed:
+
+- Every notification passes the server-wide gate (`SetGate`). A caller
+  refused wholesale receives nothing at all — not even a payload-free
+  `list_changed`, which is otherwise safe to broadcast.
+- `notifications/resources/updated` additionally passes the resource's
+  own `WithResourceGate`. The notification carries the `uri`, so it
+  reaches only streams whose caller may read that resource; pushing it
+  further would disclose the existence and uri of a gated resource.
+- Both gates are evaluated at delivery time against the identity the
+  stream's GET request presented, not once when the stream opened. A
+  session revoked mid-stream stops receiving immediately.
+
+A slow subscriber never blocks the server. Each stream has a bounded
+buffer (16 notifications); a full buffer means the client stopped
+reading, and the server drops that subscriber and closes its stream
+rather than stalling the code that raised the notification — which
+would otherwise stall every other subscriber too. `list_changed` is
+idempotent and `resources/updated` sends the client back to
+`resources/read` for current state, so a dropped client that reconnects
+and re-lists is correct again.
+
+Two transport limits, both inherited from the stream being per process:
+
+- The HTTP transport has no session id linking a POST to a GET stream,
+  so `resources/subscribe` is counted per `uri` across connections: a
+  `uri` one client subscribed to gets updates on every eligible stream.
+- The subscriber registry lives in the process that holds the
+  connections. A notification raised on one replica does not reach
+  clients connected to another — the same class of limit as the
+  per-process cursor signing key (see [pagination](#pagination)). Route
+  SSE sessions to one replica or accept that clients reconnect and
+  re-list.
+
+The stdio transport has no server-push channel, so the `Notify*` methods
+are no-ops there.
 
 ## Pagination
 
@@ -437,7 +513,10 @@ What a client sees at the edges:
   `application/json` content type (parameters allowed, plus the `+json`
   structured-suffix family) and caps the body at 1 MiB.
 - `ServeSSE(path)` returns an http.Handler where POST handles JSON-RPC and GET
-  with `Accept: text/event-stream` streams responses over SSE.
+  with `Accept: text/event-stream` opens a stream the server holds open for
+  the connection's life, carrying server-initiated notifications (see
+  [notifications](#server-initiated-notifications)). The origin/Host gate
+  runs on the GET half too: the stream it protects is a read.
 - `ServeStdio(ctx, in, out)` reads line-delimited JSON-RPC from `in` and writes
   responses to `out`, blocking until EOF or context cancellation. The recover
   guard around handler code matters most here: stdio has no net/http
@@ -487,3 +566,8 @@ tool in one call. The canonical example is in
   handler runs.** A `prompts/get` missing one is refused with invalid-params;
   the handler never sees the call. Handlers can assume required arguments are
   present.
+- **Expecting notifications to cross replicas.** The subscriber registry is
+  per process: a notification raised on one replica reaches only the clients
+  connected to it. Route SSE sessions to one replica, or accept that a
+  client reconnects and re-lists — which the spec's notification handling
+  already assumes.


### PR DESCRIPTION
Closes #287.

The blocker on this ticket was never a missing method. `sseGetHandler` wrote one
static `endpoint` event and returned immediately — the connection was not held
and there was no subscriber registry at all, so every `notifications/*` item
needed that machinery built first. Design was settled on the issue
([comment](https://github.com/DonaldMurillo/gofastr/issues/287#issuecomment-5462081663))
before any code was written.

## What landed

`notifications/tools/list_changed`, `notifications/resources/list_changed`,
`notifications/prompts/list_changed`, `notifications/resources/updated`, plus
`resources/subscribe` / `resources/unsubscribe`. `initialize` now advertises
`listChanged` and `subscribe` truthfully — both were hardcoded `false`.

## The security property, which is the whole risk

Notifications are filtered **per subscriber, at delivery time**, through the
same gates the list methods use.

`core/mcp` already defends a property twice over: a gated item is hidden from
its list method, and pagination pages the post-gate set so page shapes cannot
betray a hidden item. A naive broadcast undoes both —
`notifications/resources/updated` carries a URI, so pushing it to every stream
discloses the existence and URI of a resource the caller cannot read.

Payload-free `list_changed` still requires passing the server-wide gate: a
caller refused wholesale should not learn that something changed. Gates are
evaluated at delivery rather than subscribe time, so a session revoked
mid-stream stops receiving immediately, and app gate code never runs on the
publisher's goroutine.

## Backpressure drops, never blocks

Bounded 16-deep buffer per stream. When it fills, the subscriber is dropped and
its stream closed rather than the publisher blocking. `list_changed` is
idempotent, so a reconnecting client re-lists and is correct again — whereas a
blocked publisher would stall every other subscriber and the server code that
raised the notification.

## Verification

Seven guards mutation-proven by the author. I re-ran the headline one myself
rather than trusting the report: disabling the per-item gate in
`subscriberMayReceive` leaks the URI to a gate-refusing stream, and the test
catches it with the actual payload —

```
SECURITY: [disclosure] unexpected gated resource update on a gate-refusing stream:
{"jsonrpc":"2.0","method":"notifications/resources/updated","params":{"uri":"secret://books"}}
```

Restored, green under `-race`.

**Two pre-existing security tests were modified**, which I checked specifically
for weakening since that is the classic way a suite gets bent to fit. They are
not weakened: the `403` assertions are byte-identical, only the invocation
changed — the handler now blocks, so they drive it in a goroutine with a
cancellable context and join before reading the recorder. The comment on
`TestSSEGetHandlerEnforcesOrigin` correctly upgrades the origin gate from "a
guard hole that discloses nothing today" to load-bearing, because the stream is
now session-derived. That comment was written in anticipation of exactly this
change.

Also run: `go build ./...`, `go vet ./...`, `go test ./core/mcp/... -count=1`,
`-race`, and the docs suite.

## Limits documented rather than solved

- Subscriptions refcount **per URI, not per stream**: this transport has no
  session id linking a POST to a GET stream, so a subscribed URI reaches every
  gate-passing stream. The per-subscriber gates remain the boundary, so this is
  protocol fidelity rather than disclosure.
- A notification raised on one replica does not reach clients connected to
  another — the same class of limit already recorded for the per-process cursor
  signing key.
- stdio has no server-push channel, so `Notify*` are no-ops there.

## Not in scope

`notifications/progress`, `notifications/cancelled`, `completion/complete`,
`logging/setLevel` and `notifications/message`.

## Note on hard rule 3

This is the MCP protocol's own mandated transport at `/mcp`, not an app
surface, and not the `/__gofastr/sse` bus. It is not a precedent for
app-surface SSE, and the code says so in a comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-initiated MCP notifications for tool, resource, prompt, and resource-content changes.
  * Added resource subscription and unsubscription support.
  * SSE connections now remain open to deliver notifications in real time.
  * Capability information now accurately advertises list-change and resource-subscription support.
* **Bug Fixes**
  * Notifications respect access controls and active subscriptions.
  * Slow or disconnected clients no longer block notification delivery.
* **Documentation**
  * Documented notification behavior, filtering, buffering, and transport limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->