### PR TITLE
ui.MenuItem: an addressable id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   supported way to attach attributes to a component — cannot reach it.
   Inert for everyone else.
 
+- **`ui.MenuItem.ID`** sets the rendered menu row's `id` attribute, so page JS,
+  test suites, and aria wiring elsewhere on the page can address one exact row
+  (a Help Mode toggle a script binds to, an Imports row a shortcut targets).
+  Uniqueness is caller-owned like any HTML id, an empty value emits no `id`
+  (output unchanged), separators ignore it, and `MenuItem.ExtraAttrs` still
+  drops `id` — the field is the single owner.
+
 ## [0.76.0] - 2026-08-30
 
 ### Added

--- a/framework/docs/content/ui-new-components.md
+++ b/framework/docs/content/ui-new-components.md
@@ -117,7 +117,7 @@ raw (enumerated in `framework/ui/extraattrs_contract_test.go`). See
 - **breadcrumbs**: `core-ui/patterns/breadcrumbs`, `<nav aria-label=Breadcrumb>` trail
 - **pagination**: `core-ui/patterns/pagination`, numeric page navigation
 - **sidebar**: `framework/ui.Sidebar`, responsive primary nav with persistent, collapsible (local-storage persisted), off-canvas, and auto-hide variants; `Collapse` moves the collapsed state to the server, `GroupMarkup` swaps `<details>` groups for `button[aria-expanded][aria-controls]` + `hidden` container, `CollapseLabel`/`ExpandLabel` rename the toggle (see [Sidebar: server-owned collapse state](#sidebar-server-owned-collapse-state)); set `NavLabel` when a page has multiple navigation landmarks and mount the matching drawer with `MountSidebar`
-- **menu**: `framework/ui.Menu`, keyboard-driven dropdown built on `<details>`
+- **menu**: `framework/ui.Menu`, keyboard-driven dropdown built on `<details>`; `MenuItem.ID` gives a row an addressable `id` (caller-owned uniqueness, ignored on separators; `ExtraAttrs` still cannot set `id`)
 - **tabs**: `core-ui/patterns/tabs`, `<details>`-based tab strip, zero JS
 - **tree**: `core-ui/patterns/tree`, recursive tree with roving tabindex + lazy-load
 - **toc**: `framework/ui.TableOfContents`, auto-built sticky nav from `<h2>` / `<h3>`

--- a/framework/ui/menu.go
+++ b/framework/ui/menu.go
@@ -61,15 +61,25 @@ type MenuItem struct {
 	// Label and other fields are ignored when true.
 	Separator bool
 
+	// ID becomes the rendered row's id attribute, so page JS, test
+	// suites, or aria wiring elsewhere on the page can address this
+	// exact item (a Help Mode toggle a script binds to, an Imports
+	// row a shortcut targets). Uniqueness is caller-owned, like any
+	// HTML id: duplicates are the caller's bug, not enforced here.
+	// Ignored on separators, like every other field. Empty emits no
+	// id, leaving the output identical to a menu that never set it.
+	ID string
+
 	// Class appends to the rendered item's class list (rare; mainly
 	// for testing or one-off hooks).
 	Class string
 
 	// ExtraAttrs forwards additional attributes (data-* test hooks,
 	// analytics markers, ARIA overrides) onto the rendered item
-	// element. Keys the item owns are dropped: class (use Class), id,
-	// data-fui-* (the disclosure / rpc wiring), and the menuitem
-	// contract (type, href, tabindex, role, aria-disabled, disabled).
+	// element. Keys the item owns are dropped: class (use Class),
+	// id (use ID), data-fui-* (the disclosure / rpc wiring), and the
+	// menuitem contract (type, href, tabindex, role, aria-disabled,
+	// disabled).
 	ExtraAttrs map[string]string
 }
 
@@ -223,13 +233,19 @@ func writeMenuItem(b *strings.Builder, it MenuItem) {
 			rpcAttr += ` data-fui-confirm="` + render.Escape(it.Confirm) + `"`
 		}
 	}
+	// ID lands right after class, mirroring the panel div (class,
+	// id, role). Empty stays empty so zero-value output is unchanged.
+	idAttr := ""
+	if it.ID != "" {
+		idAttr = ` id="` + render.Escape(it.ID) + `"`
+	}
 	// ExtraAttrs join the SafeExtraAttrs contract: the item owns
 	// type/href/tabindex/role/aria-disabled/disabled plus the rpc
 	// data-fui-* wiring. serializeExtraAttrs sorts the survivors and
 	// validates each key via render.Attr (unsafe keys drop).
 	extra := serializeExtraAttrs(html.SafeExtraAttrs(it.ExtraAttrs,
 		"type", "href", "tabindex", "role", "aria-disabled", "disabled"))
-	b.WriteString(`<` + tag + ` class="` + render.Escape(cls) + `" ` + openExtra +
+	b.WriteString(`<` + tag + ` class="` + render.Escape(cls) + `"` + idAttr + ` ` + openExtra +
 		` role="menuitem" tabindex="` + tabindex + `"` + disabledAttr + rpcAttr + extra + `>`)
 	if it.Icon != "" {
 		b.WriteString(`<span class="ui-menu__icon" aria-hidden="true">` + string(it.Icon) + `</span>`)

--- a/framework/ui/menu_test.go
+++ b/framework/ui/menu_test.go
@@ -197,3 +197,181 @@ func TestMenuItemExtraAttrsCannotOverrideOwned(t *testing.T) {
 		t.Errorf("owned item attr overridden by ExtraAttrs:\n%s", out)
 	}
 }
+
+// TestMenuItemZeroValueByteIdentical pins the zero-value Menu output
+// byte-for-byte against bytes captured from main at e7deb99b (clean
+// tree, before MenuItem.ID existed): a throwaway module with a
+// replace directive rendered these exact configs twice and cmp'd the
+// runs for determinism before any edit was made. Every config leaves
+// MenuItem.ID unset, so an empty ID must not change a single byte —
+// no id attribute, no attribute reordering, no escaping drift.
+// Substring asserts cannot see any of that; only full-output
+// equality can.
+func TestMenuItemZeroValueByteIdentical(t *testing.T) {
+	for _, g := range goldenMenus {
+		t.Run(g.name, func(t *testing.T) {
+			if got := string(ui.Menu(g.cfg)); got != g.want {
+				t.Errorf("zero-value Menu output drifted from main bytes:\n--got--\n%s\n--want--\n%s", got, g.want)
+			}
+		})
+	}
+}
+
+var goldenMenus = []struct {
+	name string
+	cfg  ui.MenuConfig
+	want string
+}{
+	{
+		name: "plain-button",
+		cfg:  ui.MenuConfig{Label: "Actions", Items: []ui.MenuItem{{Label: "Edit"}}},
+		want: `<details class="ui-menu ui-menu--bottom-start" data-fui-disclosure data-fui-menu="ui-menu-57ac0b74" data-fui-comp="ui-menu"><summary class="ui-menu__trigger" aria-haspopup="menu" aria-controls="ui-menu-57ac0b74-panel">Actions<span class="ui-menu__caret" aria-hidden="true">▾</span></summary><div class="ui-menu__panel" id="ui-menu-57ac0b74-panel" role="menu" data-fui-menu-panel><button class="ui-menu__item" type="button" role="menuitem" tabindex="-1"><span class="ui-menu__label">Edit</span></button></div></details>`,
+	},
+	{
+		name: "href-anchor",
+		cfg:  ui.MenuConfig{Label: "Go", Items: []ui.MenuItem{{Label: "Home", Href: "/"}}},
+		want: `<details class="ui-menu ui-menu--bottom-start" data-fui-disclosure data-fui-menu="ui-menu-96810e5c" data-fui-comp="ui-menu"><summary class="ui-menu__trigger" aria-haspopup="menu" aria-controls="ui-menu-96810e5c-panel">Go<span class="ui-menu__caret" aria-hidden="true">▾</span></summary><div class="ui-menu__panel" id="ui-menu-96810e5c-panel" role="menu" data-fui-menu-panel><a class="ui-menu__item" href="/" role="menuitem" tabindex="-1"><span class="ui-menu__label">Home</span></a></div></details>`,
+	},
+	{
+		name: "href-refused-scheme",
+		cfg:  ui.MenuConfig{Label: "Go", Items: []ui.MenuItem{{Label: "Evil", Href: "javascript:alert(1)"}}},
+		want: `<details class="ui-menu ui-menu--bottom-start" data-fui-disclosure data-fui-menu="ui-menu-90970f37" data-fui-comp="ui-menu"><summary class="ui-menu__trigger" aria-haspopup="menu" aria-controls="ui-menu-90970f37-panel">Go<span class="ui-menu__caret" aria-hidden="true">▾</span></summary><div class="ui-menu__panel" id="ui-menu-90970f37-panel" role="menu" data-fui-menu-panel><a class="ui-menu__item" href="#" role="menuitem" tabindex="-1"><span class="ui-menu__label">Evil</span></a></div></details>`,
+	},
+	{
+		name: "danger-disabled-icon-class",
+		cfg: ui.MenuConfig{Label: "Actions", Items: []ui.MenuItem{{
+			Label: "Delete", Danger: true, Disabled: true, Class: "extra-cls",
+			Icon: render.HTML(`<svg width="12"></svg>`),
+		}}},
+		want: `<details class="ui-menu ui-menu--bottom-start" data-fui-disclosure data-fui-menu="ui-menu-020cb409" data-fui-comp="ui-menu"><summary class="ui-menu__trigger" aria-haspopup="menu" aria-controls="ui-menu-020cb409-panel">Actions<span class="ui-menu__caret" aria-hidden="true">▾</span></summary><div class="ui-menu__panel" id="ui-menu-020cb409-panel" role="menu" data-fui-menu-panel><button class="ui-menu__item ui-menu__item--danger ui-menu__item--disabled extra-cls" type="button" role="menuitem" tabindex="-1"aria-disabled="true" disabled><span class="ui-menu__icon" aria-hidden="true"><svg width="12"></svg></span><span class="ui-menu__label">Delete</span></button></div></details>`,
+	},
+	{
+		name: "disabled-anchor",
+		cfg:  ui.MenuConfig{Label: "Go", Items: []ui.MenuItem{{Label: "Locked", Href: "/x", Disabled: true}}},
+		want: `<details class="ui-menu ui-menu--bottom-start" data-fui-disclosure data-fui-menu="ui-menu-a636a70b" data-fui-comp="ui-menu"><summary class="ui-menu__trigger" aria-haspopup="menu" aria-controls="ui-menu-a636a70b-panel">Go<span class="ui-menu__caret" aria-hidden="true">▾</span></summary><div class="ui-menu__panel" id="ui-menu-a636a70b-panel" role="menu" data-fui-menu-panel><a class="ui-menu__item ui-menu__item--disabled" href="/x" role="menuitem" tabindex="-1"aria-disabled="true"><span class="ui-menu__label">Locked</span></a></div></details>`,
+	},
+	{
+		name: "rpc-confirm-method",
+		cfg: ui.MenuConfig{Label: "Row", Items: []ui.MenuItem{
+			{Label: "Delete", RPC: "/api/items/1", RPCMethod: "DELETE", Confirm: "Delete this item?", Danger: true},
+			{Label: "Save", RPC: "/api/save"},
+			{Label: "Open", Href: "/x", Confirm: "inert without rpc"},
+		}},
+		want: `<details class="ui-menu ui-menu--bottom-start" data-fui-disclosure data-fui-menu="ui-menu-af395ced" data-fui-comp="ui-menu"><summary class="ui-menu__trigger" aria-haspopup="menu" aria-controls="ui-menu-af395ced-panel">Row<span class="ui-menu__caret" aria-hidden="true">▾</span></summary><div class="ui-menu__panel" id="ui-menu-af395ced-panel" role="menu" data-fui-menu-panel><button class="ui-menu__item ui-menu__item--danger" type="button" role="menuitem" tabindex="-1" data-fui-rpc="/api/items/1" data-fui-rpc-method="DELETE" data-fui-confirm="Delete this item?"><span class="ui-menu__label">Delete</span></button><button class="ui-menu__item" type="button" role="menuitem" tabindex="-1" data-fui-rpc="/api/save" data-fui-rpc-method="POST"><span class="ui-menu__label">Save</span></button><a class="ui-menu__item" href="/x" role="menuitem" tabindex="-1"><span class="ui-menu__label">Open</span></a></div></details>`,
+	},
+	{
+		name: "extraattrs-item",
+		cfg: ui.MenuConfig{Label: "Actions", Items: []ui.MenuItem{{
+			Label: "Edit",
+			ExtraAttrs: map[string]string{
+				"data-test": "hook", "id": "smuggled", "ID": "smuggled2", "Class": "evil", "role": "evil", "tabindex": "evil",
+				"aria-label": "Edit thing", "x onclick": "alert(1)", "onmouseover": "alert(2)",
+			},
+		}}},
+		want: `<details class="ui-menu ui-menu--bottom-start" data-fui-disclosure data-fui-menu="ui-menu-57ac0b74" data-fui-comp="ui-menu"><summary class="ui-menu__trigger" aria-haspopup="menu" aria-controls="ui-menu-57ac0b74-panel">Actions<span class="ui-menu__caret" aria-hidden="true">▾</span></summary><div class="ui-menu__panel" id="ui-menu-57ac0b74-panel" role="menu" data-fui-menu-panel><button class="ui-menu__item" type="button" role="menuitem" tabindex="-1" aria-label="Edit thing" data-test="hook"><span class="ui-menu__label">Edit</span></button></div></details>`,
+	},
+	{
+		name: "separator-and-mixed",
+		cfg: ui.MenuConfig{ID: "user-menu", Label: "Account", Items: []ui.MenuItem{
+			{Label: "Profile", Href: "/me"},
+			{Separator: true},
+			{Label: "it's <b>escaped</b>", Icon: render.HTML("⚙")},
+		}},
+		want: `<details class="ui-menu ui-menu--bottom-start" data-fui-disclosure data-fui-menu="user-menu" data-fui-comp="ui-menu"><summary class="ui-menu__trigger" aria-haspopup="menu" aria-controls="user-menu-panel">Account<span class="ui-menu__caret" aria-hidden="true">▾</span></summary><div class="ui-menu__panel" id="user-menu-panel" role="menu" data-fui-menu-panel><a class="ui-menu__item" href="/me" role="menuitem" tabindex="-1"><span class="ui-menu__label">Profile</span></a><hr class="ui-menu__sep" role="separator"><button class="ui-menu__item" type="button" role="menuitem" tabindex="-1"><span class="ui-menu__icon" aria-hidden="true">⚙</span><span class="ui-menu__label">it&#39;s &lt;b&gt;escaped&lt;/b&gt;</span></button></div></details>`,
+	},
+	{
+		name: "trigger-html-position-classes",
+		cfg: ui.MenuConfig{
+			TriggerHTML:  render.HTML(`<svg class="icon"></svg>`),
+			Position:     ui.MenuTopEnd,
+			TriggerClass: `trig'ger`,
+			PanelClass:   `pan'el`,
+			ExtraAttrs:   map[string]string{"data-root": "yes", "id": "smuggled-root"},
+			Items:        []ui.MenuItem{{Label: "Settings"}},
+		},
+		want: `<details class="ui-menu ui-menu--top-end pan&#39;el" data-fui-disclosure data-fui-menu="ui-menu-6db4093c" data-root="yes" data-fui-comp="ui-menu"><summary class="ui-menu__trigger trig&#39;ger" aria-haspopup="menu" aria-controls="ui-menu-6db4093c-panel"><svg class="icon"></svg></summary><div class="ui-menu__panel" id="ui-menu-6db4093c-panel" role="menu" data-fui-menu-panel><button class="ui-menu__item" type="button" role="menuitem" tabindex="-1"><span class="ui-menu__label">Settings</span></button></div></details>`,
+	},
+	{
+		name: "position-bottom-end",
+		cfg:  ui.MenuConfig{Label: "P", Items: []ui.MenuItem{{Label: "a"}}, Position: ui.MenuBottomEnd},
+		want: `<details class="ui-menu ui-menu--bottom-end" data-fui-disclosure data-fui-menu="ui-menu-c65b0be2" data-fui-comp="ui-menu"><summary class="ui-menu__trigger" aria-haspopup="menu" aria-controls="ui-menu-c65b0be2-panel">P<span class="ui-menu__caret" aria-hidden="true">▾</span></summary><div class="ui-menu__panel" id="ui-menu-c65b0be2-panel" role="menu" data-fui-menu-panel><button class="ui-menu__item" type="button" role="menuitem" tabindex="-1"><span class="ui-menu__label">a</span></button></div></details>`,
+	},
+}
+
+// TestMenuItemIDEmittedOnRows: a set ID lands on the rendered row's
+// open tag, right after class (mirroring the panel div's class/id/role
+// order), on every row dialect — button, anchor, RPC button — and
+// leaves the framework-owned contract untouched.
+func TestMenuItemIDEmittedOnRows(t *testing.T) {
+	out := string(ui.Menu(ui.MenuConfig{Label: "Account", Items: []ui.MenuItem{
+		{Label: "Help mode", ID: "help-toggle"},
+		{Label: "Profile", ID: "profile-link", Href: "/me"},
+		{Label: "Delete", ID: "del", RPC: "/api/del", RPCMethod: "DELETE", Danger: true, Disabled: true},
+	}}))
+	for _, want := range []string{
+		`<button class="ui-menu__item" id="help-toggle" type="button" role="menuitem" tabindex="-1">`,
+		`<a class="ui-menu__item" id="profile-link" href="/me" role="menuitem" tabindex="-1">`,
+		// NOTE: no space before aria-disabled — pre-existing on main
+		// (disabledAttr lacks a leading space; browsers parse-error
+		// and recover). Pinned as-is; fixing it changes zero-value
+		// bytes and is a separate change from MenuItem.ID.
+		`<button class="ui-menu__item ui-menu__item--danger ui-menu__item--disabled" id="del" type="button" role="menuitem" tabindex="-1"aria-disabled="true" disabled data-fui-rpc="/api/del" data-fui-rpc-method="DELETE">`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("row with ID missing exact open tag %q:\n%s", want, out)
+		}
+	}
+	if n := strings.Count(out, `id="`); n != 4 { // 3 rows + the panel div
+		t.Errorf("got %d id attributes, want 4 (3 rows + panel):\n%s", n, out)
+	}
+}
+
+// TestMenuItemIDEscaped: the ID goes through render.Escape like every
+// other interpolated value, so quotes/angles cannot break out of the
+// attribute.
+func TestMenuItemIDEscaped(t *testing.T) {
+	out := string(ui.Menu(ui.MenuConfig{Label: "x", Items: []ui.MenuItem{
+		{Label: "Evil", ID: `a'b<c>"d" id="x`},
+	}}))
+	if !strings.Contains(out, `id="a&#39;b&lt;c&gt;&quot;d&quot; id=&quot;x"`) {
+		t.Errorf("ID not escaped into attribute:\n%s", out)
+	}
+	if strings.Contains(out, `id="a'b`) {
+		t.Errorf("raw ID leaked into attribute context:\n%s", out)
+	}
+}
+
+// TestMenuItemExtraAttrsIDStillDropped: one owner per attribute. ID the
+// field is the only way to an id on a row; SafeExtraAttrs keeps
+// dropping every case-variant of the key.
+func TestMenuItemExtraAttrsIDStillDropped(t *testing.T) {
+	out := string(ui.Menu(ui.MenuConfig{Label: "Actions", Items: []ui.MenuItem{{
+		Label: "Edit", ID: "real-id",
+		ExtraAttrs: map[string]string{"id": "smuggled", "ID": "smuggled2", "Id": "smuggled3"},
+	}}}))
+	if !strings.Contains(out, `id="real-id"`) {
+		t.Errorf("field-set ID missing from row:\n%s", out)
+	}
+	if strings.Contains(out, "smuggled") {
+		t.Errorf("ExtraAttrs id (some case-variant) survived onto the row:\n%s", out)
+	}
+	if n := strings.Count(out, `id="`); n != 2 { // the row + the panel div
+		t.Errorf("got %d id attributes, want 2 (row + panel):\n%s", n, out)
+	}
+}
+
+// TestMenuItemIDIgnoredOnSeparator: a separator is an <hr>; an id on it
+// is meaningless, and the component's established stance for fields on
+// the separator variant is documented ignore (Separator's own doc:
+// "Label and other fields are ignored when true").
+func TestMenuItemIDIgnoredOnSeparator(t *testing.T) {
+	out := string(ui.Menu(ui.MenuConfig{Label: "Actions", Items: []ui.MenuItem{
+		{Separator: true, ID: "sep-id", Label: "also ignored"},
+	}}))
+	if !strings.Contains(out, `<hr class="ui-menu__sep" role="separator">`) {
+		t.Errorf("separator row changed shape:\n%s", out)
+	}
+	if strings.Contains(out, "sep-id") || strings.Contains(out, "also ignored") {
+		t.Errorf("separator picked up fields it must ignore:\n%s", out)
+	}
+}


### PR DESCRIPTION
Item 3 of 3 on #319, shipped alone. Submenus and `menuitemradio` are structural changes to `MenuItem` and are sequenced separately — this unblocks the port's id-pinned rows now, for a fraction of the work.

## What

`MenuItem.ExtraAttrs` drops `id` by design, so a row a host addresses by id — a Help Mode toggle whose page JS binds to it, a row that opens an activity sheet — could not survive a migration onto `ui.Menu`. An explicit `ID` field gives that one owner.

Three decisions, all following precedent already in the file rather than inventing:

- **`id` stays dropped in `ExtraAttrs`.** `SafeExtraAttrs` already removes every case variant unconditionally, so the drop needs no new code and cannot regress per component. The field doc now points at `ID` instead of implying ids are unsupported.
- **Uniqueness is the caller's**, stated rather than enforced — the component sees one menu, not the page, so document-level uniqueness isn't checkable here. Same stance `Class` already takes.
- **An id on a separator is ignored**, matching how this struct treats `Label` on a separator and `Confirm` on a non-RPC item. Panics here are reserved for structural emptiness (empty `Items`, missing `Label`).

## The golden bytes came from main, not from this branch

The zero-value pin is the whole safety argument for existing callers, so its provenance matters: captured **before any edit**, through a throwaway module importing the clean worktree so the repo tree stayed untouched, with determinism checked by two identical runs first. A pin taken after editing would be self-satisfying and indistinguishable from a correct one.

Five mutations, each watched failing and restored — including the case-variant one: removing `id` from `SafeExtraAttrs` renders `id="real-id" ... ID="smuggled2" Id="smuggled3"`, the duplicate-attribute fold-back this guard exists to stop.

## Filed, not fixed: #327

Golden-byte capture surfaced a pre-existing defect — every disabled row emits `tabindex="-1"aria-disabled="true"` with no separating space. Invalid HTML that browsers recover from, which is why it survived.

Deliberately left alone here: fixing it changes zero-value output, and this PR's safety argument is that zero-value output is byte-identical to `main`. The pin records the malformed bytes with a `NOTE:` naming #327, to be updated in the commit that fixes it.

## Verified

`go build`, `go vet`, `gofmt`, `make analyze` clean. `framework/ui` and all of `core-ui/...` green. `ARCHITECTURE.md` deliberately untouched — a plain HTML id is not a new `data-fui-*` attribute, so hard rule 5 doesn't fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for assigning an addressable HTML `id` to menu rows through `MenuItem.ID`.
  * IDs are safely escaped and work with buttons, links, and RPC menu items.
  * Empty IDs preserve existing output; separator items ignore IDs.

* **Documentation**
  * Updated UI component documentation and the unreleased changelog with `MenuItem.ID` behavior and usage details.

* **Tests**
  * Added coverage for ID rendering, escaping, separators, and backward-compatible output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->