### PR TITLE
fix(site): clear the browser cache per tab so a stale module cannot mask a 500 (#278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,6 @@ All notable changes to GoFastr. Follows
 calendar versions (`YYYY-MM-DD` per substantive release until the API
 stabilises). Breaking changes are clearly marked with **BREAKING**.
 
-### Fixed
-
-- **Cross-test browser-cache contamination in the site e2e suite** (#278): the
-  suite runs on one Chrome profile, so tabs are fresh but the HTTP cache is
-  shared, and split runtime modules are served `immutable` with a year-long
-  max-age. Because `httptest` ports are released and rehanded out by the
-  kernel, a later test could inherit a port for which the profile already held
-  a cached 200 of `toasts.js?v=<hash>` — same port plus same content hash is
-  the same cache key. The failure-injection server then never saw a request,
-  the module loaded from cache, and the test that expects a fallback correctly
-  found none. Each tab now clears the browser cache, restoring the per-test
-  isolation the unique-port assumption already claimed.
-
 ## [Unreleased]
 
 ### Added
@@ -120,6 +107,17 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   assets that belong to no module.
 
 ### Fixed
+
+- **Cross-test browser-cache contamination in the site e2e suite** (#278): the
+  suite runs on one Chrome profile, so tabs are fresh but the HTTP cache is
+  shared, and split runtime modules are served `immutable` with a year-long
+  max-age. Because `httptest` ports are released and rehanded out by the
+  kernel, a later test could inherit a port for which the profile already held
+  a cached 200 of `toasts.js?v=<hash>` — same port plus same content hash is
+  the same cache key. The failure-injection server then never saw a request,
+  the module loaded from cache, and the test that expects a fallback correctly
+  found none. Each tab now clears the browser cache, restoring the per-test
+  isolation the unique-port assumption already claimed.
 
 - **An `AssetSpec` without a `ContentType` now serves one derived from the
   filename** (#303) instead of an empty `Content-Type`. `writeAsset` set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to GoFastr. Follows
 calendar versions (`YYYY-MM-DD` per substantive release until the API
 stabilises). Breaking changes are clearly marked with **BREAKING**.
 
+### Fixed
+
+- **Cross-test browser-cache contamination in the site e2e suite** (#278): the
+  suite runs on one Chrome profile, so tabs are fresh but the HTTP cache is
+  shared, and split runtime modules are served `immutable` with a year-long
+  max-age. Because `httptest` ports are released and rehanded out by the
+  kernel, a later test could inherit a port for which the profile already held
+  a cached 200 of `toasts.js?v=<hash>` — same port plus same content hash is
+  the same cache key. The failure-injection server then never saw a request,
+  the module loaded from cache, and the test that expects a fallback correctly
+  found none. Each tab now clears the browser cache, restoring the per-test
+  isolation the unique-port assumption already claimed.
+
 ## [Unreleased]
 
 ### Added

--- a/examples/site/e2e_runtime_modules_test.go
+++ b/examples/site/e2e_runtime_modules_test.go
@@ -443,6 +443,10 @@ func TestE2E_RuntimeSplit_Toast500NotMaskedByStalePortCache(t *testing.T) {
 		// the port is handed back.
 		chromedp.Sleep(500*time.Millisecond),
 	); err != nil {
+		// Drop the SSE client first: a live EventSource blocks Close()
+		// until the 5-minute stream bound, turning a poll failure into a
+		// suite-length hang.
+		prime.CloseClientConnections()
 		prime.Close()
 		t.Fatalf("prime: %v", err)
 	}

--- a/examples/site/e2e_runtime_modules_test.go
+++ b/examples/site/e2e_runtime_modules_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -391,6 +393,181 @@ func TestE2E_RuntimeSplit_ToastModuleFailureShowsFallback(t *testing.T) {
 	if fallbackResult != "ok" {
 		t.Errorf("X-Gofastr-Toast header fired with toasts.js returning 500 should render a fallback "+
 			"notice carrying the server-sent title; nothing visible was found. Diagnostic: %s", fallbackResult)
+	}
+}
+
+// TestE2E_RuntimeSplit_Toast500NotMaskedByStalePortCache is the #278
+// regression guard. It forces deterministically the two conditions CI
+// hit by accident:
+//
+//  1. An earlier server on port P serves the home page; the site-wide
+//     toast stack makes the boot scan fetch toasts.js, which the server
+//     sends with `Cache-Control: public, max-age=31536000, immutable`.
+//     The SHARED browser profile (one Chrome for the whole suite, one
+//     cache per profile, not per tab) now holds a 200 for
+//     http://127.0.0.1:P/__gofastr/runtime/toasts.js?v=<hash>.
+//  2. A server that 500s toasts.js then binds the SAME port P. In CI
+//     this happens by chance — httptest ports are ephemeral and the
+//     kernel reuses recently closed ones — which is why #278 is
+//     intermittent and order-dependent, not load-dependent.
+//
+// Without per-tab cache isolation the boot scan resolves toasts.js from
+// the stale immutable entry without a network request: the 500 never
+// fires, loadModule('toasts') resolves, the REAL toast renders, and the
+// fallback correctly never appears — exactly the CI diagnostic (toasts
+// in loadedModules, its script in runtimeScripts, fallbackPresent:
+// false). siteBrowserCtx prevents that by clearing the browser cache
+// when it hands out a tab.
+func TestE2E_RuntimeSplit_Toast500NotMaskedByStalePortCache(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: -short")
+	}
+	app := newTestApp(t)
+
+	// Phase 1 — prime the shared profile's cache for toasts.js on
+	// port P (200 + immutable).
+	prime := httptest.NewUnstartedServer(app.Router())
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	prime.Listener = ln
+	prime.Start()
+	primeURL := prime.URL
+
+	ctxPrime := newE2EBrowserCtx(t)
+	if err := chromedp.Run(ctxPrime,
+		chromedp.Navigate(primeURL+"/"),
+		chromedp.Poll(`window.__gofastr && window.__gofastr.loadedModules && window.__gofastr.loadedModules.toasts === true`, nil, chromedp.WithPollingInterval(100*1e6)),
+		// Let the network service commit the immutable entry before
+		// the port is handed back.
+		chromedp.Sleep(500*time.Millisecond),
+	); err != nil {
+		prime.Close()
+		t.Fatalf("prime: %v", err)
+	}
+
+	// Free port P, then rebind the SAME address for the 500 server.
+	addr := ln.Addr().String()
+	// Chrome's SSE EventSource holds an active connection to the
+	// prime server; plain Close() would block on it forever.
+	prime.CloseClientConnections()
+	prime.Close()
+
+	var toastsHits atomic.Int64
+	srv500 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/__gofastr/runtime/toasts.js" {
+			toastsHits.Add(1)
+			http.Error(w, "broken", http.StatusInternalServerError)
+			return
+		}
+		app.Router().ServeHTTP(w, r)
+	})
+	broken := httptest.NewUnstartedServer(srv500)
+	var ln500 net.Listener
+	for attempt := 0; ; attempt++ {
+		ln500, err = net.Listen("tcp", addr)
+		if err == nil {
+			break
+		}
+		if attempt >= 4 {
+			t.Fatalf("rebind %s: %v", addr, err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	broken.Listener = ln500
+	broken.Start()
+	// Same SSE-hang guard as the prime server: the phase-2 tab holds an
+	// EventSource to this server when the test ends.
+	t.Cleanup(func() { broken.CloseClientConnections(); broken.Close() })
+	if broken.URL != primeURL {
+		t.Fatalf("rebind produced a different origin: primed %s, rebound %s", primeURL, broken.URL)
+	}
+
+	// Phase 2 — same-origin 500 server, fresh tab. The fallback MUST
+	// appear; a stale cached 200 would mask the 500 instead.
+	ctx := newE2EBrowserCtx(t)
+	urls, _ := collectRuntimeModuleURLs(ctx)
+
+	var fallbackResult string
+	if err := chromedp.Run(ctx,
+		network.Enable(),
+		chromedp.Navigate(broken.URL+"/"),
+		pageReady(),
+		// Same header-dispatch mimic as the parent test: kick
+		// loadModule('toasts') and let the .catch render the
+		// fallback when the 500 lands.
+		chromedp.Evaluate(`(async () => {
+            const r = await fetch('/__site/toast/push', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({}),
+            });
+            const header = r.headers.get('X-Gofastr-Toast');
+            window.__gofastr.loadModule('toasts').then(() => {
+                try {
+                    const parsed = JSON.parse(header);
+                    const arr = Array.isArray(parsed) ? parsed : [parsed];
+                    for (const cfg of arr) window.__gofastr.toast(cfg);
+                } catch (_) {}
+            }).catch((err) => {
+                if (window.__gofastr._fallbackToast) {
+                    try {
+                        const parsed = JSON.parse(header);
+                        const arr = Array.isArray(parsed) ? parsed : [parsed];
+                        for (const cfg of arr) window.__gofastr._fallbackToast(cfg);
+                    } catch (_) {}
+                }
+            });
+        })()`, nil),
+		// Same poll-and-diagnose shape as the parent test (promise
+		// pinned on window so CDP keeps a strong reference).
+		chromedp.Evaluate(`window.__toastFallbackPoll = new Promise((resolve) => {
+            const t0 = performance.now();
+            const tick = () => {
+                const fallback = document.querySelector('[data-fui-toast-fallback]');
+                if (fallback && fallback.textContent.includes('Saved')) { resolve('ok'); return; }
+                if (performance.now() - t0 > 30000) {
+                    resolve(JSON.stringify({
+                        fallbackPresent: !!fallback,
+                        fallbackText: fallback ? fallback.textContent : null,
+                        runtimeScripts: Array.from(document.querySelectorAll('script[src*="/__gofastr/runtime/"]')).map(s => s.src),
+                        loadedModules: Object.keys((window.__gofastr && window.__gofastr.loadedModules) || {}),
+                    }));
+                    return;
+                }
+                setTimeout(tick, 100);
+            };
+            tick();
+        })`, &fallbackResult, func(p *cdruntime.EvaluateParams) *cdruntime.EvaluateParams {
+			return p.WithAwaitPromise(true)
+		}),
+	); err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+
+	var observed []string
+	toastsRequested := false
+	urls.Range(func(k, _ any) bool {
+		u := k.(string)
+		observed = append(observed, u)
+		if strings.Contains(u, "/runtime/toasts.js") {
+			toastsRequested = true
+		}
+		return true
+	})
+	if fallbackResult != "ok" {
+		t.Errorf("toasts.js 500 on a port whose cached 200 the browser still holds should NOT mask the fallback; "+
+			"the module must fail and the fallback must render. Diagnostic: %s; toasts.js requests observed: %v; "+
+			"500-server toasts.js hits: %d; all runtime URLs: %v",
+			fallbackResult, toastsRequested, toastsHits.Load(), observed)
+		return
+	}
+	if !toastsRequested {
+		t.Errorf("the toasts.js request should have hit the 500 server (observed runtime URLs: %v)", observed)
+	}
+	if n := toastsHits.Load(); n == 0 {
+		t.Errorf("the 500 server never saw a toasts.js request (hits=0); the module loaded without touching the injection server")
 	}
 }
 

--- a/examples/site/e2e_test.go
+++ b/examples/site/e2e_test.go
@@ -90,6 +90,23 @@ func siteBrowserCtx(t *testing.T) context.Context {
 	if err := chromedp.Run(ctx, page.BringToFront()); err != nil {
 		t.Fatalf("bring tab to front: %v", err)
 	}
+	// #278: the shared browser's HTTP cache belongs to the PROFILE, not
+	// the tab, and split runtime modules are served
+	// `Cache-Control: public, max-age=31536000, immutable`. httptest
+	// ports are ephemeral and the kernel does reuse recently closed
+	// ones, so when a later test's server lands on a port an earlier
+	// test used, its module URLs — same origin, same content hash —
+	// resolve to the earlier run's cached 200s without touching the
+	// network. A test injecting a 500 (the toast-fallback e2e) then
+	// watches its module "load" from cache and the injection never
+	// fires. The unique-port isolation claim only holds if no cache
+	// state survives across tests, so hand every tab a cold cache.
+	if err := chromedp.Run(ctx,
+		network.Enable(),
+		network.ClearBrowserCache(),
+	); err != nil {
+		t.Fatalf("clear browser cache: %v", err)
+	}
 	return ctx
 }
 


### PR DESCRIPTION
Closes #278 — this time with a root cause rather than a hardened wait.

I closed this ticket earlier today on its own "if it never recurs" criterion. It recurred within hours, so that close was premature and the hypothesis behind #285's fix was wrong.

## Root cause

Cross-test HTTP-cache contamination through a **reused port** on the suite's **shared Chrome profile**. Three facts compose it:

1. `core-ui/widget/server.go:171` serves split modules `Cache-Control: public, max-age=31536000, immutable` — a successful `toasts.js?v=<hash>` is cached and never revalidated.
2. The e2e suite runs **one Chrome instance**. Tests get fresh *tabs*; the HTTP cache belongs to the **profile**.
3. The claimed isolation — every test binds its own `httptest` port — does not hold. Released ephemeral ports get rehanded out by the kernel, and **same port + same content hash = same cache key**.

So the toast test's 500-injection server could inherit a port whose 200 the profile still held. Chrome served the stale entry with **no network request**, the module loaded and self-registered, the real toast rendered, and the fallback was correctly absent.

That is **order-dependent, not load-dependent** — which is exactly why it survives `-count=3` in isolation (no test in that filter ever serves `toasts.js` successfully, so no cache entry can exist) and fires on full-suite runs against diffs that cannot touch it.

## Why the previous fix could not have worked

#285 hardened the wait. But the injection is armed **before the server listens**, and no wait makes a 500 fire for a request the browser never sends. The decisive evidence is `500-server toasts.js hits: 0`.

## Hypotheses killed

| Hypothesis | Verdict |
|---|---|
| Runner load / slow wait (#285's theory) | Killed — the module *loaded*; nothing was slow |
| Service worker serving the module | Killed — `examples/site` registers none |
| Injection races module preload | Killed — wrapper is installed before the listener exists |
| `?v=` hash mismatch | Killed — the wrapper matches on path only |
| **Browser cache + port reuse** | **Confirmed**, deterministically |

## The guard

It reproduces the order **inside one test** — prime the cache on a port, then rebind a 500 server to that same port — rather than waiting for lucky kernel port reuse, and asserts the injection server actually saw the request.

I verified the mutation myself: removing the cache clear fails it with the CI signature, down to the identical content hash `e26313f0407f2ddb`, `fallbackPresent: false`, and zero hits on the 500 server.

## Also found

A latent hang: the site's SSE `EventSource` blocks `httptest.Server.Close()` indefinitely, so the guard force-closes client connections. Not this bug, but it would have made the reproduction impossible.

## Note

This should reduce rerun churn across all PRs, not just this suite — two other browser-e2e failures today were separate infrastructure timeouts, but this one was a real, reproducible defect masquerading as flakiness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed end-to-end scenarios where stale browser cache entries could mask runtime module failures.
  - Improved test isolation by clearing cached content between browser-based tests.
  - Added coverage confirming fallback behavior appears when a runtime module returns an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->