### PR TITLE
blueprint: derive marketing links and the auth gate from registered screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   supported way to attach attributes to a component — cannot reach it.
   Inert for everyone else.
 
+### Fixed
+
+- **Generated marketing chrome links and auth-gate redirects follow the
+  blueprint's registered screens** (#312) (`gofastr generate`). The marketing
+  header nav and footer shipped four literal hrefs (`/pricing`, `/about`,
+  `/terms`, `/privacy`), so a marketing blueprint without those screens got a
+  footer full of 404s; a chrome link is now emitted only when a screen
+  registers its route. The auth gate's redirect — the screen mount, the
+  entity-list island policy, the header's Sign in button, and the failed-login
+  bounce — derives from the screen hosting the login form (nested in a section
+  counts) instead of the hardcoded `/login`, which 404'd every gated page on a
+  blueprint whose sign-in lives elsewhere.
+
 ## [0.76.0] - 2026-08-30
 
 ### Added

--- a/cmd/gofastr/blueprint.go
+++ b/cmd/gofastr/blueprint.go
@@ -1085,6 +1085,47 @@ func blueprintAppHome(bp Blueprint) string {
 	return "/"
 }
 
+// blueprintMarketingLink is one entry of the marketing chrome's canonical
+// link table. The header nav and the footer columns both project out of it,
+// so the two surfaces cannot drift apart again.
+type blueprintMarketingLink struct {
+	Label  string
+	Route  string
+	Nav    bool   // included in the header nav when its route is registered
+	Column string // footer column title when registered; "" = not in the footer
+}
+
+// blueprintMarketingLinkTable is the single source of truth for the marketing
+// chrome's links. A link is emitted only when a screen registers its route —
+// the rule blueprintLoginRoute established for "/login". Before that, the
+// chrome shipped four literal hrefs, so a one-screen marketing blueprint
+// generated a footer full of 404s (#312).
+var blueprintMarketingLinkTable = []blueprintMarketingLink{
+	{Label: "Pricing", Route: "/pricing", Nav: true, Column: "Product"},
+	{Label: "About", Route: "/about", Nav: true, Column: "Company"},
+	{Label: "Terms", Route: "/terms", Column: "Legal"},
+	{Label: "Privacy", Route: "/privacy", Column: "Legal"},
+}
+
+// blueprintRegisteredMarketingLinks returns the canonical marketing links
+// whose routes bp.Screens actually registers, in table order (which is also
+// the footer's column order). Screens with path params mount at the
+// colon-style route, so the same normalization blueprintScreenMountStmt uses
+// applies here.
+func blueprintRegisteredMarketingLinks(bp Blueprint) []blueprintMarketingLink {
+	registered := make(map[string]bool, len(bp.Screens))
+	for _, s := range bp.Screens {
+		registered[blueprintScreenRoutePath(s.Route)] = true
+	}
+	var out []blueprintMarketingLink
+	for _, l := range blueprintMarketingLinkTable {
+		if registered[l.Route] {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
 // screenHasAuthForm reports whether a screen hosts a login or signup form, so
 // the generator gates it with a guest policy (signed-in users are redirected
 // to the app instead of seeing a sign-in form they don't need).
@@ -4601,7 +4642,7 @@ func renderBlueprintScreens(bp Blueprint) string {
 		sb.WriteString("func (c nodeComponent) Render() render.HTML { return noderender.RenderTrustedNode(c.node) }\n\n")
 	}
 	for _, screen := range bp.Screens {
-		sb.WriteString(blueprintScreenBody(screen, entityMap, apiBase))
+		sb.WriteString(blueprintScreenBody(bp, screen, entityMap, apiBase))
 	}
 	return sb.String()
 }
@@ -4674,7 +4715,7 @@ func writeScreenImportBlock(sb *strings.Builder, needs screenImportNeeds, anyCtx
 // blueprintScreenBody emits one screen's type declaration, Screen* methods,
 // and Render/RenderCtx: the screen content that is identical whether it
 // lands in its own file or in a per-entity crud file.
-func blueprintScreenBody(screen BlueprintScreen, entityMap map[string]framework.EntityDeclaration, apiBase string) string {
+func blueprintScreenBody(bp Blueprint, screen BlueprintScreen, entityMap map[string]framework.EntityDeclaration, apiBase string) string {
 	var sb strings.Builder
 	typeName := toCamelCase(screen.Name) + "Screen"
 	ctxScreen := screenNeedsCtx(screen)
@@ -4738,7 +4779,7 @@ func blueprintScreenBody(screen BlueprintScreen, entityMap map[string]framework.
 			var expr string
 			switch {
 			case ctxScreen && isEntityListBlock(block):
-				expr = blueprintEntityListResourceExpr(screen, block, entityMap, apiBase)
+				expr = blueprintEntityListResourceExpr(bp, screen, block, entityMap, apiBase)
 			case ctxScreen && isEntityDetailBlock(block):
 				expr = blueprintDetailExpr(block)
 			case ctxScreen && isEntityCreateBlock(block):
@@ -4746,7 +4787,7 @@ func blueprintScreenBody(screen BlueprintScreen, entityMap map[string]framework.
 			case ctxScreen && isEntityEditBlock(block):
 				expr = fmt.Sprintf("appResources[%q].Form(ctx, s.id)", strings.Trim(block.Entity, "/"))
 			default:
-				expr = renderBlueprintBlockForScreen(screen, block, []int{i}, entityMap, apiBase)
+				expr = renderBlueprintBlockForScreen(bp, screen, block, []int{i}, entityMap, apiBase)
 			}
 			sb.WriteString("\t\t" + expr + ",\n")
 		}
@@ -4932,7 +4973,7 @@ func blueprintScreenMountStmt(screen BlueprintScreen, bp Blueprint) string {
 	}
 	switch {
 	case screen.Access.Auth:
-		return fmt.Sprintf("\tsite.RegisterScreen(app.NewScreen(%q, &%s{}).WithTitle(%q)%s.WithPolicy(authPolicy(%q, %q)), %s)", route, typeName, screen.TitleOrName(), withDescription, "/login", screen.Access.Role, layoutExpr)
+		return fmt.Sprintf("\tsite.RegisterScreen(app.NewScreen(%q, &%s{}).WithTitle(%q)%s.WithPolicy(authPolicy(%q, %q)), %s)", route, typeName, screen.TitleOrName(), withDescription, blueprintLoginRoute(bp), screen.Access.Role, layoutExpr)
 	case guestRedirect && screenHasAuthForm(screen):
 		return fmt.Sprintf("\tsite.RegisterScreen(app.NewScreen(%q, &%s{}).WithTitle(%q)%s.WithPolicy(guestPolicy(%q)), %s)", route, typeName, screen.TitleOrName(), withDescription, blueprintAppHome(bp), layoutExpr)
 	default:
@@ -5004,9 +5045,9 @@ func blueprintScreenFiles(bp Blueprint, screenOrderOffset int) []generatedFile {
 func renderBlueprintStandaloneScreenFile(screen BlueprintScreen, bp Blueprint, entityMap map[string]framework.EntityDeclaration, apiBase string, order int) generatedFile {
 	var sb strings.Builder
 	sb.WriteString("package main\n\n")
-	needs := blueprintScreensImportNeeds([]BlueprintScreen{screen}, entityMap, apiBase)
+	needs := blueprintScreensImportNeeds(bp, []BlueprintScreen{screen}, entityMap, apiBase)
 	writeScreenImportBlock(&sb, needs, screenNeedsCtx(screen), true, true)
-	sb.WriteString(blueprintScreenBody(screen, entityMap, apiBase))
+	sb.WriteString(blueprintScreenBody(bp, screen, entityMap, apiBase))
 	mountName := "mount" + toCamelCase(screen.Name) + "Screen"
 	sb.WriteString(fmt.Sprintf("// %s mounts the %s screen with site.\nfunc %s(fwApp *framework.App, site *app.App, db *sql.DB) {\n%s\n}\n\n", mountName, screen.Name, mountName, blueprintScreenMountStmt(screen, bp)))
 	sb.WriteString(fmt.Sprintf("func init() {\n\tscreenRegistrars = append(screenRegistrars, screenRegistrar{order: %d, fn: %s})\n}\n", order, mountName))
@@ -5022,13 +5063,13 @@ func renderBlueprintStandaloneScreenFile(screen BlueprintScreen, bp Blueprint, e
 func renderBlueprintCrudFile(entity string, screens []BlueprintScreen, bp Blueprint, entityMap map[string]framework.EntityDeclaration, base map[string]string, editable map[string]bool, apiBase string, screenOrder map[string]int) generatedFile {
 	var sb strings.Builder
 	sb.WriteString("package main\n\n")
-	needs := blueprintScreensImportNeeds(screens, entityMap, apiBase)
+	needs := blueprintScreensImportNeeds(bp, screens, entityMap, apiBase)
 	needs.resource = true // every CRUD file emits a resource.Config assignment
 	// Island endpoints are mounted with an http.HandlerFunc closure.
 	needs.nethttp = len(entityListPlacements(bp, entity)) > 0
 	writeScreenImportBlock(&sb, needs, screensNeedCtx(screens), true, len(screens) > 0)
 	for _, s := range screens {
-		sb.WriteString(blueprintScreenBody(s, entityMap, apiBase))
+		sb.WriteString(blueprintScreenBody(bp, s, entityMap, apiBase))
 	}
 	resourceStmt := blueprintResourceRegistryOne(bp, entity, entityMap, base, editable)
 	// Mount funcs in authored (declaration) order; the resource wiring lands
@@ -5173,7 +5214,7 @@ func blueprintResourceRegistryOne(bp Blueprint, e string, entityMap map[string]f
 			continue // same screen, same entity: one endpoint serves it
 		}
 		seen[path] = true
-		cfg := blueprintEntityListConfigExpr(p.screen, p.block, entityMap, apiBase)
+		cfg := blueprintEntityListConfigExpr(bp, p.screen, p.block, entityMap, apiBase)
 		sb.WriteString(fmt.Sprintf("\tfwApp.Router().HandleFunc(\"GET\", %q, func(w http.ResponseWriter, r *http.Request) {\n", path))
 		sb.WriteString(fmt.Sprintf("\t\t%s.TableHandler()(w, r)\n", cfg))
 		sb.WriteString("\t})\n")
@@ -5236,9 +5277,9 @@ func blueprintIslandPath(apiBase string, screen BlueprintScreen, entity string) 
 // An ungated screen gets an explicit public policy rather than none: with no
 // policy TableHandler falls back to requiring sign-in, which would 401 an
 // anonymous visitor's first sort click on a public list.
-func blueprintIslandPolicyExpr(screen BlueprintScreen) string {
+func blueprintIslandPolicyExpr(bp Blueprint, screen BlueprintScreen) string {
 	if screen.Access.Auth {
-		return fmt.Sprintf("authPolicy(%q, %q)", "/login", screen.Access.Role)
+		return fmt.Sprintf("authPolicy(%q, %q)", blueprintLoginRoute(bp), screen.Access.Role)
 	}
 	return "resource.PublicIsland()"
 }
@@ -5596,8 +5637,8 @@ func blueprintDetailExpr(block BlueprintBlock) string {
 
 // blueprintEntityListResourceExpr emits the server-side list render call for a
 // top-level entity_list block: appResources["x"].WithColumns(...).List(ctx).
-func blueprintEntityListResourceExpr(screen BlueprintScreen, block BlueprintBlock, entityMap map[string]framework.EntityDeclaration, apiBase string) string {
-	return blueprintEntityListConfigExpr(screen, block, entityMap, apiBase) + ".List(ctx)"
+func blueprintEntityListResourceExpr(bp Blueprint, screen BlueprintScreen, block BlueprintBlock, entityMap map[string]framework.EntityDeclaration, apiBase string) string {
+	return blueprintEntityListConfigExpr(bp, screen, block, entityMap, apiBase) + ".List(ctx)"
 }
 
 // blueprintEntityListConfigExpr emits the refined resource.Config for one
@@ -5608,7 +5649,7 @@ func blueprintEntityListResourceExpr(screen BlueprintScreen, block BlueprintBloc
 // facets and page size live here, and an island endpoint mounted on the bare
 // registry entry would answer unfiltered, differently-columned rows to a
 // sort click on a filtered page.
-func blueprintEntityListConfigExpr(screen BlueprintScreen, block BlueprintBlock, entityMap map[string]framework.EntityDeclaration, apiBase string) string {
+func blueprintEntityListConfigExpr(bp Blueprint, screen BlueprintScreen, block BlueprintBlock, entityMap map[string]framework.EntityDeclaration, apiBase string) string {
 	entity := strings.Trim(block.Entity, "/")
 	expr := fmt.Sprintf("appResources[%q]", entity)
 	if len(block.Fields) > 0 {
@@ -5640,7 +5681,7 @@ func blueprintEntityListConfigExpr(screen BlueprintScreen, block BlueprintBlock,
 	// endpoint carries the screen's own policy, because it serves the same
 	// rows over a route the screen's gate never sees.
 	expr += fmt.Sprintf(".WithIsland(%q)", blueprintIslandPath(apiBase, screen, entity))
-	if p := blueprintIslandPolicyExpr(screen); p != "" {
+	if p := blueprintIslandPolicyExpr(bp, screen); p != "" {
 		expr += ".WithIslandPolicy(" + p + ")"
 	}
 	return expr
@@ -5742,13 +5783,13 @@ func blueprintScreenImports(bp Blueprint) screenImportNeeds {
 	for _, decl := range bp.Entities {
 		entityMap[decl.Name] = decl
 	}
-	return blueprintScreensImportNeeds(bp.Screens, entityMap, blueprintAPIBase(bp.App.APIPrefix))
+	return blueprintScreensImportNeeds(bp, bp.Screens, entityMap, blueprintAPIBase(bp.App.APIPrefix))
 }
 
 // blueprintScreensImportNeeds computes the import set for an arbitrary
 // subset of screens (one standalone file, one crud file's screens, or the
 // whole project). It is the per-file analogue of blueprintScreenImports.
-func blueprintScreensImportNeeds(screens []BlueprintScreen, entityMap map[string]framework.EntityDeclaration, apiBase string) screenImportNeeds {
+func blueprintScreensImportNeeds(bp Blueprint, screens []BlueprintScreen, entityMap map[string]framework.EntityDeclaration, apiBase string) screenImportNeeds {
 	var needs screenImportNeeds
 	// Every screen root is an html.Div now, so the package is always
 	// needed when there is a screen to render at all.
@@ -5804,7 +5845,7 @@ func blueprintScreensImportNeeds(screens []BlueprintScreen, entityMap map[string
 					// condition: the two answers drifting apart is precisely
 					// what shipped screen files calling resource.PublicIsland()
 					// without importing resource.
-					if isEntityListBlock(block) && strings.Contains(blueprintIslandPolicyExpr(screen), "resource.") {
+					if isEntityListBlock(block) && strings.Contains(blueprintIslandPolicyExpr(bp, screen), "resource.") {
 						needs.resource = true
 					}
 					continue
@@ -6026,13 +6067,13 @@ func blueprintSectionChildrenAreCards(children []BlueprintBlock) bool {
 // renderBlueprintCatalogBlock emits a framework/ui component for a catalog block
 // kind (page_header, hero, section, card, stat_card, charts, …). Returns
 // (expr, true) when handled; ("", false) to fall through to other paths.
-func renderBlueprintCatalogBlock(screen BlueprintScreen, block BlueprintBlock, path []int, entityMap map[string]framework.EntityDeclaration, apiBase string) (string, bool) {
+func renderBlueprintCatalogBlock(bp Blueprint, screen BlueprintScreen, block BlueprintBlock, path []int, entityMap map[string]framework.EntityDeclaration, apiBase string) (string, bool) {
 	kind := strings.ToLower(strings.TrimSpace(block.Kind))
 	childExprs := func() string {
 		parts := make([]string, 0, len(block.Children))
 		for i, ch := range block.Children {
 			cp := append(append([]int(nil), path...), i)
-			parts = append(parts, renderBlueprintBlockForScreen(screen, ch, cp, entityMap, apiBase))
+			parts = append(parts, renderBlueprintBlockForScreen(bp, screen, ch, cp, entityMap, apiBase))
 		}
 		return strings.Join(parts, ", ")
 	}
@@ -6194,7 +6235,7 @@ func blueprintPricingCardExpr(p map[string]any) string {
 		s("name"), s("price"), s("period"), s("description"), feats, s("cta_text"), s("cta_href"), featured)
 }
 
-func renderBlueprintBlockForScreen(screen BlueprintScreen, block BlueprintBlock, path []int, entityMap map[string]framework.EntityDeclaration, apiBase string) string {
+func renderBlueprintBlockForScreen(bp Blueprint, screen BlueprintScreen, block BlueprintBlock, path []int, entityMap map[string]framework.EntityDeclaration, apiBase string) string {
 	kind := block.Kind
 	if kind == "" {
 		kind = block.Type
@@ -6213,9 +6254,9 @@ func renderBlueprintBlockForScreen(screen BlueprintScreen, block BlueprintBlock,
 	}
 	if isEntityListBlock(block) {
 		// Server-rendered via the resource engine (ui.DataTable).
-		return blueprintEntityListResourceExpr(screen, block, entityMap, apiBase)
+		return blueprintEntityListResourceExpr(bp, screen, block, entityMap, apiBase)
 	}
-	if expr, ok := renderBlueprintCatalogBlock(screen, block, path, entityMap, apiBase); ok {
+	if expr, ok := renderBlueprintCatalogBlock(bp, screen, block, path, entityMap, apiBase); ok {
 		return expr
 	}
 	if blueprintBlockUsesNodeRenderer(block) {
@@ -7003,6 +7044,16 @@ func renderBlueprintApp(bp Blueprint) string {
 	}
 	if hasMarketing {
 		sb.WriteString("// marketingHeader / Footer wrap the public marketing layout.\n")
+		// Chrome links come from the registered screen set, never literals: a
+		// chrome href to a route no screen mounts is a shipped 404. The same
+		// rule blueprintLoginRoute established for the Sign in link (#312).
+		chrome := blueprintRegisteredMarketingLinks(bp)
+		var navLinks []string
+		for _, l := range chrome {
+			if l.Nav {
+				navLinks = append(navLinks, fmt.Sprintf("{Label: %q, Href: %q}", l.Label, l.Route))
+			}
+		}
 		toggleArg := ""
 		if len(bp.App.ThemeDark) > 0 {
 			// The app declares a dark scheme. Surface the toggle as a real
@@ -7016,7 +7067,9 @@ func renderBlueprintApp(bp Blueprint) string {
 			// one button, sized to match. No "Sign in" loop for users already past it.
 			appHome := blueprintAppHome(bp)
 			sb.WriteString("func marketingHeader(ctx context.Context) render.HTML {\n")
-			sb.WriteString("\tnav := []ui.SiteHeaderLink{{Label: \"Pricing\", Href: \"/pricing\"}, {Label: \"About\", Href: \"/about\"}}\n")
+			// nav holds only registered chrome links; with none it starts
+			// empty (valid Go for the Dashboard append below).
+			sb.WriteString(fmt.Sprintf("\tnav := []ui.SiteHeaderLink{%s}\n", strings.Join(navLinks, ", ")))
 			sb.WriteString("\tvar actions render.HTML\n")
 			sb.WriteString("\tif u, ok := handler.GetUser(ctx); ok && u != nil {\n")
 			sb.WriteString(fmt.Sprintf("\t\tnav = append(nav, ui.SiteHeaderLink{Label: \"Dashboard\", Href: %q})\n", appHome))
@@ -7040,7 +7093,11 @@ func renderBlueprintApp(bp Blueprint) string {
 			sb.WriteString("func marketingHeader() render.HTML {\n")
 			sb.WriteString("\treturn ui.SiteHeader(ui.SiteHeaderConfig{\n")
 			sb.WriteString("\t\tBrand: ui.Link(ui.LinkConfig{Href: \"/\", Text: appName}),\n")
-			sb.WriteString("\t\tNavItems: []ui.SiteHeaderLink{{Label: \"Pricing\", Href: \"/pricing\"}, {Label: \"About\", Href: \"/about\"}},\n")
+			// No NavItems line when no chrome link survives: an omitted field
+			// renders the brand + actions bar; an empty slice would add noise.
+			if len(navLinks) > 0 {
+				sb.WriteString(fmt.Sprintf("\t\tNavItems: []ui.SiteHeaderLink{%s},\n", strings.Join(navLinks, ", ")))
+			}
 			sb.WriteString("\t\tDrawer: ui.SiteHeaderDrawerSheet,\n")
 			if toggleArg != "" {
 				sb.WriteString("\t\tActions: ui.ThemeToggle(ui.ThemeToggleConfig{Variant: ui.ThemeToggleIcon}),\n")
@@ -7050,11 +7107,35 @@ func renderBlueprintApp(bp Blueprint) string {
 		sb.WriteString("func marketingFooter() render.HTML {\n")
 		sb.WriteString("\treturn ui.SiteFooter(ui.SiteFooterConfig{\n")
 		sb.WriteString("\t\tLead: ui.Link(ui.LinkConfig{Href: \"/\", Text: appName}),\n")
-		sb.WriteString("\t\tColumns: []ui.SiteFooterColumn{\n")
-		sb.WriteString("\t\t\t{Title: \"Product\", Links: []ui.SiteFooterLink{{Label: \"Pricing\", Href: \"/pricing\"}}},\n")
-		sb.WriteString("\t\t\t{Title: \"Company\", Links: []ui.SiteFooterLink{{Label: \"About\", Href: \"/about\"}}},\n")
-		sb.WriteString("\t\t\t{Title: \"Legal\", Links: []ui.SiteFooterLink{{Label: \"Terms\", Href: \"/terms\"}, {Label: \"Privacy\", Href: \"/privacy\"}}},\n")
-		sb.WriteString("\t\t},\n")
+		// A footer column is emitted only when at least one of its links
+		// survives: ui.SiteFooter renders a titled empty list for any column
+		// present, which is a heading over nothing. Column order follows the
+		// link table's declaration order.
+		type footerColumn struct {
+			title string
+			links []string
+		}
+		var columns []footerColumn
+		columnIndex := map[string]int{}
+		for _, l := range chrome {
+			if l.Column == "" {
+				continue
+			}
+			expr := fmt.Sprintf("{Label: %q, Href: %q}", l.Label, l.Route)
+			if i, ok := columnIndex[l.Column]; ok {
+				columns[i].links = append(columns[i].links, expr)
+				continue
+			}
+			columns = append(columns, footerColumn{title: l.Column, links: []string{expr}})
+			columnIndex[l.Column] = len(columns) - 1
+		}
+		if len(columns) > 0 {
+			sb.WriteString("\t\tColumns: []ui.SiteFooterColumn{\n")
+			for _, col := range columns {
+				sb.WriteString(fmt.Sprintf("\t\t\t{Title: %q, Links: []ui.SiteFooterLink{%s}},\n", col.title, strings.Join(col.links, ", ")))
+			}
+			sb.WriteString("\t\t},\n")
+		}
 		sb.WriteString("\t})\n}\n\n")
 	}
 	if len(bp.App.Theme) > 0 {

--- a/cmd/gofastr/blueprint.go
+++ b/cmd/gofastr/blueprint.go
@@ -1063,11 +1063,25 @@ func blueprintHasEntityAccess(bp Blueprint) bool {
 // defaulting to "/login". Used to point the auth battery's form-error redirect
 // at the login page (so a failed login lands back on the form, not raw JSON).
 func blueprintLoginRoute(bp Blueprint) string {
-	for _, s := range bp.Screens {
-		for _, b := range s.Body {
+	// Sections render nested children, and a login form can sit anywhere in
+	// that tree; a flat scan misses it and falls back to "/login" — an
+	// unregistered route when the blueprint's sign-in screen lives elsewhere.
+	// Same recursive walk blueprintNeedsResource uses.
+	var hasLogin func([]BlueprintBlock) bool
+	hasLogin = func(blocks []BlueprintBlock) bool {
+		for _, b := range blocks {
 			if isLoginFormBlock(b) {
-				return s.Route
+				return true
 			}
+			if hasLogin(b.Children) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, s := range bp.Screens {
+		if hasLogin(s.Body) {
+			return s.Route
 		}
 	}
 	return "/login"
@@ -1130,12 +1144,18 @@ func blueprintRegisteredMarketingLinks(bp Blueprint) []blueprintMarketingLink {
 // the generator gates it with a guest policy (signed-in users are redirected
 // to the app instead of seeing a sign-in form they don't need).
 func screenHasAuthForm(s BlueprintScreen) bool {
-	for _, b := range s.Body {
-		if isLoginFormBlock(b) || isSignupFormBlock(b) {
-			return true
+	// Same tree as blueprintLoginRoute walks: a form nested in a section's
+	// children still makes the screen guest-gated.
+	var any func([]BlueprintBlock) bool
+	any = func(blocks []BlueprintBlock) bool {
+		for _, b := range blocks {
+			if isLoginFormBlock(b) || isSignupFormBlock(b) || any(b.Children) {
+				return true
+			}
 		}
+		return false
 	}
-	return false
+	return any(s.Body)
 }
 
 // blueprintHasAuthFormScreen reports whether any screen hosts an auth form.

--- a/cmd/gofastr/blueprint_auth_route_test.go
+++ b/cmd/gofastr/blueprint_auth_route_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The auth gate redirects unauthenticated visitors to a login path baked into
+// the generated code. Hardcoding "/login" is the same defect class as #312's
+// nav links, but worse: a footer link to a missing page is a dead link, while
+// a gate pointing at a route the app never registers means EVERY auth-gated
+// page redirects to a 404 — the app has no working sign-in path at all.
+//
+// The fixture deliberately puts the login screen at /signin. A blueprint that
+// happens to use /login cannot observe this, which is exactly why the literal
+// survived: meridian routes /login, "which is luck, not design" (the comment
+// already in blueprint.go).
+func TestAuthGateRedirectsToTheBlueprintsLoginRoute(t *testing.T) {
+	const fixture = `
+app:
+  name: Chroma
+  module: github.com/example/chroma
+  auth:
+    enabled: true
+    dev_mode: true
+entities:
+  - name: notes
+    crud: true
+    fields:
+      - name: title
+        type: string
+        required: true
+screens:
+  - name: signin
+    route: /signin
+    layout: marketing
+    title: Sign in
+    body:
+      - kind: login_form
+  - name: dashboard
+    route: /dashboard
+    layout: app
+    title: Dashboard
+    access:
+      auth: true
+    body:
+      - kind: entity_list
+        entity: notes
+        text: Recent notes
+        fields: [title]
+        limit: 5
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gofastr.yml")
+	writeTestFile(t, path, fixture)
+	bp, err := loadBlueprint(path)
+	if err != nil {
+		t.Fatalf("loadBlueprint: %v", err)
+	}
+
+	if got := blueprintLoginRoute(bp); got != "/signin" {
+		t.Fatalf("fixture is wrong: blueprintLoginRoute = %q, want /signin", got)
+	}
+
+	var all strings.Builder
+	for _, f := range mustRenderBlueprintFiles(t, bp) {
+		all.WriteString(f.content)
+	}
+	out := all.String()
+
+	if !strings.Contains(out, "authPolicy(") {
+		t.Fatalf("fixture generated no auth gate; the test would pass vacuously")
+	}
+	// Both emitters must be in play: the screen mount and the island policy.
+	// Without the entity_list block the island site never renders, and a
+	// mutation restoring its literal survives — which it did, first time.
+	if !strings.Contains(out, "WithIslandPolicy(authPolicy(") {
+		t.Fatalf("fixture generated no island policy; the island half of the "+
+			"guard would be untested:\n%s", gateLines(out))
+	}
+	if strings.Contains(out, `authPolicy("/login"`) {
+		t.Errorf("auth gate redirects to a hardcoded /login, but this blueprint's login "+
+			"screen is at /signin — every gated page would 404:\n%s", gateLines(out))
+	}
+	if !strings.Contains(out, `authPolicy("/signin"`) {
+		t.Errorf("auth gate does not redirect to the blueprint's login route /signin:\n%s", gateLines(out))
+	}
+}
+
+func gateLines(out string) string {
+	var keep []string
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Contains(l, "authPolicy(") {
+			keep = append(keep, strings.TrimSpace(l))
+		}
+	}
+	return strings.Join(keep, "\n")
+}

--- a/cmd/gofastr/blueprint_auth_route_test.go
+++ b/cmd/gofastr/blueprint_auth_route_test.go
@@ -50,6 +50,22 @@ screens:
         text: Recent notes
         fields: [title]
         limit: 5
+  - name: archive
+    route: /archive
+    layout: app
+    title: Archive
+    access:
+      auth: true
+    body:
+      - kind: section
+        props:
+          heading: Archive
+        children:
+          - kind: entity_list
+            entity: notes
+            text: Older notes
+            fields: [title]
+            limit: 5
 `
 	dir := t.TempDir()
 	path := filepath.Join(dir, "gofastr.yml")
@@ -75,6 +91,12 @@ screens:
 	// Both emitters must be in play: the screen mount and the island policy.
 	// Without the entity_list block the island site never renders, and a
 	// mutation restoring its literal survives — which it did, first time.
+	//
+	// Both entity_list call sites too: dashboard mounts one flat in its body
+	// (blueprintScreenBody's direct call), archive nests one inside a section
+	// child (renderBlueprintBlockForScreen's call). The nested site threads
+	// bp separately — a mutation passing Blueprint{} there compiles, and only
+	// this screen's island policy exposes it.
 	if !strings.Contains(out, "WithIslandPolicy(authPolicy(") {
 		t.Fatalf("fixture generated no island policy; the island half of the "+
 			"guard would be untested:\n%s", gateLines(out))
@@ -85,6 +107,84 @@ screens:
 	}
 	if !strings.Contains(out, `authPolicy("/signin"`) {
 		t.Errorf("auth gate does not redirect to the blueprint's login route /signin:\n%s", gateLines(out))
+	}
+}
+
+// The scanners behind the gate walk the screen body tree, not its top level.
+// A login form nested in a section's children renders fine (screenNeedsCtx
+// already recurses), but blueprintLoginRoute and screenHasAuthForm scanned
+// s.Body flat: the gate fell back to "/login" — an unregistered route for a
+// blueprint whose sign-in lives at /signin — and the form screen lost its
+// guest policy, so signed-in users were shown a sign-in form they're past.
+// Same class as #312: a literal standing in for a route the blueprint knows.
+func TestAuthGateSeesNestedAuthForms(t *testing.T) {
+	const fixture = `
+app:
+  name: Chroma
+  module: github.com/example/chroma
+  auth:
+    enabled: true
+    dev_mode: true
+entities:
+  - name: notes
+    crud: true
+    fields:
+      - name: title
+        type: string
+        required: true
+screens:
+  - name: signin
+    route: /signin
+    layout: marketing
+    title: Sign in
+    body:
+      - kind: section
+        props:
+          heading: Welcome back
+        children:
+          - kind: login_form
+  - name: dashboard
+    route: /dashboard
+    layout: app
+    title: Dashboard
+    access:
+      auth: true
+    body:
+      - kind: entity_list
+        entity: notes
+        text: Recent notes
+        fields: [title]
+        limit: 5
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gofastr.yml")
+	writeTestFile(t, path, fixture)
+	bp, err := loadBlueprint(path)
+	if err != nil {
+		t.Fatalf("loadBlueprint: %v", err)
+	}
+
+	if got := blueprintLoginRoute(bp); got != "/signin" {
+		t.Fatalf("blueprintLoginRoute does not see the section-nested login form: got %q, want /signin", got)
+	}
+
+	var all strings.Builder
+	for _, f := range mustRenderBlueprintFiles(t, bp) {
+		all.WriteString(f.content)
+	}
+	out := all.String()
+
+	// The guest policy is the screenHasAuthForm half: without it the nested
+	// form is shown to signed-in users. Its absence would also make this
+	// assertion's guard vacuous.
+	if !strings.Contains(out, "guestPolicy(") {
+		t.Fatalf("nested form screen got no guest policy; the screenHasAuthForm half of the guard would be untested:\n%s", gateLines(out))
+	}
+	if strings.Contains(out, `authPolicy("/login"`) {
+		t.Errorf("auth gate redirects to a hardcoded /login, but this blueprint's login form is nested in a section at /signin:\n%s", gateLines(out))
+	}
+	if !strings.Contains(out, `authPolicy("/signin"`) {
+		t.Errorf("auth gate does not redirect to /signin for a section-nested login form:\n%s", gateLines(out))
 	}
 }
 

--- a/cmd/gofastr/blueprint_auth_route_test.go
+++ b/cmd/gofastr/blueprint_auth_route_test.go
@@ -177,7 +177,7 @@ screens:
 	// The guest policy is the screenHasAuthForm half: without it the nested
 	// form is shown to signed-in users. Its absence would also make this
 	// assertion's guard vacuous.
-	if !strings.Contains(out, "guestPolicy(") {
+	if !strings.Contains(out, ".WithPolicy(guestPolicy(") {
 		t.Fatalf("nested form screen got no guest policy; the screenHasAuthForm half of the guard would be untested:\n%s", gateLines(out))
 	}
 	if strings.Contains(out, `authPolicy("/login"`) {

--- a/cmd/gofastr/blueprint_marketing_links_test.go
+++ b/cmd/gofastr/blueprint_marketing_links_test.go
@@ -131,8 +131,9 @@ func TestMarketingChromeLinksMatchRegisteredScreens(t *testing.T) {
 				t.Fatal("generation produced no app.go")
 			}
 
-			// Every href the marketing chrome emits...
+			// Every href the marketing chrome emits, per surface...
 			hrefRe := regexp.MustCompile(`Href: "([^"]+)"`)
+			bodies := map[string]string{}
 			var hrefs []string
 			for _, fn := range []string{"marketingHeader", "marketingFooter"} {
 				body := generatedFuncBody(appGo, fn)
@@ -143,6 +144,7 @@ func TestMarketingChromeLinksMatchRegisteredScreens(t *testing.T) {
 				if len(found) == 0 {
 					t.Fatalf("%s emits no Href at all; the chrome assertions below would pass vacuously", fn)
 				}
+				bodies[fn] = body
 				for _, m := range found {
 					hrefs = append(hrefs, m[1])
 				}
@@ -160,6 +162,20 @@ func TestMarketingChromeLinksMatchRegisteredScreens(t *testing.T) {
 				if slices.Contains(hrefs, absent) {
 					t.Errorf("chrome still links %q though no screen registers it", absent)
 				}
+			}
+
+			// The converse, asserted PER SURFACE: /pricing is registered, so
+			// the header must carry its nav link and the footer its Product
+			// column. Against the pooled hrefs this guard is blind — a
+			// mutation that empties the header nav survives because the
+			// footer still supplies /pricing, and one that drops the whole
+			// link table passes the subset checks vacuously.
+			if !strings.Contains(bodies["marketingHeader"], `Href: "/pricing"`) {
+				t.Errorf("marketingHeader omits the registered /pricing nav link:\n%s", bodies["marketingHeader"])
+			}
+			if !strings.Contains(bodies["marketingFooter"], `Title: "Product"`) ||
+				!strings.Contains(bodies["marketingFooter"], `{Label: "Pricing", Href: "/pricing"}`) {
+				t.Errorf("marketingFooter omits the registered /pricing link's Product column:\n%s", bodies["marketingFooter"])
 			}
 		})
 	}

--- a/cmd/gofastr/blueprint_marketing_links_test.go
+++ b/cmd/gofastr/blueprint_marketing_links_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"maps"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// marketingLinksFixtureYAML is a marketing-layout blueprint that registers only
+// the routes its screens declare: /, /pricing and (auth variant) /login. No
+// /about, /terms or /privacy screen exists, so any chrome href to those routes
+// points at a route the generated app never mounts (#312).
+//
+// meridian.yml cannot observe this bug: it is the one shipped blueprint that
+// declares all four chrome routes.
+func marketingLinksFixtureYAML(withAuth bool) string {
+	var sb strings.Builder
+	sb.WriteString(`
+app:
+  name: Chroma
+  module: github.com/example/chroma
+`)
+	if withAuth {
+		sb.WriteString(`  auth:
+    enabled: true
+    dev_mode: true
+`)
+	}
+	sb.WriteString(`screens:
+  - name: home
+    route: /
+    layout: marketing
+    title: Chroma
+    body:
+      - kind: hero
+        props:
+          title: Ship it
+  - name: pricing
+    route: /pricing
+    layout: marketing
+    title: Pricing
+    body:
+      - kind: hero
+        props:
+          title: Pricing
+`)
+	if withAuth {
+		sb.WriteString(`  - name: login
+    route: /login
+    layout: marketing
+    title: Sign in
+    body:
+      - kind: login_form
+`)
+	}
+	return sb.String()
+}
+
+// generatedFuncBody returns the source of func <name> in src, brace-matched to
+// its closing brace. Empty when the function is absent.
+func generatedFuncBody(src, name string) string {
+	start := strings.Index(src, "func "+name+"(")
+	if start < 0 {
+		return ""
+	}
+	depth := 0
+	for i := start; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[start : i+1]
+			}
+		}
+	}
+	return ""
+}
+
+// Nothing compared the marketing chrome's hrefs against the routes the same
+// generation registers. A blueprint with one marketing screen and no /terms
+// screen generated a footer linking a 404. Both header branches (plain and
+// auth-aware) share the literals, so both are exercised.
+func TestMarketingChromeLinksMatchRegisteredScreens(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		withAuth bool
+	}{
+		{name: "plain", withAuth: false},
+		{name: "auth_header", withAuth: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "gofastr.yml")
+			writeTestFile(t, path, marketingLinksFixtureYAML(tc.withAuth))
+			bp, err := loadBlueprint(path)
+			if err != nil {
+				t.Fatalf("loadBlueprint: %v", err)
+			}
+			files := mustRenderBlueprintFiles(t, bp)
+
+			// The route table: every screen mount the same generation emits.
+			registered := map[string]bool{}
+			registerStmt := regexp.MustCompile(`\bsite\.Register\("([^"]+)"`)
+			registerScreenStmt := regexp.MustCompile(`\bsite\.RegisterScreen\(app\.NewScreen\("([^"]+)"`)
+			for _, f := range files {
+				for _, m := range registerStmt.FindAllStringSubmatch(f.content, -1) {
+					registered[m[1]] = true
+				}
+				for _, m := range registerScreenStmt.FindAllStringSubmatch(f.content, -1) {
+					registered[m[1]] = true
+				}
+			}
+			for _, mustExist := range []string{"/", "/pricing"} {
+				if !registered[mustExist] {
+					t.Fatalf("fixture route %s not registered; registered=%v — test fixture is broken, not the generator", mustExist, slices.Sorted(maps.Keys(registered)))
+				}
+			}
+
+			var appGo string
+			for _, f := range files {
+				if f.name == "app.go" {
+					appGo = f.content
+				}
+			}
+			if appGo == "" {
+				t.Fatal("generation produced no app.go")
+			}
+
+			// Every href the marketing chrome emits...
+			hrefRe := regexp.MustCompile(`Href: "([^"]+)"`)
+			var hrefs []string
+			for _, fn := range []string{"marketingHeader", "marketingFooter"} {
+				body := generatedFuncBody(appGo, fn)
+				if body == "" {
+					t.Fatalf("app.go has no %s function:\n%s", fn, appGo)
+				}
+				found := hrefRe.FindAllStringSubmatch(body, -1)
+				if len(found) == 0 {
+					t.Fatalf("%s emits no Href at all; the chrome assertions below would pass vacuously", fn)
+				}
+				for _, m := range found {
+					hrefs = append(hrefs, m[1])
+				}
+			}
+
+			// ...must resolve to a route the same generation registers.
+			for _, href := range hrefs {
+				if !registered[href] {
+					t.Errorf("marketing chrome links to %q, but no screen in the same generation registers that route (registered=%v)", href, slices.Sorted(maps.Keys(registered)))
+				}
+			}
+			// The fixture registers no /about, /terms or /privacy screen, so
+			// those links must not be emitted at all.
+			for _, absent := range []string{"/about", "/terms", "/privacy"} {
+				if slices.Contains(hrefs, absent) {
+					t.Errorf("chrome still links %q though no screen registers it", absent)
+				}
+			}
+		})
+	}
+}

--- a/cmd/gofastr/cov_misc_test.go
+++ b/cmd/gofastr/cov_misc_test.go
@@ -170,7 +170,7 @@ func TestRenderBlueprintBlockTypes(t *testing.T) {
 		{BlueprintBlock{Type: "weird", Text: "D"}, "div"},
 	}
 	for _, c := range cases {
-		got := renderBlueprintBlockForScreen(BlueprintScreen{}, c.block, nil, nil, "/api")
+		got := renderBlueprintBlockForScreen(Blueprint{}, BlueprintScreen{}, c.block, nil, nil, "/api")
 		if !strings.Contains(got, c.want) {
 			t.Errorf("block %q → %s, want substring %q", c.block.Type, got, c.want)
 		}

--- a/cmd/gofastr/emitter_output_context_security_test.go
+++ b/cmd/gofastr/emitter_output_context_security_test.go
@@ -264,7 +264,7 @@ func TestAuthFormHrefRejectsBadScheme(t *testing.T) {
 		// Controls: the guarded siblings. ui.LinkButton refuses the scheme, so the
 		// blueprint may legitimately emit the value and the check lands downstream.
 		{"link_button.href", func(v string) string {
-			expr, _ := renderBlueprintCatalogBlock(BlueprintScreen{Name: "home"}, BlueprintBlock{
+			expr, _ := renderBlueprintCatalogBlock(Blueprint{}, BlueprintScreen{Name: "home"}, BlueprintBlock{
 				Kind: "link_button", Props: map[string]any{"label": "Go", "href": v},
 			}, nil, nil, "")
 			return expr


### PR DESCRIPTION
Closes #312, and fixes the higher-severity sibling found while doing it.

## The filed bug

The marketing header and footer carried four literal hrefs — `/pricing`,
`/about`, `/terms`, `/privacy` — emitted whenever any screen declares
`layout: marketing`. Nothing connected them to `bp.Screens`, so a blueprint
with one marketing screen and no `/terms` screen generated an app whose footer
linked a 404.

This bug class had already been found and fixed **once, for one link**. The
comment sitting directly above these literals explains that `blueprintLoginRoute`
derives the login href because the hardcoded one pointed at a route six of the
seven shipped blueprints never register. The four literals below it were left
alone.

They now come from one table filtered by the routes `bp.Screens` registers,
shared by header and footer — two independent lists is how they drifted in the
first place. A footer column with no surviving links is omitted rather than
emitted empty, since `ui.SiteFooter` renders a present column as a title over
an empty `<ul>`.

**meridian generates byte-identical chrome**, which is the point rather than a
caveat: it declares all four routes and is the one shipped blueprint that
*cannot* observe this bug. The new test uses a fixture that can.

## The sibling, which is worse

`authPolicy` emits a **redirect** for every unauthenticated visitor to a gated
screen, and both emitters — the screen mount and the island policy — hardcoded
`"/login"`. A blueprint whose login screen sits at `/signin` generated an app
where every gated page redirects to a route it never registers. That is not a
dead footer link; it is an app with no working sign-in path.

`bp` is threaded rather than a login-path string. Both sites need it several
layers down, and a bare `string` parameter next to the existing `apiBase string`
is a swap the compiler cannot see — a distinct type makes that mistake a build
error instead of a silently wrong redirect.

## A near-miss worth recording

My first fixture gated a screen with a `hero` block. That emits no island
policy, so restoring the island literal changed nothing and **the mutation
passed** — the guard looked proved while half of it was untested. The fixture
now carries an `entity_list` block on the gated screen, and the test fails if
the generation stops emitting *either* gate, so that half cannot go quiet
again.

Both literals are mutation-proved:

```
[A: mount-site literal restored]   FAIL
[B: island-policy literal restored] FAIL
```

## Still-literal routes, reported not fixed

Found in the same emitter, left alone deliberately:

- `Href: "/"` for the header brand and footer lead, and `SignOut{Next: "/"}`.
  Same class, but `/` is the conventional target and a marketing blueprint
  without a home screen is a different conversation.
- `blueprintLoginRoute` itself falls back to `/login` when no screen hosts a
  login form, so an auth app with no login screen still links to an
  unregistered page. That is the established helper's own default; changing it
  is a design call, not a bug fix.

## Verified

`go build`, `go vet`, `gofmt` clean. `go test ./cmd/gofastr/ -count=1` green
(271s), including the generated-app gates and the meridian e2e generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9
