### PR TITLE
fix(kiln): refuse an empty plan_id, and test the refusal that mattered

### DIFF
--- a/kiln/journal/replay.go
+++ b/kiln/journal/replay.go
@@ -77,6 +77,17 @@ func Apply(s *Session, e Entry) error {
 		if err := e.Decode(&p); err != nil {
 			return err
 		}
+		// A plan with no id is not a plan, and storing one arms the only
+		// trick that gets past spendPlan's empty-id refusal: propose and
+		// approve s.Plans[""] listing a target, then emit the destructive
+		// entry with plan_id OMITTED, which decodes to "". Without
+		// spendPlan's first branch that lookup HITS an approved plan
+		// listing the target and the deletion is authorized. That branch
+		// holds today, so this is the second lock on the same door — but
+		// it removes the state that makes the door interesting.
+		if strings.TrimSpace(p.PlanID) == "" {
+			return fmt.Errorf("plan_proposed: empty plan_id")
+		}
 		s.Plans[p.PlanID] = &Plan{
 			PlanID:     p.PlanID,
 			ProposedAt: e.Timestamp,

--- a/kiln/journal/replay_security_test.go
+++ b/kiln/journal/replay_security_test.go
@@ -99,6 +99,83 @@ func TestReplayEnforcesPlanSingleUse(t *testing.T) {
 	}
 }
 
+// The empty plan_id is the one way past spendPlan that costs an attacker
+// nothing to arrange, and it had no test.
+//
+// plan_proposed did not require a non-empty id, so a hand-authored journal
+// could store and approve s.Plans[""] listing a target. A destructive entry
+// that simply OMITS plan_id decodes to "", and the lookup then HITS that
+// approved plan. Only spendPlan's `planID == ""` branch stood in the way —
+// deleting it deletes the entity, verified by mutation:
+//
+//	guard present:  delete_entity "orders": no plan_id
+//	guard removed:  err = <nil>, and s.World.Entities no longer has "orders"
+//
+// So it is checked at both ends: the empty id cannot be stored, and it
+// cannot be spent.
+func TestReplayRefusesEmptyPlanID(t *testing.T) {
+	t.Run("plan_proposed refuses an empty id", func(t *testing.T) {
+		s := newSessionWithEntity(t)
+		err := Apply(s, planEntry(KindPlanProposed, PlanProposedPayload{
+			PlanID:  "",
+			Targets: []PlanTarget{{Op: "delete_entity", Name: "orders"}},
+		}))
+		if err == nil {
+			t.Fatal("SECURITY: [integrity] a plan with an empty plan_id was stored")
+		}
+		if _, ok := s.Plans[""]; ok {
+			t.Error("SECURITY: [integrity] the refused plan is still in the session")
+		}
+	})
+
+	t.Run("whitespace is not an id either", func(t *testing.T) {
+		s := newSessionWithEntity(t)
+		if err := Apply(s, planEntry(KindPlanProposed, PlanProposedPayload{
+			PlanID:  "   ",
+			Targets: []PlanTarget{{Op: "delete_entity", Name: "orders"}},
+		})); err == nil {
+			t.Error("SECURITY: [integrity] a whitespace-only plan_id was stored")
+		}
+	})
+
+	// spendPlan's own refusal, reached directly.
+	//
+	// Going through Apply cannot test it while plan_proposed refuses the
+	// empty id first: the setup never happens, so removing spendPlan's
+	// branch fails nothing. That is exactly how the deeper of the two locks
+	// stays untested — the shallower one hides it. This plants the approved
+	// empty-id plan in the session and calls spendPlan itself.
+	t.Run("spendPlan refuses an empty id even with an approved empty-id plan", func(t *testing.T) {
+		s := newSessionWithEntity(t)
+		target := PlanTarget{Op: "delete_entity", Name: "orders"}
+		s.Plans[""] = &Plan{PlanID: "", Approved: true, Targets: []PlanTarget{target}}
+
+		if err := s.spendPlan("", target); err == nil {
+			t.Error("SECURITY: [integrity] spendPlan authorized a destructive op from an empty-id plan")
+		}
+	})
+
+	// The end-to-end shape, independent of where it gets refused: a journal
+	// that tries the whole trick must not delete anything. This is the
+	// assertion that survives either lock being reworked.
+	t.Run("the empty-id trick deletes nothing", func(t *testing.T) {
+		s := newSessionWithEntity(t)
+		_ = Apply(s, planEntry(KindPlanProposed, PlanProposedPayload{
+			PlanID:  "",
+			Targets: []PlanTarget{{Op: "delete_entity", Name: "orders"}},
+		}))
+		_ = Apply(s, planEntry(KindPlanApproved, PlanApprovedPayload{PlanID: ""}))
+
+		// plan_id omitted entirely — this is what a forged journal writes.
+		if err := Apply(s, worldEdit(OpDeleteEntity, DeleteEntityPayload{Name: "orders"})); err == nil {
+			t.Error("SECURITY: [integrity] a delete with no plan_id was authorized by an empty-id plan")
+		}
+		if _, still := s.World.Entities["orders"]; !still {
+			t.Error("SECURITY: [integrity] the empty-id plan deleted the entity")
+		}
+	})
+}
+
 // The authorized path must still work, or the guard has just broken kiln.
 func TestReplayAppliesAuthorizedDelete(t *testing.T) {
 	s := newSessionWithEntity(t)


### PR DESCRIPTION
Auditing the **kiln journal replay** item on #136. Most of it is already closed — the semantic guards named in that ticket are present and hold under mutation. One did not.

## The guard nobody had watched fail

`spendPlan`'s `planID == ""` branch is the one carrying the whole plan-gating property, and it had no test.

`plan_proposed` did not require a non-empty id, so a hand-authored `.kiln.session.jsonl` could store *and approve* `s.Plans[""]` listing a target. A destructive entry that simply **omits** `plan_id` decodes to `""`, and the lookup then hits that approved plan. Watched it, rather than reasoned it:

| | result |
|---|---|
| guard present | `delete_entity "orders": no plan_id` — entity survives |
| guard removed | `err = <nil>` — entity gone from the world |

The precondition is a local filesystem write, so this is an integrity property rather than a remote hole — the same framing #136 uses. The point stands either way: the log is supposed to be the authorization record, and one lookup miss away from not being one.

The empty id is now refused at both ends — `plan_proposed` will not store it, `spendPlan` will not spend it.

## Testing the deeper lock needs care

Reaching `spendPlan`'s branch *through* `Apply` is impossible once `plan_proposed` refuses first: the setup never happens, so removing `spendPlan`'s branch fails nothing. That is exactly how the shallower lock hides the deeper one — and how the deeper one went untested in the first place. The subtest plants the approved empty-id plan directly in the session and calls `spendPlan` itself.

## Proof

| mutation | fails |
|---|---|
| `plan_proposed` accepts an empty id | `…/plan_proposed_refuses_an_empty_id`, `…/whitespace_is_not_an_id_either` |
| `spendPlan`'s empty-id refusal removed | `…/spendPlan_refuses_an_empty_id_even_with_an_approved_empty-id_plan` |
| both removed (the pre-fix state) | all five assertions |

Full `./kiln/...` green, including the 162s integration suite.

One note on method, because it nearly cost me this finding: my first proof harness reported "both locks removed" as a **miss**. The harness was indexing the mutation's label instead of its code, so it never mutated anything — a passing test against an unmodified file, read as evidence of a gap. It now asserts the mutation actually applied before running. Second false negative from a proof harness this session; the first was a `-run` pattern that matched zero tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented destructive operations from being authorized with missing or whitespace-only plan IDs.
  * Forged journal entries that omit a plan ID no longer delete data.
  * Invalid plan proposals are rejected and are not stored.

* **Tests**
  * Added coverage for empty and whitespace-only plan IDs, including end-to-end protection against unauthorized deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->