### PR TITLE
fix(testdb): carry the per-test schema in the DSN, not in session state

### DIFF
--- a/framework/internal/testdb/searchpath_test.go
+++ b/framework/internal/testdb/searchpath_test.go
@@ -14,6 +14,8 @@ package testdb
 
 import (
 	"database/sql"
+	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -184,6 +186,82 @@ func TestWithSearchPathPreservesQuotedValues(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// Everything above asserts the SHAPE of the rewritten string. That is not
+// the property that matters: the property is that lib/pq still accepts it
+// and lands in the right schema. A rewrite can look right and not connect —
+// which is exactly what the whitespace split did.
+//
+// Builds a keyword/value DSN carrying a quoted value with a space (the case
+// that broke), rewrites it, and opens a real connection with the result.
+func TestRewrittenKeywordValueDSNStillConnects(t *testing.T) {
+	base, err := ResolvePostgresOnce()
+	if err != nil {
+		t.Skipf("Postgres unavailable: %v", err)
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		t.Skipf("TEST_POSTGRES_DSN is not a URL (%v); this test builds from one", err)
+	}
+	pass, _ := u.User.Password()
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		port = "5432"
+	}
+	// The fixture has to contain a QUOTED search_path with a space in it.
+	// Splitting on whitespace and re-joining on whitespace is lossless on
+	// its own — the damage happens only when a token is dropped, and here
+	// `search_path='stale,` is dropped while `public'` is left behind as a
+	// stray token that lib/pq cannot parse. A fixture without a quoted
+	// search_path round-trips unharmed through the broken code, so this test
+	// would pass against the bug it exists to catch. (It did, first draft.)
+	//
+	// options carries the second half of the property: a quoted value with a
+	// space that must survive untouched.
+	kv := fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable "+
+			"options='-c statement_timeout=30s' search_path='stale, public'",
+		host, port, u.User.Username(), pass, strings.TrimPrefix(u.Path, "/"))
+
+	admin, err := sql.Open("postgres", base)
+	if err != nil {
+		t.Fatalf("open admin: %v", err)
+	}
+	defer admin.Close()
+	const sn = "t_kv_rewrite_probe"
+	admin.Exec("DROP SCHEMA IF EXISTS " + sn + " CASCADE")
+	if _, err := admin.Exec("CREATE SCHEMA " + sn); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	defer admin.Exec("DROP SCHEMA " + sn + " CASCADE")
+
+	rewritten, err := withSearchPath(kv, sn)
+	if err != nil {
+		t.Fatalf("withSearchPath: %v", err)
+	}
+	db, err := sql.Open("postgres", rewritten)
+	if err != nil {
+		t.Fatalf("open rewritten: %v", err)
+	}
+	defer db.Close()
+
+	var got string
+	if err := db.QueryRow("SHOW search_path").Scan(&got); err != nil {
+		t.Fatalf("lib/pq rejected the rewritten DSN: %v", err)
+	}
+	if got != sn {
+		t.Errorf("connected, but search_path = %q, want %q", got, sn)
+	}
+	// The quoted value has to have survived intact, not just been carried.
+	var timeout string
+	if err := db.QueryRow("SHOW statement_timeout").Scan(&timeout); err != nil {
+		t.Fatalf("SHOW statement_timeout: %v", err)
+	}
+	if timeout != "30s" {
+		t.Errorf("the quoted options value did not survive the rewrite: statement_timeout = %q, want 30s", timeout)
 	}
 }
 

--- a/framework/internal/testdb/searchpath_test.go
+++ b/framework/internal/testdb/searchpath_test.go
@@ -1,0 +1,135 @@
+package testdb
+
+// The per-test schema binding has to survive a connection replacement.
+//
+// SetMaxOpenConns(1) bounds concurrency, not connection identity:
+// database/sql discards a connection whose backend died and silently opens
+// another. A schema bound with `SET search_path` on the open session is
+// gone at that point, and every statement after it runs in "$user", public
+// — the test's tables are invisible and it fails as `relation "…" does not
+// exist`, blaming the schema rather than the replaced connection.
+//
+// The failure needs a dead backend, so the test kills its own with
+// pg_terminate_backend rather than waiting for one.
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/framework/migrate"
+)
+
+// backendPID is the connection's own server process, the one to kill.
+func backendPID(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var pid int
+	if err := db.QueryRow("SELECT pg_backend_pid()").Scan(&pid); err != nil {
+		t.Fatalf("pg_backend_pid: %v", err)
+	}
+	return pid
+}
+
+func TestSearchPathSurvivesConnectionReplacement(t *testing.T) {
+	db := Open(t, migrate.DialectPostgres) // skips when no PG is reachable
+
+	var before string
+	if err := db.QueryRow("SHOW search_path").Scan(&before); err != nil {
+		t.Fatalf("SHOW search_path: %v", err)
+	}
+	if before == "" || strings.Contains(before, "public") {
+		t.Fatalf("Open did not scope the connection to a per-test schema: search_path = %q", before)
+	}
+	if _, err := db.Exec("CREATE TABLE probe (id int)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	// Kill this pool's backend from a separate, unscoped connection. The
+	// next use of db then runs on a connection database/sql opened itself,
+	// which is the case the DSN parameter exists for.
+	base, err := ResolvePostgresOnce()
+	if err != nil {
+		t.Skipf("Postgres unavailable: %v", err)
+	}
+	killer, err := sql.Open("postgres", base)
+	if err != nil {
+		t.Fatalf("open killer: %v", err)
+	}
+	defer killer.Close()
+	if _, err := killer.Exec("SELECT pg_terminate_backend($1)", backendPID(t, db)); err != nil {
+		t.Fatalf("terminate backend: %v", err)
+	}
+
+	// The first statement after the kill may itself be the one that
+	// discovers the dead connection, so allow one retry for the discovery
+	// and require the SECOND to be on a live, correctly scoped connection.
+	var after string
+	if err := db.QueryRow("SHOW search_path").Scan(&after); err != nil {
+		if err := db.QueryRow("SHOW search_path").Scan(&after); err != nil {
+			t.Fatalf("SHOW search_path after replacement: %v", err)
+		}
+	}
+	if after != before {
+		t.Errorf("search_path did not survive the connection replacement: was %q, now %q — the per-test schema must travel in the DSN, not a session-level SET", before, after)
+	}
+	if _, err := db.Exec("INSERT INTO probe VALUES (1)"); err != nil {
+		t.Errorf("insert after the connection was replaced: %v (the replacement landed outside the test's schema)", err)
+	}
+}
+
+func TestWithSearchPathRewritesBothDSNForms(t *testing.T) {
+	cases := []struct {
+		name, dsn, want string
+	}{
+		{
+			name: "url",
+			dsn:  "postgres://test:test@localhost:5432/framework_test?sslmode=disable",
+			want: "search_path=t_x_1",
+		},
+		{
+			name: "url with an existing search_path is replaced, not doubled",
+			dsn:  "postgres://test@localhost/db?search_path=stale&sslmode=disable",
+			want: "search_path=t_x_1",
+		},
+		{
+			name: "keyword/value",
+			dsn:  "host=localhost user=test dbname=framework_test sslmode=disable",
+			want: "search_path=t_x_1",
+		},
+		{
+			name: "keyword/value with an existing search_path is replaced",
+			dsn:  "host=localhost search_path=stale dbname=db",
+			want: "search_path=t_x_1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := withSearchPath(tc.dsn, "t_x_1")
+			if err != nil {
+				t.Fatalf("withSearchPath: %v", err)
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("got %q, want it to contain %q", got, tc.want)
+			}
+			if strings.Contains(got, "stale") {
+				t.Errorf("the stale search_path survived: %q", got)
+			}
+			if n := strings.Count(got, "search_path="); n != 1 {
+				t.Errorf("got %d search_path parameters, want exactly 1: %q", n, got)
+			}
+		})
+	}
+}
+
+// The schema name is interpolated into a DSN, so anything outside what
+// NewSchemaName emits is refused rather than passed through.
+func TestWithSearchPathRefusesUnsafeSchemaNames(t *testing.T) {
+	for _, bad := range []string{"", "has space", "quote'", "UPPER", "semi;colon", "amp&sand"} {
+		if got, err := withSearchPath("postgres://h/db", bad); err == nil {
+			t.Errorf("withSearchPath(%q) returned %q, want an error", bad, got)
+		}
+	}
+	if _, err := withSearchPath("postgres://h/db", "t_ok_123_4"); err != nil {
+		t.Errorf("a NewSchemaName-shaped name was refused: %v", err)
+	}
+}

--- a/framework/internal/testdb/searchpath_test.go
+++ b/framework/internal/testdb/searchpath_test.go
@@ -121,6 +121,87 @@ func TestWithSearchPathRewritesBothDSNForms(t *testing.T) {
 	}
 }
 
+// A libpq value may be single-quoted and contain spaces, so a whitespace
+// split mangles it: `search_path='stale, public'` splits into
+// `search_path='stale,` and `public'`, and dropping the first leaves the
+// second behind as a stray token. A quoted value that merely CONTAINS
+// "search_path=" loses its tail to the same filter. lib/pq then reports a
+// malformed DSN rather than the schema, so the symptom points anywhere but
+// here.
+func TestWithSearchPathPreservesQuotedValues(t *testing.T) {
+	cases := []struct {
+		name, dsn, keep string
+	}{
+		{
+			name: "quoted search_path with a space is removed whole",
+			dsn:  "host=localhost search_path='stale, public' dbname=db",
+			keep: "dbname=db",
+		},
+		{
+			name: "an unrelated quoted value with a space survives",
+			dsn:  "host=localhost password='a b c' dbname=db",
+			keep: "password='a b c'",
+		},
+		{
+			// libpq's `options` really can carry `-c search_path=…`, so this
+			// is the realistic shape, not a contrived one: a filter that
+			// matches on the substring would eat half of it.
+			name: "a quoted value containing search_path= is not filtered",
+			dsn:  "host=localhost options='-c search_path=y' dbname=db",
+			keep: "options='-c search_path=y'",
+		},
+		{
+			name: "an escaped quote inside a value does not end it",
+			dsn:  `host=localhost password='a\'b c' dbname=db`,
+			keep: `password='a\'b c'`,
+		},
+		{
+			name: "whitespace around the equals sign",
+			dsn:  "host = localhost dbname=db",
+			keep: "host = localhost",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := withSearchPath(tc.dsn, "t_new_1")
+			if err != nil {
+				t.Fatalf("withSearchPath: %v", err)
+			}
+			if !strings.Contains(got, tc.keep) {
+				t.Errorf("got %q, want it to keep %q intact", got, tc.keep)
+			}
+			if strings.Contains(got, "stale") {
+				t.Errorf("the stale search_path survived: %q", got)
+			}
+			if n := strings.Count(got, "search_path=t_new_1"); n != 1 {
+				t.Errorf("got %d copies of the new search_path, want 1: %q", n, got)
+			}
+			// A leftover fragment is the actual bug: the old value's tail
+			// surviving as a token of its own.
+			for _, frag := range []string{" public'", " y'"} {
+				if strings.Contains(got, frag) {
+					t.Errorf("a quoted value was split, leaving %q behind: %q", frag, got)
+				}
+			}
+		})
+	}
+}
+
+// A DSN the tokeniser cannot parse is an error, not a guess: silently
+// reshaping a connection string is how the whitespace-split bug read.
+func TestWithSearchPathRefusesMalformedDSNs(t *testing.T) {
+	for _, bad := range []string{
+		"postgres://%",              // url.Parse fails
+		"host=localhost dbname",     // key with no value
+		"host=localhost password='", // unterminated quote
+		"=novalue dbname=db",        // empty key
+	} {
+		if got, err := withSearchPath(bad, "t_x_1"); err == nil {
+			t.Errorf("withSearchPath(%q) returned %q, want an error", bad, got)
+		}
+	}
+}
+
 // The schema name is interpolated into a DSN, so anything outside what
 // NewSchemaName emits is refused rather than passed through.
 func TestWithSearchPathRefusesUnsafeSchemaNames(t *testing.T) {

--- a/framework/internal/testdb/testdb.go
+++ b/framework/internal/testdb/testdb.go
@@ -184,16 +184,91 @@ func withSearchPath(dsn, schema string) (string, error) {
 		u.RawQuery = q.Encode()
 		return u.String(), nil
 	}
-	// Keyword/value form. Drop any existing search_path= pair, then append.
-	var kept []string
-	for _, f := range strings.Fields(dsn) {
-		if strings.HasPrefix(f, "search_path=") {
+	// Keyword/value form. Drop any existing search_path pair, then append.
+	pairs, err := splitKeywordValueDSN(dsn)
+	if err != nil {
+		return "", err
+	}
+	kept := make([]string, 0, len(pairs)+1)
+	for _, p := range pairs {
+		if p.key == "search_path" {
 			continue
 		}
-		kept = append(kept, f)
+		kept = append(kept, p.raw)
 	}
 	kept = append(kept, "search_path="+schema)
 	return strings.Join(kept, " "), nil
+}
+
+// dsnPair is one keyword/value entry: its key, and the original text of the
+// whole `key=value` so re-emitting a kept pair cannot change its meaning.
+type dsnPair struct{ key, raw string }
+
+// splitKeywordValueDSN tokenises a libpq keyword/value DSN.
+//
+// strings.Fields is wrong here, and quietly so. libpq values may be
+// single-quoted and contain spaces, so `search_path='stale, public'` splits
+// into `search_path='stale,` and `public'` — dropping the first leaves the
+// second behind as a stray token, and a quoted value that merely CONTAINS
+// "search_path=" loses its tail to the same filter. Either way the rewritten
+// DSN is malformed, and lib/pq reports that rather than the schema.
+//
+// Follows libpq's fe-connect.c: whitespace around the key and the `=` is
+// allowed; a value is either single-quoted with backslash escapes, or runs to
+// the next whitespace. A DSN this cannot parse is an error, not a guess —
+// silently reshaping a connection string is how the original bug read.
+func splitKeywordValueDSN(dsn string) ([]dsnPair, error) {
+	var out []dsnPair
+	i := 0
+	isSpace := func(c byte) bool { return c == ' ' || c == '\t' || c == '\n' || c == '\r' }
+	for {
+		for i < len(dsn) && isSpace(dsn[i]) {
+			i++
+		}
+		if i >= len(dsn) {
+			return out, nil
+		}
+		start := i
+		for i < len(dsn) && dsn[i] != '=' && !isSpace(dsn[i]) {
+			i++
+		}
+		key := dsn[start:i]
+		if key == "" {
+			return nil, fmt.Errorf("dsn: empty key at offset %d", start)
+		}
+		for i < len(dsn) && isSpace(dsn[i]) {
+			i++
+		}
+		if i >= len(dsn) || dsn[i] != '=' {
+			return nil, fmt.Errorf("dsn: key %q has no value", key)
+		}
+		i++ // '='
+		for i < len(dsn) && isSpace(dsn[i]) {
+			i++
+		}
+		if i < len(dsn) && dsn[i] == '\'' {
+			i++ // opening quote
+			for {
+				if i >= len(dsn) {
+					return nil, fmt.Errorf("dsn: unterminated quoted value for key %q", key)
+				}
+				if dsn[i] == '\\' && i+1 < len(dsn) {
+					i += 2
+					continue
+				}
+				if dsn[i] == '\'' {
+					i++ // closing quote
+					break
+				}
+				i++
+			}
+		} else {
+			for i < len(dsn) && !isSpace(dsn[i]) {
+				i++
+			}
+		}
+		out = append(out, dsnPair{key: key, raw: dsn[start:i]})
+	}
 }
 
 // ForEachDialect runs fn against every dialect in Dialects as a t.Run

--- a/framework/internal/testdb/testdb.go
+++ b/framework/internal/testdb/testdb.go
@@ -12,6 +12,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -119,19 +120,80 @@ func Open(t *testing.T, dialect migrate.Dialect) *sql.DB {
 		if _, err := db.ExecContext(context.Background(), "CREATE SCHEMA "+schemaName); err != nil {
 			t.Fatalf("create schema %s: %v", schemaName, err)
 		}
-		if _, err := db.ExecContext(context.Background(), "SET search_path TO "+schemaName); err != nil {
-			t.Fatalf("set search_path: %v", err)
+		// The schema binding travels in the DSN, not as `SET search_path` on
+		// the open session. SetMaxOpenConns(1) bounds concurrency, not
+		// connection identity: database/sql discards a connection whose
+		// backend died and silently opens a replacement, and a replacement
+		// starts at the default search_path. Every statement after that
+		// point runs in "$user", public — so the test's tables are invisible
+		// and it fails as `relation "…" does not exist`, pointing at the
+		// schema rather than at the connection that was actually replaced.
+		// lib/pq forwards unrecognised DSN parameters to the server as
+		// startup options, so carrying it here applies it to every
+		// connection the pool ever opens. Proven by killing the backend with
+		// pg_terminate_backend: the session-level SET does not survive it and
+		// the DSN parameter does (TestSearchPathSurvivesConnectionReplacement).
+		scoped, err := withSearchPath(base, schemaName)
+		if err != nil {
+			t.Fatalf("scope dsn to %s: %v", schemaName, err)
 		}
+		scopedDB, err := sql.Open("postgres", scoped)
+		if err != nil {
+			t.Fatalf("open pg (scoped): %v", err)
+		}
+		scopedDB.SetMaxOpenConns(1)
 		t.Cleanup(func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
+			scopedDB.Close()
 			db.ExecContext(ctx, "DROP SCHEMA "+schemaName+" CASCADE")
 			db.Close()
 		})
-		return db
+		return scopedDB
 	}
 	t.Fatalf("unknown dialect: %s", dialect)
 	return nil
+}
+
+// withSearchPath returns dsn with search_path set to schema, so every
+// connection the pool opens from it starts already scoped.
+//
+// Both DSN spellings lib/pq accepts are handled: a URL
+// (postgres://user@host/db?sslmode=disable) and keyword/value
+// (host=… user=… dbname=…). An existing search_path is replaced rather than
+// appended — two of them would leave which one wins up to the parser.
+//
+// schema comes from NewSchemaName, which emits only [a-z0-9_], so it needs
+// no quoting here; anything else is refused rather than interpolated.
+func withSearchPath(dsn, schema string) (string, error) {
+	if schema == "" {
+		return "", errors.New("empty schema name")
+	}
+	for _, r := range schema {
+		if !(r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '_') {
+			return "", fmt.Errorf("schema %q is not [a-z0-9_]; refusing to put it in a DSN", schema)
+		}
+	}
+	if strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://") {
+		u, err := url.Parse(dsn)
+		if err != nil {
+			return "", fmt.Errorf("parse dsn: %w", err)
+		}
+		q := u.Query()
+		q.Set("search_path", schema)
+		u.RawQuery = q.Encode()
+		return u.String(), nil
+	}
+	// Keyword/value form. Drop any existing search_path= pair, then append.
+	var kept []string
+	for _, f := range strings.Fields(dsn) {
+		if strings.HasPrefix(f, "search_path=") {
+			continue
+		}
+		kept = append(kept, f)
+	}
+	kept = append(kept, "search_path="+schema)
+	return strings.Join(kept, " "), nil
 }
 
 // ForEachDialect runs fn against every dialect in Dialects as a t.Run


### PR DESCRIPTION
Found while investigating #353. **It is not that bug** — see below — but it is a real latent flake source in the same place, so it is worth fixing on its own.

## The bug

`testdb.Open` bound each test's Postgres schema with `SET search_path` on the connection it happened to hold. `SetMaxOpenConns(1)` bounds concurrency, not connection *identity*: `database/sql` discards a connection whose backend died and silently opens a replacement, and a replacement starts at `"$user", public`. Every statement after that runs outside the test's schema.

The failure mode is what makes it worth fixing: it surfaces as `relation "notes" does not exist`, which points at the schema — the one thing that is fine — rather than at the connection that was replaced.

`lib/pq` forwards unrecognised DSN parameters to the server as startup options, so the binding now travels in the DSN and applies to every connection the pool ever opens. `withSearchPath` handles both DSN spellings, replaces an existing `search_path` rather than appending a second one, and refuses any schema name outside what `NewSchemaName` emits instead of interpolating it.

## Proof

`TestSearchPathSurvivesConnectionReplacement` kills its own backend with `pg_terminate_backend` rather than waiting for one to die. Reverting `Open` to the session-level `SET`:

```
--- FAIL: TestSearchPathSurvivesConnectionReplacement
    search_path did not survive the connection replacement:
      was "t_testsearchpathsurvivesconnecti_54285_103", now "\"$user\", public"
    insert after the connection was replaced: pq: relation "probe" does not exist (42P01)
```

116 packages green against a real Postgres with the fix in place (`./framework/... ./battery/queue/... ./core/...`).

## What this rules out for #353

Three mechanisms tested against a live Postgres, three refuted — #353's symptom is `sql: no rows in result set`:

| mechanism | actual error |
|---|---|
| connection replaced, `search_path` lost | `pq: relation "notes" does not exist (42P01)` |
| backend dies *inside* the transaction | `driver: bad connection` |
| context cancelled mid-query | `pq: canceling statement due to user request (57014)` |

None of them produce an empty `RETURNING`. So #353 is not connection loss, not cancellation, and not schema drift — the insert ran and came back with no rows, which on a plain `INSERT … VALUES … RETURNING` needs a different explanation. I have updated #353 with this.

I also could not reproduce #353 itself: the full CI race step, all 16 packages against a real Postgres, is green, and `TestInTx` alone is 30/30 under `-race`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL test connections now preserve their per-test schema after connection replacement.
  * Improved database connection handling for both URL and keyword/value connection formats.
  * Existing schema search-path settings are safely replaced without creating duplicates.
  * Added validation to reject unsafe schema names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->