### PR TITLE
widget: a failed chrome fetch stops being a silent no-op

### DIFF
--- a/core-ui/runtime/src/widgets.js
+++ b/core-ui/runtime/src/widgets.js
@@ -134,7 +134,19 @@
       if (ks.length > 32) delete NS._chromeCache[ks[0]];
     }
     let html = '';
-    try { html = await NS._chromeCache[key]; } catch (_) {}
+    try { html = await NS._chromeCache[key]; } catch (err) {
+      // #339: by the time the fetch fails, the click's visible work is
+      // done — a ctx-carrying trigger dropped the SSR-inlined node above,
+      // and the node is NOT put back: its render is ctx-less, so
+      // restoring it would show chrome for an entity the trigger did not
+      // name (the #321 bug). Swallowing the error turned the click into a
+      // silent no-op. Tell the user, the way a dead form RPC does
+      // (src/rpc.js): _toastOrFallback (kernel) loads the toasts module
+      // on demand and degrades to the unstyled fallback, so the message
+      // appears even on a page with no toast stack.
+      console.error('[gofastr] widget chrome fetch failed', err);
+      NS._toastOrFallback?.({ variant: 'error', title: 'Could not open that panel.', ttl: 6000 });
+    }
     if (html) NS.mountWidget(cfg, html);
   };
 

--- a/core-ui/runtime/src/widgets.js
+++ b/core-ui/runtime/src/widgets.js
@@ -99,6 +99,10 @@
     // cache. '\0' cannot survive HTML attribute parsing, so name+ctx
     // pairs cannot collide.
     const key = name + '\0' + (ctx || '');
+    // Cache identity for THIS open. gofastr:navigate swaps NS._chromeCache
+    // for a fresh object, so an inequality later means the user left the
+    // page this click belonged to.
+    const openedAgainst = NS._chromeCache;
     const cached = NS._chromeCache[key];
     if (cached) {
       // LRU refresh: delete + re-insert moves the key to the recency
@@ -145,7 +149,16 @@
       // on demand and degrades to the unstyled fallback, so the message
       // appears even on a page with no toast stack.
       console.error('[gofastr] widget chrome fetch failed', err);
-      NS._toastOrFallback?.({ variant: 'error', title: 'Could not open that panel.', ttl: 6000 });
+      // Only tell the user if they are still on the page they clicked on.
+      // An SPA navigation swaps _chromeCache, so a mismatch means this
+      // failure belongs to a click they walked away from: the toast would
+      // land on a page they never clicked, and in the worst case say
+      // "Could not open that panel." while that panel is open, because
+      // they re-opened it successfully after navigating. Same signal the
+      // delete-path above already keys on.
+      if (openedAgainst === NS._chromeCache) {
+        NS._toastOrFallback?.({ variant: 'error', title: 'Could not open that panel.', ttl: 6000 });
+      }
     }
     if (html) NS.mountWidget(cfg, html);
   };

--- a/core-ui/runtime/widget_chromectx_e2e_test.go
+++ b/core-ui/runtime/widget_chromectx_e2e_test.go
@@ -391,7 +391,17 @@ func TestWidgetChromeCtx_FailedFetchAfterNavKeepsNewCache(t *testing.T) {
 	// only the entry in the cache it started against.
 	c.releaseSlow()
 	step("settle", chromedp.Sleep(400*time.Millisecond))
+	// #339 + #345 review: that failure belongs to a click the user walked
+	// away from, so it must NOT toast here. The panel they are looking at
+	// opened successfully two steps ago — an unguarded catch would tell
+	// them "Could not open that panel." about a panel that is open.
+	var staleToasts int
+	step("no-stale-toast",
+		chromedp.Evaluate(`document.querySelectorAll('[data-fui-toast-id]').length`, &staleToasts))
 	step("close-after", closeWidget())
+	if staleToasts != 0 {
+		t.Errorf("a pre-navigation fetch failure raised %d toast(s) on the page the user moved to; the panel it names is open", staleToasts)
+	}
 	// Re-open on the new page: served from the new cache (2 fetches
 	// total), not refetched because the failed old fetch deleted the
 	// new cache's entry (3).

--- a/core-ui/runtime/widget_chromectx_e2e_test.go
+++ b/core-ui/runtime/widget_chromectx_e2e_test.go
@@ -465,3 +465,72 @@ func TestWidgetChromeCtx_LRURecency(t *testing.T) {
 		t.Errorf("total chrome fetches = %d, want 34 (32 fills + c32 insert + c1 evicted re-open; both c0 re-opens hit cache)", total)
 	}
 }
+
+// TestWidgetChromeCtx_FailedFetchSurfacesToast pins #339: when a
+// ctx-carrying trigger drops SSR-inlined chrome (its render is ctx-less,
+// #321) and the replacement fetch then fails, the click must not end in
+// silence. Before the fix the dropped node was already gone, the error was
+// swallowed, and the click did nothing at all — no dialog, no message. The
+// failure must be observable the way a dead form RPC's is: a toast appears
+// (rendered by the toasts module, which _toastOrFallback loads on demand).
+// Two neighbours are pinned in the same run: the dropped SSR node is NOT
+// re-inserted (that would re-show ctx-less chrome, the #321 bug), and a
+// SUCCESSFUL ctx open must not toast.
+func TestWidgetChromeCtx_FailedFetchSurfacesToast(t *testing.T) {
+	body := `
+<div data-fui-widget="dlg" hidden><span>ssr chrome</span></div>
+<button id="open-ok" data-fui-open="dlg" data-fui-ctx="okctx">OK</button>
+<button id="open-slow" data-fui-open="dlg" data-fui-ctx="slowfail">Slow</button>`
+	c := startChromeCtxServer(t, body)
+	ctx := chromeCtxBrowser(t)
+
+	var okMark, toastTitle string
+	var happyToasts, dlgNodes int
+	step := func(name string, acts ...chromedp.Action) {
+		t.Helper()
+		if err := chromedp.Run(ctx, acts...); err != nil {
+			t.Fatalf("step %s: %v", name, err)
+		}
+		t.Logf("step %s ok", name)
+	}
+
+	step("nav", chromedp.Navigate(c.Srv.URL+"/"), chromedp.WaitVisible(`#ready`, chromedp.ByID), chromedp.Sleep(200*time.Millisecond))
+	// Success first, while no toast could exist yet: a healthy ctx open
+	// drops the SSR node, fetches fresh chrome, mounts — and stays quiet.
+	step("open-ok", chromedp.Click(`#open-ok`, chromedp.ByID),
+		chromedp.WaitVisible(`#ctxmark`, chromedp.ByQuery),
+		chromedp.Text(`#ctxmark`, &okMark, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelectorAll('[data-fui-toast-id]').length`, &happyToasts))
+	step("close-ok", closeWidget())
+	// Failure: the SSR node is gone (open-ok dropped it), so this open is
+	// a pure chrome fetch — the gated one, released into a 500.
+	step("open-slow", chromedp.Click(`#open-slow`, chromedp.ByID))
+	c.waitSlowArrived(t)
+	c.releaseSlow()
+	step("toast-visible", chromedp.WaitVisible(`[data-fui-toast-id]`, chromedp.ByQuery),
+		chromedp.Text(`.ui-notification__title`, &toastTitle, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelectorAll('[data-fui-widget="dlg"]').length`, &dlgNodes))
+
+	if okMark != "ctx=okctx|user=alice" {
+		t.Errorf("healthy open mark = %q, want ctx=okctx|user=alice", okMark)
+	}
+	if happyToasts != 0 {
+		t.Errorf("successful ctx open produced %d toast(s) — the happy path must stay quiet", happyToasts)
+	}
+	if dlgNodes != 0 {
+		t.Errorf("%d [data-fui-widget] node(s) after the failed open — the dropped SSR chrome must not be re-inserted (#321)", dlgNodes)
+	}
+	if toastTitle != "Could not open that panel." {
+		t.Errorf("toast title = %q, want the failed-open message", toastTitle)
+	}
+	_, perCtx, total := c.snapshot()
+	if got := perCtx["slowfail"]; got != 1 {
+		t.Errorf("chrome fetches for slowfail = %d, want 1", got)
+	}
+	if got := perCtx["okctx"]; got != 1 {
+		t.Errorf("chrome fetches for okctx = %d, want 1", got)
+	}
+	if total != 2 {
+		t.Errorf("total chrome fetches = %d, want 2", total)
+	}
+}


### PR DESCRIPTION
Closes #339. Third item of the 0.77.1 batch.

## The bug

A ctx-carrying trigger drops any SSR-inlined chrome for its widget — that render is ctx-less, so keeping it would show the wrong entity — and fetches a replacement keyed by `(name, ctx)`. When that fetch failed, the node was already gone and the error was swallowed by an empty `catch`. The click did **nothing whatsoever**: no dialog, no message, nothing in the console.

That is better than what it replaced in v0.77.0, which showed the *wrong entity's* dialog. It is still not good — silence is the property worth removing.

## The fix

The catch now logs and fires an error toast through the kernel's existing `_toastOrFallback`, which demand-loads the toasts module and falls back to the inline renderer, so the message appears even on a page with no toast stack. Same house pattern `rpc.js` uses for a dead submission.

**The dropped node is deliberately not re-inserted.** Its chrome names no entity, so restoring it re-shows chrome the trigger did not ask for — the exact bug this path was changed to fix. Re-insertion buys something on screen at the cost of correctness, and that trade is wrong here.

## Proof

Removing the toast call reddens `TestWidgetChromeCtx_FailedFetchSurfacesToast`; restored, green. The test drives the **existing** slowfail gate in `widget_chromectx_e2e_test.go` (first request for ctx `slowfail` blocks, then 500s) rather than new harness, so it exercises the real failure path.

Also confirmed a successful ctx open does not toast — a test that only asserts the happy path would pass with this fix deleted.

## Cost

Module-only. Widgets gz6 **2699 → 2782** against a 3072 budget. Core fragments and `runtime.js` are **byte-identical to main** — `_toastOrFallback` already existed in the kernel, so nothing was added to the core bundle, which has 8 bytes of headroom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed panel loads now display an error toast instead of failing silently.
  * Prevented previously removed server-rendered panel content from reappearing after an unsuccessful load.

* **Quality Improvements**
  * Verified that successful panel opens remain toast-free.
  * Added coverage for failed and successful panel-loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->