### PR TITLE
evals: report where the capture budget went when the guard times out

### DIFF
--- a/evals/ui-quality/internal/evalrunner/capture.go
+++ b/evals/ui-quality/internal/evalrunner/capture.go
@@ -382,11 +382,13 @@ func captureCandidate(ctx context.Context, baseURL, blindDir string, scenario Sc
 			// number goes stale the first time someone tunes the budget.
 			const captureBudget = 45 * time.Second
 			captureCtx, cancel := context.WithTimeout(tab, captureBudget)
-			// #342: this budget starts BEFORE the browser exists. chromedp
-			// launches Chrome lazily on the first action, and the first
-			// action here is the guard's fetch.Enable — so a slow launch is
-			// billed to a budget meant for the capture, and the deadline
-			// surfaces pointing at the guard rather than at startup.
+			// #342: on the FIRST shot this budget starts before the browser
+			// exists. chromedp launches Chrome lazily on the first action,
+			// and the first action here is the guard's fetch.Enable — so a
+			// slow launch is billed to a budget meant for the capture, and
+			// the deadline surfaces pointing at the guard rather than at
+			// startup. Later shots reuse that browser: a new tab inherits
+			// the running process, so their number is guard time only.
 			//
 			// On CI this fails at ~45.04s while a quiet local run is 3.3s
 			// and a CPU-saturated one is 7.5s, so the gap is far larger
@@ -407,8 +409,17 @@ func captureCandidate(ctx context.Context, baseURL, blindDir string, scenario Sc
 			if guardErr != nil {
 				cancel()
 				closeTab()
-				issues = append(issues, fmt.Sprintf("%s %s: install network guard after %s of the %s budget (first chromedp call on a cold tab, so this includes the browser launch): %v",
-					page.Name, vp.ID, budgetUsed.Round(time.Millisecond), captureBudget, guardErr))
+				// Attribute honestly: only the first shot pays for the
+				// browser launch. Saying "includes the browser launch" on
+				// shot 5 would point the reader at a startup that happened
+				// four shots ago — the exact misattribution this diagnostic
+				// exists to remove.
+				launchNote := "browser already running, so this is guard time only"
+				if shotIndex == 1 {
+					launchNote = "first shot, so this includes the browser launch"
+				}
+				issues = append(issues, fmt.Sprintf("%s %s: install network guard after %s of the %s budget (%s): %v",
+					page.Name, vp.ID, budgetUsed.Round(time.Millisecond), captureBudget, launchNote, guardErr))
 				continue
 			}
 			emulationActions := []chromedp.Action{chromedp.EmulateReset()}

--- a/evals/ui-quality/internal/evalrunner/capture.go
+++ b/evals/ui-quality/internal/evalrunner/capture.go
@@ -392,10 +392,12 @@ func captureCandidate(ctx context.Context, baseURL, blindDir string, scenario Sc
 			// and a CPU-saturated one is 7.5s, so the gap is far larger
 			// than contention explains and nobody has measured where it
 			// goes. Report the split rather than guess again: budgetUsed is
-			// how much of the 45s was gone by the time the guard returned.
-			// A failure that says "44.8s of 45s" is a launch problem; one
-			// that says "0.9s of 45s" is not, and the two want opposite
-			// fixes.
+			// how much of the budget was gone by the time the guard
+			// returned. A failure near the full budget is a launch problem;
+			// one far below it is not, and the two want opposite fixes.
+			// (Stated without the number on purpose — see the constant
+			// above. Writing it here is the drift that comment forbids,
+			// and this comment had it.)
 			guardStart := time.Now()
 			networkGuard, guardErr := newCandidateNetworkGuard(baseURL)
 			if guardErr == nil {

--- a/evals/ui-quality/internal/evalrunner/capture.go
+++ b/evals/ui-quality/internal/evalrunner/capture.go
@@ -377,15 +377,36 @@ func captureCandidate(ctx context.Context, baseURL, blindDir string, scenario Sc
 			// after cancel closes the shared tab and makes every later shot fail
 			// with context canceled. Give each screenshot its own tab instead.
 			tab, closeTab := chromedp.NewContext(browser)
-			captureCtx, cancel := context.WithTimeout(tab, 45*time.Second)
+			// Named so the diagnostic below cannot drift from it. Writing
+			// "45s" into the message and the duration separately is how a
+			// number goes stale the first time someone tunes the budget.
+			const captureBudget = 45 * time.Second
+			captureCtx, cancel := context.WithTimeout(tab, captureBudget)
+			// #342: this budget starts BEFORE the browser exists. chromedp
+			// launches Chrome lazily on the first action, and the first
+			// action here is the guard's fetch.Enable — so a slow launch is
+			// billed to a budget meant for the capture, and the deadline
+			// surfaces pointing at the guard rather than at startup.
+			//
+			// On CI this fails at ~45.04s while a quiet local run is 3.3s
+			// and a CPU-saturated one is 7.5s, so the gap is far larger
+			// than contention explains and nobody has measured where it
+			// goes. Report the split rather than guess again: budgetUsed is
+			// how much of the 45s was gone by the time the guard returned.
+			// A failure that says "44.8s of 45s" is a launch problem; one
+			// that says "0.9s of 45s" is not, and the two want opposite
+			// fixes.
+			guardStart := time.Now()
 			networkGuard, guardErr := newCandidateNetworkGuard(baseURL)
 			if guardErr == nil {
 				guardErr = installCandidateNetworkGuard(captureCtx, networkGuard)
 			}
+			budgetUsed := time.Since(guardStart)
 			if guardErr != nil {
 				cancel()
 				closeTab()
-				issues = append(issues, fmt.Sprintf("%s %s: install network guard: %v", page.Name, vp.ID, guardErr))
+				issues = append(issues, fmt.Sprintf("%s %s: install network guard after %s of the %s budget (first chromedp call on a cold tab, so this includes the browser launch): %v",
+					page.Name, vp.ID, budgetUsed.Round(time.Millisecond), captureBudget, guardErr))
 				continue
 			}
 			emulationActions := []chromedp.Action{chromedp.EmulateReset()}


### PR DESCRIPTION
Refs #342. Instrumentation, not a fix — deliberately.

## Why not a fix

#342 has failed on main three times, always `install network guard: context deadline exceeded` at ~45.04s, and **nobody can say where the 45 seconds went**. I have already shipped two guesses at it and the experiment refuted both — the first made the test slower and failing where removing it passed.

Measured since then, on `main`, serially:

| condition | runs | result | time |
|---|---|---|---|
| quiet | 10 | 10 pass | ~3.3s |
| 28 busy loops on 14 cores | 5 | 5 pass | ~7.5s |

15/15. So it is **not** non-deterministic locally — I claimed it was, that was wrong, and it is corrected on the ticket. CPU contention does not come close to 45s either. Whatever CI hits is something else, and no amount of local re-running will name it.

## What this adds

The failure message now carries the split:

```
install network guard after 44.812s of the 45s budget
  (first chromedp call on a cold tab, so this includes the browser launch): ...
```

A failure reading **"after 44.8s of 45s"** is a launch problem. One reading **"after 0.9s"** is not. Those want opposite fixes, and right now they are indistinguishable in the only place the failure is ever observed.

The budget starts before the browser exists — chromedp launches Chrome on the first action, and the first action here is the guard's `fetch.Enable` — so a slow launch is billed to a budget meant for the capture. That remains a hypothesis; this is how it gets confirmed or killed by the next red run instead of by me guessing a third time.

## One thing the proof caught

The first version hardcoded `45s` in the message next to a measured duration. Forcing a 1ms budget printed **"after 1ms of the 45s budget"** — a stale number written into the fix for stale numbers. The budget is now a named constant the message formats, so the two cannot drift.

Verified by forcing the failure: at a 1ms budget it reads **"after 2ms of the 1ms budget"**. Both values come from the code, neither from prose.

## Scope

One file, one message, one constant. No behaviour change — the suite passes unchanged (15.3s).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot capture diagnostics by reporting elapsed and total capture time when network-guard setup fails.
  * Helps distinguish slow browser startup from failures occurring during screenshot capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->