### PR TITLE
fix(middleware): a non-positive Timeout means no deadline, not an instant one

### DIFF
--- a/core/middleware/idempotency.go
+++ b/core/middleware/idempotency.go
@@ -29,8 +29,12 @@ const IdempotencyKeyHeader = "Idempotency-Key"
 //   - replay non-nil, ok=true: a cached response already exists for this
 //     key and fingerprint; the middleware should write replay back and
 //     skip the downstream handler.
-//   - replay nil, ok=true: the caller is the first writer for this key.
-//     It must call Finish exactly once with the captured response.
+//   - replay nil, ok=false, err=nil: the caller is the first writer for
+//     this key. It must call Finish exactly once with the captured
+//     response. (Both shipped stores return ok=false here, and the
+//     middleware's replay branch is `ok && replay != nil`, so ok=false is
+//     the contract. This line used to say ok=true, which no implementation
+//     and no caller has ever agreed with.)
 //   - ok=false, err=ErrFingerprintMismatch: same key was used previously
 //     with a different request fingerprint. The middleware responds 422.
 //   - ok=false, err=ErrInFlight: another request with the same key is

--- a/core/middleware/timeout.go
+++ b/core/middleware/timeout.go
@@ -281,6 +281,20 @@ func Timeout(d time.Duration) Middleware {
 				}
 				effective = rt.Budget
 			}
+			// Same rule for the constructor's own duration as for a route
+			// budget, and for the same reason: zero means no deadline, as
+			// it does in net/http. Without this, time.NewTimer(0) fires
+			// before the handler can finish and every request 504s — so
+			// `Timeout(cfg.RequestTimeout)` with the field unset turned
+			// the whole surface off rather than leaving it untimed. The
+			// framework's own wiring guards it (app.go only installs the
+			// middleware when RequestTimeout > 0), which is why nothing
+			// in-repo tripped it; a direct caller of the core API had no
+			// such cover.
+			if effective <= 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
 			ctx := newTimeoutCtx(r.Context())
 			// End-of-request cleanup: release the propagation callback
 			// and anyone still selecting on ctx.Done(). A context that
@@ -378,6 +392,27 @@ func Timeout(d time.Duration) Middleware {
 				// written for parity, observed by no one.
 				abandon(r.Context().Err())
 			case <-timer.C:
+				// A select whose cases are BOTH ready picks between them
+				// uniformly at random. When the handler closes done just
+				// inside the budget but this goroutine is descheduled past
+				// the deadline, that coin flip discards a finished response
+				// and 504s a request that succeeded — visible only under
+				// load, which is where a spurious 504 costs the most.
+				// The handler winning is the answer the client should get,
+				// so re-check done before abandoning.
+				//
+				// The r.Context().Done() case above needs no equivalent:
+				// the client is gone, and delivering or abandoning both
+				// write to a socket nobody is reading.
+				select {
+				case <-done:
+					if childPanic != nil {
+						panic(childPanic)
+					}
+					tw.finish()
+					return
+				default:
+				}
 				if abandon(context.DeadlineExceeded) {
 					// Name the route, not just the path: "why does this
 					// endpoint 504" starts from this line. Streaming

--- a/core/middleware/timeout_zero_test.go
+++ b/core/middleware/timeout_zero_test.go
@@ -1,0 +1,191 @@
+package middleware
+
+// Two ways Timeout could 504 a request that did not time out.
+//
+// Both were found auditing #136's "never-looked" list. Neither is reachable
+// through the framework's own wiring — app.go installs the middleware only
+// when RequestTimeout > 0, and the deadline race needs the middleware
+// goroutine descheduled across the boundary — which is exactly why the
+// existing suite was green over both.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+// A zero duration means "no deadline" in net/http, and this file's own
+// route-budget path already reads it that way ("a negative Budget skips the
+// deadline entirely"). The constructor did not: time.NewTimer(0) fires
+// before the handler can run, so EVERY request 504d.
+//
+// The trap is a config field left unset — `Timeout(cfg.RequestTimeout)`
+// then turns the surface off rather than leaving it untimed, and it fails
+// closed on every request rather than loudly at startup.
+func TestTimeoutZeroOrNegativeMeansNoDeadline(t *testing.T) {
+	for _, d := range []time.Duration{0, -time.Second} {
+		t.Run(d.String(), func(t *testing.T) {
+			var served int
+			h := Timeout(d)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				served++
+				// Long enough that any live deadline of d would fire.
+				time.Sleep(20 * time.Millisecond)
+				w.WriteHeader(http.StatusOK)
+			}))
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("Timeout(%v) returned %d, want 200: a non-positive duration means no deadline, as it does for a route budget and in net/http", d, rec.Code)
+			}
+			if served != 1 {
+				t.Errorf("handler ran %d times, want 1", served)
+			}
+		})
+	}
+
+	// The route-override path, whose behaviour the constructor now matches.
+	// If these ever disagree again, the same value means two things in one
+	// file, which is how this got missed.
+	t.Run("route budget agrees", func(t *testing.T) {
+		h := Timeout(time.Minute)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req = req.WithContext(WithRouteTimeout(req.Context(), RouteTimeout{Budget: 0}))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("RouteTimeout{Budget:0} returned %d, want 200", rec.Code)
+		}
+	})
+
+	// The guard must not disarm a real deadline.
+	t.Run("a positive duration still times out", func(t *testing.T) {
+		h := Timeout(10 * time.Millisecond)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(2 * time.Second)
+			w.WriteHeader(http.StatusOK)
+		}))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+		if rec.Code != http.StatusGatewayTimeout {
+			t.Errorf("a hung handler under a 10ms budget returned %d, want 504", rec.Code)
+		}
+	})
+}
+
+// The deadline branch re-checks done before abandoning, because a select
+// whose cases are both ready picks between them at random. When the handler
+// RETURNS just inside the budget but the middleware goroutine is descheduled
+// past the deadline, that coin flip discards a finished response.
+//
+// This is a demonstration, not a regression gate, and the fix ships WITHOUT
+// a test that catches its removal. Both halves of that are worth stating.
+//
+// No deterministic version exists. A select picks randomly only when both
+// channels are ready at the moment it is *evaluated*; enter it earlier and
+// it blocks and wakes on the first one. Producing the overlap needs the
+// middleware goroutine descheduled across the deadline, which nothing
+// outside the runtime can arrange.
+//
+// And the occurrence is unconfirmed HERE. The hazard is certain — the Go
+// spec makes the ready-vs-ready choice uniform, so the branch is reachable
+// by construction — but with the re-check removed this probe found
+// 0 misfires in 4000 iterations under 10 CPU burners (~50 genuine overruns
+// per 2000, so the deadline was firing plenty). An audit worker reported
+// ~2 per 2000 on the same shape; that result is not reproduced here.
+// The one-line tie-break is kept because it cannot make anything worse and
+// the branch is reachable, not because a failure was observed.
+//
+// If you are reading this while chasing a spurious 504: run
+//
+//	GOFASTR_TIMEOUT_RACE_PROBE=1 go test ./core/middleware/ -run DeadlineRace
+//
+// under load, and note the instrument's one trap — the 504 path returns
+// while the handler is still running, so reading its elapsed time straight
+// after ServeHTTP reads zero for exactly the requests under test. Counting
+// those as overruns makes the probe blind to what it is looking for. That
+// is what the `finished` channel below is for; the first draft omitted it
+// and confidently reported 0 in 4000.
+func TestTimeoutDeadlineRaceProbe(t *testing.T) {
+	if os.Getenv("GOFASTR_TIMEOUT_RACE_PROBE") == "" {
+		t.Skip("load-dependent probe; set GOFASTR_TIMEOUT_RACE_PROBE=1")
+	}
+	const (
+		budget = 3 * time.Millisecond
+		work   = 2 * time.Millisecond
+		iters  = 2000
+	)
+	var misfires, overruns int
+	for i := 0; i < iters; i++ {
+		var mu sync.Mutex
+		var elapsed time.Duration
+		// The 504 path returns while the handler goroutine is still
+		// running, so reading elapsed straight after ServeHTTP reads zero
+		// for exactly the requests under test — and classifying those as
+		// overruns makes the probe blind to the thing it is looking for.
+		// (First draft did that and reported 0 misfires in 4000.)
+		finished := make(chan struct{})
+
+		h := Timeout(budget)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			time.Sleep(work)
+			w.WriteHeader(http.StatusOK)
+			mu.Lock()
+			elapsed = time.Since(start)
+			mu.Unlock()
+			close(finished)
+		}))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+		select {
+		case <-finished:
+		case <-time.After(time.Second):
+			t.Fatalf("iteration %d: handler never finished", i)
+		}
+		mu.Lock()
+		e := elapsed
+		mu.Unlock()
+		switch {
+		case rec.Code == http.StatusOK:
+		case e >= budget:
+			overruns++ // handler genuinely missed its budget
+		default:
+			misfires++
+			t.Errorf("handler returned in %v, inside the %v budget, and the client got 504", e, budget)
+		}
+	}
+	t.Logf("iterations=%d proven misfires=%d genuine overruns=%d", iters, misfires, overruns)
+}
+
+// The deadline still wins when the handler really did overrun, so the fix
+// above is a tie-break and not a disarm.
+func TestTimeoutStillAbandonsAnOverrunHandler(t *testing.T) {
+	released := make(chan struct{})
+	h := Timeout(10 * time.Millisecond)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-released
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		close(released)
+		t.Fatal("the middleware never returned for a hung handler")
+	}
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Errorf("hung handler returned %d, want 504", rec.Code)
+	}
+	close(released)
+	_ = context.Canceled
+}


### PR DESCRIPTION
Found auditing #136's never-looked list. Three things, one package.

## `Timeout(0)` 504s every request instead of meaning "no deadline"

`Timeout` never guarded its duration, so `time.NewTimer(0)` fires before the handler can run. Measured:

| call | result |
|---|---|
| `Timeout(0)` | 504 on 50 of 50 instant requests |
| `Timeout(-1s)` | 504 on 50 of 50 |
| `RouteTimeout{Budget: 0}` | 200 |

Same value, same file, opposite meanings. The route path was already right and says so in its own comment — "a negative Budget skips the deadline entirely, matching net/http where a zero duration means no timeout". The constructor now reads it the same way.

The trap is a config field left unset: `Timeout(cfg.RequestTimeout)` with `RequestTimeout` zero turns the surface **off** rather than leaving it untimed, and it fails closed on every request rather than loudly at startup. Nothing in-repo tripped it because `app.go` installs the middleware only when `RequestTimeout > 0` — the cover is the framework's wiring, not the API, and a direct caller of the core package has no such cover.

Mutation-proved: removing the guard fails `TestTimeoutZeroOrNegativeMeansNoDeadline` on both the `0s` and `-1s` cases.

## Deadline branch tie-break — kept, but not proven, and the test says so

A `select` whose cases are both ready picks between them uniformly at random, so a handler that *returns* inside its budget can still 504 when the middleware goroutine is descheduled past the deadline. The branch now re-checks `done` before abandoning.

**This ships without a gate.** Two reasons, both in the test comment:

1. No deterministic version exists. A select picks randomly only when both channels are ready at the moment it is *evaluated*; enter it earlier and it blocks and wakes on the first one. Producing the overlap needs a deschedule nothing outside the runtime can arrange.
2. I could not reproduce the failure. With the re-check removed, the load probe found **0 misfires in 4000 iterations under 10 CPU burners** (~50 genuine overruns per 2000, so the deadline was firing plenty). The audit worker reported ~2 per 2000 on the same shape. Not reproduced here.

The tie-break is kept because the branch is reachable by construction — the Go spec makes the ready-vs-ready choice uniform — and because it cannot make anything worse. Not because a failure was observed. That distinction is written into the test rather than left to a commit message.

The probe also carries the trap that cost my first draft its answer: the 504 path returns while the handler is still running, so reading its elapsed time straight after `ServeHTTP` reads zero for exactly the requests under test. Counting those as overruns makes the instrument blind to what it is looking for — fixing it moved ~250 of every 300 "overruns" per 2000 into their real bucket.

## `IdempotencyStore.Begin` doc had the wrong convention

It said "replay nil, ok=true: the caller is the first writer". Both shipped stores return `ok=false` there (`idempotency_sql.go:168-171`, `idempotency.go:498`) and the middleware's replay branch is `ok && replay != nil`, so `ok=false` is the contract and always was. Implementations and caller agreed with each other; only the comment was wrong. A store author following it would ship `ok=true`, which happens to still work — so the cost is confined to misleading the next implementer.

## Verification

`go test ./core/middleware/ -count=1` green (9.0s); `go test -race ./core/middleware/ -count=1` green (24.7s).
