### PR TITLE
ci: serialize the chromium-ui shard, it launches two Chromes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,7 +442,15 @@ jobs:
             # files out and passes. Verified locally green before
             # landing: `go test -tags chromium ./framework/ui/
             # ./framework/pluginhost/` (~12s).
-            run: go test -count=1 -timeout=10m -tags chromium ./framework/ui/ ./framework/pluginhost/
+            # -p 1: both packages drive their own headless Chrome, and go
+            # test runs packages CONCURRENTLY by default. Launching two
+            # Chromes on one runner is the documented "chrome failed to
+            # start" contention this workflow already serializes elsewhere
+            # (see the header note on TestBlueprintCLIGeneratesEntireWorkingAppE2E).
+            # It bit here as "websocket url timeout reached" in
+            # TestCardFooterPinsToBottomInGrid on a PR that touched neither
+            # package.
+            run: go test -count=1 -timeout=10m -p 1 -tags chromium ./framework/ui/ ./framework/pluginhost/
           - suite: ui-quality-evals
             # Its capture tests drive a real headless Chrome; kept out of
             # the deterministic -p 2 run for the same contention reason.


### PR DESCRIPTION
A bug in a change I made today.

## What happened

`browser e2e · chromium-ui` failed on #349 — a PR touching only `evals/ui-quality`, which cannot affect either package the shard runs:

```
--- FAIL: TestCardFooterPinsToBottomInGrid (20.04s)
    card_footer_pin_chromium_test.go:76: websocket url timeout reached
```

That is Chrome failing to report its DevTools WebSocket URL — a browser that did not come up in time.

## Why

I gave the shard two packages in one invocation:

```
go test -count=1 -timeout=10m -tags chromium ./framework/ui/ ./framework/pluginhost/
```

**`go test` runs packages concurrently by default**, and both of these drive their own headless Chrome — `framework/ui` has four chromium-tagged files, `framework/pluginhost` one. So the shard launches two Chromes on one runner.

That is a failure class this workflow already documents and already serializes for. From its own header: `TestBlueprintCLIGeneratesEntireWorkingAppE2E` was pulled onto a separate runner because of "chrome failed to start" under parallel load, 3/6 runs. I reintroduced the same contention in a new shard while adding it a few hours ago.

## The fix

`-p 1`. Verified locally: `framework/ui` 12.4s, `pluginhost` 1.1s, both green. The shard name is unchanged, so `TestReleaseManifestMatchesCI` still matches — confirmed by running it.

## One connection worth recording

The ui-quality flake this shard sits beside (#342) fails as a cold-Chrome timeout too — `install network guard: context deadline exceeded`, where the guard is the first chromedp call and therefore pays for the browser launch.

**Same family, different trigger.** That job runs a single package with nothing to contend with, so serializing does not explain it, and I am not claiming this fixes it. #342 still needs the instrumentation in #349 to say where its budget actually goes.

What this does say is that cold Chrome startup on these runners is marginal enough to break two different suites in two different ways — context worth having before anyone reaches for a bigger timeout.
