### PR TITLE
fix(mcp)!: emit _meta.ui.csp as the spec's object, not a string (#291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Changed
 
+- **BREAKING — `mcp.AppConfig.CSP` is a struct, not a string**: the MCP
+  Apps spec defines `_meta.ui.csp` as an object
+  (`connectDomains`/`resourceDomains`/`frameDomains`/`baseUriDomains`), and
+  GoFastr emitted a bare string there, so a spec-compliant host could not
+  parse the policy at all. `CSP` is now `mcp.AppCSP` with those four fields.
+  Breaking loudly rather than behind a shim, because the old field produced
+  JSON no conformant host could consume — there is no working caller to
+  preserve. An app that sets no CSP emits the same `_meta` as before.
+
 - **BREAKING — `kiln acp` speaks the real ACP session surface** (#287):
   `tools/list`, `tools/call`, `prompt` and `shutdown` are gone and
   `initialize` changed shape. None of those were methods in the published

--- a/core/mcp/app.go
+++ b/core/mcp/app.go
@@ -12,6 +12,36 @@ import (
 // iframe inside the conversation.
 const AppResourceMimeType = "text/html;profile=mcp-app"
 
+// AppCSP is the structured `_meta.ui.csp` object from the MCP Apps spec
+// (2026-01-26). The host, not the app, assembles the iframe's actual
+// Content-Security-Policy from these origin allowlists; each field maps to
+// one CSP directive:
+//
+//   - ConnectDomains: fetch/XHR/WebSocket endpoints → connect-src
+//   - ResourceDomains: images, scripts, styles, fonts, media → img-src,
+//     script-src, style-src, font-src, media-src
+//   - FrameDomains: nested iframes → frame-src
+//   - BaseURIDomains: <base href> origins → base-uri
+//
+// A field that is empty or omitted allows no external origins: the secure
+// default. The JSON tags are the spec's wire names (note baseUriDomains,
+// not baseURIDomains — a mismatched tag is silently the wrong field name
+// on the wire).
+type AppCSP struct {
+	ConnectDomains  []string `json:"connectDomains,omitempty"`
+	ResourceDomains []string `json:"resourceDomains,omitempty"`
+	FrameDomains    []string `json:"frameDomains,omitempty"`
+	BaseURIDomains  []string `json:"baseUriDomains,omitempty"`
+}
+
+// isZero reports whether c marshals to an empty object, i.e. every field
+// is empty (omitempty drops each one). RegisterApp uses it to omit the
+// `csp` key entirely for an app that sets no origins.
+func (c AppCSP) isZero() bool {
+	return len(c.ConnectDomains) == 0 && len(c.ResourceDomains) == 0 &&
+		len(c.FrameDomains) == 0 && len(c.BaseURIDomains) == 0
+}
+
 // AppConfig describes an MCP App: an interactive HTML widget plus the tool
 // that launches it. RegisterApp wires both halves: a `ui://` resource
 // carrying the HTML and a tool whose `_meta` links to it, so the model can
@@ -30,7 +60,12 @@ type AppConfig struct {
 
 	// Optional resource `_meta.ui` fields the host honors when sandboxing
 	// the iframe.
-	CSP         string         // Content-Security-Policy for the widget
+	//
+	// BREAKING: CSP was a raw policy string in earlier versions. The
+	// change to the spec's structured AppCSP is deliberate and ships
+	// without a shim: the string form emitted JSON no conformant host
+	// could consume, so no working caller exists to break.
+	CSP         AppCSP         // _meta.ui.csp origin allowlists
 	Permissions map[string]any // iframe permissions descriptor
 
 	// ToolMeta merges extra keys into the tool's `_meta` (alongside the
@@ -79,11 +114,12 @@ func (s *Server) RegisterApp(cfg AppConfig) error {
 		mime = AppResourceMimeType
 	}
 
-	// Resource `_meta.ui` (csp / permissions) when provided.
+	// Resource `_meta.ui` (csp / permissions) when provided. A zero AppCSP
+	// omits the csp key (no empty object on the wire).
 	var resOpts []ResourceOption
-	if cfg.CSP != "" || cfg.Permissions != nil {
+	if !cfg.CSP.isZero() || cfg.Permissions != nil {
 		ui := map[string]any{}
-		if cfg.CSP != "" {
+		if !cfg.CSP.isZero() {
 			ui["csp"] = cfg.CSP
 		}
 		if cfg.Permissions != nil {

--- a/core/mcp/apps_test.go
+++ b/core/mcp/apps_test.go
@@ -302,7 +302,7 @@ func sampleApp() AppConfig {
 		Handler:     func(context.Context, map[string]any) (any, error) { return "ok", nil },
 		ResourceURI: "ui://app/studio.html",
 		HTML:        "<h1>studio</h1>",
-		CSP:         "default-src 'self'",
+		CSP:         AppCSP{ConnectDomains: []string{"https://api.example.com"}},
 	}
 }
 
@@ -330,8 +330,11 @@ func TestRegisterApp_WiresToolAndResource(t *testing.T) {
 		t.Errorf("resource fields wrong: %v", res)
 	}
 	ui := res["_meta"].(map[string]any)["ui"].(map[string]any)
-	if ui["csp"] != "default-src 'self'" {
-		t.Errorf("resource csp not carried: %v", ui)
+	csp, ok := ui["csp"].(map[string]any)
+	if !ok {
+		t.Errorf("resource csp not an object: %v", ui)
+	} else if _, ok := csp["connectDomains"]; !ok {
+		t.Errorf("resource csp missing connectDomains: %v", csp)
 	}
 
 	// The resource reads back the HTML.
@@ -339,6 +342,126 @@ func TestRegisterApp_WiresToolAndResource(t *testing.T) {
 	read := wireResult(t, s.HandleRequest(context.Background(), Request{JSONRPC: "2.0", ID: 3, Method: "resources/read", Params: p}))
 	if read["contents"].([]any)[0].(map[string]any)["text"] != "<h1>studio</h1>" {
 		t.Errorf("resource HTML mismatch: %v", read)
+	}
+}
+
+// listResources drives resources/list and returns the wire-shaped result.
+func listResources(t *testing.T, s *Server) []any {
+	t.Helper()
+	rm := wireResult(t, s.HandleRequest(context.Background(), Request{
+		JSONRPC: "2.0", ID: 1, Method: "resources/list",
+	}))
+	res, ok := rm["resources"].([]any)
+	if !ok || len(res) == 0 {
+		t.Fatalf("no resources listed: %v", rm)
+	}
+	return res
+}
+
+// listAppUI registers app and returns its resource `_meta.ui` off the wire.
+func listAppUI(t *testing.T, app AppConfig) map[string]any {
+	t.Helper()
+	s := NewServer()
+	if err := s.RegisterApp(app); err != nil {
+		t.Fatal(err)
+	}
+	res := listResources(t, s)[0].(map[string]any)
+	ui, ok := res["_meta"].(map[string]any)["ui"].(map[string]any)
+	if !ok {
+		t.Fatalf("resource _meta.ui missing: %#v", res["_meta"])
+	}
+	return ui
+}
+
+// The wire contract: `_meta.ui.csp` is an object with the spec's key
+// names, not a policy string. This is the test the original bug (a raw
+// string under csp) would have failed.
+func TestRegisterApp_CSPObjectOnWire(t *testing.T) {
+	app := sampleApp()
+	app.CSP = AppCSP{
+		ConnectDomains:  []string{"https://api.openweathermap.org"},
+		ResourceDomains: []string{"https://cdn.jsdelivr.net"},
+	}
+	csp, ok := listAppUI(t, app)["csp"].(map[string]any)
+	if !ok {
+		t.Fatalf("_meta.ui.csp is not an object: %v", listAppUI(t, app))
+	}
+
+	// Byte-exact on the marshalled JSON: the wire shape is the contract,
+	// and encoding/json sorts map keys, so this is deterministic.
+	b, err := json.Marshal(csp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"connectDomains":["https://api.openweathermap.org"],"resourceDomains":["https://cdn.jsdelivr.net"]}`
+	if string(b) != want {
+		t.Errorf("csp wire shape:\n got %s\nwant %s", b, want)
+	}
+
+	// Round-trip: the tags must also read the spec's names back into
+	// the right Go fields (a wrong tag drops or misplaces data).
+	var back AppCSP
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.ConnectDomains[0] != "https://api.openweathermap.org" ||
+		back.ResourceDomains[0] != "https://cdn.jsdelivr.net" ||
+		len(back.FrameDomains) != 0 || len(back.BaseURIDomains) != 0 {
+		t.Errorf("csp round-trip lost fields: %+v", back)
+	}
+}
+
+// A zero AppCSP emits no csp key (no empty object either), and an app
+// with neither CSP nor permissions emits no _meta at all, as before.
+func TestRegisterApp_ZeroCSPOmitsKey(t *testing.T) {
+	// Empty-but-non-nil slice still counts as zero: omitempty would
+	// marshal it away, so the csp key must not appear.
+	app := sampleApp()
+	app.CSP = AppCSP{ConnectDomains: []string{}}
+	app.Permissions = map[string]any{"fullscreen": true}
+	if ui := listAppUI(t, app); ui["csp"] != nil {
+		t.Errorf("zero AppCSP emitted a csp key: %v", ui)
+	}
+
+	// Neither csp nor permissions: the resource carries no _meta.
+	app = sampleApp()
+	app.CSP = AppCSP{}
+	app.Permissions = nil
+	s := NewServer()
+	if err := s.RegisterApp(app); err != nil {
+		t.Fatal(err)
+	}
+	res := listResources(t, s)[0].(map[string]any)
+	if _, ok := res["_meta"]; ok {
+		t.Errorf("app without csp/permissions emitted _meta: %v", res["_meta"])
+	}
+}
+
+// Each allowlist appears under its exact spec wire name; baseUriDomains
+// is the one Go convention would spell differently.
+func TestRegisterApp_CSPEachFieldSpecName(t *testing.T) {
+	app := sampleApp()
+	app.CSP = AppCSP{
+		ConnectDomains:  []string{"https://api.example.com"},
+		ResourceDomains: []string{"https://cdn.example.com"},
+		FrameDomains:    []string{"https://embed.example.com"},
+		BaseURIDomains:  []string{"https://base.example.com"},
+	}
+	csp := listAppUI(t, app)["csp"].(map[string]any)
+	want := map[string]string{
+		"connectDomains":  "https://api.example.com",
+		"resourceDomains": "https://cdn.example.com",
+		"frameDomains":    "https://embed.example.com",
+		"baseUriDomains":  "https://base.example.com",
+	}
+	for key, origin := range want {
+		got, ok := csp[key].([]any)
+		if !ok || len(got) != 1 || got[0] != origin {
+			t.Errorf("csp.%s = %#v, want [%s]", key, csp[key], origin)
+		}
+	}
+	if n := len(csp); n != len(want) {
+		t.Errorf("csp has %d keys, want exactly the 4 spec fields: %v", n, csp)
 	}
 }
 

--- a/framework/docs/content/agent-ready.md
+++ b/framework/docs/content/agent-ready.md
@@ -455,10 +455,20 @@ framework.WithMCPApp(mcp.AppConfig{
     InputSchema: schema,
     Handler:     studioTool,
     ResourceURI: "ui://myapp/studio.html",
-    HTML:        studioHTML,            // self-contained, inline JS/CSS
-    CSP:         "default-src 'self'",  // rides on the resource's _meta.ui
+    HTML:        studioHTML,  // self-contained, inline JS/CSS
+    CSP: mcp.AppCSP{  // rides on the resource's _meta.ui
+        ConnectDomains:  []string{"https://api.openweathermap.org"},
+        ResourceDomains: []string{"https://cdn.jsdelivr.net"},
+    },
 })
 ```
+
+`CSP` is the spec's structured object, not a policy string: the host turns
+each allowlist into the matching iframe directive (`connectDomains` →
+`connect-src`; `resourceDomains` → `img-src`/`script-src`/`style-src`/
+`font-src`/`media-src`; `frameDomains` → `frame-src`; `baseUriDomains` →
+`base-uri`). An empty or omitted field allows no external origins, and a
+zero `AppCSP` emits no `csp` key at all.
 
 The widget HTML is the app author's job (a single vanilla-JS file needs no
 build step). `WithMCPApp` is an explicit opt-in registered during

--- a/framework/docs/content/mcp.md
+++ b/framework/docs/content/mcp.md
@@ -555,6 +555,22 @@ widget plus the tool that launches it, as a `ui://` resource and a linking
 tool in one call. The canonical example is in
 [agent-readiness](agent-ready.md).
 
+`AppConfig.CSP` is the spec's structured `_meta.ui.csp` object (an
+`mcp.AppCSP`), not a policy string. The host assembles the iframe's actual
+Content-Security-Policy from its origin allowlists:
+
+```go
+CSP: mcp.AppCSP{
+	ConnectDomains:  []string{"https://api.openweathermap.org"}, // connect-src
+	ResourceDomains: []string{"https://cdn.jsdelivr.net"},        // img/script/style/font/media-src
+},
+```
+
+The remaining fields are `FrameDomains` (frame-src) and `BaseURIDomains`
+(base-uri; the wire name is `baseUriDomains`, the spec's spelling). An empty
+or omitted field allows no external origins, and a zero `AppCSP` emits no
+`csp` key at all.
+
 ## Common mistakes
 
 - **Wrapping a handler in `mcp.Gated` and expecting the tool to disappear from


### PR DESCRIPTION
Part of #291, shippable ahead of the feature work because it fixes a live
defect rather than adding surface.

## The bug

`core/mcp/app.go` declared `AppConfig.CSP` as a `string` and emitted it raw as
`ui["csp"]`. The MCP Apps spec
([ext-apps, `2026-01-26`, Stable](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx))
defines `_meta.ui.csp` as an object:

```typescript
interface McpUiResourceCsp {
    connectDomains?: string[],
    resourceDomains?: string[],
    frameDomains?: string[],
    baseUriDomains?: string[],
}
```

So a spec-compliant host receives a string where it expects an object and
cannot use the policy at all. Every MCP App GoFastr served shipped with an
unusable CSP declaration. There is [a bug report of a host ignoring these
fields](https://github.com/anthropics/claude-ai-mcp/issues/40) — that is what
this looks like from the other side.

I confirmed the shape against the spec source rather than the secondary
write-ups that surface first, because this changes exported API.

## ⚠️ BREAKING

`mcp.AppConfig.CSP` changes from `string` to `mcp.AppCSP`.

Breaking loudly rather than behind a shim, deliberately: the old field produced
JSON no conformant host could consume, so there is no working caller to
preserve, and a silent coercion would leave the same defect in place under a
quieter name. A compile error is the correct way for an affected caller to find
out. No in-repo code set it.

An app that sets no CSP emits the same `_meta` as before.

## Why the test asserts on JSON, not the struct

The wire names are the spec's, not Go's — `BaseURIDomains` carries the tag
`baseUriDomains`. A struct-level assertion passes with wrong JSON tags, which
is exactly how the original defect survived. So the test marshals and asserts
on the bytes.

Mutation-proven, and I re-ran one myself rather than trusting the report:

| Mutation | Result |
|---|---|
| tag `baseUriDomains` → `baseUriDomain` | `csp.baseUriDomains = <nil>, want [https://base.example.com]` |
| re-emit the original string (`ui["csp"] = "default-src 'self'"`) | `_meta.ui.csp is not an object` |
| break `isZero` | zero `AppCSP` emitted a `csp` key |

The second is the regression guard for this exact defect.

Run: `gofmt -l` clean, `go build ./...`, `go vet ./...`,
`go test ./core/mcp/... ./framework/docs/... -count=1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - CSP configuration now uses structured origin allowlists instead of a raw policy string.
  - Added support for connection, resource, frame, and base URI domain fields.
  - Existing apps without CSP continue to omit CSP metadata.

- **Documentation**
  - Updated examples and reference documentation to explain the new CSP format, field mappings, and omission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->