### PR TITLE
feat(mcp): ship the MCP Apps widget client (#291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Added
 
+- **MCP Apps widget client** (#291): `core/mcp` served the app side already
+  (`RegisterApp`, `_meta.ui`), but the JS that runs inside the host's iframe
+  and talks to the chat host did not exist, so every plugin author hand-rolled
+  it. `WidgetClientJS()` / `RegisterWidgetClientRoute` ship it the way
+  pluginhost ships its frame client: the `ui/initialize` handshake followed by
+  `ui/notifications/initialized`, the six widget-to-host requests
+  (`tools/call`, `resources/read`, `ui/open-link`, `ui/request-display-mode`,
+  `ui/message`, `ui/update-model-context`) and handler registration for the
+  host-to-widget notifications.
+
+  Every method-name string is pinned against non-comment JS, so a one-character
+  typo — a widget that silently never fires — fails a test instead of shipping.
+  Requests are correlated by id through a null-prototype map bounded at 64 in
+  flight, rejecting `E_SATURATED` without posting rather than growing, with
+  timeout, send-failure and teardown all rejecting rather than hanging.
+  Messages are accepted only from the host window by `event.source`: the widget
+  frame is opaque-origin, so an origin-string check is the wrong tool.
+
+  GoFastr serves the widget side; it is not a chat host, and the host half is
+  deliberately absent.
+
 - **`RoleAgent` — an agent-only HTTP surface** (#291): `GOFASTR_ROLE=agent`
   (or `WithRole(RoleAgent)`) serves `/mcp` and health only, forwarding MCP to
   the app router so auth and owner scoping are identical to the serve role.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 - **MCP Apps widget client** (#291): `core/mcp` served the app side already
   (`RegisterApp`, `_meta.ui`), but the JS that runs inside the host's iframe
   and talks to the chat host did not exist, so every plugin author hand-rolled
-  it. `WidgetClientJS()` / `RegisterWidgetClientRoute` ship it the way
+  it. `WidgetClientJS()` / `WidgetClientHandler()` ship it the way
   pluginhost ships its frame client: the `ui/initialize` handshake followed by
   `ui/notifications/initialized`, the six widget-to-host requests
   (`tools/call`, `resources/read`, `ui/open-link`, `ui/request-display-mode`,

--- a/core/mcp/widgetclient.go
+++ b/core/mcp/widgetclient.go
@@ -3,11 +3,9 @@ package mcp
 import (
 	_ "embed"
 	"net/http"
-
-	"github.com/DonaldMurillo/gofastr/core/router"
 )
 
-// WidgetClientScriptURL is the route serving the MCP Apps widget client
+// WidgetClientScriptURL is the path serving the MCP Apps widget client
 // (widgetclient.js). Widget documents hot-link it to get the ext-apps
 // handshake, JSON-RPC envelope, source check, and request/response
 // semantics without hand-rolling a postMessage RPC per app.
@@ -16,37 +14,22 @@ const WidgetClientScriptURL = "/__gofastr/mcp/app/widgetclient.js"
 //go:embed widgetclient.js
 var widgetClientJSBytes []byte
 
-// WidgetClientRouteMethod is the router method the widget client route is
-// registered under.
-const WidgetClientRouteMethod = "GET"
-
-// RegisterWidgetClientRoute serves the widget client at
-// [WidgetClientScriptURL] on the given router. It is IDEMPOTENT: register it
-// from wherever the router is assembled; only the first registration lands.
+// WidgetClientHandler returns the handler serving the widget client at
+// [WidgetClientScriptURL]. Mount it wherever the HTTP surface is assembled:
+//
+//	rt.Get(mcp.WidgetClientScriptURL, mcp.WidgetClientHandler())
+//
+// It hands back a handler rather than taking a router for the same reason
+// [Server.ServeSSE] does: the protocol package stays decoupled from any
+// particular router.
 //
 // Like pluginhost's frame client, this script is fetched BY opaque-origin
 // frame documents (the host renders the widget in a sandboxed iframe), so it
 // carries the Cross-Origin-Resource-Policy relaxation: the same-origin
 // default would refuse the "null"-origin frame's <script src>. See
 // writeWidgetClientAsset for why that is the only framing header it sets.
-func RegisterWidgetClientRoute(rt *router.Router) {
-	if widgetClientRouteRegistered(rt) {
-		return
-	}
-	rt.Get(WidgetClientScriptURL, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		writeWidgetClientAsset(w)
-	}))
-}
-
-// widgetClientRouteRegistered reports whether the widget client route is
-// already on the router, keeping RegisterWidgetClientRoute idempotent.
-func widgetClientRouteRegistered(rt *router.Router) bool {
-	for _, rr := range rt.Routes() {
-		if rr.Method == WidgetClientRouteMethod && rr.Pattern == WidgetClientScriptURL {
-			return true
-		}
-	}
-	return false
+func WidgetClientHandler() http.Handler {
+	return http.HandlerFunc(writeWidgetClientAsset)
 }
 
 // writeWidgetClientAsset emits the client with the framing headers a script
@@ -55,7 +38,7 @@ func widgetClientRouteRegistered(rt *router.Router) bool {
 // deliberately not touched here; Cross-Origin-Resource-Policy is the one
 // that gates the frame's cross-origin <script src>, and it must be
 // "cross-origin" or the sandboxed widget can never load its client.
-func writeWidgetClientAsset(w http.ResponseWriter) {
+func writeWidgetClientAsset(w http.ResponseWriter, r *http.Request) {
 	h := w.Header()
 	h.Set("Content-Type", "text/javascript; charset=utf-8")
 	// Never let a browser MIME-sniff this into a more dangerous type.

--- a/core/mcp/widgetclient.go
+++ b/core/mcp/widgetclient.go
@@ -1,0 +1,79 @@
+package mcp
+
+import (
+	_ "embed"
+	"net/http"
+
+	"github.com/DonaldMurillo/gofastr/core/router"
+)
+
+// WidgetClientScriptURL is the route serving the MCP Apps widget client
+// (widgetclient.js). Widget documents hot-link it to get the ext-apps
+// handshake, JSON-RPC envelope, source check, and request/response
+// semantics without hand-rolling a postMessage RPC per app.
+const WidgetClientScriptURL = "/__gofastr/mcp/app/widgetclient.js"
+
+//go:embed widgetclient.js
+var widgetClientJSBytes []byte
+
+// WidgetClientRouteMethod is the router method the widget client route is
+// registered under.
+const WidgetClientRouteMethod = "GET"
+
+// RegisterWidgetClientRoute serves the widget client at
+// [WidgetClientScriptURL] on the given router. It is IDEMPOTENT: register it
+// from wherever the router is assembled; only the first registration lands.
+//
+// Like pluginhost's frame client, this script is fetched BY opaque-origin
+// frame documents (the host renders the widget in a sandboxed iframe), so it
+// carries the Cross-Origin-Resource-Policy relaxation: the same-origin
+// default would refuse the "null"-origin frame's <script src>. See
+// writeWidgetClientAsset for why that is the only framing header it sets.
+func RegisterWidgetClientRoute(rt *router.Router) {
+	if widgetClientRouteRegistered(rt) {
+		return
+	}
+	rt.Get(WidgetClientScriptURL, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeWidgetClientAsset(w)
+	}))
+}
+
+// widgetClientRouteRegistered reports whether the widget client route is
+// already on the router, keeping RegisterWidgetClientRoute idempotent.
+func widgetClientRouteRegistered(rt *router.Router) bool {
+	for _, rr := range rt.Routes() {
+		if rr.Method == WidgetClientRouteMethod && rr.Pattern == WidgetClientScriptURL {
+			return true
+		}
+	}
+	return false
+}
+
+// writeWidgetClientAsset emits the client with the framing headers a script
+// fetched by an opaque-origin iframe needs. X-Frame-Options and CSP
+// frame-ancestors govern document embedding, not script bytes, so they are
+// deliberately not touched here; Cross-Origin-Resource-Policy is the one
+// that gates the frame's cross-origin <script src>, and it must be
+// "cross-origin" or the sandboxed widget can never load its client.
+func writeWidgetClientAsset(w http.ResponseWriter) {
+	h := w.Header()
+	h.Set("Content-Type", "text/javascript; charset=utf-8")
+	// Never let a browser MIME-sniff this into a more dangerous type.
+	h.Set("X-Content-Type-Options", "nosniff")
+	// The URL is unversioned and the bytes carry no validator; no-store
+	// forces a fresh fetch per widget load instead of a stale copy across
+	// server upgrades. (A prod build would content-hash the URL instead.)
+	h.Set("Cache-Control", "no-store, max-age=0")
+	h.Set("Cross-Origin-Resource-Policy", "cross-origin")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(widgetClientJSBytes)
+}
+
+// WidgetClientJS returns a copy of the embedded widget client, for authors
+// who fold the script into their own widget HTML instead of hot-linking
+// [WidgetClientScriptURL].
+func WidgetClientJS() []byte {
+	b := make([]byte, len(widgetClientJSBytes))
+	copy(b, widgetClientJSBytes)
+	return b
+}

--- a/core/mcp/widgetclient.js
+++ b/core/mcp/widgetclient.js
@@ -43,8 +43,9 @@
   // requests. Null-proto so a "__proto__"/"constructor" id looks up as
   // undefined instead of a truthy Object.prototype member.
   var pending = Object.create(null);
-  // method -> handler, for inbound host → widget notifications.
-  var notificationHandlers = Object.create(null);
+  // method -> handler, for inbound host → widget traffic: the
+  // notifications, plus the ui/resource-teardown request handler.
+  var inboundHandlers = Object.create(null);
   var reqCounter = 0;
 
   function message(method, params, id) {
@@ -117,13 +118,22 @@
   }
 
   function register(method, handler) {
-    notificationHandlers[method] = handler;
+    inboundHandlers[method] = handler;
   }
 
   // --- Inbound dispatch (host → widget) --------------------------------------
 
-  function runHandler(method, params) {
-    var h = notificationHandlers[method];
+  // A JSON-RPC response to a host request. Results here are always {}
+  // or a plain error object, so the post cannot throw DataCloneError.
+  function reply(id, result, err) {
+    var msg = { jsonrpc: JSON_RPC_VERSION, id: id };
+    if (err) msg.error = err;
+    else msg.result = result;
+    postToHost(msg);
+  }
+
+  function handleNotification(method, params) {
+    var h = inboundHandlers[method];
     if (typeof h !== "function") return; // unknown method → ignored, not thrown
     try { h(params || {}); } catch (e) {
       if (typeof console !== "undefined" && console.error) {
@@ -132,15 +142,27 @@
     }
   }
 
-  function handleNotification(method, params) {
-    runHandler(method, params);
-    // ui/resource-teardown is the host saying this widget is going away.
-    // The app's registered handler runs first (it may still post a final
-    // notification); after it, every request still in flight can never be
-    // answered — fail them instead of leaking until each timer fires.
-    if (method === "ui/resource-teardown") {
-      rejectOutstanding({ code: "E_TEARDOWN", message: "widget torn down" });
-    }
+  // Host teardown (spec 2026-01-26: a REQUEST, not a notification — the
+  // host SHOULD wait for the response before tearing the resource down,
+  // to prevent data loss). The app's registered handler runs first,
+  // awaited if it returns a promise; the response is posted, and only
+  // then — with the response on the wire — is every outstanding request
+  // failed. Same ordering as pluginhost's frame client teardown.
+  function handleTeardown(msg) {
+    var handler = inboundHandlers["ui/resource-teardown"];
+    var run = (typeof handler === "function")
+      ? function () { return handler(msg.params || {}); }
+      : function () { return undefined; }; // no hook — still respond
+    Promise.resolve().then(run).then(
+      function () {
+        reply(msg.id, {}, null);
+        rejectOutstanding({ code: "E_TEARDOWN", message: "widget torn down" });
+      },
+      function (err) {
+        reply(msg.id, null, { code: "E_HANDLER", message: String(err && err.message || err) });
+        rejectOutstanding({ code: "E_TEARDOWN", message: "widget torn down" });
+      }
+    );
   }
 
   function onWindowMessage(event) {
@@ -154,8 +176,15 @@
     if (msg.jsonrpc !== JSON_RPC_VERSION) return;
 
     if (msg.method !== undefined) {
-      // Host → widget REQUESTS (method + id) are not part of this
-      // client's surface; dropping them is the ignore-don't-throw rule.
+      // ui/resource-teardown is the ONE host → widget request on this
+      // client's surface (the host waits for the response before
+      // removing the resource), so it is answered, never dropped. Any
+      // other request is not part of the surface; dropping it is the
+      // ignore-don't-throw rule.
+      if (msg.method === "ui/resource-teardown" && msg.id !== undefined) {
+        handleTeardown(msg);
+        return;
+      }
       if (msg.id !== undefined) return;
       handleNotification(msg.method, msg.params);
       return;
@@ -205,9 +234,9 @@
     updateModelContext: function (params, timeoutMs) { return request("ui/update-model-context", params, timeoutMs); },
     // The widget resized itself; params carries the new size.
     sizeChanged: function (params) { notify("ui/notifications/size-changed", params); },
-    // Host → widget notification handler (method → handler);
-    // re-registering a method overwrites. Notifications with no
-    // registered handler are ignored, never thrown.
+    // Host → widget inbound handler (method → handler);
+    // re-registering a method overwrites. Inbound notifications with
+    // no registered handler are ignored, never thrown.
     on: register,
     // Named registrars for the host → widget notifications.
     onToolInput: function (handler) { register("ui/notifications/tool-input", handler); },
@@ -215,8 +244,14 @@
     onToolResult: function (handler) { register("ui/notifications/tool-result", handler); },
     onToolCancelled: function (handler) { register("ui/notifications/tool-cancelled", handler); },
     onHostContextChanged: function (handler) { register("ui/notifications/host-context-changed", handler); },
-    onResourceTeardown: function (handler) { register("ui/resource-teardown", handler); },
-    onMessage: function (handler) { register("notifications/message", handler); }
+    onMessage: function (handler) { register("notifications/message", handler); },
+    // The one host → widget REQUEST: ui/resource-teardown (spec
+    // 2026-01-26 — the host waits for the response before tearing the
+    // resource down). The handler may return a promise; the client
+    // answers after it settles — result {} on success, a JSON-RPC
+    // error if it throws — then fails every outstanding request with
+    // E_TEARDOWN.
+    onResourceTeardown: function (handler) { register("ui/resource-teardown", handler); }
   };
 
   window.addEventListener("message", onWindowMessage);

--- a/core/mcp/widgetclient.js
+++ b/core/mcp/widgetclient.js
@@ -1,0 +1,228 @@
+/*!
+ * mcp/widgetclient.js — widget-side client for MCP Apps (GoFastr).
+ *
+ * Plain JavaScript (IIFE, no imports, no external URLs). Runs INSIDE the
+ * host-rendered sandboxed iframe of an MCP App and speaks the MCP Apps
+ * widget protocol (ext-apps, spec 2026-01-26): JSON-RPC 2.0 over
+ * postMessage, no extra framing. GoFastr serves the widget side of MCP
+ * Apps and is not a host; this script is what an app author loads
+ * instead of hand-rolling the postMessage RPC.
+ *
+ * Security invariants (mirror of pluginhost's frame client — do NOT
+ * weaken):
+ *   - Messages are accepted only when event.source === window.parent.
+ *     We do NOT check event.origin: this frame IS an opaque origin (its
+ *     origin string is literally "null"), so origin-string checks are a
+ *     trap in both directions; the window identity is the gate.
+ *   - Posts use targetOrigin "*" — the frame is opaque-origin, so a
+ *     concrete targetOrigin is the wrong tool; the source check is the
+ *     gate.
+ *
+ * Usage (inside the widget document, after this script loads):
+ *
+ *   var app = window.__gofastrMcpApp;
+ *   app.connect({ availableDisplayModes: ["inline"] }).then(function (host) {
+ *     // host.protocolVersion / hostCapabilities / hostInfo / hostContext
+ *   });
+ *   app.callTool({ name: "search", arguments: { q: "hi" } }).then(...);
+ *   app.onToolResult(function (params) { ... });
+ *   app.sizeChanged({ width: 320, height: 240 });
+ */
+(function () {
+  'use strict';
+
+  // --- Protocol constants (pinned by widgetclient_test.go) -------------------
+
+  var JSON_RPC_VERSION = "2.0";    // the envelope; there is no other framing
+  var RESPONSE_TIMEOUT_MS = 30000; // request → response default; tools/call
+                                   // turns can be slow — pass an explicit
+                                   // timeoutMs when they are slower still
+  var MAX_INFLIGHT = 64;           // pending-request bound
+
+  // id -> {resolve, reject, timer} for OUR outbound (widget → host)
+  // requests. Null-proto so a "__proto__"/"constructor" id looks up as
+  // undefined instead of a truthy Object.prototype member.
+  var pending = Object.create(null);
+  // method -> handler, for inbound host → widget notifications.
+  var notificationHandlers = Object.create(null);
+  var reqCounter = 0;
+
+  function message(method, params, id) {
+    var msg = { jsonrpc: JSON_RPC_VERSION, method: method };
+    if (params) msg.params = params;
+    if (id !== undefined) msg.id = id;
+    return msg;
+  }
+
+  function postToHost(msg) {
+    // The widget frame is an opaque origin; targetOrigin MUST be "*". The
+    // real gate is the event.source === window.parent check on both sides.
+    window.parent.postMessage(msg, "*");
+  }
+
+  // A non-positive / NaN / infinite timeoutMs is not a timeout — fall back
+  // to the protocol default instead of handing garbage to setTimeout.
+  function validTimeout(timeoutMs) {
+    return (typeof timeoutMs === "number" && isFinite(timeoutMs) && timeoutMs > 0)
+      ? timeoutMs
+      : RESPONSE_TIMEOUT_MS;
+  }
+
+  // Fail every outstanding request (host teardown, pagehide) so nothing
+  // hangs; responses arriving after this are dropped by id.
+  function rejectOutstanding(err) {
+    for (var id in pending) {
+      if (Object.prototype.hasOwnProperty.call(pending, id)) {
+        clearTimeout(pending[id].timer);
+        pending[id].reject(err);
+      }
+    }
+    pending = Object.create(null);
+  }
+
+  function request(method, params, timeoutMs) {
+    if (Object.keys(pending).length >= MAX_INFLIGHT) {
+      // Reject BEFORE posting: a widget that ignores the rejection would
+      // otherwise stack unbounded entries waiting to time out.
+      return Promise.reject({
+        code: "E_SATURATED",
+        message: "request map saturated at " + MAX_INFLIGHT + " in flight: " + method
+      });
+    }
+    timeoutMs = validTimeout(timeoutMs);
+    return new Promise(function (resolve, reject) {
+      var id = ++reqCounter;
+      var timer = setTimeout(function () {
+        if (pending[id]) {
+          delete pending[id];
+          reject({ code: "E_TIMEOUT", message: "request " + method + " timed out" });
+        }
+      }, timeoutMs);
+      pending[id] = { resolve: resolve, reject: reject, timer: timer };
+      try {
+        postToHost(message(method, params, id));
+      } catch (e) {
+        // A non-structured-cloneable params postMessage throw must clean
+        // up the pending entry + timer, or it lingers to timeout and
+        // counts toward MAX_INFLIGHT.
+        clearTimeout(timer);
+        delete pending[id];
+        reject({ code: "E_SEND", message: "request " + method + " not sendable: " + String(e && e.message || e) });
+      }
+    });
+  }
+
+  function notify(method, params) {
+    postToHost(message(method, params));
+  }
+
+  function register(method, handler) {
+    notificationHandlers[method] = handler;
+  }
+
+  // --- Inbound dispatch (host → widget) --------------------------------------
+
+  function runHandler(method, params) {
+    var h = notificationHandlers[method];
+    if (typeof h !== "function") return; // unknown method → ignored, not thrown
+    try { h(params || {}); } catch (e) {
+      if (typeof console !== "undefined" && console.error) {
+        console.error("[mcpapp] handler for " + method + " threw", e);
+      }
+    }
+  }
+
+  function handleNotification(method, params) {
+    runHandler(method, params);
+    // ui/resource-teardown is the host saying this widget is going away.
+    // The app's registered handler runs first (it may still post a final
+    // notification); after it, every request still in flight can never be
+    // answered — fail them instead of leaking until each timer fires.
+    if (method === "ui/resource-teardown") {
+      rejectOutstanding({ code: "E_TEARDOWN", message: "widget torn down" });
+    }
+  }
+
+  function onWindowMessage(event) {
+    // Security gate: accept ONLY the parent window — NOT event.origin
+    // (the sandboxed widget reports origin "null"; source identity is
+    // the gate).
+    var fromParent = event.source === window.parent;
+    if (!fromParent) return;
+    var msg = event.data;
+    if (!msg || typeof msg !== "object") return;
+    if (msg.jsonrpc !== JSON_RPC_VERSION) return;
+
+    if (msg.method !== undefined) {
+      // Host → widget REQUESTS (method + id) are not part of this
+      // client's surface; dropping them is the ignore-don't-throw rule.
+      if (msg.id !== undefined) return;
+      handleNotification(msg.method, msg.params);
+      return;
+    }
+
+    // A response to one of OUR requests, correlated by id. A late
+    // response — already timed out or torn down — finds no pending
+    // entry and is dropped.
+    var p = pending[msg.id];
+    if (!p) return;
+    clearTimeout(p.timer);
+    delete pending[msg.id];
+    if (msg.error) p.reject(msg.error);
+    else p.resolve(msg.result);
+  }
+
+  // --- Public client ----------------------------------------------------------
+
+  window.__gofastrMcpApp = {
+    // Handshake (call once). Sends ui/initialize carrying the app's
+    // appCapabilities, resolves with the host's result — protocolVersion,
+    // hostCapabilities, hostInfo, hostContext — and only then sends the
+    // ui/notifications/initialized notification.
+    connect: function (appCapabilities, timeoutMs) {
+      return request("ui/initialize", { appCapabilities: appCapabilities || {} }, timeoutMs)
+        .then(function (result) {
+          notify("ui/notifications/initialized");
+          return result;
+        });
+    },
+    // Widget → host request (any spec method): params is the method's
+    // spec params object, verbatim. Rejects with the host's JSON-RPC
+    // error object, or one of our codes: E_TIMEOUT (no response within
+    // timeoutMs, default 30s), E_SATURATED (MAX_INFLIGHT in flight),
+    // E_SEND (params not cloneable), E_TEARDOWN (widget torn down or
+    // page hidden).
+    request: request,
+    // Widget → host notification (fire-and-forget).
+    notify: notify,
+    // Named senders: each pins one spec method string; params pass
+    // through verbatim, so the payload shape is the spec's, not ours.
+    callTool: function (params, timeoutMs) { return request("tools/call", params, timeoutMs); },
+    readResource: function (params, timeoutMs) { return request("resources/read", params, timeoutMs); },
+    openLink: function (params, timeoutMs) { return request("ui/open-link", params, timeoutMs); },
+    requestDisplayMode: function (params, timeoutMs) { return request("ui/request-display-mode", params, timeoutMs); },
+    message: function (params, timeoutMs) { return request("ui/message", params, timeoutMs); },
+    updateModelContext: function (params, timeoutMs) { return request("ui/update-model-context", params, timeoutMs); },
+    // The widget resized itself; params carries the new size.
+    sizeChanged: function (params) { notify("ui/notifications/size-changed", params); },
+    // Host → widget notification handler (method → handler);
+    // re-registering a method overwrites. Notifications with no
+    // registered handler are ignored, never thrown.
+    on: register,
+    // Named registrars for the host → widget notifications.
+    onToolInput: function (handler) { register("ui/notifications/tool-input", handler); },
+    onToolInputPartial: function (handler) { register("ui/notifications/tool-input-partial", handler); },
+    onToolResult: function (handler) { register("ui/notifications/tool-result", handler); },
+    onToolCancelled: function (handler) { register("ui/notifications/tool-cancelled", handler); },
+    onHostContextChanged: function (handler) { register("ui/notifications/host-context-changed", handler); },
+    onResourceTeardown: function (handler) { register("ui/resource-teardown", handler); },
+    onMessage: function (handler) { register("notifications/message", handler); }
+  };
+
+  window.addEventListener("message", onWindowMessage);
+  // The widget document is going away — outstanding requests can never
+  // get a response; fail them now instead of leaking until timeout.
+  window.addEventListener("pagehide", function () {
+    rejectOutstanding({ code: "E_TEARDOWN", message: "page hidden" });
+  });
+})();

--- a/core/mcp/widgetclient_test.go
+++ b/core/mcp/widgetclient_test.go
@@ -1,0 +1,326 @@
+package mcp
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/router"
+)
+
+// The MCP Apps widget client lives in widgetclient.js and speaks ext-apps
+// JSON-RPC 2.0 over postMessage to the chat host. Its invariants can't be
+// Go-typed away, so the dangerous regressions — a typo'd method string is a
+// widget that silently never works — are pinned at the source level
+// (deterministic, no browser), in the style of pluginhost's frame client
+// pins. Every pin runs against non-comment JS: the header comment names the
+// same strings, so a whole-file Contains would stay green with the code
+// deleted.
+
+// nonCommentJS strips whole-line and trailing // comments, returning the
+// executable lines joined — the same approach as pluginhost's
+// TestBrokerJS_NeverEmitsAllowSameOrigin scan, so pins can't be satisfied by
+// prose.
+func nonCommentJS(js string) string {
+	var b strings.Builder
+	for line := range strings.SplitSeq(js, "\n") {
+		code := strings.TrimSpace(line)
+		if strings.HasPrefix(code, "//") || strings.HasPrefix(code, "*") ||
+			strings.HasPrefix(code, "/*") {
+			continue
+		}
+		if idx := strings.Index(code, "//"); idx >= 0 {
+			code = strings.TrimSpace(code[:idx])
+		}
+		b.WriteString(code)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// jsBody slices code from the start marker to the end marker (first
+// occurrence after start), so a pin can be scoped to one function instead of
+// being satisfied by an unrelated line elsewhere in the file.
+func jsBody(code, start, end string) string {
+	si := strings.Index(code, start)
+	if si < 0 {
+		return ""
+	}
+	rest := code[si:]
+	ei := strings.Index(rest[len(start):], end)
+	if ei < 0 {
+		return ""
+	}
+	return rest[:len(start)+ei]
+}
+
+// Every method-name string of the ext-apps widget surface, pinned QUOTED in
+// executable code: the outbound requests and notifications appear at their
+// sender/registration sites, so a typo'd or deleted literal fails here
+// instead of shipping a widget that silently never works.
+func TestWidgetClientJS_PinMethodNames(t *testing.T) {
+	code := nonCommentJS(string(widgetClientJSBytes))
+	for _, m := range []string{
+		// Widget → host: handshake.
+		"ui/initialize",
+		"ui/notifications/initialized",
+		// Widget → host requests.
+		"tools/call",
+		"resources/read",
+		"ui/open-link",
+		"ui/request-display-mode",
+		"ui/message",
+		"ui/update-model-context",
+		// Widget → host notification.
+		"ui/notifications/size-changed",
+		// Host → widget notifications (dispatchable, so registrable).
+		"ui/notifications/tool-input",
+		"ui/notifications/tool-input-partial",
+		"ui/notifications/tool-result",
+		"ui/notifications/tool-cancelled",
+		"ui/notifications/host-context-changed",
+		"ui/resource-teardown",
+		"notifications/message",
+	} {
+		if !strings.Contains(code, `"`+m+`"`) {
+			t.Errorf("widget client missing quoted method literal %q in executable code", m)
+		}
+	}
+}
+
+// The handshake order: ui/initialize is sent as a request and
+// ui/notifications/initialized is notified only from inside its response
+// handler, so the textual order inside connect() is load-bearing — flipping
+// it sends initialized before the host answered initialize.
+func TestWidgetClientJS_HandshakeNotifiesAfterInitializeResult(t *testing.T) {
+	code := nonCommentJS(string(widgetClientJSBytes))
+	body := jsBody(code, "connect: function", "request: request")
+	if body == "" {
+		t.Fatal("connect() body not found in widget client")
+	}
+	ii := strings.Index(body, `"ui/initialize"`)
+	ni := strings.Index(body, `"ui/notifications/initialized"`)
+	if ii < 0 || ni < 0 {
+		t.Fatal("connect() must reference both handshake literals")
+	}
+	if ni < ii {
+		t.Error("ui/notifications/initialized must be sent after the ui/initialize response, not before")
+	}
+	if !strings.Contains(body, "appCapabilities: appCapabilities") {
+		t.Error("connect() must carry the app's appCapabilities in ui/initialize params")
+	}
+}
+
+// (1) postMessage source validation, mirror of pluginhost's frame client:
+// messages are accepted ONLY from the parent window, never gated on
+// event.origin (the sandboxed widget reports origin "null"; an origin-string
+// check is the wrong tool in both directions), the JSON-RPC version is
+// checked, and host→widget REQUESTS are dropped rather than dispatched.
+func TestWidgetClientJS_ValidatesMessageSource(t *testing.T) {
+	code := nonCommentJS(string(widgetClientJSBytes))
+	if !strings.Contains(code, "event.source === window.parent") &&
+		!strings.Contains(code, "window.parent === event.source") {
+		t.Error("onWindowMessage must accept only messages whose source is the parent window (in code, not prose)")
+	}
+	if strings.Contains(code, "event.origin") {
+		t.Error("onWindowMessage must not gate on event.origin — the widget frame is opaque-origin; source identity is the gate")
+	}
+	if !strings.Contains(code, "msg.jsonrpc !== JSON_RPC_VERSION") {
+		t.Error("onWindowMessage must reject a wrong JSON-RPC version")
+	}
+	if !strings.Contains(code, "if (msg.id !== undefined) return;") {
+		t.Error("onWindowMessage must drop host→widget requests (method + id) instead of dispatching them as notifications")
+	}
+}
+
+// (2) The widget→host post uses targetOrigin "*" (the frame is opaque, a
+// concrete targetOrigin is the wrong tool); the source check, not an origin
+// string, is the gate. Mirror of the pluginhost pin so nobody "hardens" it
+// into an origin that silently drops every message.
+func TestWidgetClientJS_PostsWithWildcardTargetOrigin(t *testing.T) {
+	js := string(widgetClientJSBytes)
+	if !strings.Contains(js, `postMessage(msg, "*")`) {
+		t.Error(`postToHost must use targetOrigin "*" (source check is the gate)`)
+	}
+}
+
+// (3) No external URLs: the client runs inside the host's sandboxed widget
+// iframe, and a script that phones home would punch out of the isolation the
+// host put it in. Mirror of the pluginhost scan: whole comment lines are
+// skipped but trailing comments are NOT stripped (a URL's own "//" would be
+// read as a comment start and destroy the scheme before the check), so a URL
+// in a trailing comment flags — the safe direction.
+func TestWidgetClientJS_NoExternalURLs(t *testing.T) {
+	js := string(widgetClientJSBytes)
+	for line := range strings.SplitSeq(js, "\n") {
+		code := strings.TrimSpace(line)
+		if strings.HasPrefix(code, "//") || strings.HasPrefix(code, "*") ||
+			strings.HasPrefix(code, "/*") {
+			continue // whole-line comment
+		}
+		if strings.Contains(code, "http://") || strings.Contains(code, "https://") {
+			t.Errorf("external URL in executable code: %q", strings.TrimSpace(line))
+		}
+	}
+}
+
+// The envelope is JSON-RPC 2.0 with no extra framing: the constant is
+// declared once and used on BOTH the outbound construction and the inbound
+// check, so a drifted version silently drops every message on one side.
+func TestWidgetClientJS_EnvelopeVersion(t *testing.T) {
+	re := regexp.MustCompile(`JSON_RPC_VERSION = "(\d+\.\d+)"`)
+	m := re.FindStringSubmatch(string(widgetClientJSBytes))
+	if m == nil {
+		t.Fatal("widget client: JSON_RPC_VERSION declaration not found")
+	}
+	if m[1] != "2.0" {
+		t.Errorf("JSON_RPC_VERSION = %q, want 2.0 (JSON-RPC 2.0 is the ext-apps transport)", m[1])
+	}
+	code := nonCommentJS(string(widgetClientJSBytes))
+	if !strings.Contains(code, "jsonrpc: JSON_RPC_VERSION") {
+		t.Error("outbound messages must be built from JSON_RPC_VERSION")
+	}
+	if !strings.Contains(code, "msg.jsonrpc !== JSON_RPC_VERSION") {
+		t.Error("inbound messages must be checked against JSON_RPC_VERSION")
+	}
+}
+
+// The channel contract, mirroring pluginhost's frame client: a bounded
+// in-flight map that rejects (not hangs, not posts) when full, a timeout
+// that rejects and frees the entry, send-throw cleanup, teardown that fails
+// everything outstanding, and notification handlers that ignore unknown
+// methods instead of throwing.
+func TestWidgetClientJS_ChannelContract(t *testing.T) {
+	code := nonCommentJS(string(widgetClientJSBytes))
+	for _, s := range []string{
+		"MAX_INFLIGHT = 64;", // anchored: "= 64" alone would also match 640
+		`"E_TIMEOUT"`,
+		`"E_SATURATED"`,
+		`"E_SEND"`,
+		`"E_TEARDOWN"`,
+	} {
+		if !strings.Contains(code, s) {
+			t.Errorf("widget client missing channel contract literal %s", s)
+		}
+	}
+	// The bound must be ENFORCED, not just declared: pin the saturation
+	// check that rejects before posting.
+	if !strings.Contains(code, "Object.keys(pending).length >= MAX_INFLIGHT") {
+		t.Error("request() must reject when the pending map is full")
+	}
+	// The pending map must be null-proto wherever it is (re)created — the
+	// declaration AND the reset — so a "__proto__" id looks up as
+	// undefined instead of a truthy Object.prototype member. Two
+	// occurrences, not one, or the reset regressed to {}.
+	if n := strings.Count(code, "pending = Object.create(null)"); n < 2 {
+		t.Errorf("pending map must be Object.create(null) at declaration and reset, found %d", n)
+	}
+	// Timeout path: the entry is freed BEFORE the reject, so the timer
+	// slot does not leak and a late response is dropped by id.
+	to := jsBody(code, "var timer = setTimeout(function () {", "}, timeoutMs);")
+	if to == "" {
+		t.Fatal("request() timeout callback not found")
+	}
+	if !strings.Contains(to, "delete pending[id]") || !strings.Contains(to, `"E_TIMEOUT"`) {
+		t.Error("timeout must delete the pending entry and reject with E_TIMEOUT")
+	}
+	// A non-cloneable-params postMessage throw on the request path must
+	// clean up the pending entry instead of leaking it to timeout /
+	// spurious saturation.
+	catch := jsBody(code, "} catch (e) {", "reject({ code: \"E_SEND\"")
+	if catch == "" {
+		t.Fatal("request() send-throw catch not found")
+	}
+	if !strings.Contains(catch, "clearTimeout(timer)") || !strings.Contains(catch, "delete pending[id]") {
+		t.Error("send-throw catch must clear the timer and delete the pending entry before rejecting")
+	}
+	// Unknown notification methods are ignored, never thrown.
+	if !strings.Contains(code, `if (typeof h !== "function") return;`) {
+		t.Error("notification dispatch must return early when no handler is registered (ignore, don't throw)")
+	}
+	// Host teardown runs the app's handler, THEN fails every outstanding
+	tn := jsBody(code, "function handleNotification(", "\n}")
+	if tn == "" {
+		t.Fatal("handleNotification() not found")
+	}
+	if !strings.Contains(tn, `"ui/resource-teardown"`) || !strings.Contains(tn, "rejectOutstanding") {
+		t.Error("ui/resource-teardown must fail every outstanding request with rejectOutstanding")
+	}
+	if !strings.Contains(code, `"pagehide"`) {
+		t.Error("pagehide must fail outstanding requests instead of leaking until timeout")
+	}
+}
+
+// RegisterWidgetClientRoute is idempotent: a duplicate router pattern
+// panics, so a second registration must be a no-op. Mirror of pluginhost's
+// TestRegisterFrameClientRoute_Idempotent.
+func TestRegisterWidgetClientRoute_Idempotent(t *testing.T) {
+	rt := router.New()
+	RegisterWidgetClientRoute(rt)
+	RegisterWidgetClientRoute(rt) // must NOT panic
+	RegisterWidgetClientRoute(rt)
+
+	n := 0
+	for _, rr := range rt.Routes() {
+		if rr.Method == WidgetClientRouteMethod && rr.Pattern == WidgetClientScriptURL {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("widget client route registered %d times, want exactly 1", n)
+	}
+}
+
+// The route serves the script with the headers an opaque-origin widget
+// iframe needs: the CORP cross-origin relaxation (a same-origin default
+// would block the "null"-origin frame's script fetch), nosniff, and the
+// no-store dev cache. The body is exactly the embedded client.
+func TestWidgetClientRouteServedHeaders(t *testing.T) {
+	rt := router.New()
+	RegisterWidgetClientRoute(rt)
+
+	srv := httptest.NewServer(rt)
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + WidgetClientScriptURL)
+	if err != nil {
+		t.Fatalf("GET widget client: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("widget client status=%d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/javascript") {
+		t.Errorf("widget client Content-Type=%q", ct)
+	}
+	if got := resp.Header.Get("Cross-Origin-Resource-Policy"); got != "cross-origin" {
+		t.Errorf("widget client CORP=%q, want cross-origin (opaque-origin fetcher)", got)
+	}
+	if resp.Header.Get("X-Content-Type-Options") != "nosniff" {
+		t.Error("widget client must carry nosniff")
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != "no-store, max-age=0" {
+		t.Errorf("widget client Cache-Control=%q", cc)
+	}
+	if !bytes.Equal(body, WidgetClientJS()) {
+		t.Error("widget client route must serve exactly the embedded bytes")
+	}
+}
+
+// WidgetClientJS returns a copy: a caller scribbling on the buffer must not
+// corrupt the embedded script for every other caller.
+func TestWidgetClientJS_ReturnsACopy(t *testing.T) {
+	b := WidgetClientJS()
+	if len(b) == 0 {
+		t.Fatal("WidgetClientJS() empty")
+	}
+	orig := string(WidgetClientJS())
+	b[0] = 'X'
+	if string(WidgetClientJS()) != orig {
+		t.Error("WidgetClientJS() must return a copy, not the embedded slice")
+	}
+}

--- a/core/mcp/widgetclient_test.go
+++ b/core/mcp/widgetclient_test.go
@@ -117,12 +117,21 @@ func TestWidgetClientJS_HandshakeNotifiesAfterInitializeResult(t *testing.T) {
 // messages are accepted ONLY from the parent window, never gated on
 // event.origin (the sandboxed widget reports origin "null"; an origin-string
 // check is the wrong tool in both directions), the JSON-RPC version is
-// checked, and host→widget REQUESTS are dropped rather than dispatched.
+// checked, and host→widget requests are dropped rather than dispatched —
+// except ui/resource-teardown, the one inbound request, which is answered
+// (pinned by the channel-contract test).
 func TestWidgetClientJS_ValidatesMessageSource(t *testing.T) {
 	code := nonCommentJS(string(widgetClientJSBytes))
 	if !strings.Contains(code, "event.source === window.parent") &&
 		!strings.Contains(code, "window.parent === event.source") {
 		t.Error("onWindowMessage must accept only messages whose source is the parent window (in code, not prose)")
+	}
+	// The check above pins the comparison (===, not !==); this pins the
+	// BRANCH polarity — negation and return together. The bare predicate
+	// stays green when the branch is inverted to `if (fromParent)
+	// return;`, which would accept messages from any window.
+	if !strings.Contains(code, "if (!fromParent) return;") {
+		t.Error("onWindowMessage must return when the message is NOT from the parent window — the negated branch is the gate, not the bare predicate")
 	}
 	if strings.Contains(code, "event.origin") {
 		t.Error("onWindowMessage must not gate on event.origin — the widget frame is opaque-origin; source identity is the gate")
@@ -189,8 +198,8 @@ func TestWidgetClientJS_EnvelopeVersion(t *testing.T) {
 
 // The channel contract, mirroring pluginhost's frame client: a bounded
 // in-flight map that rejects (not hangs, not posts) when full, a timeout
-// that rejects and frees the entry, send-throw cleanup, teardown that fails
-// everything outstanding, and notification handlers that ignore unknown
+// that rejects and frees the entry, send-throw cleanup, a teardown REQUEST
+// that is answered before it fails everything outstanding, and notification
 // methods instead of throwing.
 func TestWidgetClientJS_ChannelContract(t *testing.T) {
 	code := nonCommentJS(string(widgetClientJSBytes))
@@ -240,13 +249,49 @@ func TestWidgetClientJS_ChannelContract(t *testing.T) {
 	if !strings.Contains(code, `if (typeof h !== "function") return;`) {
 		t.Error("notification dispatch must return early when no handler is registered (ignore, don't throw)")
 	}
-	// Host teardown runs the app's handler, THEN fails every outstanding
-	tn := jsBody(code, "function handleNotification(", "\n}")
+	// Host teardown (spec 2026-01-26: a REQUEST, not a notification — the
+	// host SHOULD wait for the response before tearing the resource
+	// down): the app's handler runs awaited, the response is posted, and
+	// only THEN are outstanding requests failed — the response must be
+	// on the wire before the host removes the frame.
+	tn := jsBody(code, "function handleTeardown(", "function onWindowMessage(")
 	if tn == "" {
-		t.Fatal("handleNotification() not found")
+		t.Fatal("handleTeardown() not found")
 	}
-	if !strings.Contains(tn, `"ui/resource-teardown"`) || !strings.Contains(tn, "rejectOutstanding") {
-		t.Error("ui/resource-teardown must fail every outstanding request with rejectOutstanding")
+	if !strings.Contains(tn, `"ui/resource-teardown"`) {
+		t.Error("handleTeardown must run the registered ui/resource-teardown handler")
+	}
+	if !strings.Contains(tn, "Promise.resolve().then") {
+		t.Error("handleTeardown must await the handler — a promise return must delay the response")
+	}
+	if !strings.Contains(tn, "reply(msg.id, {}, null);") {
+		t.Error("handleTeardown must answer the request with result {} on success")
+	}
+	if !strings.Contains(tn, `reply(msg.id, null, { code: "E_HANDLER"`) {
+		t.Error("handleTeardown must answer with a JSON-RPC error when the handler throws — the host is waiting on the response")
+	}
+	// Every rejectOutstanding sits immediately after a reply: the
+	// response is posted FIRST, on both the success and error paths.
+	tnLines := strings.Split(tn, "\n")
+	for i, line := range tnLines {
+		if strings.Contains(line, "rejectOutstanding(") &&
+			(i == 0 || !strings.Contains(tnLines[i-1], "reply(msg.id")) {
+			t.Error("handleTeardown must post the response BEFORE rejectOutstanding fails outstanding requests")
+		}
+	}
+	// And the routing: teardown is dispatched on the REQUEST path, ahead
+	// of the unknown-request drop.
+	om := jsBody(code, "function onWindowMessage(", "var p = pending[msg.id];")
+	if om == "" {
+		t.Fatal("onWindowMessage() dispatch not found")
+	}
+	ti := strings.Index(om, `if (msg.method === "ui/resource-teardown" && msg.id !== undefined) {`)
+	di := strings.Index(om, "if (msg.id !== undefined) return;")
+	if ti < 0 || di < 0 || di < ti {
+		t.Error("onWindowMessage must route the ui/resource-teardown request to handleTeardown before dropping unknown requests")
+	}
+	if ti >= 0 && !strings.Contains(om[ti:], "handleTeardown(msg);") {
+		t.Error("the teardown route must call handleTeardown")
 	}
 	if !strings.Contains(code, `"pagehide"`) {
 		t.Error("pagehide must fail outstanding requests instead of leaking until timeout")

--- a/core/mcp/widgetclient_test.go
+++ b/core/mcp/widgetclient_test.go
@@ -8,8 +8,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-
-	"github.com/DonaldMurillo/gofastr/core/router"
 )
 
 // The MCP Apps widget client lives in widgetclient.js and speaks ext-apps
@@ -255,35 +253,15 @@ func TestWidgetClientJS_ChannelContract(t *testing.T) {
 	}
 }
 
-// RegisterWidgetClientRoute is idempotent: a duplicate router pattern
-// panics, so a second registration must be a no-op. Mirror of pluginhost's
-// TestRegisterFrameClientRoute_Idempotent.
-func TestRegisterWidgetClientRoute_Idempotent(t *testing.T) {
-	rt := router.New()
-	RegisterWidgetClientRoute(rt)
-	RegisterWidgetClientRoute(rt) // must NOT panic
-	RegisterWidgetClientRoute(rt)
-
-	n := 0
-	for _, rr := range rt.Routes() {
-		if rr.Method == WidgetClientRouteMethod && rr.Pattern == WidgetClientScriptURL {
-			n++
-		}
-	}
-	if n != 1 {
-		t.Fatalf("widget client route registered %d times, want exactly 1", n)
-	}
-}
-
-// The route serves the script with the headers an opaque-origin widget
+// The handler serves the script with the headers an opaque-origin widget
 // iframe needs: the CORP cross-origin relaxation (a same-origin default
 // would block the "null"-origin frame's script fetch), nosniff, and the
 // no-store dev cache. The body is exactly the embedded client.
-func TestWidgetClientRouteServedHeaders(t *testing.T) {
-	rt := router.New()
-	RegisterWidgetClientRoute(rt)
+func TestWidgetClientHandlerServedHeaders(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.Handle(WidgetClientScriptURL, WidgetClientHandler())
 
-	srv := httptest.NewServer(rt)
+	srv := httptest.NewServer(mux)
 	defer srv.Close()
 	resp, err := http.Get(srv.URL + WidgetClientScriptURL)
 	if err != nil {

--- a/framework/docs/content/mcp.md
+++ b/framework/docs/content/mcp.md
@@ -594,19 +594,19 @@ var rt *router.Router
 var widgetHTML string
 -->
 ```go
-// Hot-link: register the route (idempotent) and reference the URL from a
-// <script src> in the app's HTML. The route serves the script with
-// Cross-Origin-Resource-Policy: cross-origin so the opaque-origin iframe
+// Hot-link: mount the handler at WidgetClientScriptURL and reference the
+// URL from a <script src> in the app's HTML. The handler serves the script
+// with Cross-Origin-Resource-Policy: cross-origin so the opaque-origin iframe
 // can fetch it; whether the HOST's iframe CSP allows the fetch is governed
 // by the app's declared AppCSP.ResourceDomains, like any cross-origin script.
-mcp.RegisterWidgetClientRoute(rt)
+rt.Get(mcp.WidgetClientScriptURL, mcp.WidgetClientHandler())
 
 // Or fold the bytes into the HTML you hand to RegisterApp, and the widget
 // carries its own client with no route and no CSP dependency.
 widgetHTML = "<script>" + string(mcp.WidgetClientJS()) + "</script>"
 ```
 
-The route is `/__gofastr/mcp/app/widgetclient.js`
+The script URL is `/__gofastr/mcp/app/widgetclient.js`
 ([WidgetClientScriptURL]). Inside the widget document the client exposes
 itself as `window.__gofastrMcpApp`:
 

--- a/framework/docs/content/mcp.md
+++ b/framework/docs/content/mcp.md
@@ -571,6 +571,126 @@ The remaining fields are `FrameDomains` (frame-src) and `BaseURIDomains`
 or omitted field allows no external origins, and a zero `AppCSP` emits no
 `csp` key at all.
 
+## MCP Apps widget client
+
+`RegisterApp` ships the server half of an MCP App: the `ui://` resource and
+the linking tool. The widget half — the JavaScript that runs inside the
+host's sandboxed iframe and talks to the chat host — is the widget client,
+a plain embedded script with no imports and no external URLs. It speaks the
+ext-apps widget protocol (spec 2026-01-26): JSON-RPC 2.0 over `postMessage`,
+no extra framing. GoFastr serves the widget side of MCP Apps and is not a
+host: nothing here renders another server's widget, and nothing in the
+framework speaks the host half of this protocol.
+
+Two ways to get the script into your widget's HTML:
+
+<!-- gofastr:compile
+import (
+	"github.com/DonaldMurillo/gofastr/core/mcp"
+	"github.com/DonaldMurillo/gofastr/core/router"
+)
+
+var rt *router.Router
+var widgetHTML string
+-->
+```go
+// Hot-link: register the route (idempotent) and reference the URL from a
+// <script src> in the app's HTML. The route serves the script with
+// Cross-Origin-Resource-Policy: cross-origin so the opaque-origin iframe
+// can fetch it; whether the HOST's iframe CSP allows the fetch is governed
+// by the app's declared AppCSP.ResourceDomains, like any cross-origin script.
+mcp.RegisterWidgetClientRoute(rt)
+
+// Or fold the bytes into the HTML you hand to RegisterApp, and the widget
+// carries its own client with no route and no CSP dependency.
+widgetHTML = "<script>" + string(mcp.WidgetClientJS()) + "</script>"
+```
+
+The route is `/__gofastr/mcp/app/widgetclient.js`
+([WidgetClientScriptURL]). Inside the widget document the client exposes
+itself as `window.__gofastrMcpApp`:
+
+```js
+var app = window.__gofastrMcpApp;
+
+app.connect({ availableDisplayModes: ["inline"] }).then(function (host) {
+  // host.protocolVersion, host.hostCapabilities, host.hostInfo,
+  // host.hostContext (theme, locale, displayMode, …)
+});
+
+app.callTool({ name: "search", arguments: { q: "gofastr" } })
+  .then(function (result) { /* result.content, result.isError */ });
+
+app.onToolResult(function (params) { /* a finished tool call */ });
+app.sizeChanged({ width: 320, height: 240 });
+```
+
+### The handshake
+
+`connect(appCapabilities, timeoutMs?)` sends the `ui/initialize` request
+carrying your `appCapabilities` (`experimental`, `tools.listChanged`,
+`availableDisplayModes`), resolves with the host's result — `protocolVersion`,
+`hostCapabilities`, `hostInfo`, `hostContext` — and only then sends the
+`ui/notifications/initialized` notification. Call it once, on load. If the
+host never answers, the promise rejects after `timeoutMs` (default 30s) and
+you may call `connect` again.
+
+### The method surface
+
+Widget → host requests, each a named method plus the generic escape hatch
+(`params` is the spec's params object, passed through verbatim):
+
+| Client call | Wire method |
+|---|---|
+| `callTool(params, timeoutMs?)` | `tools/call` |
+| `readResource(params, timeoutMs?)` | `resources/read` |
+| `openLink(params, timeoutMs?)` | `ui/open-link` |
+| `requestDisplayMode(params, timeoutMs?)` | `ui/request-display-mode` |
+| `message(params, timeoutMs?)` | `ui/message` |
+| `updateModelContext(params, timeoutMs?)` | `ui/update-model-context` |
+| `request(method, params, timeoutMs?)` | any spec request method |
+
+Widget → host notifications: `sizeChanged(params)` sends
+`ui/notifications/size-changed`; `notify(method, params)` sends any other.
+
+Host → widget notifications, each with a named registrar plus the generic
+`on(method, handler)`:
+
+| Registrar | Wire method |
+|---|---|
+| `onToolInput(handler)` | `ui/notifications/tool-input` |
+| `onToolInputPartial(handler)` | `ui/notifications/tool-input-partial` |
+| `onToolResult(handler)` | `ui/notifications/tool-result` |
+| `onToolCancelled(handler)` | `ui/notifications/tool-cancelled` |
+| `onHostContextChanged(handler)` | `ui/notifications/host-context-changed` |
+| `onResourceTeardown(handler)` | `ui/resource-teardown` |
+| `onMessage(handler)` | `notifications/message` |
+
+A notification with no registered handler is ignored, never thrown; a
+handler that throws is logged to `console.error` and does not break the
+dispatch loop. `onResourceTeardown` runs your handler and then fails every
+request still in flight, because the host that is removing the widget will
+never answer them.
+
+### Failures
+
+Every request returns a Promise. It rejects with the host's JSON-RPC error
+object when the host answers with an error, or with one of the client's own
+codes:
+
+| Code | Meaning |
+|---|---|
+| `E_TIMEOUT` | No response within `timeoutMs` (default 30s — pass a larger value for slow `tools/call` turns). |
+| `E_SATURATED` | 64 requests already in flight; rejected before posting. |
+| `E_SEND` | `postMessage` threw — usually params that are not structured-cloneable. |
+| `E_TEARDOWN` | The widget was torn down (`ui/resource-teardown`) or the page hidden. |
+
+Responses that arrive after a timeout or teardown are dropped by request id,
+so a late answer never resolves an already-rejected Promise. Inbound
+messages are accepted only from `window.parent` (`event.source`, not
+`event.origin` — the sandboxed widget's origin is opaque and reports as
+`"null"`), and only when the envelope says `jsonrpc: "2.0"`.
+
 ## Common mistakes
 
 - **Wrapping a handler in `mcp.Gated` and expecting the tool to disappear from

--- a/framework/docs/content/mcp.md
+++ b/framework/docs/content/mcp.md
@@ -663,14 +663,23 @@ Host → widget notifications, each with a named registrar plus the generic
 | `onToolResult(handler)` | `ui/notifications/tool-result` |
 | `onToolCancelled(handler)` | `ui/notifications/tool-cancelled` |
 | `onHostContextChanged(handler)` | `ui/notifications/host-context-changed` |
-| `onResourceTeardown(handler)` | `ui/resource-teardown` |
 | `onMessage(handler)` | `notifications/message` |
 
 A notification with no registered handler is ignored, never thrown; a
 handler that throws is logged to `console.error` and does not break the
-dispatch loop. `onResourceTeardown` runs your handler and then fails every
-request still in flight, because the host that is removing the widget will
-never answer them.
+dispatch loop.
+
+### Host teardown
+
+`ui/resource-teardown` is the one host → widget **request** (ext-apps
+2026-01-26): the host sends it with a request id and SHOULD wait for the
+response before tearing the resource down, to prevent data loss. Register
+a request handler with `onResourceTeardown(handler)`; `params.reason`
+says why the widget is going away. The handler may return a promise —
+the client answers the request only after it settles, with `result: {}`
+on success or a JSON-RPC error if the handler throws — and then fails
+every request still in flight with `E_TEARDOWN`, because the host that
+is removing the widget will never answer them.
 
 ### Failures
 


### PR DESCRIPTION
Advances #291. The ticket stays open — the framework wiring and the role's bearer-only middleware posture are still to come.

Kept entirely out of `framework/pluginhost/`: another agent owns #300 and #303 there. It is read as precedent, never edited.

## What this is

`core/mcp` already served the app side (`RegisterApp`, `_meta.ui`, `AppCSP`). The JS that runs **inside the host's iframe** and talks to the chat host did not exist, so every plugin author hand-rolled the handshake and the request correlation.

`WidgetClientJS()` / `RegisterWidgetClientRoute` ship it as an embedded, served artifact, the same shape `pluginhost.FrameClientJS` uses.

## The contract is the spec's, not a recollection

Verified against [ext-apps `2026-01-26`](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx) before the brief was written — same discipline that caught the `_meta.ui.csp` string-vs-object bug earlier today.

`ui/initialize` → `ui/notifications/initialized`; six widget→host requests (`tools/call`, `resources/read`, `ui/open-link`, `ui/request-display-mode`, `ui/message`, `ui/update-model-context`); handler registration for the host→widget notifications.

**Every method string is pinned against non-comment JS.** The failure mode here is a one-character typo producing a widget that silently never fires, and a pin satisfied by a header comment would not catch it — that exact vacuity has bitten this repo before. I verified by mutation: `tool-result` → `tool-results` fails with `missing quoted method literal "ui/notifications/tool-result" in executable code`.

## Channel safety

Null-prototype pending map bounded at 64 in flight; at the bound `request()` rejects `E_SATURATED` **without posting** rather than growing. Timeout, a non-cloneable send, and teardown all reject rather than leaving a caller hanging. Messages are accepted only from the host window via `event.source` — the widget frame is opaque-origin, so an origin-string check is the wrong tool, the reasoning `frameclient.js` already documents.

Default request timeout is 30s rather than pluginhost's 5s, because a `tools/call` round-trips through an agent host and 5s would reject healthy calls. Overridable per call.

## Worth noting about the verification

40 mutations, all red-then-green. Two initially stayed **green and exposed vacuous pins in the author's own tests**, both then fixed and re-mutated:

- the `appCapabilities` pin matched the function *parameter name* rather than the wire-key construction;
- `"MAX_INFLIGHT = 64"` is a substring of `= 640`, so raising the bound tenfold would have passed. Now anchored with the semicolon.

That second one is the kind of pin that looks rigorous and proves nothing.

## Deliberately absent

The host half — GoFastr serves widgets, it is not a chat host. The route is author-mounted rather than wired into `WithMCP`; that is a later ticket, not an oversight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an MCP Apps widget client for iframe-based widgets to connect with hosts and exchange requests, responses, and notifications.
  * Added support for tool calls, resource reads, link opening, display mode requests, messages, model context updates, and size changes.
  * Added timeout, saturation, send-failure, and teardown handling for reliable communication.
  * Added a secure, cache-controlled route and an option to inline the client script.

* **Documentation**
  * Documented setup, embedding options, API methods, handshake behavior, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->