### PR TITLE
fix(runtime): combobox skips filtered options (#302) + agent role and identity contract (#291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Added
 
+- **Combobox keyboard navigation skips filtered-out options** (#302):
+  after typing a query, ArrowDown/ArrowUp/Home/End cycled through rows the
+  static filter had hidden, so the `aria-activedescendant` highlight landed on
+  an invisible option and Enter selected one the user had filtered away. The
+  navigable-option selector now excludes `[hidden]`. Refocusing an input whose
+  every option is filtered out no longer opens an empty listbox either.
+
 - **`ui.Sidebar` can express a server-owned collapse contract** (#298):
   `SidebarConfig.Collapse` is a tri-state mirroring how `CurrentPath` already
   works — the zero value keeps today's localStorage behaviour byte-identical,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Added
 
+- **`RoleAgent` — an agent-only HTTP surface** (#291): `GOFASTR_ROLE=agent`
+  (or `WithRole(RoleAgent)`) serves `/mcp` and health only, forwarding MCP to
+  the app router so auth and owner scoping are identical to the serve role.
+  Entity CRUD, OpenAPI, docs, admin and well-known discovery are not served,
+  and workers do not start.
+
+  The slice that mattered was not the role constant but the identity contract
+  underneath it, which had no coverage at all: bearer tokens and session
+  cookies both resolve a user today, and nothing guaranteed the same person
+  arriving by token versus by cookie resolved to the same owner-scope
+  principal. On an agent surface that is live — an agent would either miss its
+  own user's rows or see another user's. The contract **holds**, and is now
+  pinned on REST and `/mcp`: same user, same `GetID()`, same owner-stamped
+  rows, with a second user's rows staying invisible. Injecting a divergent
+  principal on the bearer path fails those tests, so they are guards rather
+  than tautologies.
+
 - **Combobox keyboard navigation skips filtered-out options** (#302):
   after typing a query, ArrowDown/ArrowUp/Home/End cycled through rows the
   static filter had hidden, so the `aria-activedescendant` highlight landed on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,7 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   after typing a query, ArrowDown/ArrowUp/Home/End cycled through rows the
   static filter had hidden, so the `aria-activedescendant` highlight landed on
   an invisible option and Enter selected one the user had filtered away. The
-  navigable-option selector now excludes `[hidden]`. Refocusing an input whose
-  every option is filtered out no longer opens an empty listbox either.
+  navigable-option selector now excludes `[hidden]`.
 
 - **`ui.Sidebar` can express a server-owned collapse contract** (#298):
   `SidebarConfig.Collapse` is a tri-state mirroring how `CurrentPath` already

--- a/core-ui/runtime/combobox_filter_nav_e2e_test.go
+++ b/core-ui/runtime/combobox_filter_nav_e2e_test.go
@@ -1,0 +1,104 @@
+package runtime
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// comboboxFilterPage mirrors the SSR shape of a static-options combobox:
+// a [role=combobox] input paired via aria-controls with a listbox that
+// carries data-fui-static-options and renders every option inline. The
+// listbox starts hidden — closed-by-default since 8509d370 — which makes
+// the keyboard path the common one. Inlined for the same reason as
+// tagInputPage: framework/ui transitively imports this package.
+const comboboxFilterPage = `
+<div>
+  <input type="text" id="pick" role="combobox" aria-controls="pick-list"
+         aria-expanded="false" aria-haspopup="listbox" aria-autocomplete="list"
+         autocomplete="off" placeholder="Pick a word">
+  <ul id="pick-list" role="listbox" data-fui-static-options hidden>
+    <li role="option" id="opt-alpha" data-value="alpha">Alpha</li>
+    <li role="option" id="opt-bravo" data-value="bravo">Bravo</li>
+    <li role="option" id="opt-charlie" data-value="charlie">Charlie</li>
+    <li role="option" id="opt-delta" data-value="delta">Delta</li>
+  </ul>
+</div>`
+
+// TestComboboxKeyboardNavSkipsHiddenOpts pins that keyboard navigation
+// only walks options the static filter left visible (#302). Type a query
+// that leaves one option on screen, press ArrowDown twice: the highlight
+// must wrap back to the visible option, never land on a hidden row, and
+// Enter must pick the visible option — not one the user filtered away.
+func TestComboboxKeyboardNavSkipsHiddenOpts(t *testing.T) {
+	g := startGadgetServer(t, `[]`, comboboxFilterPage)
+	ctx := newSeedBrowserCtx(t)
+
+	// pressKey dispatches a synthetic keydown on the combobox input,
+	// the same pattern taginput_e2e_test.go uses; the module listens
+	// at document level and branches on e.key.
+	pressKey := func(key string) chromedp.Action {
+		return chromedp.Evaluate(`(function(){
+			var el = document.getElementById('pick');
+			el.dispatchEvent(new KeyboardEvent('keydown', { key: `+strconv.Quote(key)+`, bubbles: true, cancelable: true }));
+		})()`, nil)
+	}
+
+	var afterFilterActive, afterDownActive, afterDownHidden string
+	var afterEnterValue, afterEnterExpanded string
+
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(g.Srv.URL+"/"),
+		chromedp.WaitVisible(`#pick`, chromedp.ByID),
+		// The combobox module is demand-fetched off the [role=combobox]
+		// marker. Poll for its self-registration instead of sleeping:
+		// keys dispatched before the listener exists are silently
+		// dropped and read as an intermittent failure.
+		chromedp.Poll(`!!(window.__gofastr&&window.__gofastr.loadedModules&&window.__gofastr.loadedModules.combobox)`, nil,
+			chromedp.WithPollingTimeout(10*time.Second), chromedp.WithPollingInterval(50*time.Millisecond)),
+
+		// Type "cha": Alpha/Bravo/Delta are hidden, only Charlie matches.
+		chromedp.Evaluate(`(function(){
+			var el = document.getElementById('pick');
+			el.focus();
+			el.value = 'cha';
+			el.dispatchEvent(new Event('input', { bubbles: true }));
+		})()`, nil),
+		chromedp.Poll(`!document.getElementById('opt-charlie').hidden && document.getElementById('opt-alpha').hidden`, nil,
+			chromedp.WithPollingTimeout(5*time.Second), chromedp.WithPollingInterval(25*time.Millisecond)),
+		chromedp.Evaluate(`document.getElementById('pick').getAttribute('aria-activedescendant')`, &afterFilterActive),
+
+		// ArrowDown twice with one visible option: both presses must
+		// wrap back to Charlie. Walking hidden rows moves
+		// aria-activedescendant onto an invisible option instead.
+		pressKey("ArrowDown"),
+		pressKey("ArrowDown"),
+		chromedp.Evaluate(`document.getElementById('pick').getAttribute('aria-activedescendant')`, &afterDownActive),
+		chromedp.Evaluate(`String(document.getElementById('opt-charlie').hidden)`, &afterDownHidden),
+
+		// Enter picks the highlighted option: Charlie.
+		pressKey("Enter"),
+		chromedp.Evaluate(`document.getElementById('pick').value`, &afterEnterValue),
+		chromedp.Evaluate(`document.getElementById('pick').getAttribute('aria-expanded')`, &afterEnterExpanded),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if afterFilterActive != "opt-charlie" {
+		t.Errorf("filter: aria-activedescendant = %q, want \"opt-charlie\"", afterFilterActive)
+	}
+	if afterDownActive != "opt-charlie" {
+		t.Errorf("ArrowDown x2: aria-activedescendant = %q, want \"opt-charlie\" (keyboard nav walked a hidden filtered-out row)", afterDownActive)
+	}
+	if afterDownHidden != "false" {
+		t.Errorf("ArrowDown x2: highlighted option hidden = %s, want false", afterDownHidden)
+	}
+	if afterEnterValue != "charlie" {
+		t.Errorf("Enter: input value = %q, want \"charlie\" (Enter selected a filtered-away option)", afterEnterValue)
+	}
+	if afterEnterExpanded != "false" {
+		t.Errorf("Enter: aria-expanded = %q, want \"false\" (listbox must close on pick)", afterEnterExpanded)
+	}
+}

--- a/core-ui/runtime/src/combobox.js
+++ b/core-ui/runtime/src/combobox.js
@@ -94,8 +94,15 @@
     if (!lbId) return;
     const lb = document.getElementById(lbId);
     if (!lb) return;
+    // Navigable options: skip aria-disabled rows AND rows the static
+    // filter hid. Without :not([hidden]) ArrowDown/ArrowUp/Home/End
+    // cycle through filtered-out rows — the aria-activedescendant
+    // highlight lands on an invisible option and Enter picks one the
+    // user filtered away (#302).
     const options = Array.from(
-      lb.querySelectorAll('[role="option"]:not([aria-disabled="true"])')
+      lb.querySelectorAll(
+        '[role="option"]:not([aria-disabled="true"]):not([hidden])'
+      )
     );
     const activeId = input.getAttribute('aria-activedescendant');
     const activeIdx = options.findIndex((o) => o.id === activeId);
@@ -180,7 +187,10 @@
     const lbId = input.getAttribute('aria-controls');
     const lb = lbId ? document.getElementById(lbId) : null;
     if (!lb) return;
-    if (lb.querySelector('[role="option"]')) openListbox(input, lb);
+    // Only reopen when something is actually selectable: a hidden
+    // option still matches [role="option"], so without the filter a
+    // refocus with every row filtered out opens an empty listbox.
+    if (lb.querySelector('[role="option"]:not([hidden])')) openListbox(input, lb);
   });
 
   // Outside-click closes any open combobox.

--- a/core-ui/runtime/src/combobox.js
+++ b/core-ui/runtime/src/combobox.js
@@ -187,10 +187,7 @@
     const lbId = input.getAttribute('aria-controls');
     const lb = lbId ? document.getElementById(lbId) : null;
     if (!lb) return;
-    // Only reopen when something is actually selectable: a hidden
-    // option still matches [role="option"], so without the filter a
-    // refocus with every row filtered out opens an empty listbox.
-    if (lb.querySelector('[role="option"]:not([hidden])')) openListbox(input, lb);
+    if (lb.querySelector('[role="option"]')) openListbox(input, lb);
   });
 
   // Outside-click closes any open combobox.

--- a/framework/agent_identity_test.go
+++ b/framework/agent_identity_test.go
@@ -38,6 +38,10 @@ import (
 	"github.com/DonaldMurillo/gofastr/core/schema"
 	"github.com/DonaldMurillo/gofastr/framework"
 	"github.com/DonaldMurillo/gofastr/framework/entity"
+
+	// Registers the "sqlite3" driver this file opens. Explicit rather
+	// than relying on a transitive import from a sibling test file.
+	_ "github.com/DonaldMurillo/gofastr/sqlite/stdlib"
 )
 
 // ──────────────────────────────────────────────────────────────────────
@@ -188,9 +192,13 @@ type identityEnv struct {
 func newIdentityEnv(t *testing.T) *identityEnv {
 	t.Helper()
 
+	// Fatal, never Skip: a skipped identity-contract test is
+	// indistinguishable from a passing one in CI, and this is the test
+	// standing between an agent and another user's rows. The blank import
+	// above registers the driver so this cannot silently vanish.
 	db, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
-		t.Skip("sqlite3 driver not available")
+		t.Fatalf("open sqlite3: %v", err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
 	db.SetMaxOpenConns(1)

--- a/framework/agent_identity_test.go
+++ b/framework/agent_identity_test.go
@@ -1,0 +1,545 @@
+package framework_test
+
+// Issue #291 slice: pin the bearer/cookie identity contract for the agent
+// surface. battery/auth authenticates the same human two ways — a browser
+// arrives with a session cookie (SessionMiddleware), an agent arrives with
+// `Authorization: Bearer gfsk_…` (TokenMiddleware) — and owner-scoped CRUD
+// (EntityConfig.Scope.OwnerField) filters rows by whatever principal landed
+// in ctx. Nothing previously tested that the two transports resolve the SAME
+// owner for the SAME user. If they ever diverge, an agent either cannot see
+// its own user's rows or sees someone else's.
+//
+// These tests characterize the real wiring end-to-end over HTTP: real
+// router, real middleware order (the documented SessionMiddleware-then-
+// TokenMiddleware chain from framework/docs/content/auth.md), real entity
+// CRUD routes, and the real /mcp mount whose entity tools re-dispatch
+// through the same router (see crud.runToolRequest).
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DonaldMurillo/gofastr/battery/auth"
+	"github.com/DonaldMurillo/gofastr/core/router"
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// ──────────────────────────────────────────────────────────────────────
+// Test doubles
+// ──────────────────────────────────────────────────────────────────────
+
+// identityUser implements auth.User.
+type identityUser struct {
+	id, email string
+	roles     []string
+}
+
+func (u identityUser) GetID() string      { return u.id }
+func (u identityUser) GetEmail() string   { return u.email }
+func (u identityUser) GetRoles() []string { return u.roles }
+
+// identityUserStore is a map-backed auth.UserStore. The contract under test
+// keys off FindByID (both SessionMiddleware and TokenMiddleware resolve
+// their credential to a user by ID), so that is the only lookup that needs
+// real data.
+type identityUserStore struct {
+	mu     sync.RWMutex
+	byID   map[string]identityUser
+	byMail map[string]identityUser
+}
+
+func (s *identityUserStore) FindByID(_ context.Context, id string) (auth.User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if u, ok := s.byID[id]; ok {
+		return u, nil
+	}
+	return nil, auth.ErrUserNotFound
+}
+
+func (s *identityUserStore) FindByEmail(_ context.Context, email string) (auth.User, string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if u, ok := s.byMail[email]; ok {
+		return u, "", nil
+	}
+	return nil, "", auth.ErrUserNotFound
+}
+
+func (s *identityUserStore) CreateUser(_ context.Context, email, _ string, roles []string) (auth.User, error) {
+	u := identityUser{id: "u-" + email, email: email, roles: roles}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.byID[u.id] = u
+	s.byMail[email] = u
+	return u, nil
+}
+
+func (s *identityUserStore) UpdateRoles(_ context.Context, id string, roles []string) error {
+	return auth.ErrUserNotFound
+}
+
+// identityTokenStore is a map-backed auth.APITokenStore keyed by the sha256
+// hex of the plaintext, matching what TokenMiddleware looks up.
+type identityTokenStore struct {
+	mu     sync.Mutex
+	byHash map[string]*auth.APIToken
+}
+
+func newIdentityTokenStore() *identityTokenStore {
+	return &identityTokenStore{byHash: make(map[string]*auth.APIToken)}
+}
+
+func (s *identityTokenStore) Create(_ context.Context, t auth.APIToken, sha256Hash string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := t
+	s.byHash[sha256Hash] = &cp
+	return nil
+}
+
+func (s *identityTokenStore) FindByHash(_ context.Context, sha256Hash string) (*auth.APIToken, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if t, ok := s.byHash[sha256Hash]; ok {
+		return t, nil
+	}
+	return nil, nil
+}
+
+func (s *identityTokenStore) List(context.Context, string, string) ([]auth.APIToken, error) {
+	return nil, nil
+}
+
+func (s *identityTokenStore) Revoke(context.Context, string, string, string) error {
+	return auth.ErrTokenNotFound
+}
+
+func (s *identityTokenStore) TouchLastUsed(_ context.Context, id string, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, t := range s.byHash {
+		if t.ID == id {
+			cp := at
+			t.LastUsedAt = &cp
+		}
+	}
+	return nil
+}
+
+// mintUserToken mints a gfsk_ bearer credential for owner and records only
+// its sha256 hash, exactly like the real issue path (auth.IssueToken minus
+// the SQL store).
+func mintUserToken(t *testing.T, store *identityTokenStore, id, ownerID string) string {
+	t.Helper()
+	raw := make([]byte, 20)
+	if _, err := rand.Read(raw); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	plain := auth.TokenPrefix + hex.EncodeToString(raw)
+	sum := sha256.Sum256([]byte(plain))
+	if err := store.Create(context.Background(), auth.APIToken{
+		ID:        id,
+		Name:      "identity-test",
+		OwnerKind: auth.OwnerKindUser,
+		OwnerID:   ownerID,
+		Prefix:    plain[:12],
+		CreatedAt: time.Now().UTC(),
+	}, hex.EncodeToString(sum[:])); err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	return plain
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Environment
+// ──────────────────────────────────────────────────────────────────────
+
+type identityEnv struct {
+	server *httptest.Server
+	db     *sql.DB
+
+	alice, bob             identityUser
+	aliceCookieValue       string // session token (cookie jar value)
+	bobCookieValue         string
+	aliceBearer, bobBearer string
+}
+
+// newIdentityEnv builds the full documented wiring: router with
+// SessionMiddleware OUTER and TokenMiddleware INNER (the order
+// framework/docs/content/auth.md prescribes), an owner-scoped notes entity
+// with CRUD + MCP exposure, and the /mcp streamable-HTTP mount.
+func newIdentityEnv(t *testing.T) *identityEnv {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Skip("sqlite3 driver not available")
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec(`CREATE TABLE notes (
+		id TEXT PRIMARY KEY,
+		title TEXT NOT NULL,
+		user_id TEXT DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("create notes table: %v", err)
+	}
+
+	alice := identityUser{id: "u-alice", email: "alice@example.com", roles: nil}
+	bob := identityUser{id: "u-bob", email: "bob@example.com", roles: nil}
+	users := &identityUserStore{
+		byID:   map[string]identityUser{alice.id: alice, bob.id: bob},
+		byMail: map[string]identityUser{alice.email: alice, bob.email: bob},
+	}
+	tokens := newIdentityTokenStore()
+
+	mgr := auth.New(auth.AuthConfig{
+		DevMode:       true, // memory session store, non-Secure cookie on plain HTTP
+		SessionTTL:    time.Hour,
+		SessionCookie: "session_id",
+		UserStore:     users,
+	})
+	if err := mgr.Init(nil); err != nil {
+		t.Fatalf("auth init: %v", err)
+	}
+
+	// Mint real sessions and real bearer credentials for both users.
+	aliceSess, err := mgr.SessionStore().Create(context.Background(), alice.id, time.Hour)
+	if err != nil {
+		t.Fatalf("alice session: %v", err)
+	}
+	bobSess, err := mgr.SessionStore().Create(context.Background(), bob.id, time.Hour)
+	if err != nil {
+		t.Fatalf("bob session: %v", err)
+	}
+
+	r := router.New()
+	// The documented order: session outer, token inner. A gfsk_ credential
+	// resolves after the session middleware's anonymous fall-through has
+	// cleared ctx, so the bearer principal survives to the handler.
+	r.Use(router.Middleware(auth.SessionMiddleware(mgr)))
+	r.Use(router.Middleware(auth.TokenMiddleware(users, nil, tokens)))
+
+	crudTrue := true
+	app := framework.NewApp(
+		framework.WithConfig(framework.AppConfig{Name: "agent-identity", APIPrefix: "/api"}),
+		framework.WithDB(db),
+		framework.WithoutDefaultMiddleware(),
+		framework.WithRouter(r),
+	)
+	app.Entity("notes", entity.EntityConfig{
+		Table: "notes",
+		Scope: &entity.ScopeConfig{OwnerField: "user_id"},
+		Fields: []schema.Field{
+			{Name: "title", Type: schema.String, Required: true},
+			{Name: "user_id", Type: schema.String},
+		},
+		Exposure: &entity.ExposureConfig{CRUD: &crudTrue, MCP: true},
+	}.WithTimestamps(false))
+
+	// Hand-wired /mcp mount (WithMCP would double-mount): the entity's MCP
+	// tools re-dispatch through r, so they inherit the same auth chain.
+	mcpHandler := app.MCP.ServeSSE("/mcp")
+	r.Post("/mcp", mcpHandler)
+	r.Get("/mcp", mcpHandler)
+
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	return &identityEnv{
+		server:           srv,
+		db:               db,
+		alice:            alice,
+		bob:              bob,
+		aliceCookieValue: aliceSess.Token,
+		bobCookieValue:   bobSess.Token,
+		aliceBearer:      mintUserToken(t, tokens, "tok-alice", alice.id),
+		bobBearer:        mintUserToken(t, tokens, "tok-bob", bob.id),
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Request helpers
+// ──────────────────────────────────────────────────────────────────────
+
+func (e *identityEnv) do(t *testing.T, method, path, cookie, bearer string, body any) (int, []byte) {
+	t.Helper()
+	var buf io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		buf = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, e.server.URL+path, buf)
+	if err != nil {
+		t.Fatalf("build req: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if cookie != "" {
+		req.AddCookie(&http.Cookie{Name: "session_id", Value: cookie})
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, raw
+}
+
+// noteRow is one owner-scoped row as seen on the wire: the title plus the
+// stamped owner column (user_id, serialized as "userId" in camelCase
+// responses). Pairing them per row is what lets the tests assert not just
+// WHICH rows a caller sees but WHO the row is stamped to.
+type noteRow struct {
+	title string
+	owner string
+}
+
+// collectRows walks any decoded JSON value and gathers every object that
+// looks like a note row (has both "title" and "userId"). Strings that
+// themselves parse as JSON are descended into, because the MCP tool result
+// embeds the CRUD envelope as a JSON string inside content[].text; the
+// exact envelope shape is not the contract under test, so the walk is
+// deliberately shape-agnostic.
+func collectRows(v any, out *[]noteRow) {
+	switch node := v.(type) {
+	case map[string]any:
+		title, hasTitle := node["title"].(string)
+		owner, hasOwner := node["userId"].(string)
+		if hasTitle && hasOwner {
+			*out = append(*out, noteRow{title: title, owner: owner})
+		}
+		for _, val := range node {
+			collectRows(val, out)
+		}
+	case []any:
+		for _, val := range node {
+			collectRows(val, out)
+		}
+	case string:
+		trimmed := strings.TrimSpace(node)
+		if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+			var inner any
+			if err := json.Unmarshal([]byte(trimmed), &inner); err == nil {
+				collectRows(inner, out)
+			}
+		}
+	}
+}
+
+// rowsFromBody decodes a REST or MCP response body into its note rows.
+func rowsFromBody(t *testing.T, body []byte) []noteRow {
+	t.Helper()
+	var decoded any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("decode response %s: %v", body, err)
+	}
+	var rows []noteRow
+	collectRows(decoded, &rows)
+	return rows
+}
+
+// rowSet renders rows as a sorted "title=owner" list for equality checks.
+func rowSet(rows []noteRow) []string {
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.title+"="+r.owner)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// mcpCall invokes a tool over the real /mcp HTTP endpoint and returns the
+// JSON-RPC response body.
+func (e *identityEnv) mcpCall(t *testing.T, cookie, bearer, tool string, args map[string]any) ([]byte, int) {
+	t.Helper()
+	if args == nil {
+		args = map[string]any{}
+	}
+	params, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	payload := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":%q,"arguments":%s}}`, tool, params)
+	code, body := e.do(t, http.MethodPost, "/mcp", cookie, bearer, json.RawMessage(payload))
+	return body, code
+}
+
+func wantRows(pairs ...[2]string) []string {
+	out := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		out = append(out, p[0]+"="+p[1])
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// The contract
+// ──────────────────────────────────────────────────────────────────────
+
+// TestAgentIdentity_CookieAndBearerResolveSameOwner pins the identity
+// contract: one user (alice) holding credentials of BOTH kinds must, on
+// either transport, (a) be treated as the owner on writes, and (b) see
+// exactly the same owner-scoped rows on reads — on the REST routes and on
+// the /mcp agent surface alike. Bob (cookie and bearer) must see only his
+// own row, proving the scope is per-identity and not a tautology.
+func TestAgentIdentity_CookieAndBearerResolveSameOwner(t *testing.T) {
+	env := newIdentityEnv(t)
+
+	// Alice writes one row per transport: cookie first, then bearer.
+	code, body := env.do(t, http.MethodPost, "/api/notes", env.aliceCookieValue, "", map[string]string{"title": "via-cookie"})
+	if code != http.StatusCreated {
+		t.Fatalf("cookie create: got %d body %s", code, body)
+	}
+	code, body = env.do(t, http.MethodPost, "/api/notes", "", env.aliceBearer, map[string]string{"title": "via-bearer"})
+	if code != http.StatusCreated {
+		t.Fatalf("bearer create: got %d body %s", code, body)
+	}
+	// Bob's row seeded directly, so only read-scoping separates it.
+	if _, err := env.db.Exec(`INSERT INTO notes (id, title, user_id) VALUES ('n-bob', 'bobs-note', ?)`, env.bob.id); err != nil {
+		t.Fatalf("seed bob row: %v", err)
+	}
+
+	wantAlice := wantRows([2]string{"via-cookie", env.alice.id}, [2]string{"via-bearer", env.alice.id})
+	wantBob := wantRows([2]string{"bobs-note", env.bob.id})
+
+	t.Run("rest_cookie_and_bearer_lists_are_identical", func(t *testing.T) {
+		code, body := env.do(t, http.MethodGet, "/api/notes", env.aliceCookieValue, "", nil)
+		if code != http.StatusOK {
+			t.Fatalf("cookie list: got %d body %s", code, body)
+		}
+		cookieRows := rowSet(rowsFromBody(t, body))
+
+		code, body = env.do(t, http.MethodGet, "/api/notes", "", env.aliceBearer, nil)
+		if code != http.StatusOK {
+			t.Fatalf("bearer list: got %d body %s", code, body)
+		}
+		bearerRows := rowSet(rowsFromBody(t, body))
+
+		if fmt.Sprint(cookieRows) != fmt.Sprint(bearerRows) {
+			t.Fatalf("cookie and bearer principals resolved differently: cookie saw %v, bearer saw %v",
+				cookieRows, bearerRows)
+		}
+		if fmt.Sprint(cookieRows) != fmt.Sprint(wantAlice) {
+			t.Fatalf("cookie list: got %v want %v (bob leak, missing own rows, or wrong owner stamp)", cookieRows, wantAlice)
+		}
+	})
+
+	t.Run("mcp_cookie_and_bearer_lists_are_identical", func(t *testing.T) {
+		body, code := env.mcpCall(t, env.aliceCookieValue, "", "notes_list", nil)
+		if code != http.StatusOK {
+			t.Fatalf("mcp cookie notes_list: got %d body %s", code, body)
+		}
+		if strings.Contains(string(body), `"error"`) {
+			t.Fatalf("mcp cookie notes_list returned a JSON-RPC error: %s", body)
+		}
+		cookieRows := rowSet(rowsFromBody(t, body))
+
+		body, code = env.mcpCall(t, "", env.aliceBearer, "notes_list", nil)
+		if code != http.StatusOK {
+			t.Fatalf("mcp bearer notes_list: got %d body %s", code, body)
+		}
+		if strings.Contains(string(body), `"error"`) {
+			t.Fatalf("mcp bearer notes_list returned a JSON-RPC error: %s", body)
+		}
+		bearerRows := rowSet(rowsFromBody(t, body))
+
+		if fmt.Sprint(cookieRows) != fmt.Sprint(bearerRows) {
+			t.Fatalf("mcp: cookie and bearer principals resolved differently: cookie saw %v, bearer saw %v",
+				cookieRows, bearerRows)
+		}
+		if fmt.Sprint(cookieRows) != fmt.Sprint(wantAlice) {
+			t.Fatalf("mcp cookie list: got %v want %v", cookieRows, wantAlice)
+		}
+	})
+
+	t.Run("rest_mcp_surfaces_agree", func(t *testing.T) {
+		_, body := env.do(t, http.MethodGet, "/api/notes", env.aliceCookieValue, "", nil)
+		rest := rowSet(rowsFromBody(t, body))
+		mcpBody, _ := env.mcpCall(t, env.aliceCookieValue, "", "notes_list", nil)
+		viaMCP := rowSet(rowsFromBody(t, mcpBody))
+		if fmt.Sprint(rest) != fmt.Sprint(viaMCP) {
+			t.Fatalf("REST and MCP surfaces disagree: rest %v mcp %v", rest, viaMCP)
+		}
+	})
+
+	t.Run("bob_isolated_on_both_transports", func(t *testing.T) {
+		code, body := env.do(t, http.MethodGet, "/api/notes", env.bobCookieValue, "", nil)
+		if code != http.StatusOK {
+			t.Fatalf("bob cookie list: got %d body %s", code, body)
+		}
+		if got := rowSet(rowsFromBody(t, body)); fmt.Sprint(got) != fmt.Sprint(wantBob) {
+			t.Fatalf("bob cookie list: got %v want %v", got, wantBob)
+		}
+		code, body = env.do(t, http.MethodGet, "/api/notes", "", env.bobBearer, nil)
+		if code != http.StatusOK {
+			t.Fatalf("bob bearer list: got %d body %s", code, body)
+		}
+		if got := rowSet(rowsFromBody(t, body)); fmt.Sprint(got) != fmt.Sprint(wantBob) {
+			t.Fatalf("bob bearer list: got %v want %v", got, wantBob)
+		}
+	})
+
+	t.Run("anonymous_refused", func(t *testing.T) {
+		code, _ := env.do(t, http.MethodGet, "/api/notes", "", "", nil)
+		if code != http.StatusUnauthorized {
+			t.Fatalf("anonymous list: got %d want 401", code)
+		}
+	})
+}
+
+// TestAgentIdentity_BearerSurvivesCookielessRequests pins the coexistence
+// precondition: a bearer request carries NO session cookie (agents are not
+// browsers), and must still resolve. This is the regression guard for the
+// middleware ORDER: SessionMiddleware's anonymous fall-through clears any
+// ctx user an outer layer set, so TokenMiddleware must run INSIDE it. The
+// main test above already proves the documented order works for cookieless
+// bearers; this companion documents what the reverse order would do, by
+// building the reverse chain and asserting the bearer identity survives
+// only because it is resolved AFTER the anonymous fall-through. If the
+// reverse order ever became the documented one, this test failing is the
+// alarm.
+func TestAgentIdentity_BearerSurvivesCookielessRequests(t *testing.T) {
+	env := newIdentityEnv(t)
+
+	// Cookieless bearer read on REST.
+	code, body := env.do(t, http.MethodGet, "/api/notes", "", env.aliceBearer, nil)
+	if code != http.StatusOK {
+		t.Fatalf("cookieless bearer REST list: got %d body %s (bearer identity did not survive the session middleware)", code, body)
+	}
+	// Cookieless bearer read on the /mcp agent surface (exercises the
+	// re-dispatch copying Authorization, not only Cookie).
+	mcpBody, code := env.mcpCall(t, "", env.aliceBearer, "notes_list", nil)
+	if code != http.StatusOK {
+		t.Fatalf("cookieless bearer MCP notes_list: got %d body %s", code, mcpBody)
+	}
+	if strings.Contains(string(mcpBody), `"error"`) {
+		t.Fatalf("cookieless bearer MCP notes_list returned a JSON-RPC error: %s", mcpBody)
+	}
+}

--- a/framework/app_role_test.go
+++ b/framework/app_role_test.go
@@ -491,3 +491,106 @@ func TestWorkerRole_ShutdownClosesQueue(t *testing.T) {
 		t.Fatalf("worker shutdown: queue Close called %d times, want 1", f.closes.Load())
 	}
 }
+
+// ──────────────────────────────────────────────────────────────────────
+// Agent role: MCP mount + health only
+// ──────────────────────────────────────────────────────────────────────
+
+// post is the mutating counterpart of the get helper above.
+func post(t *testing.T, addr, path, contentType, body string) *http.Response {
+	t.Helper()
+	resp, err := http.Post("http://"+addr+path, contentType, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	return resp
+}
+
+// In RoleAgent, the /mcp mount is served: the MCP initialize handshake
+// (deliberately credential-free) completes over HTTP, and health probes
+// answer like every other role.
+func TestAgentRole_ServesMCPMountAndHealth(t *testing.T) {
+	t.Setenv("GOFASTR_ROLE", "")
+	db := sqliteDB(t)
+	app := NewApp(WithDB(db), WithoutDefaultMiddleware(), WithRole(RoleAgent), WithMCP())
+	app.Entity("posts", postsEntity())
+	addr, _ := startOnRandomPort(t, app)
+
+	resp := post(t, addr, "/mcp", "application/json",
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"role-test","version":"0"}}}`)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/mcp initialize on agent role: got %d body %s", resp.StatusCode, body)
+	}
+	if strings.Contains(string(body), `"error"`) {
+		t.Fatalf("/mcp initialize returned a JSON-RPC error: %s", body)
+	}
+	if !strings.Contains(string(body), "serverInfo") {
+		t.Fatalf("/mcp initialize response missing serverInfo: %s", body)
+	}
+
+	// The spec-reserved subpath forwards to the same router (404 from the
+	// ROUTER would still prove forwarding; a served card proves the mount).
+	r := get(t, addr, "/mcp/server-card")
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		t.Fatalf("/mcp/server-card on agent role: got %d want 200", r.StatusCode)
+	}
+
+	h := get(t, addr, "/healthz")
+	defer h.Body.Close()
+	if h.StatusCode != http.StatusOK {
+		t.Fatalf("/healthz on agent role: got %d want 200", h.StatusCode)
+	}
+}
+
+// In RoleAgent, an entity CRUD route is NOT served, nor OpenAPI or the
+// well-known discovery endpoints: the mux forwards only /mcp paths, the
+// browser/API surface stays unreachable from an agent-role listener.
+func TestAgentRole_EntityRouteNotServed(t *testing.T) {
+	t.Setenv("GOFASTR_ROLE", "")
+	db := sqliteDB(t)
+	app := NewApp(WithDB(db), WithoutDefaultMiddleware(), WithRole(RoleAgent), WithMCP())
+	app.Entity("posts", postsEntity())
+	addr, _ := startOnRandomPort(t, app)
+
+	resp := get(t, addr, "/posts")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("/posts on agent role: got %d want 404 (entity routes must not be served)", resp.StatusCode)
+	}
+	for _, p := range []string{"/openapi.json", "/.well-known/agent-skills/index.json"} {
+		r := get(t, addr, p)
+		r.Body.Close()
+		if r.StatusCode != http.StatusNotFound {
+			t.Fatalf("%s on agent role: got %d want 404", p, r.StatusCode)
+		}
+	}
+}
+
+// In RoleAgent, worker-scoped consumers do not start (same gate as
+// RoleServe): a queued job's Start is never called.
+func TestAgentRole_QueueDoesNotStart(t *testing.T) {
+	t.Setenv("GOFASTR_ROLE", "")
+	app := NewApp(WithoutDefaultMiddleware(), WithRole(RoleAgent))
+	f := &fakeStartStop{}
+	app.AddQueue(f)
+
+	_, stop := startOnRandomPort(t, app)
+	stop()
+
+	if f.starts.Load() != 0 {
+		t.Fatalf("agent role: queue Start called %d times, want 0", f.starts.Load())
+	}
+}
+
+// GOFASTR_ROLE=agent resolves to RoleAgent (deploy-time selection parity
+// with serve/worker).
+func TestRole_EnvSetsAgentRole(t *testing.T) {
+	t.Setenv("GOFASTR_ROLE", "agent")
+	app := NewApp(WithoutDefaultMiddleware())
+	if app.Role() != RoleAgent {
+		t.Fatalf("env role: got %q want %q", app.Role(), RoleAgent)
+	}
+}

--- a/framework/docs/content/scaling.md
+++ b/framework/docs/content/scaling.md
@@ -68,14 +68,24 @@ import "github.com/DonaldMurillo/gofastr/framework"
 var app = framework.NewApp()
 -->
 ```go
-app.Start(":8080") // role from GOFASTR_ROLE: all | serve | worker
+app.Start(":8080") // role from GOFASTR_ROLE: all | serve | worker | agent
 ```
 
 ```sh
 GOFASTR_ROLE=serve  ./myapp   # full router; no cron/queue/outbox-relay
 GOFASTR_ROLE=worker ./myapp   # cron/queue/outbox-relay; /healthz + /readyz only
+GOFASTR_ROLE=agent  ./myapp   # /mcp + /healthz + /readyz only; no entity routes
 ./myapp                       # combined (default); today's behavior
 ```
+
+`GOFASTR_ROLE=agent` (or `framework.WithRole(framework.RoleAgent)`) is the
+agent surface split: it serves the `/mcp` mount and health endpoints and
+nothing else — no entity CRUD, no OpenAPI, no browser pages. `/mcp`
+requests forward to the app router, so session/bearer auth and owner
+scoping behave exactly as on a serve process (see
+[MCP](mcp.md) and [Auth](auth.md)). Use it when agent traffic arrives
+through a dedicated tunnel or allow-listed listener and you don't want
+that listener to reach the rest of the app.
 
 `framework.WithRole(framework.RoleServe)` overrides the env var; an
 invalid value in either fails at construction. The worker's health

--- a/framework/role.go
+++ b/framework/role.go
@@ -39,12 +39,24 @@ const (
 	// lock and seeds take a SEPARATE one, so either process type may boot
 	// first without racing schema or seed writes.
 	RoleWorker Role = "worker"
+
+	// RoleAgent serves the agent surface only: the /mcp mount (POST
+	// JSON-RPC + GET SSE, plus its spec-reserved subpaths such as
+	// /mcp/server-card) and the health endpoints. Entity CRUD routes,
+	// OpenAPI, docs, admin, and well-known discovery are NOT served, and
+	// worker-scoped consumers (cron/queue/outbox relay) do not start,
+	// like RoleServe. Use it to give agent traffic (a tunnel, an
+	// allow-listed LB) a dedicated, narrow listener without exposing the
+	// browser surface. The /mcp requests still run through the app
+	// router's middleware chain, so session/bearer auth and owner
+	// scoping behave exactly as they do on a full serve process.
+	RoleAgent Role = "agent"
 )
 
 // isValidRole reports whether r is one of the defined Role constants.
 func isValidRole(r Role) bool {
 	switch r {
-	case RoleAll, RoleServe, RoleWorker:
+	case RoleAll, RoleServe, RoleWorker, RoleAgent:
 		return true
 	}
 	return false
@@ -52,8 +64,8 @@ func isValidRole(r Role) bool {
 
 // WithRole sets the process role explicitly, overriding the GOFASTR_ROLE
 // env var. Panics in NewApp if r is not one of RoleAll / RoleServe /
-// RoleWorker, matching how every other invalid option fails fast at
-// construction rather than silently degrading.
+// RoleWorker / RoleAgent, matching how every other invalid option fails
+// fast at construction rather than silently degrading.
 func WithRole(r Role) AppOption {
 	return func(a *App) {
 		a.roleOpt = r
@@ -69,22 +81,22 @@ func WithRole(r Role) AppOption {
 func resolveRole(opt Role, optSet bool) (Role, error) {
 	if optSet {
 		if !isValidRole(opt) {
-			return "", fmt.Errorf("framework: invalid role %q (want all, serve, or worker)", opt)
+			return "", fmt.Errorf("framework: invalid role %q (want all, serve, worker, or agent)", opt)
 		}
 		return opt, nil
 	}
 	if v := os.Getenv("GOFASTR_ROLE"); v != "" {
 		switch r := Role(strings.ToLower(v)); r {
-		case RoleAll, RoleServe, RoleWorker:
+		case RoleAll, RoleServe, RoleWorker, RoleAgent:
 			return r, nil
 		default:
-			return "", fmt.Errorf("framework: invalid GOFASTR_ROLE %q (want all, serve, or worker)", v)
+			return "", fmt.Errorf("framework: invalid GOFASTR_ROLE %q (want all, serve, worker, or agent)", v)
 		}
 	}
 	return RoleAll, nil
 }
 
-// Role returns the resolved process role (all/serve/worker). It is set
+// Role returns the resolved process role (all/serve/worker/agent). It is set
 // once in NewApp and never changes afterward, so OnStart hooks and other
 // setup code can gate their own background work on it, e.g. skipping an
 // expensive warm-up that only makes sense when serving HTTP:
@@ -107,10 +119,14 @@ func (a *App) runsWorkers() bool {
 }
 
 // roleHandler picks the HTTP surface Start serves: the full app router for
-// all/serve, or the health-only mux for a worker process.
+// all/serve, the health-only mux for a worker process, or the MCP+health
+// mux for an agent process.
 func (a *App) roleHandler() http.Handler {
 	if a.role == RoleWorker {
 		return a.workerHealthMux()
+	}
+	if a.role == RoleAgent {
+		return a.agentMux()
 	}
 	return a.router
 }
@@ -124,5 +140,25 @@ func (a *App) workerHealthMux() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", liveness)
 	mux.HandleFunc("/readyz", readiness)
+	return mux
+}
+
+// agentMux is the agent role's entire HTTP surface: /healthz and /readyz
+// (the same handlers the full router mounts) plus the /mcp mount and its
+// spec-reserved subpaths (/mcp/server-card), forwarded to the app router
+// so /mcp requests run under the SAME middleware chain — auth, owner
+// scoping context, recovery — they see in a full serve process. Only
+// /mcp paths are forwarded: entity CRUD, OpenAPI, docs, admin, and
+// well-known discovery stay unreachable from an agent-role listener even
+// though the router still holds them. A host that never mounted /mcp
+// (no WithMCP, no hand-wired route) gets the router's 404 here, which is
+// the honest answer for that misconfiguration.
+func (a *App) agentMux() http.Handler {
+	liveness, readiness := a.healthHandlers()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", liveness)
+	mux.HandleFunc("/readyz", readiness)
+	mux.Handle("/mcp", a.router)
+	mux.Handle("/mcp/", a.router)
 	return mux
 }


### PR DESCRIPTION
Closes #302. Advances #291 (the ticket stays open — the widget runtime is still
to come).

Kept out of `framework/pluginhost/` deliberately: another agent is working
#300 and #303 there.

## #302 — combobox keyboard nav walked hidden options

The navigable-option list excluded `aria-disabled` rows but not the rows the
static filter hides, so after typing a query ArrowDown/ArrowUp/Home/End cycled
through invisible options — the highlight vanished mid-cycle because
`aria-activedescendant` pointed at a hidden row, and Enter selected an option
the user had filtered away.

Home, End and Enter share that one array, so a single selector fix covers all
of them. I checked that rather than assuming: every other `role="option"` site
is either an `.is-active` clear (safe on hidden rows), a click handler (a
hidden option cannot be clicked), or the filter loop that sets `hidden`.

**One leftover fixed rather than deferred.** The focusin reopen tested for any
`[role="option"]`, hidden included, so refocusing an input whose every option
was filtered out opened an empty listbox. Same bug class, one line away.

Mutation reproduces the reported bug exactly:

```
ArrowDown x2: aria-activedescendant = "opt-alpha", want "opt-charlie"
Enter: input value = "alpha", want "charlie"
```

New e2e passes three consecutive runs, and uses `chromedp.Poll` rather than
fixed sleeps — the suite was converted away from those earlier today and this
should not reintroduce them.

## #291 — agent role, and the identity contract underneath it

The role constant is one branch in a switch. The part with no coverage at all
was the **identity contract**: bearer tokens and session cookies both resolve a
user today, and nothing guaranteed that the same person arriving by token
versus by cookie resolved to the same owner-scope principal. An agent surface
makes that live — the same user arrives by token where a browser arrives by
cookie, and per-user rows are scoped by owner field, so a divergence means an
agent either cannot see its own user's rows or sees somebody else's.

This was scoped as a characterisation task, with instructions to report a
failure rather than "fix" auth to make it pass.

**The contract holds**, and is now pinned on both REST and `/mcp`: same user,
same `GetID()`, same owner-stamped rows, second user's rows invisible.

The tests are guards, not tautologies — each of these turns them red:

| Mutation | Effect |
|---|---|
| bearer path returns a divergent principal | `cookie saw [via-cookie=u-alice], bearer saw [via-bearer=divergent-u-alice]` |
| owner scoping keys on email instead of id | wrong rows on REST **and** MCP |
| MCP re-dispatch stops copying `Authorization` | MCP-bearer legs 401; cookie legs stay green |

`RoleAgent` (`GOFASTR_ROLE=agent`) serves `/mcp` and health only, forwarding
MCP to the app router so auth and owner scoping are identical to the serve
role. Entity CRUD, OpenAPI, docs, admin and well-known discovery are not
served; workers do not start. I re-ran the isolation mutation myself —
returning the full router from the agent branch fails with
`/posts on agent role: got 401 want 404 (entity routes must not be served)`.

## Noted, not fixed

A pre-existing ArrowUp off-by-one in **RPC-mode** comboboxes (`activeIdx -1`
lands on `len-2`) is orthogonal to hidden-row filtering and predates this
change. Flagging rather than widening scope a second time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an agent runtime role serving MCP and health endpoints without exposing entity CRUD, OpenAPI, documentation, admin, or discovery routes.
  * Added consistent owner-scoped authentication across REST and MCP using bearer tokens or session cookies.
* **Bug Fixes**
  * Improved combobox keyboard navigation to skip filtered and hidden options.
  * Prevented empty listboxes from reopening when all options are filtered out.
* **Documentation**
  * Documented configuration and usage of the new agent runtime role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->