### PR TITLE
feat(framework): mount the MCP Apps widget client automatically (#291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Added
 
+- **The widget client mounts itself** (#291): an app that registers an MCP App
+  with `WithMCPApp` now serves the widget client at
+  `mcp.WidgetClientScriptURL` automatically, rather than every author wiring
+  the same route by hand. It mounts only when at least one app is registered,
+  mirroring how `initialize` advertises `resources`/`prompts` only when
+  something is registered, and it yields with a warning to a route the host
+  already mounted rather than panicking on the conflict. `RoleAgent` forwards
+  the path to the app router, because in a role-split deployment the agent
+  listener is the origin a widget fetches its script from — not forwarding it
+  would 404 every widget exactly when the agent process is the MCP endpoint.
+
 - **MCP Apps widget client** (#291): `core/mcp` served the app side already
   (`RegisterApp`, `_meta.ui`), but the JS that runs inside the host's iframe
   and talks to the chat host did not exist, so every plugin author hand-rolled

--- a/framework/app.go
+++ b/framework/app.go
@@ -2991,6 +2991,26 @@ func (a *App) Start(addr string) error {
 	if len(a.mcpApps) > 0 && !a.mcpAutoMount && !a.routerHasMCPRoute() {
 		a.Logger().Warn("WithMCPApp registered but /mcp is not mounted: the widget and its tool will be unreachable; add framework.WithMCP()")
 	}
+	// The MCP Apps widget client script (mcp.WidgetClientScriptURL): the
+	// script every registered widget document hot-links. Mounted as soon
+	// as at least one MCP App is registered, the same rule the server's
+	// capabilities follow (resources/prompts advertise only when
+	// something is registered), so an app with no widgets carries no
+	// public script route. Independent of mcpAutoMount: a host that
+	// hand-wired /mcp still registered a widget whose HTML references
+	// this URL, and the iframe fetching it hits this router either way.
+	// A router already serving the URL (a host that followed the manual
+	// mount docs, or assembles its router by hand) keeps its route: the
+	// auto-mount yields with a warning instead of a route-conflict
+	// panic, and the bytes are identical either way.
+	if len(a.mcpApps) > 0 {
+		if a.routerHasWidgetClientRoute() {
+			a.Logger().Warn("widget client auto-mount skipped: " +
+				mcp.WidgetClientScriptURL + " is already mounted by the host")
+		} else {
+			a.router.Get(mcp.WidgetClientScriptURL, mcp.WidgetClientHandler())
+		}
+	}
 	// Entity MCP tools (Exposure.MCP: true) have the same prod-only 404
 	// failure mode: dev auto-mounts /mcp so the tools work locally, a
 	// production binary without WithMCP() registers them onto a dispatcher

--- a/framework/app_role_test.go
+++ b/framework/app_role_test.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DonaldMurillo/gofastr/core/mcp"
 	"github.com/DonaldMurillo/gofastr/core/schema"
 	"github.com/DonaldMurillo/gofastr/framework/cron"
 	"github.com/DonaldMurillo/gofastr/framework/entity"
@@ -566,6 +568,40 @@ func TestAgentRole_EntityRouteNotServed(t *testing.T) {
 		if r.StatusCode != http.StatusNotFound {
 			t.Fatalf("%s on agent role: got %d want 404", p, r.StatusCode)
 		}
+	}
+}
+
+// In RoleAgent, the MCP Apps widget client script is served: a widget
+// document fetches it from the same public origin that serves /mcp, and
+// in a role-split deployment that origin is the agent listener.
+func TestAgentRole_ServesWidgetClientScript(t *testing.T) {
+	t.Setenv("GOFASTR_ROLE", "")
+	app := NewApp(WithoutDefaultMiddleware(), WithRole(RoleAgent), WithMCP(),
+		WithMCPApp(widgetClientAppCfg()))
+	addr, _ := startOnRandomPort(t, app)
+
+	resp := get(t, addr, mcp.WidgetClientScriptURL)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("widget client script on agent role: got %d want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !bytes.Equal(body, mcp.WidgetClientJS()) {
+		t.Error("agent role must serve the same embedded widget client bytes as the full router")
+	}
+}
+
+// In RoleAgent with no MCP App registered, the script URL is the
+// router's 404: forwarding the path must not mount anything by itself.
+func TestAgentRole_WidgetClientAbsentNoApp(t *testing.T) {
+	t.Setenv("GOFASTR_ROLE", "")
+	app := NewApp(WithoutDefaultMiddleware(), WithRole(RoleAgent), WithMCP())
+	addr, _ := startOnRandomPort(t, app)
+
+	resp := get(t, addr, mcp.WidgetClientScriptURL)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("widget client script with no app on agent role: got %d want 404", resp.StatusCode)
 	}
 }
 

--- a/framework/docs/content/mcp.md
+++ b/framework/docs/content/mcp.md
@@ -582,6 +582,20 @@ no extra framing. GoFastr serves the widget side of MCP Apps and is not a
 host: nothing here renders another server's widget, and nothing in the
 framework speaks the host half of this protocol.
 
+A framework app serves the script by itself: as soon as one MCP App is
+registered with `WithMCPApp`, `Start` mounts `mcp.WidgetClientHandler()`
+at `mcp.WidgetClientScriptURL` on the app router. The condition follows
+the server's capability rule (`resources` and `prompts` are advertised
+only when something is registered): no widget, no public script route.
+The mount does not require `WithMCP()`; a host that wired `/mcp` by hand
+still gets it, because the widget's HTML references this URL on the app's
+public router either way. A router already serving the URL (you mounted
+the handler yourself) keeps that route: the automatic mount steps aside
+with a warning, and the bytes are the same. In a role-split deployment
+the agent role (`framework.WithRole(framework.RoleAgent)`) forwards the
+script URL to the app router along with `/mcp`, so widgets keep loading
+when the agent process is the origin the MCP host resolved.
+
 Two ways to get the script into your widget's HTML:
 
 <!-- gofastr:compile
@@ -594,11 +608,14 @@ var rt *router.Router
 var widgetHTML string
 -->
 ```go
-// Hot-link: mount the handler at WidgetClientScriptURL and reference the
-// URL from a <script src> in the app's HTML. The handler serves the script
-// with Cross-Origin-Resource-Policy: cross-origin so the opaque-origin iframe
-// can fetch it; whether the HOST's iframe CSP allows the fetch is governed
-// by the app's declared AppCSP.ResourceDomains, like any cross-origin script.
+// Hot-link: reference the script URL from a <script src> in the app's
+// HTML. A framework app that uses WithMCPApp serves it automatically
+// (see above); mounting the handler yourself is for a router assembled
+// by hand (core/mcp standalone, or RegisterApp without WithMCPApp). The
+// handler serves the script with Cross-Origin-Resource-Policy:
+// cross-origin so the opaque-origin iframe can fetch it; whether the
+// HOST's iframe CSP allows the fetch is governed by the app's declared
+// AppCSP.ResourceDomains, like any cross-origin script.
 rt.Get(mcp.WidgetClientScriptURL, mcp.WidgetClientHandler())
 
 // Or fold the bytes into the HTML you hand to RegisterApp, and the widget
@@ -720,6 +737,10 @@ messages are accepted only from `window.parent` (`event.source`, not
 - **Serving `ListTools()` output to a remote caller.** It applies no
   per-caller gates. The JSON-RPC path serves `ListToolsFor(ctx)`; reach for
   that (or let the transport do it) whenever the listing leaves the process.
+- **Calling `app.MCP.RegisterApp` directly and expecting the script
+  route.** The automatic widget client mount keys on `WithMCPApp`
+  registrations. Registering through the primitives, or running
+  `core/mcp` standalone, means mounting `WidgetClientHandler()` yourself.
 - **Forgetting that required prompt arguments are checked before the
   handler runs.** A `prompts/get` missing one is refused with invalid-params;
   the handler never sees the call. Handlers can assume required arguments are

--- a/framework/mcp_app_test.go
+++ b/framework/mcp_app_test.go
@@ -160,7 +160,15 @@ func TestWidgetClientHeaders_SurviveMount(t *testing.T) {
 // of panicking with a route conflict, and the bytes are the same.
 func TestWidgetClientRoute_HandMountWins(t *testing.T) {
 	app := NewApp(WithoutDefaultMiddleware(), WithMCPApp(widgetClientAppCfg()))
-	app.Router().Get(mcp.WidgetClientScriptURL, mcp.WidgetClientHandler())
+	// A SENTINEL body, not mcp.WidgetClientHandler(): mounting the real
+	// handler here would make "the hand mount survived" and "the automatic
+	// mount replaced it" byte-identical, so the test could not tell them
+	// apart and would pass either way.
+	const sentinel = "// hand-mounted sentinel"
+	app.Router().Get(mcp.WidgetClientScriptURL, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/javascript; charset=utf-8")
+		_, _ = w.Write([]byte(sentinel))
+	}))
 
 	addr, _ := startOnRandomPort(t, app) // Start must not hit the route conflict
 
@@ -168,5 +176,12 @@ func TestWidgetClientRoute_HandMountWins(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("hand-mounted widget client script: got %d want 200", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(body) != sentinel {
+		t.Errorf("hand-mounted route was replaced by the automatic mount: served %d bytes, want the sentinel", len(body))
 	}
 }

--- a/framework/mcp_app_test.go
+++ b/framework/mcp_app_test.go
@@ -1,7 +1,10 @@
 package framework
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/DonaldMurillo/gofastr/core/mcp"
@@ -61,5 +64,109 @@ func TestWithMCPApp_DuplicateNameFailsBuild(t *testing.T) {
 	app := NewApp(WithMCPApp(cfg), WithMCPApp(cfg2))
 	if err := app.InitPlugins(); err == nil {
 		t.Fatal("duplicate MCP app tool name should fail the build")
+	}
+}
+
+// widgetClientAppCfg is one minimal MCP App registration, the minimum
+// that makes the framework mount the widget client script route.
+func widgetClientAppCfg() mcp.AppConfig {
+	return mcp.AppConfig{
+		Name:        "studio",
+		Description: "open the studio widget",
+		InputSchema: map[string]any{"type": "object"},
+		Handler:     func(context.Context, map[string]any) (any, error) { return "ok", nil },
+		ResourceURI: "ui://demo/studio.html",
+		HTML:        "<h1>studio</h1>",
+	}
+}
+
+// The widget client script route mounts as soon as one MCP App is
+// registered, with or without WithMCP: the iframe fetching the script
+// hits the app's public router however /mcp itself was wired.
+func TestWidgetClientRoute_MountedWithApp(t *testing.T) {
+	app := NewApp(WithoutDefaultMiddleware(), WithMCPApp(widgetClientAppCfg()))
+	addr, _ := startOnRandomPort(t, app)
+
+	resp := get(t, addr, mcp.WidgetClientScriptURL)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("widget client script with a registered app: got %d want 200", resp.StatusCode)
+	}
+}
+
+// An app with no MCP App registered serves no widget client route: the
+// script is public surface only when a widget exists to hot-link it, the
+// same rule the resources/prompts capabilities follow (advertised only
+// when something is registered).
+func TestWidgetClientRoute_AbsentWithoutApp(t *testing.T) {
+	app := NewApp(WithoutDefaultMiddleware(), WithMCP())
+	addr, _ := startOnRandomPort(t, app)
+
+	resp := get(t, addr, mcp.WidgetClientScriptURL)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("widget client script with no app registered: got %d want 404", resp.StatusCode)
+	}
+}
+
+// The mounted route serves exactly the bytes core/mcp embeds, so the
+// mount cannot drift from the script the package ships.
+func TestWidgetClientRoute_ServesSourceBytes(t *testing.T) {
+	app := NewApp(WithoutDefaultMiddleware(), WithMCPApp(widgetClientAppCfg()))
+	addr, _ := startOnRandomPort(t, app)
+
+	resp := get(t, addr, mcp.WidgetClientScriptURL)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read widget client body: %v", err)
+	}
+	if !bytes.Equal(body, mcp.WidgetClientJS()) {
+		t.Fatalf("mounted route serves %d bytes, WidgetClientJS() returns %d; the mount must serve the embedded script verbatim",
+			len(body), len(mcp.WidgetClientJS()))
+	}
+}
+
+// The framing headers the handler sets (content type, nosniff, CORP
+// cross-origin, no-store) survive the mount through the DEFAULT
+// middleware stack: a wrapping middleware could strip or override them,
+// and a sandboxed widget iframe cannot load the script without CORP.
+func TestWidgetClientHeaders_SurviveMount(t *testing.T) {
+	app := NewApp(WithMCPApp(widgetClientAppCfg()))
+	addr, _ := startOnRandomPort(t, app)
+
+	resp := get(t, addr, mcp.WidgetClientScriptURL)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("widget client script through default middleware: got %d want 200", resp.StatusCode)
+	}
+	h := resp.Header
+	if ct := h.Get("Content-Type"); ct != "text/javascript; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want %q", ct, "text/javascript; charset=utf-8")
+	}
+	if ct := h.Get("X-Content-Type-Options"); ct != "nosniff" {
+		t.Errorf("X-Content-Type-Options = %q, want nosniff", ct)
+	}
+	if corp := h.Get("Cross-Origin-Resource-Policy"); corp != "cross-origin" {
+		t.Errorf("Cross-Origin-Resource-Policy = %q, want cross-origin", corp)
+	}
+	if cc := h.Get("Cache-Control"); cc != "no-store, max-age=0" {
+		t.Errorf("Cache-Control = %q, want %q", cc, "no-store, max-age=0")
+	}
+}
+
+// A host that already serves the script URL itself (the manual mount for
+// hand-assembled routers) keeps its route: the auto-mount yields instead
+// of panicking with a route conflict, and the bytes are the same.
+func TestWidgetClientRoute_HandMountWins(t *testing.T) {
+	app := NewApp(WithoutDefaultMiddleware(), WithMCPApp(widgetClientAppCfg()))
+	app.Router().Get(mcp.WidgetClientScriptURL, mcp.WidgetClientHandler())
+
+	addr, _ := startOnRandomPort(t, app) // Start must not hit the route conflict
+
+	resp := get(t, addr, mcp.WidgetClientScriptURL)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("hand-mounted widget client script: got %d want 200", resp.StatusCode)
 	}
 }

--- a/framework/mcp_control.go
+++ b/framework/mcp_control.go
@@ -201,6 +201,18 @@ func (a *App) routerHasMCPRoute() bool {
 	return false
 }
 
+// routerHasWidgetClientRoute reports whether the host already serves the
+// MCP Apps widget client script, so the WithMCPApp auto-mount can yield
+// to it instead of panicking with a route conflict.
+func (a *App) routerHasWidgetClientRoute() bool {
+	for _, r := range a.router.Routes() {
+		if r.Pattern == mcp.WidgetClientScriptURL && r.Method == http.MethodGet {
+			return true
+		}
+	}
+	return false
+}
+
 func (a *App) toolModuleEnable(ctx context.Context, params map[string]any) (any, error) {
 	return a.toggleModule(ctx, params, true)
 }

--- a/framework/role.go
+++ b/framework/role.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/DonaldMurillo/gofastr/core/mcp"
 )
 
 // Role selects which responsibilities a single binary assumes at boot.
@@ -153,6 +155,13 @@ func (a *App) workerHealthMux() http.Handler {
 // though the router still holds them. A host that never mounted /mcp
 // (no WithMCP, no hand-wired route) gets the router's 404 here, which is
 // the honest answer for that misconfiguration.
+//
+// The MCP Apps widget client script (mcp.WidgetClientScriptURL) is
+// forwarded too: a widget document fetches it from the same public
+// origin that serves /mcp, and in a role-split deployment that origin is
+// this listener. Refusing it here would 404 every widget exactly when
+// the agent role is the MCP endpoint. Same honesty rule: an app that
+// mounted nothing there (no WithMCPApp) gets the router's 404.
 func (a *App) agentMux() http.Handler {
 	liveness, readiness := a.healthHandlers()
 	mux := http.NewServeMux()
@@ -160,5 +169,6 @@ func (a *App) agentMux() http.Handler {
 	mux.HandleFunc("/readyz", readiness)
 	mux.Handle("/mcp", a.router)
 	mux.Handle("/mcp/", a.router)
+	mux.Handle(mcp.WidgetClientScriptURL, a.router)
 	return mux
 }


### PR DESCRIPTION
Advances #291. Kept out of `framework/pluginhost/` — #305 is open there.

`core/mcp` shipped the widget client as a handler, so every MCP Apps author's first job was wiring the same route by hand. The framework now does it.

## Two judgement calls, both defended rather than defaulted

**When it mounts:** only when at least one app is registered via `WithMCPApp`, mirroring how `initialize` advertises `resources`/`prompts` only when something is registered. An app with no widgets serves no public script route. Both sides are pinned.

Mounting is deliberately **independent of whether `/mcp` was auto-mounted**: a host that hand-wired `/mcp` still registers widgets whose HTML references the script on the public router, and the existing warn-don't-fail path shows that configuration is supported. A route the host already mounted **wins with a warning** rather than a conflict panic, since hand-mounting was the documented path until now and the bytes are identical either way.

**Whether the agent role serves it:** yes, by forwarding to the app router. The widget document is rendered by the MCP host and fetches its script from the same origin serving `/mcp` — in a role-split deployment that is the agent listener. Not forwarding would 404 every widget exactly when the agent process *is* the MCP endpoint, silently breaking the role that landed earlier today. It forwards rather than mounts, so an agent-role app with no registered app gets the router's honest 404.

## The guard that earned itself

`TestWidgetClientHeaders_SurviveMount` looked like belt-and-braces until its mutation ran: with the handler's headers dropped, the **default middleware fills in `Cross-Origin-Resource-Policy: same-origin`** — the precise silent widget-breaking override, observed rather than hypothesised. A mounted route inheriting app middleware is exactly where that happens.

Seven mutations, all red→green. I re-ran the agent-role one myself; my first attempt produced a *compile* error (unused import) rather than a failing test, which is not a proof, so I redid it as a behavioural mutation — forwarding a different path — and got the real `got 404 want 200`.

## Layering

`core/mcp` still reaches **0** `core/router` and **0** OpenTelemetry packages, verified. That constraint is why the client is a handler rather than a registrar, after it dragged in 20 otel packages earlier today; the mounting belongs in `framework/`, which may import the router.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP Apps now automatically serve the widget client script when an app is registered.
  * Agent deployments forward widget script requests correctly.
* **Bug Fixes**
  * Existing custom widget-script routes are preserved, with a warning instead of a startup failure.
  * Requests return not found when no MCP App is configured.
* **Documentation**
  * Added setup guidance, routing behavior, and common-mistake notes for widget client scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->