### PR TITLE
ui: pin that VacateHidden alone arms the tabs module

### DIFF
--- a/framework/ui/tabs_contract_test.go
+++ b/framework/ui/tabs_contract_test.go
@@ -153,6 +153,18 @@ func TestTabsVacateHiddenShipsStashOnly(t *testing.T) {
 	if !strings.Contains(out, `data-fui-tabs-vacate="true"`) {
 		t.Errorf("wrapper must carry the vacate marker:\n%s", out)
 	}
+	// VacateHidden ALONE must arm the module loader. Without it the panels
+	// ship empty and nothing ever restores them: the stash is inert data and
+	// the tabs module is the only thing that reads it.
+	//
+	// Nothing covered this arm. TestTabsStateAttrsOnAndOff asserts the
+	// attribute only under StateAttrs, TestTabsContractKnobsCompose sets all
+	// three knobs at once, and the runtime e2e fixtures hand-write
+	// data-fui-prefetch="tabs" into their HTML — so none of them can observe
+	// the component failing to emit it.
+	if !strings.Contains(out, `data-fui-prefetch="tabs"`) {
+		t.Errorf("VacateHidden alone must arm data-fui-prefetch=\"tabs\"; without the module the vacated panels never come back:\n%s", out)
+	}
 	if !strings.Contains(out, `data-fui-tab-index="0" role="tabpanel">alpha-body<`) {
 		t.Errorf("active panel content must ship in the DOM:\n%s", out)
 	}


### PR DESCRIPTION
Tier-B item from the v0.77.0 pre-release audit — a hollow guard over code that is currently correct.

## The gap

`VacateHidden` ships hidden panels empty and parks their content in an adjacent stash script. **The stash is inert data** — the demand-loaded `tabs` module is the only thing that reads it. So a `VacateHidden` strip that fails to arm `data-fui-prefetch="tabs"` vacates its panels and never restores them.

Three tests touch that attribute and **none could observe it going missing**:

- `TestTabsStateAttrsOnAndOff` asserts it only under `StateAttrs`
- `TestTabsContractKnobsCompose` sets all three knobs at once, so it cannot isolate this arm
- the runtime e2e fixtures in `tabs_contract_e2e_test.go` **hand-write** `data-fui-prefetch="tabs"` into their own HTML — a fixture that structurally cannot express the failure

That last one is the interesting shape. The e2e looks like coverage of the loading path, and it is, but it supplies the attribute itself rather than rendering it from the component — so the component could stop emitting it and every one of those tests would stay green.

## Proof

Narrowing the emission from `cfg.StateAttrs || cfg.VacateHidden` to `cfg.StateAttrs` reddens this test and nothing else in the package. Restored, green.

One assertion, no production change.