### PR TITLE
widget: one toast per failed chrome fetch, not one per click

### DIFF
--- a/core-ui/runtime/src/widgets.js
+++ b/core-ui/runtime/src/widgets.js
@@ -99,10 +99,6 @@
     // cache. '\0' cannot survive HTML attribute parsing, so name+ctx
     // pairs cannot collide.
     const key = name + '\0' + (ctx || '');
-    // Cache identity for THIS open. gofastr:navigate swaps NS._chromeCache
-    // for a fresh object, so an inequality later means the user left the
-    // page this click belonged to.
-    const openedAgainst = NS._chromeCache;
     const cached = NS._chromeCache[key];
     if (cached) {
       // LRU refresh: delete + re-insert moves the key to the recency
@@ -127,6 +123,22 @@
           return await r.text();
         } catch (err) {
           delete cache[key];
+          // #347: report HERE, not in the awaiters' catch below. Every
+          // click that joined this in-flight promise runs its own catch,
+          // so reporting there gave one toast per click for a single
+          // failed request — the dedup covered the fetch and not the
+          // telling. This runs exactly once per fetch.
+          //
+          // #339/#345: only if the user is still on the page they
+          // clicked on. `cache` is the object this fetch started
+          // against; gofastr:navigate swaps NS._chromeCache, so a
+          // mismatch means they walked away — and in the worst case
+          // they re-opened the panel successfully after navigating, and
+          // the toast would deny an open panel.
+          console.error('[gofastr] widget chrome fetch failed', err);
+          if (cache === NS._chromeCache) {
+            NS._toastOrFallback?.({ variant: 'error', title: 'Could not open that panel.', ttl: 6000 });
+          }
           throw err;
         }
       })();
@@ -138,28 +150,11 @@
       if (ks.length > 32) delete NS._chromeCache[ks[0]];
     }
     let html = '';
-    try { html = await NS._chromeCache[key]; } catch (err) {
-      // #339: by the time the fetch fails, the click's visible work is
-      // done — a ctx-carrying trigger dropped the SSR-inlined node above,
-      // and the node is NOT put back: its render is ctx-less, so
-      // restoring it would show chrome for an entity the trigger did not
-      // name (the #321 bug). Swallowing the error turned the click into a
-      // silent no-op. Tell the user, the way a dead form RPC does
-      // (src/rpc.js): _toastOrFallback (kernel) loads the toasts module
-      // on demand and degrades to the unstyled fallback, so the message
-      // appears even on a page with no toast stack.
-      console.error('[gofastr] widget chrome fetch failed', err);
-      // Only tell the user if they are still on the page they clicked on.
-      // An SPA navigation swaps _chromeCache, so a mismatch means this
-      // failure belongs to a click they walked away from: the toast would
-      // land on a page they never clicked, and in the worst case say
-      // "Could not open that panel." while that panel is open, because
-      // they re-opened it successfully after navigating. Same signal the
-      // delete-path above already keys on.
-      if (openedAgainst === NS._chromeCache) {
-        NS._toastOrFallback?.({ variant: 'error', title: 'Could not open that panel.', ttl: 6000 });
-      }
-    }
+    // Reporting lives in the fetch's own catch above, so this one stays
+    // silent: it runs per awaiter, and a shared in-flight promise can have
+    // several. Rethrowing here would surface an unhandled rejection for a
+    // failure already reported once.
+    try { html = await NS._chromeCache[key]; } catch (_) {}
     if (html) NS.mountWidget(cfg, html);
   };
 

--- a/core-ui/runtime/widget_chromectx_e2e_test.go
+++ b/core-ui/runtime/widget_chromectx_e2e_test.go
@@ -495,7 +495,7 @@ func TestWidgetChromeCtx_FailedFetchSurfacesToast(t *testing.T) {
 	ctx := chromeCtxBrowser(t)
 
 	var okMark, toastTitle string
-	var happyToasts, dlgNodes int
+	var happyToasts, failToasts, dlgNodes int
 	step := func(name string, acts ...chromedp.Action) {
 		t.Helper()
 		if err := chromedp.Run(ctx, acts...); err != nil {
@@ -516,13 +516,23 @@ func TestWidgetChromeCtx_FailedFetchSurfacesToast(t *testing.T) {
 	// a pure chrome fetch — the gated one, released into a 500.
 	step("open-slow", chromedp.Click(`#open-slow`, chromedp.ByID))
 	c.waitSlowArrived(t)
+	// #347: click again while the first fetch is still in flight. Both
+	// clicks await the SAME cached promise, so the request dedups — and
+	// the REPORTING has to dedup with it. Reporting from each awaiter's
+	// catch gave two toasts for one failed request.
+	step("open-slow-again", chromedp.Click(`#open-slow`, chromedp.ByID))
 	c.releaseSlow()
 	step("toast-visible", chromedp.WaitVisible(`[data-fui-toast-id]`, chromedp.ByQuery),
+		chromedp.Sleep(400*time.Millisecond),
 		chromedp.Text(`.ui-notification__title`, &toastTitle, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelectorAll('[data-fui-toast-id]').length`, &failToasts),
 		chromedp.Evaluate(`document.querySelectorAll('[data-fui-widget="dlg"]').length`, &dlgNodes))
 
 	if okMark != "ctx=okctx|user=alice" {
 		t.Errorf("healthy open mark = %q, want ctx=okctx|user=alice", okMark)
+	}
+	if failToasts != 1 {
+		t.Errorf("two clicks on one failing fetch produced %d toast(s), want exactly 1: the request dedups on the cached promise, so the reporting must too", failToasts)
 	}
 	if happyToasts != 0 {
 		t.Errorf("successful ctx open produced %d toast(s) — the happy path must stay quiet", happyToasts)


### PR DESCRIPTION
Closes #347.

## The bug

Two clicks on a `data-fui-ctx` trigger before its chrome fetch resolves produced **two** error toasts for **one** request. Both clicks await the same cached promise, so the *request* dedups correctly — but each awaiter then ran its own `catch`, and the *reporting* did not dedup with it.

## The fix

Report from the fetch's own `catch`, which runs exactly once per request.

That catch already holds `cache` — the cache object the fetch started against — which is the same navigation signal the awaiter path was keying on via `openedAgainst`. So the #345 post-navigation suppression comes along unchanged rather than being reimplemented in a second place.

The awaiters' catch stays and is silent. It deliberately does **not** rethrow: that would raise an unhandled rejection for a failure already reported once.

## Proof

The dedup needed its own case, because the existing guards cannot see it — with reporting moved back to the awaiters, `TestWidgetChromeCtx_FailedFetchSurfacesToast` (#339), the happy-path-quiet assertion, and the post-navigation suppression (#345) **all still pass**. Only the new assertion reds:

```
two clicks on one failing fetch produced 2 toast(s), want exactly 1:
the request dedups on the cached promise, so the reporting must too
```

With the fix: 1 toast. Full `ChromeCtx|Composed|Budget` family green.

## Sibling check, from the ticket

The RPC path was swept before touching this and does **not** share the shape:

- `_dispatchRPC` uses per-signal abort controllers, so a rapid double-click aborts the prior request — and it already filters `AbortError` (`rpc.js:284`). Without that it would report a failure for a request the user themselves superseded.
- `_submitForm`'s catch has no abort filter, but its fetch carries no `signal`, so no `AbortError` can reach it. Each submit is its own request: a double-submit is two real failures and two accurate messages.

So this fix is correctly local, not one half of a pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate error notifications when multiple actions share the same failed request.
  - Ensured failed widget loads display a single toast after the request completes.

- **Tests**
  - Added coverage confirming that repeated clicks during one in-progress request produce only one failure notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->