### PR TITLE
fix: three audit findings — Timeout(0), testdb search_path, kiln empty plan_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -459,6 +459,29 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   already passed an allowlisted environment. Their credential denylists were
   hand-copied and had drifted; neither recognised a bare `*_TOKEN`.
 
+- **Generated llm.md describes the routes the mount serves** (#358,
+  sibling of the #266 openapi/llm.md fix further down): `App.View`
+  registers its entities read-only, but `EntityLLMMD` took only the
+  entity — read-only lives on `CrudRouteOptions`, which no entity
+  declaration carries — so every view served a doc telling agents to
+  call POST, PUT, PATCH, DELETE and the three `_batch` routes, all of
+  which answer 404/405, and the `/api/llm.md` index counted eight
+  endpoints where three are served. The doc now takes its answer from
+  the mount: a read-only mount's llm.md omits the write, batch and
+  Create/Update-column sections, the index counts three endpoints and
+  labels the row `read-only`, and the `limit` row prints the same cap
+  the List route clamps `?limit` with (a hardcoded "max 100" told
+  agents an entity with `MaxListLimit: 3` would serve 100).
+  **BREAKING for direct callers**: `crud.RegistryLLMMD` /
+  `crud.RegistryLLMMDHandler`'s mount predicate widened from
+  `func(*entity.Entity) bool` to `func(*entity.Entity) crud.MountInfo`
+  (nil still documents standard CRUD for every entity), and
+  `crud.EntityLLMMD` / `crud.LLMMDHandler` / `crud.LLMMDHandlerFor`
+  gained an optional `LLMMDOptions` — pass `LLMMDOptions{ReadOnly:
+  true}` beside a read-only mount. The framework's own route
+  registration passes both automatically; only hand-rolled mounts need
+  the option.
+
 ## [0.77.0] - 2026-08-31
 
 ### Added

--- a/cmd/gofastr/emitter_quoting_audit_test.go
+++ b/cmd/gofastr/emitter_quoting_audit_test.go
@@ -1,0 +1,962 @@
+package main
+
+// Exhaustive audit of every IR-derived string's quoting in the blueprint Go
+// emitters (issue #136 tail: "the entity/screen emitters' quoting of
+// IR-derived strings was not audited").
+//
+// Method (see the brief): do NOT eyeball the emitters. Enumerate every field
+// of the blueprint IR, drive a hostile value through the REAL declaration
+// path (YAML -> loadBlueprint -> validateBlueprint -> renderBlueprintFiles),
+// and use go/parser on the emitted bytes as the oracle. The audit table below
+// is derived from the IR structs (Blueprint, BlueprintApp, BlueprintScreen,
+// BlueprintBlock, BlueprintTransition, BlueprintAction, BlueprintEndpoint,
+// BlueprintNamedStub, BlueprintNavItem, BlueprintSeedEntity,
+// framework.EntityDeclaration) — every string field, not a sample.
+//
+// Re-derive the enumeration with:
+//
+//	grep -n 'type Blueprint' cmd/gofastr/blueprint.go
+//	sed -n '33,201p' cmd/gofastr/blueprint.go        # the IR structs
+//	grep -n 'Sprintf\|WriteString' cmd/gofastr/blueprint.go cmd/gofastr/generate.go \
+//	  cmd/gofastr/generate_typed.go | grep -v '%q\|%d\|%t\|%w'
+//
+// Anti-vacuity (the repo's #1 defect class is a test that cannot fail):
+//
+//  1. Every site first runs a BENIGN CONTROL through the same pipeline and
+//     must validate + render + leave the marker bytes in the emitted tree.
+//     A site whose control never appears is classified notEmitted (dead or
+//     runtime-only field) and its hostile runs are skipped, loudly.
+//  2. The injection oracle is proven to fire on synthetic broken source
+//     (TestAuditOracleDetectsSyntheticInjection).
+//  3. The emitter's parse backstop is proven to fire
+//     (TestAuditParseBackstopFires).
+//
+// A hostile run then has exactly two acceptable outcomes: rejected at the
+// boundary (load error; the value differs from the passing control only in
+// that one scalar, so the error is attributable to the hostile value) or
+// emitted inertly (files render, every .go parses, no injected identifier).
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/dotenv"
+	"github.com/DonaldMurillo/gofastr/framework"
+)
+
+// auditPayloads are the byte sequences that break out of Go literals. The
+// marker PWNX must appear as a Go identifier for the injection to count.
+var auditPayloads = []string{
+	"x`+PWNX()+`y",                  // closes a raw string and calls
+	`x"+PWNX()+"y`,                  // closes an interpreted string and calls
+	"x\nfunc PWNX() {}\nvar z = \"", // newline: live declaration after a comment or raw literal
+	"x\r\nPWNX()",                   // CRLF variant
+	"*/\nfunc PWNX() {}\n/*",        // comment terminator
+	"\\\"+PWNX()+\"",                // backslash + quote combo
+}
+
+const auditControl = "CtrlMark9"
+
+// yamlQ renders s as a YAML double-quoted scalar. Control characters are
+// escaped so a hostile value cannot restructure the document itself.
+func yamlQ(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if r < 0x20 {
+				b.WriteString(fmt.Sprintf(`\x%02x`, r))
+			} else {
+				b.WriteRune(r)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// auditYAML is a blueprint exercising every IR section at once. Markers
+// (__NAME__) are scalar placeholders; each audit site owns exactly one.
+const auditYAML = `app:
+  name: __APP_NAME__
+  description: __APP_DESC__
+  module: github.com/audit/app
+  base_url: __APP_BASEURL__
+  db:
+    driver: sqlite
+    url: __APP_DBURL__
+  static_dir: __APP_STATICDIR__
+  api_prefix: __APP_APIPREFIX__
+  theme:
+    primary: __APP_THEME_PRIMARY__
+    font_heading: __APP_FONT__
+    dark:
+      primary: __APP_DARK_PRIMARY__
+  auth:
+    enabled: true
+    dev_mode: true
+    base_path: __AUTH_BASEPATH__
+    jwt_secret: __AUTH_JWTSECRET__
+  admin:
+    enabled: true
+    path: __ADMIN_PATH__
+    role: __ADMIN_ROLE__
+    login_path: __ADMIN_LOGIN__
+    seed_email: __ADMIN_EMAIL__
+    seed_password: __ADMIN_PASSWORD__
+  pwa:
+    enabled: true
+    name: __PWA_NAME__
+    short_name: __PWA_SHORT__
+    description: __PWA_DESC__
+    start_url: /
+    scope: /
+    display: standalone
+    theme_color: __PWA_THEMECOLOR__
+    background_color: __PWA_BGCOLOR__
+
+entities:
+  - name: __ENTITY_NAME__
+    crud: true
+    table: __ENTITY_TABLE__
+    search_fields: [title]
+    indices:
+      - name: __INDEX_NAME__
+        columns: [status]
+    properties:
+      label: __PROP_LABEL__
+      icon: __PROP_ICON__
+    fields:
+      - name: __FIELD_NAME__
+        type: string
+        required: true
+      - name: ctrlmark
+        type: string
+      - name: status
+        type: enum
+        values: [__ENUM_VALUE__, published]
+        default: published
+      - name: meta
+        type: json
+      - name: author_id
+        type: relation
+        to: users
+      - name: published_on
+        type: timestamp
+    relations:
+      - type: belongs_to
+        name: __RELATION_NAME__
+        entity: users
+        foreign_key: __RELATION_FK__
+  - name: users
+    crud: true
+    fields:
+      - name: name
+        type: string
+        required: true
+
+nav:
+  - label: __NAV_LABEL__
+    href: __NAV_HREF__
+    icon: __NAV_ICON__
+    role: __NAV_ROLE__
+  - label: nested
+    href: /isl
+    items:
+      - label: __NAV_ITEM_LABEL__
+        href: /isl
+
+screens:
+  - name: __SCREEN_NAME__
+    route: __SCREEN_ROUTE__
+    title: __SCREEN1_TITLE__
+    description: __SCREEN1_DESC__
+    body:
+      - type: heading
+        level: 1
+        text: __HEAD_TEXT__
+      - type: paragraph
+        text: __PARA_TEXT__
+        class: __PARA_CLASS__
+      - type: link
+        text: link
+        href: __LINK_HREF__
+      - kind: markdown
+        text: __MD_TEXT__
+      - kind: callout
+        text: __CALLOUT_TEXT__
+        props:
+          title: __CALLOUT_TITLE__
+      - type: text
+        text: with action
+        actions:
+          - name: __ACTION_NAME__
+            event: click
+            client_js: __ACTION_JS__
+      - kind: span
+        text: span body
+        island: __BLOCK_ISLAND__
+      - kind: span
+        text: span body 2
+        widget: __BLOCK_WIDGET__
+
+  - name: dash
+    route: /dash
+    title: __DASH_TITLE__
+    layout: app
+    access:
+      auth: true
+      role: __ACCESS_ROLE__
+    body:
+      - kind: page_header
+        props:
+          title: __PH_TITLE__
+          subtitle: __PH_SUBTITLE__
+          eyebrow: __PH_EYEBROW__
+      - kind: hero
+        props:
+          title: Hero
+          cta_text: __HERO_CTA_TEXT__
+          cta_href: /form
+          secondary_text: __HERO2_TEXT__
+          secondary_href: /tickets
+          eyebrow: __HERO_EYEBROW__
+      - kind: stat_card
+        props:
+          label: __STAT_LABEL__
+          value: __STAT_VALUE__
+      - kind: stat_card
+        props:
+          label: sourced
+          source:
+            entity: tickets
+            group_by: status
+      - kind: bar_chart
+        props:
+          title: __CHART_TITLE__
+          source:
+            entity: tickets
+            group_by: __CHART_GROUPBY__
+      - kind: link_button
+        props:
+          label: __LB_LABEL__
+          href: __LB_HREF__
+          variant: secondary
+      - kind: pricing
+        props:
+          plans:
+            - name: __PLAN_NAME__
+              price: "$9"
+              period: mo
+              description: __PLAN_DESC__
+              cta_text: Go
+              cta_href: /form
+              features: [__PLAN_FEATURE__, second]
+              featured: true
+      - kind: section
+        props:
+          heading: __SECTION_HEADING__
+          eyebrow: __SECTION_EYEBROW__
+          description: __SECTION_DESC__
+          label: __SECTION_LABEL__
+          class: __SECTION_CLASS__
+          id: __SECTION_ID__
+        children:
+          - kind: card
+            props:
+              heading: __CARD_HEADING__
+              text: __CARD_TEXT__
+      - kind: stack
+        props:
+          gap: md
+        children:
+          - type: heading
+            level: 2
+            text: __CHILD_TEXT__
+
+  - name: tickets
+    route: /tickets
+    body:
+      - kind: entity_list
+        text: __LIST_HEADING__
+        entity: __BLOCK_ENTITY__
+        fields: [__LIST_FIELD__, status]
+        limit: 5
+        empty_text: __LIST_EMPTY__
+        search: __LIST_SEARCH__
+        filters: [status]
+        create: true
+
+  - name: ticket
+    route: /tickets/{id}
+    body:
+      - kind: entity_detail
+        entity: tickets
+        transitions:
+          - label: __TRANS_LABEL__
+            status: __TRANS_STATUS__
+            variant: __TRANS_VARIANT__
+            stamp: published_on
+
+  - name: form
+    route: /form
+    body:
+      - kind: entity_form
+        text: __FORM_TITLE__
+        entity: tickets
+        mode: __FORM_MODE__
+        fields: [title, status, author_id]
+
+  - name: isl
+    route: /isl
+    body:
+      - type: heading
+        level: 2
+        text: island host
+
+  - name: login
+    route: /login
+    body:
+      - kind: login_form
+        text: __LOGIN_TEXT__
+        props:
+          action: __LOGIN_ACTION__
+          next: __LOGIN_NEXT__
+          register_href: /form
+
+endpoints:
+  - name: tickets_feed
+    method: __EP_METHOD__
+    path: __EP_PATH__
+    entity: tickets
+    handler: __EP_HANDLER__
+    description: __EP_DESC__
+
+middleware:
+  - name: __MW_NAME__
+    description: __MW_DESC__
+
+plugins:
+  - name: __PLUGIN_NAME__
+    description: __PLUGIN_DESC__
+
+helpers:
+  - name: __HELPER_NAME__
+    description: __HELPER_DESC__
+
+seed:
+  - entity: tickets
+    rows:
+      - title: __SEED_STRING__
+        status: published
+        meta: [__SEED_LIST__, x]
+`
+
+// auditControlValues maps each marker to the benign, schema-valid value its
+// control run (and the default fixture) uses. Values that cross a grammar
+// (colors, columns, enums) must satisfy it; markers for free-text fields can
+// use the generic auditControl.
+var auditControlValues = map[string]string{
+	"__APP_NAME__":          "Audit App",
+	"__APP_DESC__":          "audit description",
+	"__APP_BASEURL__":       "https://audit.example.com",
+	"__APP_DBURL__":         "file:audit.db",
+	"__APP_STATICDIR__":     "static",
+	"__APP_APIPREFIX__":     "api",
+	"__APP_THEME_PRIMARY__": "#2500aa",
+	"__APP_FONT__":          "",
+	"__APP_DARK_PRIMARY__":  "#2500dd",
+	"__AUTH_BASEPATH__":     "/auth",
+	"__AUTH_JWTSECRET__":    "ctrl-secret",
+	"__ADMIN_PATH__":        "/admin",
+	"__ADMIN_ROLE__":        "admin",
+	"__ADMIN_LOGIN__":       "/login",
+	"__ADMIN_EMAIL__":       "admin@audit.dev",
+	"__ADMIN_PASSWORD__":    "ctrl-pw",
+	"__PWA_NAME__":          "Audit",
+	"__PWA_SHORT__":         "PwaShortCtrl",
+	"__PWA_DESC__":          "pwa desc ctrl",
+	"__PWA_THEMECOLOR__":    "#2500bb",
+	"__PWA_BGCOLOR__":       "#2500cc",
+	"__ENTITY_TABLE__":      "tickets",
+	"__INDEX_NAME__":        "idx_ctrl",
+	"__PROP_LABEL__":        "Tickets",
+	"__PROP_ICON__":         "ticket",
+	"__ENUM_VALUE__":        "open",
+	"__RELATION_NAME__":     "author",
+	"__RELATION_FK__":       "author_id",
+	"__NAV_LABEL__":         "Dash",
+	"__NAV_ICON__":          "gauge",
+	"__NAV_ROLE__":          "admin",
+	"__NAV_ITEM_LABEL__":    "Nested",
+	"__SCREEN1_TITLE__":     "Home",
+	"__SCREEN1_DESC__":      "home desc",
+	"__HEAD_TEXT__":         "heading",
+	"__PARA_TEXT__":         "paragraph",
+	"__PARA_CLASS__":        "ctrl-class",
+	"__LINK_HREF__":         "/form",
+	"__MD_TEXT__":           "# md",
+	"__CALLOUT_TITLE__":     "note",
+	"__CALLOUT_TEXT__":      "callout body",
+	"__ACTION_NAME__":       "ctrlAction",
+	"__ACTION_JS__":         "console.log(1)",
+	"__BLOCK_ISLAND__":      "ctrlIsland",
+	"__BLOCK_WIDGET__":      "ctrlWidget",
+	"__ACCESS_ROLE__":       "admin",
+	"__PH_TITLE__":          "Dashboard",
+	"__PH_SUBTITLE__":       "subtitlectrl",
+	"__PH_EYEBROW__":        "eyebrow",
+	"__HERO_CTA_TEXT__":     "Go",
+	"__HERO2_TEXT__":        "More",
+	"__HERO_EYEBROW__":      "hero eyebrow",
+	"__STAT_LABEL__":        "MRR",
+	"__STAT_VALUE__":        "$1k",
+	"__CHART_TITLE__":       "Chart",
+	"__CHART_GROUPBY__":     "ctrlmark",
+	"__LB_LABEL__":          "Press",
+	"__LB_HREF__":           "/form",
+	"__PLAN_NAME__":         "Pro",
+	"__PLAN_DESC__":         "plan desc",
+	"__PLAN_FEATURE__":      "feat",
+	"__SECTION_HEADING__":   "Section",
+	"__SECTION_EYEBROW__":   "sec eyebrow",
+	"__SECTION_DESC__":      "sec desc",
+	"__SECTION_LABEL__":     "sec label",
+	"__SECTION_CLASS__":     "sec-class",
+	"__SECTION_ID__":        "sec-id",
+	"__CARD_HEADING__":      "Card",
+	"__CARD_TEXT__":         "card body",
+	"__CHILD_TEXT__":        "child heading",
+	"__LIST_HEADING__":      "Tickets",
+	"__LIST_FIELD__":        "ctrlmark",
+	"__LIST_EMPTY__":        "none yet",
+	"__LIST_SEARCH__":       "ctrlmark",
+	"__TRANS_LABEL__":       "Publish",
+	"__TRANS_STATUS__":      "published",
+	"__TRANS_VARIANT__":     "primary",
+	"__FORM_TITLE__":        "New ticket",
+	"__FORM_MODE__":         "create",
+	"__LOGIN_TEXT__":        "Sign in",
+	"__LOGIN_ACTION__":      "/auth/login",
+	"__LOGIN_NEXT__":        "/",
+	"__EP_DESC__":           "feeddescctrl",
+	"__MW_NAME__":           "requestLogger",
+	"__MW_DESC__":           "mwdescctrl",
+	"__PLUGIN_NAME__":       "metrics",
+	"__PLUGIN_DESC__":       "plugindescctrl",
+	"__HELPER_NAME__":       "gravatar",
+	"__HELPER_DESC__":       "helperdescctrl",
+	"__SEED_STRING__":       "first ticket",
+	"__SEED_LIST__":         "tagged",
+	"__ENTITY_NAME__":       "tickets",
+	"__FIELD_NAME__":        "title",
+	"__SCREEN_NAME__":       "home",
+	"__SCREEN_ROUTE__":      "/",
+	"__DASH_TITLE__":        "DashCtrl",
+	"__BLOCK_ENTITY__":      "tickets",
+	"__EP_METHOD__":         "GET",
+	"__EP_PATH__":           "/feed",
+	"__EP_HANDLER__":        "ticketsFeed",
+	"__NAV_HREF__":          "/dash",
+}
+
+// Every IR string field the emitters read, one site each.
+var auditSites = []auditSite{
+	// app.*
+	{"app.name"},
+	{"app.description"},
+	{"app.base_url"},
+	{"app.db.url"},
+	{"app.static_dir"},
+	{"app.api_prefix"},
+	{"app.theme.primary"},
+	{"app.theme.font_heading"},
+	{"app.theme.dark.primary"},
+	{"app.auth.base_path"},
+	{"app.auth.jwt_secret"},
+	{"app.admin.path"},
+	{"app.admin.role"},
+	{"app.admin.login_path"},
+	{"app.admin.seed_email"},
+	{"app.admin.seed_password"},
+	{"app.pwa.name"},
+	{"app.pwa.short_name"},
+	{"app.pwa.description"},
+	{"app.pwa.theme_color"},
+	{"app.pwa.background_color"},
+	// entities.*
+	{"entity.name"},
+	{"entity.table"},
+	{"entity.index.name"},
+	{"entity.properties.label"},
+	{"entity.properties.icon"},
+	{"field.name"},
+	{"field.enum_value"},
+	{"relation.name"}, // known non-finding: re-derived here
+	{"relation.foreign_key"},
+	// screens.*
+	{"screen.name"},
+	{"screen.route"},
+	{"screen.title.access-gated"}, // WithTitle sink: only gated screens mount through it
+	{"screen.title"},
+	{"screen.description"},
+	{"screen.access.role"},
+	// blocks: generic
+	{"block.heading.text"},
+	{"block.text"},
+	{"block.class"},
+	{"block.href"},
+	{"block.markdown.text"},
+	{"block.callout.title"},
+	{"block.callout.text"},
+	{"block.action.name"},
+	{"block.action.client_js"},
+	{"block.island"},
+	{"block.widget"},
+	// blocks: catalog props
+	{"props.page_header.title"},
+	{"props.page_header.subtitle"},
+	{"props.page_header.eyebrow"},
+	{"props.hero.cta_text"},
+	{"props.hero.secondary_text"},
+	{"props.hero.eyebrow"},
+	{"props.stat_card.label"},
+	{"props.stat_card.value"},
+	{"props.chart.title"},
+	{"props.chart.group_by"},
+	{"props.link_button.label"},
+	{"props.link_button.href"},
+	{"props.pricing.plan.name"},
+	{"props.pricing.plan.description"},
+	{"props.pricing.plan.feature"},
+	{"props.section.heading"},
+	{"props.section.eyebrow"},
+	{"props.section.description"},
+	{"props.section.label"},
+	{"props.section.class"},
+	{"props.section.id"},
+	{"props.card.heading"},
+	{"props.card.text"},
+	{"block.child.text"},
+	// blocks: entity_list / detail / form
+	{"block.entity"},
+	{"entity_list.heading"},
+	{"entity_list.fields[]"},
+	{"entity_list.empty_text"},
+	{"entity_list.search"},
+	{"entity_detail.transition.label"},
+	{"entity_detail.transition.status"},
+	{"entity_detail.transition.variant"},
+	{"entity_form.title"},
+	{"entity_form.mode"},
+	{"login_form.text"},
+	{"login_form.props.action"},
+	{"login_form.props.next"},
+	// nav.*
+	{"nav.label"},
+	{"nav.href"},
+	{"nav.icon"},
+	{"nav.role"},
+	{"nav.items[].label"},
+	// seed.*
+	{"seed.row.string"},
+	{"seed.row.list_item"},
+	// endpoints / stubs
+	{"endpoint.method"},
+	{"endpoint.path"},
+	{"endpoint.handler"},
+	{"endpoint.description"},
+	{"middleware.name"},
+	{"middleware.description"},
+	{"plugin.name"},
+	{"plugin.description"},
+	{"helper.name"},
+	{"helper.description"},
+}
+
+// auditSite is one IR field under test; marker is derived from name by
+// convention in markerFor below, so the table stays readable.
+type auditSite struct {
+	name string
+}
+
+// siteMarker maps a site name to its YAML marker. Kept explicit next to the
+// control values: the marker is the single source of truth for both.
+func siteMarker(name string) string {
+	pairs := map[string]string{
+		"app.name": "__APP_NAME__", "app.description": "__APP_DESC__",
+		"app.base_url": "__APP_BASEURL__", "app.db.url": "__APP_DBURL__",
+		"app.static_dir": "__APP_STATICDIR__", "app.api_prefix": "__APP_APIPREFIX__",
+		"app.theme.primary": "__APP_THEME_PRIMARY__", "app.theme.font_heading": "__APP_FONT__",
+		"app.theme.dark.primary": "__APP_DARK_PRIMARY__", "app.auth.base_path": "__AUTH_BASEPATH__",
+		"app.auth.jwt_secret": "__AUTH_JWTSECRET__", "app.admin.path": "__ADMIN_PATH__",
+		"app.admin.role": "__ADMIN_ROLE__", "app.admin.login_path": "__ADMIN_LOGIN__",
+		"app.admin.seed_email": "__ADMIN_EMAIL__", "app.admin.seed_password": "__ADMIN_PASSWORD__",
+		"app.pwa.name": "__PWA_NAME__", "app.pwa.short_name": "__PWA_SHORT__",
+		"app.pwa.description": "__PWA_DESC__", "app.pwa.theme_color": "__PWA_THEMECOLOR__",
+		"app.pwa.background_color": "__PWA_BGCOLOR__",
+		"entity.table":             "__ENTITY_TABLE__", "entity.index.name": "__INDEX_NAME__",
+		"entity.properties.label": "__PROP_LABEL__", "entity.properties.icon": "__PROP_ICON__",
+		"field.enum_value": "__ENUM_VALUE__", "relation.name": "__RELATION_NAME__",
+		"relation.foreign_key": "__RELATION_FK__",
+		"screen.title":         "__SCREEN1_TITLE__", "screen.description": "__SCREEN1_DESC__",
+		"screen.access.role": "__ACCESS_ROLE__",
+		"block.heading.text": "__HEAD_TEXT__", "block.text": "__PARA_TEXT__",
+		"block.class": "__PARA_CLASS__", "block.href": "__LINK_HREF__",
+		"block.markdown.text": "__MD_TEXT__", "block.callout.title": "__CALLOUT_TITLE__",
+		"block.callout.text": "__CALLOUT_TEXT__", "block.action.name": "__ACTION_NAME__",
+		"block.action.client_js": "__ACTION_JS__", "block.island": "__BLOCK_ISLAND__",
+		"block.widget":            "__BLOCK_WIDGET__",
+		"props.page_header.title": "__PH_TITLE__", "props.page_header.subtitle": "__PH_SUBTITLE__",
+		"props.page_header.eyebrow": "__PH_EYEBROW__", "props.hero.cta_text": "__HERO_CTA_TEXT__",
+		"props.hero.secondary_text": "__HERO2_TEXT__", "props.hero.eyebrow": "__HERO_EYEBROW__",
+		"props.stat_card.label": "__STAT_LABEL__", "props.stat_card.value": "__STAT_VALUE__",
+		"props.chart.title": "__CHART_TITLE__", "props.chart.group_by": "__CHART_GROUPBY__",
+		"props.link_button.label": "__LB_LABEL__", "props.link_button.href": "__LB_HREF__",
+		"props.pricing.plan.name": "__PLAN_NAME__", "props.pricing.plan.description": "__PLAN_DESC__",
+		"props.pricing.plan.feature": "__PLAN_FEATURE__", "props.section.heading": "__SECTION_HEADING__",
+		"props.section.eyebrow": "__SECTION_EYEBROW__", "props.section.description": "__SECTION_DESC__",
+		"props.section.label": "__SECTION_LABEL__", "props.section.class": "__SECTION_CLASS__",
+		"props.section.id": "__SECTION_ID__", "props.card.heading": "__CARD_HEADING__",
+		"props.card.text": "__CARD_TEXT__", "block.child.text": "__CHILD_TEXT__",
+		"entity_list.heading": "__LIST_HEADING__", "entity_list.fields[]": "__LIST_FIELD__",
+		"entity_list.empty_text": "__LIST_EMPTY__", "entity_list.search": "__LIST_SEARCH__",
+		"entity_detail.transition.label": "__TRANS_LABEL__", "entity_detail.transition.status": "__TRANS_STATUS__",
+		"entity_detail.transition.variant": "__TRANS_VARIANT__", "entity_form.title": "__FORM_TITLE__",
+		"entity_form.mode": "__FORM_MODE__", "login_form.text": "__LOGIN_TEXT__",
+		"login_form.props.action": "__LOGIN_ACTION__", "login_form.props.next": "__LOGIN_NEXT__",
+		"nav.label": "__NAV_LABEL__", "nav.icon": "__NAV_ICON__", "nav.role": "__NAV_ROLE__",
+		"nav.items[].label": "__NAV_ITEM_LABEL__",
+		"seed.row.string":   "__SEED_STRING__", "seed.row.list_item": "__SEED_LIST__",
+		"endpoint.description": "__EP_DESC__",
+		"middleware.name":      "__MW_NAME__", "middleware.description": "__MW_DESC__",
+		"plugin.name": "__PLUGIN_NAME__", "plugin.description": "__PLUGIN_DESC__",
+		"helper.name": "__HELPER_NAME__", "helper.description": "__HELPER_DESC__",
+		"entity.name": "__ENTITY_NAME__", "field.name": "__FIELD_NAME__",
+		"screen.name": "__SCREEN_NAME__", "screen.route": "__SCREEN_ROUTE__",
+		"screen.title.access-gated": "__DASH_TITLE__",
+		"block.entity":              "__BLOCK_ENTITY__",
+		"endpoint.method":           "__EP_METHOD__", "endpoint.path": "__EP_PATH__",
+		"endpoint.handler": "__EP_HANDLER__", "nav.href": "__NAV_HREF__",
+	}
+	return pairs[name]
+}
+
+// buildAuditYAML returns the base blueprint with the given marker replaced by
+// value (as a YAML scalar) and every other marker set to its control value.
+func buildAuditYAML(marker, value string) string {
+	y := auditYAML
+	for m, ctrl := range auditControlValues {
+		repl := yamlQ(ctrl)
+		if m == marker {
+			repl = yamlQ(value)
+		}
+		y = strings.ReplaceAll(y, m, repl)
+	}
+	return y
+}
+
+// loadAudit renders the audit blueprint with marker set to value through the
+// real declaration path: temp file -> loadBlueprint (validate) ->
+// renderBlueprintFiles.
+func loadAudit(t *testing.T, marker, value string) (files []generatedFile, rejected error) {
+	t.Helper()
+	y := buildAuditYAML(marker, value)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gofastr.yml")
+	if err := os.WriteFile(path, []byte(y), 0o600); err != nil {
+		t.Fatalf("write blueprint: %v", err)
+	}
+	bp, err := loadBlueprint(path)
+	if err != nil {
+		return nil, err
+	}
+	fs, rerr := renderBlueprintFiles(bp)
+	if rerr != nil {
+		return nil, fmt.Errorf("render refused (fail-closed): %w", rerr)
+	}
+	return fs, nil
+}
+
+// auditControlFor returns the benign value a site's control run uses.
+func auditControlFor(marker string) string {
+	if v, ok := auditControlValues[marker]; ok && v != "" {
+		return v
+	}
+	return auditControl
+}
+
+// auditInjectedIdent reports whether src contains the marker as a Go
+// identifier (the injection oracle), and whether it parses at all.
+func auditInjectedIdent(name, src string) (injected bool, parseErr error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, name, src, parser.AllErrors)
+	if err != nil {
+		return false, err
+	}
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok && strings.Contains(id.Name, "PWNX") {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found, nil
+}
+
+// markerInFiles reports whether the (case-folded) marker appears anywhere in
+// the emitted tree, so a control run can prove the site actually emits.
+func markerInFiles(files []generatedFile, marker string) bool {
+	fold := strings.ToLower(marker)
+	for _, f := range files {
+		if strings.Contains(strings.ToLower(f.content), fold) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAuditBlueprintEmitterQuotingExhaustive(t *testing.T) {
+	// No network in the audit: font woff2 fetching is stubbed out.
+	prev := fontFetcher
+	fontFetcher = func(string) ([]byte, error) { return nil, fmt.Errorf("offline") }
+	t.Cleanup(func() { fontFetcher = prev })
+
+	// Phase 1: controls. Prove every site is reachable and non-vacuous.
+	emits := map[string]bool{}
+	for _, site := range auditSites {
+		site := site
+		t.Run("control/"+site.name, func(t *testing.T) {
+			marker := siteMarker(site.name)
+			ctrl := auditControlFor(marker)
+			files, err := loadAudit(t, marker, ctrl)
+			if err != nil {
+				t.Fatalf("CONTROL FAILED for %s: the audit blueprint does not pass the real pipeline with a benign value (%q): %v.\n"+
+					`Every hostile result for this site would be vacuous; fix the fixture.`, site.name, ctrl, err)
+			}
+			emits[site.name] = markerInFiles(files, ctrl)
+		})
+	}
+
+	// Phase 2: hostile payloads per site.
+	for _, site := range auditSites {
+		site := site
+		if !emits[site.name] {
+			// Distinguish "not emitted by these emitters" from a broken
+			// control: the control subtest above already failed loudly if the
+			// pipeline broke, so reaching here means the value never lands in
+			// any generated file. Record it; there is nothing to break out of.
+			t.Logf("site %s: control value never appears in the emitted tree (field unused by the Go emitters); hostile runs skipped", site.name)
+			continue
+		}
+		marker := siteMarker(site.name)
+		for _, payload := range auditPayloads {
+			payload := payload
+			label := strings.NewReplacer("\n", "N", "\r", "R", "`", "BT", `"`, "Q", "\\", "S", "/", "SL", "*", "ST").Replace(payload)
+			t.Run(site.name+"/"+label, func(t *testing.T) {
+				files, err := loadAudit(t, marker, payload)
+				if err != nil {
+					// Rejected at the boundary (or the emitter refused
+					// fail-closed). Acceptable: nothing was generated.
+					t.Logf("outcome: %s / %q: rejected or fail-closed: %v", site.name, payload, err)
+					return
+				}
+				t.Logf("outcome: %s / %q: emitted inertly (%d files)", site.name, payload, len(files))
+				for _, f := range files {
+					if !strings.HasSuffix(f.name, ".go") {
+						continue
+					}
+					if !strings.Contains(f.content, "PWNX") {
+						continue
+					}
+					injected, perr := auditInjectedIdent(f.name, f.content)
+					if perr != nil {
+						t.Fatalf("SECURITY [injection] %s: emitted %s does not parse: %v", site.name, f.name, perr)
+					}
+					if injected {
+						t.Fatalf("SECURITY [injection] %s: hostile value left its literal and became an identifier in %s", site.name, f.name)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestAuditEnvRoundTrip pins the .env sink: a hostile secret value must
+// survive the generated .env byte-exactly when read back by the loader the
+// generated app itself uses, and must not introduce new variable assignments.
+func TestAuditEnvRoundTrip(t *testing.T) {
+	prev := fontFetcher
+	fontFetcher = func(string) ([]byte, error) { return nil, fmt.Errorf("offline") }
+	t.Cleanup(func() { fontFetcher = prev })
+	for _, secret := range auditPayloads {
+		files, err := loadAudit(t, "__AUTH_JWTSECRET__", secret)
+		if err != nil {
+			continue // rejected upstream; nothing to round-trip
+		}
+		var env []generatedFile
+		for _, f := range files {
+			if f.name == ".env" {
+				env = append(env, f)
+			}
+		}
+		if len(env) == 0 {
+			continue
+		}
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".env")
+		if err := os.WriteFile(path, []byte(env[0].content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		vals, err := dotenv.Load(path)
+		if err != nil {
+			t.Fatalf("SECURITY [env] hostile jwt_secret produced an unloadable .env: %v", err)
+		}
+		if got := vals["JWT_SECRET"]; got != secret {
+			t.Fatalf("SECURITY [env] jwt_secret did not round-trip: wrote %q, read back %q", secret, got)
+		}
+		for key := range vals {
+			switch key {
+			case "JWT_SECRET", "DATABASE_URL", "ADMIN_SEED_PASSWORD":
+			default:
+				t.Fatalf("SECURITY [env] hostile jwt_secret injected a new assignment %q into .env", key)
+			}
+		}
+	}
+}
+
+// TestAuditOracleDetectsSyntheticInjection proves the oracle can fail
+// (CLAUDE.md hard rule 11): source where the marker escaped its literal is
+// flagged, source where it stayed data is not. If this test fails, every
+// "clean" verdict above is worthless.
+func TestAuditOracleDetectsSyntheticInjection(t *testing.T) {
+	bad := "package main\n\nvar s = `x` + PWNX() + `y`\n"
+	injected, perr := auditInjectedIdent("bad.go", bad)
+	if perr != nil {
+		t.Fatalf("oracle could not parse its own synthetic source: %v", perr)
+	}
+	if !injected {
+		t.Fatal("ORACLE IS VACUOUS: synthetic breakout source was not flagged")
+	}
+	badInterp := "package main\n\nvar s = \"x\" + PWNX() + \"y\"\n"
+	injected, _ = auditInjectedIdent("bad2.go", badInterp)
+	if !injected {
+		t.Fatal("ORACLE IS VACUOUS: interpreted-string breakout not flagged")
+	}
+	good := "package main\n\nvar s = \"x`+PWNX()+`y\"\n"
+	injected, perr = auditInjectedIdent("good.go", good)
+	if perr != nil {
+		t.Fatalf("oracle broke on inert source: %v", perr)
+	}
+	if injected {
+		t.Fatal("oracle false-positive: payload inside a quoted literal is data, not code")
+	}
+}
+
+// TestAuditParseBackstopFires proves the emitter-side backstop
+// (assertBlueprintGoParses) actually fires on a broken file rather than
+// silently passing everything.
+func TestAuditParseBackstopFires(t *testing.T) {
+	err := assertBlueprintGoParses([]generatedFile{
+		{name: "broken.go", content: "package main\nfunc ( {\n"},
+		{name: "fine.go", content: "package main\n"},
+	})
+	if err == nil {
+		t.Fatal("BACKSTOP IS VACUOUS: assertBlueprintGoParses accepted unparseable Go")
+	}
+	if !strings.Contains(err.Error(), "broken.go") {
+		t.Fatalf("backstop error does not name the offending file: %v", err)
+	}
+}
+
+// TestAuditUnvalidatedEmitterPath drives hostile NAMES through the emitters
+// with no validator in front (the loadBlueprintPath(path, false) surface that
+// generate --add uses before re-validation, and any struct-level caller).
+// Every identifier-shaped field must either keep the output parseable AND
+// inert, or make renderBlueprintFiles refuse (fail-closed via
+// assertBlueprintGoParses). Silent executable output is the finding.
+func TestAuditUnvalidatedEmitterPath(t *testing.T) {
+	prev := fontFetcher
+	fontFetcher = func(string) ([]byte, error) { return nil, fmt.Errorf("offline") }
+	t.Cleanup(func() { fontFetcher = prev })
+
+	hostileNames := []string{
+		"x`+PWNX()+`y",
+		`x"+PWNX()+"y`,
+		"x\nfunc PWNX() {}\nvar z = \"",
+	}
+	base := func() Blueprint {
+		return Blueprint{
+			App: BlueprintApp{Name: "app", Module: "m"},
+			Entities: []framework.EntityDeclaration{{
+				Name:   "tickets",
+				Fields: []framework.FieldDeclaration{{Name: "title", Type: "string"}},
+			}},
+			Screens: []BlueprintScreen{
+				{Name: "home", Route: "/", Type: "page"},
+			},
+		}
+	}
+	for _, hn := range hostileNames {
+		for _, mutate := range []struct {
+			what string
+			mut  func(*Blueprint, string)
+		}{
+			{"entity.name", func(b *Blueprint, v string) { b.Entities[0].Name = v }},
+			{"field.name", func(b *Blueprint, v string) { b.Entities[0].Fields[0].Name = v }},
+			{"relation.name", func(b *Blueprint, v string) {
+				b.Entities = append(b.Entities, framework.EntityDeclaration{
+					Name:   "targets",
+					Fields: []framework.FieldDeclaration{{Name: "label", Type: "string"}},
+				})
+				b.Entities[0].Relations = []framework.Relation{{
+					Type: framework.RelManyToOne, Name: v, Entity: "targets",
+				}}
+			}},
+			{"screen.name", func(b *Blueprint, v string) { b.Screens[0].Name = v }},
+			{"endpoint.handler", func(b *Blueprint, v string) {
+				b.Endpoints = []BlueprintEndpoint{{Name: "e", Method: "GET", Path: "/x", Handler: v}}
+			}},
+		} {
+			label := strings.NewReplacer("\n", "N", "`", "BT", `"`, "Q").Replace(mutate.what + "/" + hn)
+			t.Run(label, func(t *testing.T) {
+				bp := base()
+				mutate.mut(&bp, hn)
+				files, err := renderBlueprintFiles(bp)
+				if err != nil {
+					return // refused, fail-closed: acceptable
+				}
+				for _, f := range files {
+					if !strings.HasSuffix(f.name, ".go") || !strings.Contains(f.content, "PWNX") {
+						continue
+					}
+					injected, perr := auditInjectedIdent(f.name, f.content)
+					if perr != nil {
+						t.Fatalf("SECURITY [unvalidated-path] %s: emitted %s does not parse: %v", mutate.what, f.name, perr)
+					}
+					if injected {
+						t.Fatalf("SECURITY [unvalidated-path] %s: hostile name became an identifier in %s", mutate.what, f.name)
+					}
+				}
+			})
+		}
+	}
+}

--- a/cmd/gofastr/generate_cli.go
+++ b/cmd/gofastr/generate_cli.go
@@ -441,7 +441,16 @@ func buildCLISpec(decls []framework.EntityDeclaration, opts cliOptions, clientIm
 		ClientImport: clientImport,
 		Selection:    cliSelectionNote(opts),
 	}
-
+	// Selection is baked verbatim into the generated main.go header
+	// comment — the same sink --binary is control-char-guarded for above.
+	// --api-prefix and --out reach it from argv without their own checks
+	// (only/exclude/verbs values are already constrained to entity names
+	// and known verbs), so guard the composed value once, at the sink.
+	for _, r := range spec.Selection {
+		if r < 0x20 || r == 0x7f {
+			return cliSpec{}, fmt.Errorf("selection flags are baked into the generated main.go header comment and must not contain control characters: %q", spec.Selection)
+		}
+	}
 	matchesAny := func(decl framework.EntityDeclaration, names []string) bool {
 		for _, name := range names {
 			if cliEntityMatches(decl, name) {
@@ -548,6 +557,19 @@ func buildEntityModel(decl framework.EntityDeclaration, verbs []string) cliEntit
 
 func buildCLIEntity(decl framework.EntityDeclaration, verbs []string) (cliEntity, error) {
 	ent := buildEntityModel(decl, verbs)
+	// The CLI re-emits declaration strings into Go source: ent.Struct in
+	// identifier position (run%sList, %sCommands) and ent.Table raw inside
+	// "/%s/" string literals. The blueprint path into entities/ is guarded
+	// upstream (validateBlueprint: isGoIdentifier + query.SafeIdent), but
+	// packReadEntities also reads hand-written entity files, so the guard
+	// belongs at this emitter too: refuse what would break out of the
+	// emitted code rather than munge it, mirroring validateBlueprint.
+	if !isGoIdentifier(ent.Struct) {
+		return cliEntity{}, fmt.Errorf("entity %q does not produce a valid Go identifier (%q); it is emitted as generated function names. Rename it to letters, digits and underscores starting with a letter", decl.Name, ent.Struct)
+	}
+	if strings.ContainsFunc(ent.Table, func(r rune) bool { return r == '"' || r == '\\' || r < 0x20 || r == 0x7f }) {
+		return cliEntity{}, fmt.Errorf("entity %q table %q contains a character that cannot survive the Go string literals it is emitted into. Rename the table", decl.Name, ent.Table)
+	}
 	if cliReservedCommands[ent.Command] {
 		return cliEntity{}, fmt.Errorf("entity %q: its command form %q collides with a CLI built-in. Exclude it with --exclude=%s, or rename the table", decl.Name, ent.Command, decl.Name)
 	}

--- a/cmd/gofastr/generate_cli_injection_security_test.go
+++ b/cmd/gofastr/generate_cli_injection_security_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/framework"
+)
+
+// declaration-derived string: can it break out of the literal or identifier
+// it lands in?
+//
+// Two input paths with different trust boundaries:
+//
+//   - --from-openapi (the real boundary: the spec can be a URL). Every
+//     spec-derived string lands via %q or behind an identifier-grammar
+//     check (oaValidIdent/oaValidFlag). Proven here, not assumed.
+//   - entity mode (reads the app's own entities/ via packReadEntities).
+//     Names land in identifier position (ent.Struct via toCamelCase, which
+//     passes quotes through) and tables land RAW inside "/%s/" Go string
+//     literals. The blueprint path into entities/ is guarded upstream
+//     (validateBlueprint: isGoIdentifier + query.SafeIdent + the
+//     parse-backstop), but `generate cli` reads hand-written entity files
+//     too, so the boundary has to hold HERE as well, mirroring the same
+//     guards validateBlueprint applies.
+
+// TestGenerateCLI_HostileTableCannotBreakOutOfPathLiterals: a table
+// containing a Go string-literal delimiter must be refused, not emitted.
+// Before the guard, `table: x"); pwn(); ("` rendered as
+//
+//	g.client.Do(g.ctx, http.MethodGet, "/x"); pwn(); ("/"+url.PathEscape(id), ...)
+//
+// — the payload at expression position in generated, syntactically valid Go.
+func TestGenerateCLI_HostileTableCannotBreakOutOfPathLiterals(t *testing.T) {
+	for _, table := range []string{
+		`x"); pwn(); ("`,
+		`x\` + "\n" + `y`,
+		"x\"y",
+	} {
+		decls := []framework.EntityDeclaration{{
+			Name:  "events",
+			Table: table,
+			Fields: []framework.FieldDeclaration{
+				{Name: "title", Type: "string"},
+			},
+		}}
+		_, err := buildCLISpec(decls, defaultCLIOptions(), "example.com/app/entities/client")
+		if err == nil {
+			t.Errorf("table %q: buildCLISpec accepted a table that breaks the emitted Go string literal", table)
+			continue
+		}
+		if !strings.Contains(err.Error(), "table") {
+			t.Errorf("table %q: error does not name the table: %v", table, err)
+		}
+	}
+}
+
+// TestGenerateCLI_EntityNameMustDeriveIdentifier: ent.Struct lands in
+// identifier position (run%sList, %sCommands). toCamelCase splits only on
+// _/-/space, so a name with a quote or paren carries it straight into the
+// identifier — refused here, exactly as validateBlueprint refuses it for
+// `gofastr generate`.
+func TestGenerateCLI_EntityNameMustDeriveIdentifier(t *testing.T) {
+	for _, name := range []string{`po"sts`, "po sts()", "2fa_tokens", "日本"} {
+		decls := []framework.EntityDeclaration{{
+			Name: name,
+			Fields: []framework.FieldDeclaration{
+				{Name: "title", Type: "string"},
+			},
+		}}
+		_, err := buildCLISpec(decls, defaultCLIOptions(), "example.com/app/entities/client")
+		if err == nil {
+			t.Errorf("name %q: buildCLISpec accepted a name that does not derive a Go identifier", name)
+		}
+	}
+}
+
+// TestGenerateCLI_PlainNamesStillGenerate: the guards above must not
+// over-fire. Dashed table names generate valid literals and command words
+// today and keep doing so.
+func TestGenerateCLI_PlainNamesStillGenerate(t *testing.T) {
+	decls := []framework.EntityDeclaration{{
+		Name:  "events",
+		Table: "blog-posts",
+		Fields: []framework.FieldDeclaration{
+			{Name: "title", Type: "string"},
+		},
+	}}
+	spec, err := buildCLISpec(decls, defaultCLIOptions(), "example.com/app/entities/client")
+	if err != nil {
+		t.Fatalf("plain dashed table rejected: %v", err)
+	}
+	files := renderCLIFiles(spec)
+	joined := ""
+	for _, f := range files {
+		joined += f.content
+	}
+	if !strings.Contains(joined, `"/blog-posts/"`) {
+		t.Errorf("expected the dashed table in a path literal")
+	}
+}
+
+// TestGenerateCLI_SelectionSinkIsCommentBodied demonstrates WHY the
+// spec-build guard exists: renderCLIMain itself cannot defend a comment —
+// a newline in spec.Selection lands at statement position and the file
+// stops parsing. The buildCLISpec guard is what keeps such a spec from
+// rendering; this pins the hazard so the guard is never "simplified" away.
+func TestGenerateCLI_SelectionSinkIsCommentBodied(t *testing.T) {
+	opts := defaultCLIOptions()
+	opts.apiPrefix = "api\nx()"
+	spec := cliSpec{Binary: "myapp", EnvPrefix: "MYAPP", APIPrefix: "/api", Selection: cliSelectionNote(opts)}
+	main := renderCLIMain(spec)
+	fset := token.NewFileSet()
+	if _, err := parser.ParseFile(fset, "main.go", main, 0); err == nil {
+		t.Errorf("a newline in the baked selection did NOT break main.go — the sink moved; revisit the buildCLISpec guard's coverage")
+	}
+}
+
+// TestGenerateCLI_SelectionControlCharsRefusedAtSpecBuild: the fix —
+// buildCLISpec refuses a selection carrying control characters, naming the
+// sink it protects.
+func TestGenerateCLI_SelectionControlCharsRefusedAtSpecBuild(t *testing.T) {
+	opts := defaultCLIOptions()
+	opts.apiPrefix = "api\nx()"
+	_, err := buildCLISpec(cliFixtureDecls(), opts, "example.com/app/entities/client")
+	if err == nil {
+		t.Fatalf("buildCLISpec accepted a --api-prefix carrying a newline into the generated source header")
+	}
+}
+
+// TestGenerateCLI_OpenAPIHostileStringsStayQuoted proves the --from-openapi
+// boundary: hostile PATH templates, summaries, and parameter names from a
+// URL-fetched spec stay inside quoted literals, and the emitted operations.go
+// still parses. Identifiers (operationIds) are grammar-checked and refused
+// separately (TestOpenAPICLI_BadIdentifierFails).
+func TestGenerateCLI_OpenAPIHostileStringsStayQuoted(t *testing.T) {
+	hostilePath := `/a"); pwn(); ("/{id}`
+	hostileSummary := "sum`mary \" \\ \n end"
+	doc := fmt.Sprintf(`{"openapi":"3.0.3","paths":{%q:{"get":{"operationId":"getThing",`+
+		`"summary":%q,"parameters":[{"name":"id","in":"path","required":true,"schema":{"type":"string"}}]}}}}`,
+		hostilePath, hostileSummary)
+	m := decodeJSONMap(t, doc)
+	spec, err := buildOpenAPICLISpec(m, defaultCLIOptions(), "example.com/app/internal/client")
+	if err != nil {
+		t.Fatalf("hostile-but-valid spec refused: %v", err)
+	}
+	if len(spec.Ops) != 1 {
+		t.Fatalf("expected 1 op, got %d", len(spec.Ops))
+	}
+	ops := renderCLIOpsFile(spec)
+	fset := token.NewFileSet()
+	if _, err := parser.ParseFile(fset, "operations.go", ops, 0); err != nil {
+		t.Fatalf("hostile spec strings produced unparseable operations.go: %v\n%s", err, ops)
+	}
+	// The payload must never appear outside a quoted literal: strip every
+	// double-quoted Go string and search the residue.
+	residue := stripGoDoubleQuoted(ops)
+	for _, needle := range []string{"pwn()", "sum`mary"} {
+		if strings.Contains(residue, needle) {
+			t.Errorf("payload %q reached code position in operations.go:\n%s", needle, ops)
+		}
+	}
+	// And the path literal must decode back to the exact hostile path.
+	if !strings.Contains(ops, fmt.Sprintf("%q", hostilePath)) {
+		t.Errorf("path template not emitted as the exact quoted literal")
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func decodeJSONMap(t *testing.T, doc string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(doc), &m); err != nil {
+		t.Fatalf("bad fixture: %v", err)
+	}
+	return m
+}
+
+// stripGoDoubleQuoted removes double-quoted string regions (with \" escapes)
+// from Go source, leaving identifiers, keywords, and structure.
+func stripGoDoubleQuoted(src string) string {
+	var b strings.Builder
+	inStr := false
+	esc := false
+	for _, r := range src {
+		switch {
+		case inStr && esc:
+			esc = false
+		case inStr && r == '\\':
+			esc = true
+		case inStr && r == '"':
+			inStr = false
+		case !inStr && r == '"':
+			inStr = true
+		case !inStr:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/cmd/gofastr/pack.go
+++ b/cmd/gofastr/pack.go
@@ -552,7 +552,16 @@ func writeYAMLEntry(sb *strings.Builder, key string, val any, indent int, path s
 	switch v := val.(type) {
 	case map[string]any:
 		if len(v) == 0 {
-			sb.WriteString(pad + key + ": {}\n")
+			// core/yaml rejects flow mappings outright (parseScalar →
+			// flowMapError), so `key: {}` writes a file decodeBlueprint
+			// cannot read back. A bare `key:` line is the exact inverse:
+			// parseMap reads it as an empty map node, which is what the
+			// grouped decoders produce for an authored bare `scope:` /
+			// `pagination:` / `exposure:` / `access:` and what mapValue
+			// gives for an empty map inside properties, props, or seed
+			// rows. Trailing-at-EOF is the same case: parseMap's
+			// p.pos >= len(p.lines) branch also yields the empty map node.
+			sb.WriteString(pad + key + ":\n")
 			return nil
 		}
 		sb.WriteString(pad + key + ":\n")
@@ -584,7 +593,17 @@ func writeYAMLEntry(sb *strings.Builder, key string, val any, indent int, path s
 }
 
 func writeYAMLListItem(sb *strings.Builder, item any, indent int, order []string, path string) error {
-	if m, ok := item.(map[string]any); ok && len(m) > 0 {
+	if m, ok := item.(map[string]any); ok {
+		if len(m) == 0 {
+			// Empty-map list item, the seed-row shape of the `key: {}`
+			// defect above: `- {}` is the flow mapping parseList refuses,
+			// and the fallthrough used to print the Go value ("- map[]"),
+			// which re-parses as a STRING. parseList reads a bare `-` item
+			// as an empty map node — the exact inverse of an authored bare
+			// `-` row.
+			sb.WriteString(strings.Repeat(" ", indent) + "-\n")
+			return nil
+		}
 		var tmp strings.Builder
 		if err := writeYAMLMap(&tmp, m, indent+2, order, path); err != nil {
 			return err
@@ -595,7 +614,18 @@ func writeYAMLListItem(sb *strings.Builder, item any, indent int, order []string
 		return nil
 	}
 	sb.WriteString(strings.Repeat(" ", indent) + "- ")
-	writeScalarInline(sb, item)
+	// parseList cuts ANY unquoted block-list item at the first ':' into a
+	// map entry (`- postgres://u@h/db` re-parses as {postgres: "//u@h/db"}),
+	// because ':' is the item grammar's key/value delimiter. Block VALUES
+	// follow the laxer rule — parseScalar only rejects ": " — and
+	// needsQuote encodes exactly that, so it cannot carry this rule without
+	// quoting every URL-shaped block value in every real pack. Quote here,
+	// in the one context the list rule governs.
+	if s, ok := item.(string); ok && strings.Contains(s, ":") {
+		sb.WriteString(quoteYAMLStringEscaped(s))
+	} else {
+		writeScalarInline(sb, item)
+	}
 	sb.WriteString("\n")
 	return nil
 }
@@ -722,6 +752,15 @@ func quoteYAMLString(s string) string {
 	if !needsQuote(s) {
 		return s
 	}
+	return quoteYAMLStringEscaped(s)
+}
+
+// quoteYAMLStringEscaped is quoteYAMLString's always-quote form, for callers
+// that have a context-specific reason to quote beyond needsQuote's
+// value-context rules (writeYAMLListItem: a ':' anywhere in a block-list
+// item is the map-cut delimiter). Same escaping contract as
+// quoteYAMLString: exact bytes back through parseQuoted's strconv.Unquote.
+func quoteYAMLStringEscaped(s string) string {
 	var b strings.Builder
 	b.WriteByte('"')
 	for i := 0; i < len(s); {

--- a/cmd/gofastr/pack_roundtrip_test.go
+++ b/cmd/gofastr/pack_roundtrip_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Two serializer defects found by the #362 audit, both stated as the property
+// the serializer's own banner claims (pack.go: parse ∘ pack is the identity
+// on decodeBlueprint output) rather than as predicates on the writer:
+//
+//  1. writeYAMLEntry emitted `key: {}` for an empty map, and core/yaml
+//     rejects flow mappings outright (parseScalar → flowMapError), so a
+//     blueprint that legitimately decodes to an empty grouped struct — an
+//     authored bare `scope:`, `pagination:`, `exposure:`, `access:`, or an
+//     empty map inside properties/seed rows — packed to a file
+//     decodeBlueprintString could not read at all.
+//  2. needsQuote("a:b") is false, which is correct for block VALUES (the
+//     parser only rejects ": " there), but parseList cuts ANY unquoted block
+//     list item at the first ':' into a map entry. Two different rules, and
+//     the writer applied the value rule where the list rule governs: a
+//     colon-bearing string in a mixed block list (the realistic payload is a
+//     URL) re-packed as `- a: b` and re-read as a map the source never
+//     declared.
+//
+// The comparison is reflect.DeepEqual over the WHOLE Blueprint, so a field
+// the writer silently drops fails the comparison rather than being skipped
+// by it — a comparison that only walks fields both sides have cannot see a
+// dropped one.
+
+// TestPack_EmptyMapsRoundTrip: every grouped decoder returns a non-nil zero
+// struct for a present-but-empty node, so each shape below is authored YAML
+// that decodes cleanly. The serializer must emit the exact inverse — a bare
+// `key:` line, which re-parses as an empty map — instead of `key: {}`.
+func TestPack_EmptyMapsRoundTrip(t *testing.T) {
+	yml := `app:
+  name: EmptyMaps
+  module: example.com/emptymaps
+entities:
+  - name: posts
+    scope:
+    pagination:
+    exposure:
+      access:
+    fields:
+      - name: title
+        type: string
+    properties:
+      meta:
+seed:
+  - entity: posts
+    rows:
+      - title: first
+        meta:
+      -
+      - title: second
+`
+	a, err := decodeBlueprintString(yml)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	// The fixture must actually exercise the fix, or a green run proves
+	// nothing: every empty shape below is the non-nil-zero-struct form the
+	// grouped decoders produce for a present-but-empty node.
+	if len(a.Entities) != 1 {
+		t.Fatalf("fixture does not exercise the fix: %+v", a.Entities)
+	}
+	e := a.Entities[0]
+	if e.Scope == nil || e.Pagination == nil || e.Exposure == nil || e.Exposure.Access == nil {
+		t.Fatalf("fixture does not exercise the fix: bare group node decoded to nil — scope=%v pagination=%v exposure=%v", e.Scope, e.Pagination, e.Exposure)
+	}
+	if s, ok := e.Properties["meta"].(map[string]any); !ok || len(s) != 0 {
+		t.Fatalf("fixture does not exercise the fix: properties.meta = %#v, want empty non-nil map", e.Properties["meta"])
+	}
+	rows := a.Seed[0].Rows
+	if m, ok := rows[0]["meta"].(map[string]any); !ok || len(m) != 0 {
+		t.Fatalf("fixture does not exercise the fix: rows[0].meta = %#v, want empty non-nil map", rows[0]["meta"])
+	}
+	if len(rows) != 3 || len(rows[1]) != 0 {
+		t.Fatalf("fixture does not exercise the fix: rows = %#v, want a fully empty row in the middle", rows)
+	}
+
+	out, err := encodeBlueprintYAML(a)
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	b, err := decodeBlueprintString(out)
+	if err != nil {
+		t.Fatalf("pack emitted an unreadable file: %v\n--- yaml ---\n%s", err, out)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("empty-map round-trip mismatch.\n%s\n--- serialized yaml ---\n%s", firstBlueprintDiff(a, b), out)
+	}
+}
+
+// TestPack_ColonScalarsInMixedListsRoundTrip: a quoted item `- "a:b"` decodes
+// as the string "a:b" (parseList skips the map-cut for a leading quote). The
+// serializer must re-quote it — in the block-list context ANY colon is the
+// map-cut delimiter, unlike block values where only ": " is — or the item
+// re-parses as {a: b} and two different strings become the same map.
+func TestPack_ColonScalarsInMixedListsRoundTrip(t *testing.T) {
+	yml := `app:
+  name: Colons
+  module: example.com/colons
+entities:
+  - name: posts
+    fields:
+      - name: title
+        type: string
+    properties:
+      links:
+        - "postgres://u@h/db"
+        - "a:b"
+        - label: home
+screens:
+  - name: home
+    route: /
+    body:
+      - kind: card
+        props:
+          links:
+            - "https://cdn.example.net/img.png"
+            - alt: hero
+`
+	a, err := decodeBlueprintString(yml)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	// Oracle stated independently of the fix: the quoted items must have
+	// decoded as STRINGS, or the mismatch below could be blamed on the
+	// fixture instead of the writer.
+	if len(a.Entities) != 1 {
+		t.Fatalf("fixture does not exercise the fix: %+v", a.Entities)
+	}
+	links, ok := a.Entities[0].Properties["links"].([]any)
+	if !ok || len(links) != 3 {
+		t.Fatalf("fixture does not exercise the fix: properties.links = %#v", a.Entities[0].Properties["links"])
+	}
+	for i, want := range []string{"postgres://u@h/db", "a:b"} {
+		if got, ok := links[i].(string); !ok || got != want {
+			t.Fatalf("fixture does not exercise the fix: properties.links[%d] = %#v, want the string %q", i, links[i], want)
+		}
+	}
+	blocks := a.Screens[0].Body
+	if len(blocks) != 1 {
+		t.Fatalf("fixture does not exercise the fix: screens[0].body = %+v", blocks)
+	}
+	if _, ok := blocks[0].Props["links"].([]any); !ok {
+		t.Fatalf("fixture does not exercise the fix: block props.links = %#v", blocks[0].Props["links"])
+	}
+
+	out, err := encodeBlueprintYAML(a)
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	b, err := decodeBlueprintString(out)
+	if err != nil {
+		t.Fatalf("pack emitted an unreadable file: %v\n--- yaml ---\n%s", err, out)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("colon-scalar round-trip mismatch.\n%s\n--- serialized yaml ---\n%s", firstBlueprintDiff(a, b), out)
+	}
+}

--- a/core-ui/runtime/carousel_teardown_e2e_test.go
+++ b/core-ui/runtime/carousel_teardown_e2e_test.go
@@ -1,0 +1,265 @@
+package runtime
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// carouselSlideHTML is one slide's inner markup; slides are numbered so a
+// stray scroll can be told apart in debugging output.
+func carouselSlideHTML(n int) string {
+	return `<li class="ui-carousel__slide" data-fui-carousel-slide="` + strconv.Itoa(n) + `">S` + strconv.Itoa(n) + `</li>`
+}
+
+// carouselFixture renders the framework/ui.Carousel SSR shape (root marker,
+// track with tabindex, slides, prev/next buttons) with autorotate=80ms so
+// ~12 rotate ticks land per second — enough margin that counter deltas are
+// unambiguous without making the test slow.
+func carouselFixture(id string) string {
+	return `<div class="ui-carousel" id="` + id + `" data-fui-carousel="true" data-fui-carousel-autorotate="80">` +
+		`<ul class="ui-carousel__track" data-fui-carousel-track="true" tabindex="0" aria-label="slides">` +
+		carouselSlideHTML(0) + carouselSlideHTML(1) + carouselSlideHTML(2) +
+		`</ul>` +
+		`<button type="button" class="ui-carousel__prev" data-fui-carousel-prev="true" aria-label="Previous">&#8249;</button>` +
+		`<button type="button" class="ui-carousel__next" data-fui-carousel-next="true" aria-label="Next">&#8250;</button>` +
+		`</div>`
+}
+
+// startCarouselNavServer serves two layout-less pages that share one
+// document. Page A has an autorotate carousel INSIDE <main> (swapped out on
+// SPA nav) and one OUTSIDE <main> (persists, the shell-owned shape). Page B
+// is plain content. Every swap path (runtime.js loadPage) replaces the
+// content cell BEFORE dispatching gofastr:navigate, which is the ordering
+// this test pins the carousel module's teardown against.
+func startCarouselNavServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	js, err := RuntimeJS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/__gofastr/runtime.js", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Write([]byte(js))
+	})
+	mux.HandleFunc("/__gofastr/runtime/", func(w http.ResponseWriter, r *http.Request) {
+		name := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/__gofastr/runtime/"), ".js")
+		src, ok := Module(name)
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Write([]byte(src))
+	})
+	mux.HandleFunc("/__gofastr/widgets", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[]`))
+	})
+	page := func(body string) string {
+		return `<!doctype html><html><head><title>carousel teardown</title>` +
+			// Inline route manifest: without it the router does not
+			// intercept the anchor and the click becomes a full page
+			// load (fresh document, window wiped). Same shape every
+			// SPA-nav e2e test in this package uses.
+			`<script type="application/json" id="gofastr-routes">[{"path":"/"},{"path":"/b"}]</script>` +
+			`</head><body>` +
+			body +
+			`<span id="ready">ready</span>` +
+			`<script src="/__gofastr/runtime.js"></script></body></html>`
+	}
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		var body string
+		if r.URL.Path == "/b" {
+			body = `<main><p id="bmark">page B</p></main>`
+		} else {
+			// c2 sits OUTSIDE <main>: it survives the /a -> /b swap the
+			// way a carousel in a shared layout layer does in production.
+			body = carouselFixture("c2") +
+				`<main>` + carouselFixture("c1") + `<a id="nav" href="/b">go to B</a></main>`
+		}
+		fmt.Fprint(w, page(body))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestCarouselAutoRotateTeardownOnNav pins the autorotate interval's
+// lifetime across an SPA navigation.
+//
+// attach() arms a setInterval per autorotate carousel and stores stop() on
+// the element (_fuiCarouselStop). The gofastr:navigate handler is the only
+// teardown path, and it looks for carousels via
+// document.querySelectorAll — but every loadPage swap path replaces the
+// content cell BEFORE finishNav dispatches gofastr:navigate
+// (runtime.js: swapAtSlot -> finishNav). Two failures fall out:
+//
+//  1. LEAK: a carousel inside the swapped region is already detached when
+//     the handler runs, document.querySelectorAll cannot see it, its
+//     interval is never cleared. It keeps firing step() — querySelectorAll
+//     + getComputedStyle + scrollTo over the detached subtree — for the
+//     remaining lifetime of the page, and the closure pins the subtree in
+//     memory. Every autorotate carousel on every SPA nav away leaks one.
+//  2. FEATURE DEATH: a carousel that PERSISTS (outside the swapped cell,
+//     e.g. in a shared layout layer) IS found by the handler and stopped —
+//     and scan() then skips it (fuiCarouselBound guard), so its autorotate
+//     never restarts. One SPA nav anywhere permanently kills rotation on
+//     every surviving carousel.
+//
+// The liveness probe overrides querySelectorAll on each carousel element
+// (an own property; slides() dispatches through it on every rotate tick)
+// and counts calls. Instrumentation happens after wiring, so deltas are
+// pure interval ticks.
+func TestCarouselAutoRotateTeardownOnNav(t *testing.T) {
+	srv := startCarouselNavServer(t)
+	ctx := newSeedBrowserCtx(t)
+
+	read := func(el, expr string, dst *string) chromedp.Action {
+		return chromedp.Evaluate(`(function(){
+			var el = window.__probe['`+el+`'];
+			return String(`+expr+`);
+		})()`, dst)
+	}
+
+	var c1A, c1B, c1C, c2A, c2B, c2C string
+	var c1Conn, c2Conn, loc string
+
+	// Two observation windows AFTER the navigation: the first proves the
+	// present state, the second (a beat later) proves it is stable, not a
+	// timing artifact of the swap itself.
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`#c1`, chromedp.ByID),
+		// Let the marker scan idle-load carousel.js and wire both
+		// carousels (same budget the other module e2e tests use).
+		chromedp.Sleep(700*time.Millisecond),
+
+		// Instrument both carousels AFTER wiring.
+		chromedp.Evaluate(`(function(){
+			window.__probe = {};
+			['#c1','#c2'].forEach(function(sel){
+				var el = document.querySelector(sel);
+				var orig = el.querySelectorAll.bind(el);
+				el.__qsa = 0;
+				el.querySelectorAll = function(s){ el.__qsa++; return orig(s); };
+				window.__probe[sel] = el;
+			});
+		})()`, nil),
+		// Baseline: both intervals must be alive pre-nav, otherwise the
+		// probe proves nothing. 80ms rotate -> ~4 ticks in 350ms.
+		chromedp.Sleep(350*time.Millisecond),
+		read("#c1", `window.__probe['#c1'].__qsa`, &c1A),
+		read("#c2", `window.__probe['#c2'].__qsa`, &c2A),
+
+		// Real SPA navigation: the runtime intercepts the anchor click,
+		// swaps main's innerHTML, THEN dispatches gofastr:navigate.
+		chromedp.Click(`#nav`, chromedp.ByID),
+		chromedp.WaitVisible(`#bmark`, chromedp.ByID),
+		chromedp.Sleep(500*time.Millisecond),
+		read("#c1", `window.__probe['#c1'].__qsa`, &c1B),
+		read("#c2", `window.__probe['#c2'].__qsa`, &c2B),
+		chromedp.Sleep(350*time.Millisecond),
+		read("#c1", `window.__probe['#c1'].__qsa`, &c1C),
+		read("#c2", `window.__probe['#c2'].__qsa`, &c2C),
+
+		read("#c1", `window.__probe['#c1'].isConnected`, &c1Conn),
+		read("#c2", `window.__probe['#c2'].isConnected`, &c2Conn),
+		chromedp.Evaluate(`location.pathname`, &loc),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fixture sanity: the nav really happened and the two carousels sit on
+	// the expected sides of the swap boundary. Without these, a pass could
+	// be an artifact of the navigation not firing at all.
+	if loc != "/b" {
+		t.Fatalf("fixture: SPA nav did not happen, location = %q", loc)
+	}
+	if c1Conn != "false" {
+		t.Fatalf("fixture: #c1 should be detached after the swap, isConnected = %s", c1Conn)
+	}
+	if c2Conn != "true" {
+		t.Fatalf("fixture: #c2 should persist across the swap, isConnected = %s", c2Conn)
+	}
+
+	toInt := func(s string) int {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			t.Fatalf("counter not numeric: %q", s)
+		}
+		return n
+	}
+	if toInt(c1A) < 2 {
+		t.Fatalf("fixture: #c1 interval was not rotating pre-nav (%s ticks), probe invalid", c1A)
+	}
+	if toInt(c2A) < 2 {
+		t.Fatalf("fixture: #c2 interval was not rotating pre-nav (%s ticks), probe invalid", c2A)
+	}
+
+	leak := toInt(c1C) - toInt(c1B)
+	if leak != 0 {
+		t.Errorf("LEAK: detached carousel's autorotate interval is still firing — %d rotate ticks against a detached subtree after SPA nav (counter %s -> %s -> %s)", leak, c1B, c1C, c1C)
+	}
+	persisted := toInt(c2C) - toInt(c2B)
+	if persisted < 2 {
+		t.Errorf("FEATURE DEATH: persisted carousel's autorotate stopped permanently after an unrelated SPA nav — %d ticks in the post-nav window (counter %s -> %s -> %s), want >= 2 (rotation must continue; the carousel is still connected and visible)", persisted, c2B, c2C, c2C)
+	}
+}
+
+// TestCarouselInjectedAfterLoadGetsWired pins the other half of the
+// scanner registration: a carousel arriving via an island/RPC swap (any
+// innerHTML insertion after module load) must be wired by
+// _moduleScanners.carousel — core's MutationObserver re-runs loaded
+// modules' scanners over inserted subtrees. Before the registration the
+// module only scanned at load and on gofastr:navigate, so a carousel
+// inside a swapped island was dead DOM (no Prev/Next, no autorotate).
+//
+// Observable: the wiring flag flips AND an injected autorotate carousel
+// actually starts rotating (QSA probe, same technique as the teardown
+// test).
+func TestCarouselInjectedAfterLoadGetsWired(t *testing.T) {
+	srv := startCarouselNavServer(t)
+	ctx := newSeedBrowserCtx(t)
+
+	var bound, ticksA, ticksB string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`#c1`, chromedp.ByID),
+		// Module loaded + initial carousels wired.
+		chromedp.Sleep(700*time.Millisecond),
+
+		// Simulate an island swap: innerHTML insertion of a carousel
+		// the module has never seen (fresh element, no bound flag).
+		chromedp.Evaluate(`(function(){
+			var host = document.querySelector('main');
+			host.insertAdjacentHTML('beforeend', `+strconv.Quote(carouselFixture("inj"))+`);
+			var el = document.getElementById('inj');
+			var orig = el.querySelectorAll.bind(el);
+			el.__qsa = 0;
+			el.querySelectorAll = function(s){ el.__qsa++; return orig(s); };
+		})()`, nil),
+		chromedp.Sleep(350*time.Millisecond),
+		chromedp.Evaluate(`String(document.getElementById('inj').dataset.fuiCarouselBound || '')`, &bound),
+		chromedp.Evaluate(`String(document.getElementById('inj').__qsa)`, &ticksA),
+		chromedp.Sleep(350*time.Millisecond),
+		chromedp.Evaluate(`String(document.getElementById('inj').__qsa)`, &ticksB),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if bound != "1" {
+		t.Errorf("injected carousel was not wired — data-fui-carousel-bound = %q, want \"1\" (the _moduleScanners.carousel registration is the only wiring path for island-swapped carousels)", bound)
+	}
+	if ticksA == "0" || ticksB == ticksA {
+		t.Errorf("injected autorotate carousel is not rotating — ticks %s -> %s, want growing (wired + interval armed)", ticksA, ticksB)
+	}
+}

--- a/core-ui/runtime/carousel_teardown_e2e_test.go
+++ b/core-ui/runtime/carousel_teardown_e2e_test.go
@@ -207,11 +207,11 @@ func TestCarouselAutoRotateTeardownOnNav(t *testing.T) {
 
 	leak := toInt(c1C) - toInt(c1B)
 	if leak != 0 {
-		t.Errorf("LEAK: detached carousel's autorotate interval is still firing — %d rotate ticks against a detached subtree after SPA nav (counter %s -> %s -> %s)", leak, c1B, c1C, c1C)
+		t.Errorf("LEAK: detached carousel's autorotate interval is still firing — %d rotate ticks against a detached subtree after SPA nav (counter A-pre-nav %s -> B-post-nav %s -> C-a-beat-later %s)", leak, c1A, c1B, c1C)
 	}
 	persisted := toInt(c2C) - toInt(c2B)
 	if persisted < 2 {
-		t.Errorf("FEATURE DEATH: persisted carousel's autorotate stopped permanently after an unrelated SPA nav — %d ticks in the post-nav window (counter %s -> %s -> %s), want >= 2 (rotation must continue; the carousel is still connected and visible)", persisted, c2B, c2C, c2C)
+		t.Errorf("FEATURE DEATH: persisted carousel's autorotate stopped permanently after an unrelated SPA nav — %d ticks in the post-nav window (counter A-pre-nav %s -> B-post-nav %s -> C-a-beat-later %s), want >= 2 (rotation must continue; the carousel is still connected and visible)", persisted, c2A, c2B, c2C)
 	}
 }
 

--- a/core-ui/runtime/runtime_test.go
+++ b/core-ui/runtime/runtime_test.go
@@ -906,32 +906,38 @@ func TestWidget_InjectSignalAria_TextModeOnly(t *testing.T) {
 }
 
 // TestCarousel_TimerTeardownOnNav guards F16a: the carousel setInterval
-// must be cleared on gofastr:navigate so auto-rotate doesn't leak across
-// SPA navigation. The nav handler must call stop/clearInterval, not just
-// re-scan for new carousels.
+// must be cleared for carousels that leave the document on SPA nav so
+// auto-rotate doesn't leak. The mechanism is a module-level `rotating`
+// registry walked by pruneDetached() — the swap runs BEFORE the
+// gofastr:navigate dispatch, so carousels inside the swapped region are
+// already detached and invisible to document.querySelectorAll; the
+// registry is the only structure that still holds them.
+//
+// Source-shape pin only: the behavioural proof (detached carousel stops
+// ticking, persisted carousel keeps ticking) is
+// TestCarouselAutoRotateTeardownOnNav in carousel_teardown_e2e_test.go.
 func TestCarousel_TimerTeardownOnNav(t *testing.T) {
 	src, ok := Module("carousel")
 	if !ok {
 		t.Fatal("carousel module not embedded")
 	}
-	// Require evidence that the navigate handler calls stop() or clearInterval
-	// on the tracked active carousels. The simplest form: the nav listener
-	// iterates a tracking structure and stops each timer. We accept any of:
-	//   - "activeCarousels" Set referenced in navigate handler
-	//   - "stop(" called inside or near the navigate handler
-	//   - "_fuiCarouselStop" teardown helper
 	idx := strings.Index(src, "gofastr:navigate")
 	if idx == -1 {
 		t.Fatal("carousel missing gofastr:navigate handler")
 	}
 	// Extract 600 chars after the navigate listener registration.
 	body := src[idx:min(idx+600, len(src))]
-	teardownEvidence := strings.Contains(body, "stop(") ||
+	teardownEvidence := strings.Contains(body, "pruneDetached()") ||
+		strings.Contains(body, "stop(") ||
 		strings.Contains(body, "clearInterval") ||
-		strings.Contains(body, "activeCarousels") ||
 		strings.Contains(body, "_fuiCarouselStop")
 	if !teardownEvidence {
-		t.Error("carousel gofastr:navigate handler must stop auto-rotate timers — no teardown evidence found near the navigate listener")
+		t.Error("carousel gofastr:navigate handler must tear down auto-rotate timers for detached carousels — no teardown evidence found near the navigate listener")
+	}
+	// The registry itself: teardown is unreachable without it (the
+	// detached carousel can only be found through the Set).
+	if !strings.Contains(src, "rotating.add(carousel)") || !strings.Contains(src, "isConnected") {
+		t.Error("carousel teardown must track autorotate carousels in the module-level registry and prune by isConnected")
 	}
 }
 

--- a/core-ui/runtime/src/carousel.js
+++ b/core-ui/runtime/src/carousel.js
@@ -12,6 +12,11 @@
 (function () {
   'use strict';
 
+  // Every carousel with a live autorotate interval. Detached elements
+  // cannot be found through the document, so teardown walks THIS set,
+  // not querySelectorAll — see the gofastr:navigate handler below.
+  const rotating = new Set();
+
   function track(carousel) {
     return carousel.querySelector('[data-fui-carousel-track]');
   }
@@ -140,25 +145,39 @@
         // user has actively hovered or focused the carousel, that
         // would yank a slide out from under their pointer.
         let userPaused = false;
+        // dead is set by teardown for carousels that left the document:
+        // start() must refuse afterwards, otherwise the document-level
+        // visibilitychange listener would re-arm the interval on a
+        // detached subtree the next time the tab regains focus.
+        let dead = false;
         function start() {
-          if (timer || userPaused) return;
+          if (dead || timer || userPaused) return;
           timer = setInterval(function () {
             if (document.visibilityState === 'hidden') return;
             step(carousel, 1);
           }, rotateMs);
         }
         function stop() { if (timer) { clearInterval(timer); timer = null; } }
-        // Expose stop so the SPA-nav teardown can clear the timer.
-        carousel._fuiCarouselStop = stop;
+        const onVis = function () {
+          if (document.visibilityState === 'hidden') stop(); else start();
+        };
+        // kill fully disarms a carousel that left the DOM: interval,
+        // document listener, and registry entry. Called by teardown.
+        function kill() {
+          dead = true;
+          stop();
+          document.removeEventListener('visibilitychange', onVis);
+          rotating.delete(carousel);
+        }
+        carousel._fuiCarouselKill = kill;
+        rotating.add(carousel);
         carousel.addEventListener('mouseenter', function () { userPaused = true; stop(); });
         carousel.addEventListener('mouseleave', function () { userPaused = false; start(); });
         carousel.addEventListener('focusin', function () { userPaused = true; stop(); });
         carousel.addEventListener('focusout', function (ev) {
           if (!carousel.contains(ev.relatedTarget)) { userPaused = false; start(); }
         });
-        document.addEventListener('visibilitychange', function () {
-          if (document.visibilityState === 'hidden') stop(); else start();
-        });
+        document.addEventListener('visibilitychange', onVis);
         start();
       }
     }
@@ -225,21 +244,49 @@
 
   function scan(root) {
     const scope = root && root.querySelectorAll ? root : document;
+    // The MutationObserver scanner path passes each INSERTED node as
+    // root; a carousel inserted as that node itself (island swap) is
+    // not its own descendant, so test the root before scanning below it.
+    if (scope !== document && scope.matches && scope.matches('[data-fui-carousel]')) attach(scope);
     scope.querySelectorAll('[data-fui-carousel]').forEach(attach);
   }
   scan(document);
-  window.addEventListener('gofastr:navigate', function () {
-    // Tear down auto-rotate timers from the previous page before
-    // rescanning so stale setIntervals don't accumulate across SPA nav.
-    // attach() stores stop() on _fuiCarouselStop for exactly this path.
-    document.querySelectorAll('[data-fui-carousel]').forEach(function (c) {
-      if (typeof c._fuiCarouselStop === 'function') {
-        c._fuiCarouselStop();
-        delete c._fuiCarouselStop;
+  // Teardown for autorotate carousels that left the document. The DOM
+  // swap runs BEFORE gofastr:navigate dispatches (runtime.js: swapAtSlot
+  // -> finishNav), so by the time any listener runs the previous page's
+  // carousels are detached and invisible to document.querySelectorAll.
+  // Walking the registry by isConnected is the only reliable signal —
+  // and it must NOT touch carousels that are still connected: one that
+  // lives in a shared layout layer outlives the swap and must keep
+  // rotating (scan() skips it below, its fuiCarouselBound guard makes a
+  // stop-then-rescan a permanent stop).
+  function pruneDetached() {
+    rotating.forEach(function (c) {
+      if (!c.isConnected && typeof c._fuiCarouselKill === 'function') {
+        c._fuiCarouselKill();
       }
     });
+  }
+  window.addEventListener('gofastr:navigate', function () {
+    pruneDetached();
     scan(document);
   });
+  // Same prune + wire for island/RPC swaps: core's MutationObserver
+  // re-runs every loaded module's scanner over inserted subtrees, which
+  // is both the teardown trigger for replaced carousels and the only
+  // wiring path for carousels arriving outside a full SPA navigation.
+  window.__gofastr = window.__gofastr || {};
+  window.__gofastr._moduleScanners = window.__gofastr._moduleScanners || {};
+  window.__gofastr._moduleScanners.carousel = function (root) {
+    pruneDetached();
+    scan(root);
+  };
   window.__gofastr = window.__gofastr || {};
   window.__gofastr.carousel = { rescan: scan };
+  // Loader contract (runtime.js loadModule): a module announces itself
+  // by setting loadedModules[name]; the MutationObserver scanner loop
+  // ONLY runs scanners whose flag is set. carousel.js never set it, so
+  // every _moduleScanners registration was dead code and
+  // loadModule('carousel') could not resolve from the cached flag.
+  (window.__gofastr.loadedModules ||= {}).carousel = true;
 })();

--- a/core-ui/runtime/src/fileupload.js
+++ b/core-ui/runtime/src/fileupload.js
@@ -19,94 +19,102 @@
   'use strict';
   function wireFileUploads(root) {
     const scope = root && root.querySelectorAll ? root : document;
-    const zones = scope.querySelectorAll('[data-fui-fileupload]');
-    for (const zone of zones) {
-      if (zone.__fuiWired) continue;
-      zone.__fuiWired = true;
-      const input = zone.querySelector('input[type="file"]');
-      if (!input) continue;
-      const filename = zone.querySelector('.ui-fileupload__filename');
-
-      const fmtBytes = (n) => {
-        if (n < 1024) return n + ' B';
-        if (n < 1024 * 1024) return (n / 1024).toFixed(1) + ' KB';
-        return (n / (1024 * 1024)).toFixed(2) + ' MB';
-      };
-      const render = () => {
-        if (!filename) return;
-        filename.innerHTML = '';
-        const files = input.files;
-        if (!files || files.length === 0) return;
-        filename.classList.add('is-populated');
-        // Thumbnail uses the first IMAGE in the set (not necessarily
-        // files[0] which could be a non-image like a doc submitted
-        // alongside screenshots). One FileReader per pick keeps
-        // payload small even with 50 photos.
-        const firstImage = Array.from(files).find(f => f.type && f.type.startsWith('image/'));
-        if (firstImage) {
-          const img = document.createElement('img');
-          img.className = 'ui-fileupload__thumb';
-          img.alt = '';
-          const reader = new FileReader();
-          reader.onload = (e) => { img.src = e.target.result; };
-          reader.readAsDataURL(firstImage);
-          filename.appendChild(img);
-        }
-        const list = document.createElement('ul');
-        list.className = 'ui-fileupload__list';
-        for (const f of files) {
-          const li = document.createElement('li');
-          li.textContent = f.name + ' · ' + fmtBytes(f.size);
-          list.appendChild(li);
-        }
-        filename.appendChild(list);
-      };
-      input.addEventListener('change', render);
-      // Initial render for SSR-restored states (some browsers
-      // restore input.files on back-nav).
-      render();
-
-      // Dragover state is added to the zone itself (always) AND to
-      // any owning component wrapper (ui-fileupload / ui-dropzone /
-      // …) so each component's stylesheet can style whichever it
-      // prefers. The wrapper-class lookup walks the closest matching
-      // [data-fui-comp^="ui-"] ancestor.
-      const wrapperFor = (el) => el.closest('[data-fui-comp]');
-      const onEnter = (e) => {
-        e.preventDefault();
-        zone.classList.add('is-dragover');
-        wrapperFor(zone)?.classList.add('is-dragover');
-      };
-      const onLeave = (e) => {
-        e.preventDefault();
-        // dragleave fires when moving to a child, guard via relatedTarget.
-        if (zone.contains(e.relatedTarget)) return;
-        zone.classList.remove('is-dragover');
-        wrapperFor(zone)?.classList.remove('is-dragover');
-      };
-      const onDrop = (e) => {
-        e.preventDefault();
-        zone.classList.remove('is-dragover');
-        wrapperFor(zone)?.classList.remove('is-dragover');
-        const files = e.dataTransfer && e.dataTransfer.files;
-        if (!files || files.length === 0) return;
-        if (input.disabled) return;
-        // Assign via DataTransfer so the input's `files` becomes the
-        // dropped list, input.files is read-only except through a
-        // DataTransfer object.
-        const dt = new DataTransfer();
-        for (const f of files) {
-          if (!input.multiple && dt.items.length > 0) break;
-          dt.items.add(f);
-        }
-        input.files = dt.files;
-        input.dispatchEvent(new Event('change', { bubbles: true }));
-      };
-      zone.addEventListener('dragenter', onEnter);
-      zone.addEventListener('dragover', onEnter);
-      zone.addEventListener('dragleave', onLeave);
-      zone.addEventListener('drop', onDrop);
+    // The MutationObserver scanner path passes each INSERTED node as
+    // root; a zone inserted as that node itself (island / RPC innerHTML
+    // swap on an in-document element) is not its own descendant, so test
+    // the root before scanning below it.
+    if (scope !== document && scope.matches && scope.matches('[data-fui-fileupload]')) {
+      wireZone(scope);
     }
+    scope.querySelectorAll('[data-fui-fileupload]').forEach(wireZone);
+  }
+
+  function wireZone(zone) {
+    if (zone.__fuiWired) return;
+    zone.__fuiWired = true;
+    const input = zone.querySelector('input[type="file"]');
+    if (!input) return;
+    const filename = zone.querySelector('.ui-fileupload__filename');
+
+    const fmtBytes = (n) => {
+      if (n < 1024) return n + ' B';
+      if (n < 1024 * 1024) return (n / 1024).toFixed(1) + ' KB';
+      return (n / (1024 * 1024)).toFixed(2) + ' MB';
+    };
+    const render = () => {
+      if (!filename) return;
+      filename.innerHTML = '';
+      const files = input.files;
+      if (!files || files.length === 0) return;
+      filename.classList.add('is-populated');
+      // Thumbnail uses the first IMAGE in the set (not necessarily
+      // files[0] which could be a non-image like a doc submitted
+      // alongside screenshots). One FileReader per pick keeps
+      // payload small even with 50 photos.
+      const firstImage = Array.from(files).find(f => f.type && f.type.startsWith('image/'));
+      if (firstImage) {
+        const img = document.createElement('img');
+        img.className = 'ui-fileupload__thumb';
+        img.alt = '';
+        const reader = new FileReader();
+        reader.onload = (e) => { img.src = e.target.result; };
+        reader.readAsDataURL(firstImage);
+        filename.appendChild(img);
+      }
+      const list = document.createElement('ul');
+      list.className = 'ui-fileupload__list';
+      for (const f of files) {
+        const li = document.createElement('li');
+        li.textContent = f.name + ' · ' + fmtBytes(f.size);
+        list.appendChild(li);
+      }
+      filename.appendChild(list);
+    };
+    input.addEventListener('change', render);
+    // Initial render for SSR-restored states (some browsers
+    // restore input.files on back-nav).
+    render();
+
+    // Dragover state is added to the zone itself (always) AND to
+    // any owning component wrapper (ui-fileupload / ui-dropzone /
+    // …) so each component's stylesheet can style whichever it
+    // prefers. The wrapper-class lookup walks the closest matching
+    // [data-fui-comp^="ui-"] ancestor.
+    const wrapperFor = (el) => el.closest('[data-fui-comp]');
+    const onEnter = (e) => {
+      e.preventDefault();
+      zone.classList.add('is-dragover');
+      wrapperFor(zone)?.classList.add('is-dragover');
+    };
+    const onLeave = (e) => {
+      e.preventDefault();
+      // dragleave fires when moving to a child, guard via relatedTarget.
+      if (zone.contains(e.relatedTarget)) return;
+      zone.classList.remove('is-dragover');
+      wrapperFor(zone)?.classList.remove('is-dragover');
+    };
+    const onDrop = (e) => {
+      e.preventDefault();
+      zone.classList.remove('is-dragover');
+      wrapperFor(zone)?.classList.remove('is-dragover');
+      const files = e.dataTransfer && e.dataTransfer.files;
+      if (!files || files.length === 0) return;
+      if (input.disabled) return;
+      // Assign via DataTransfer so the input's `files` becomes the
+      // dropped list, input.files is read-only except through a
+      // DataTransfer object.
+      const dt = new DataTransfer();
+      for (const f of files) {
+        if (!input.multiple && dt.items.length > 0) break;
+        dt.items.add(f);
+      }
+      input.files = dt.files;
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+    zone.addEventListener('dragenter', onEnter);
+    zone.addEventListener('dragover', onEnter);
+    zone.addEventListener('dragleave', onLeave);
+    zone.addEventListener('drop', onDrop);
   }
 
   // Module-level registration:

--- a/core-ui/runtime/src/taginput.js
+++ b/core-ui/runtime/src/taginput.js
@@ -96,6 +96,12 @@
   document.addEventListener('keydown', function (ev) {
     const t = ev.target;
     if (!t || !t.matches || !t.matches('input[data-fui-tag-input]')) return;
+    // IME composition (CJK input): the Enter that confirms a conversion
+    // candidate carries isComposing=true and the field still holds the
+    // pre-conversion text. Committing there ships the raw romaji/pinyin
+    // as a tag; let the composition finish instead. Same guard as
+    // widgethelpers.js submit-on-enter and shortcut.js.
+    if (ev.isComposing) return;
     if (ev.key === 'Enter' || ev.key === ',') {
       __fuiTagInputLastEnter = performance.now();
       ev.preventDefault();

--- a/core-ui/runtime/taginput_ime_e2e_test.go
+++ b/core-ui/runtime/taginput_ime_e2e_test.go
@@ -1,0 +1,82 @@
+package runtime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// TestTagInputEnterDuringCompositionDoesNotCommit pins the IME contract
+// for the taginput module: the Enter that CONFIRMS a composition candidate
+// (Japanese kana→kanji, Chinese pinyin, Korean) must not commit a tag.
+// During composition, keydown carries isComposing=true and the field holds
+// the pre-conversion text; committing there both ships the raw romaji /
+// pinyin as a tag and clears the composition.
+//
+// The repo already holds this contract for the other Enter handlers:
+// src/widgethelpers.js (submit-on-enter) and src/shortcut.js both return
+// on e.isComposing. taginput.js's keydown handler is the one Enter path
+// that never got the guard.
+//
+// The synthetic event sets isComposing in the KeyboardEventInit dict,
+// which Chrome honours, and a compositionstart is dispatched first so the
+// field is observably mid-composition.
+func TestTagInputEnterDuringCompositionDoesNotCommit(t *testing.T) {
+	g := startGadgetServer(t, `[]`, tagInputPage)
+	ctx := newSeedBrowserCtx(t)
+
+	var afterCompose, afterPlain, composingEcho string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(g.Srv.URL+"/"),
+		chromedp.WaitVisible(`#tags`, chromedp.ByID),
+		chromedp.Sleep(600*time.Millisecond),
+
+		// Echo back what the browser did with the init dict, so a
+		// browser that drops isComposing fails the fixture check
+		// instead of vacuously passing the commit assertion.
+		chromedp.Evaluate(`(function(){
+			var seen = null;
+			document.addEventListener('keydown', function (e) { seen = e.isComposing; }, { capture: true, once: true });
+			document.getElementById('tags').dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', isComposing: true, bubbles: true, cancelable: true }));
+			return String(seen);
+		})()`, &composingEcho),
+
+		// Mid-composition Enter: field holds the pre-conversion text,
+		// composition is open. No tag may be committed.
+		chromedp.Evaluate(`(function(){
+			var el = document.getElementById('tags');
+			el.focus();
+			el.value = 'nihongo';
+			el.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+			el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', isComposing: true, bubbles: true, cancelable: true }));
+		})()`, nil),
+		chromedp.Sleep(120*time.Millisecond),
+		chromedp.Evaluate(`String(document.querySelectorAll('.ui-tag-input__chip').length)`, &afterCompose),
+
+		// Control: a plain Enter (no composition) must still commit —
+		// otherwise the fix over-reached and broke the primary contract.
+		chromedp.Evaluate(`(function(){
+			var el = document.getElementById('tags');
+			el.focus();
+			el.value = 'committed';
+			el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', isComposing: false, bubbles: true, cancelable: true }));
+		})()`, nil),
+		chromedp.Sleep(120*time.Millisecond),
+		chromedp.Evaluate(`String(document.querySelectorAll('.ui-tag-input__chip').length)`, &afterPlain),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if composingEcho != "true" {
+		t.Fatalf("fixture: synthetic keydown did not carry isComposing=true (echo = %s); the commit assertion below would be vacuous", composingEcho)
+	}
+	// Page ships one SSR chip ("go"); the composing Enter must leave that
+	// count unchanged AND leave the text in the field.
+	if afterCompose != "1" {
+		t.Errorf("IME: Enter during composition committed a tag — chip count went 1 -> %s; the pre-conversion text must stay in the field until composition ends", afterCompose)
+	}
+	if afterPlain != "2" {
+		t.Errorf("control: plain Enter must still commit a tag — chip count = %s, want 2 (SSR 'go' + 'committed')", afterPlain)
+	}
+}

--- a/core-ui/runtime/upload_filename_e2e_test.go
+++ b/core-ui/runtime/upload_filename_e2e_test.go
@@ -1,0 +1,168 @@
+package runtime
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// framework/ui.FileDropzone emit (dropzone.go / fileupload.go): the
+// fileupload zone carries data-fui-fileupload + .ui-fileupload__filename,
+// the dropzone root carries data-fui-comp="ui-dropzone" + an input with
+// data-fui-dropzone-preview + a sibling [data-fui-dropzone-preview-for]
+// container. A filename is attacker-controlled (the uploader controls the
+// name of the file they pick), so the runtime must insert it as TEXT.
+const uploadFilenamePage = `
+<div class="ui-fileupload" data-fui-comp="ui-fileupload">
+  <label class="ui-fileupload__label" for="f1">Doc</label>
+  <div class="ui-fileupload__zone" data-fui-fileupload>
+    <input type="file" id="f1" name="f" class="ui-fileupload__input">
+    <p class="ui-fileupload__prompt">Drop files or click to browse</p>
+    <p class="ui-fileupload__filename" aria-live="polite"></p>
+  </div>
+</div>
+<div class="ui-dropzone" data-fui-comp="ui-dropzone">
+
+    <div class="ui-dropzone__zone" data-fui-fileupload="true">
+      <input type="file" id="dz1" name="photos" class="ui-dropzone__input" data-fui-dropzone-preview multiple>
+      <p class="ui-dropzone__prompt">Drop images</p>
+      <p class="ui-dropzone__filename"></p>
+    </div>
+  </label>
+  <div class="ui-dropzone__previews" data-fui-dropzone-preview-for="dz1" aria-live="polite"></div>
+</div>
+<div id="injhost"></div>`
+
+// setFilesFor assigns a single File with the given name/type to the input
+// via DataTransfer (input.files is read-only otherwise) and fires the
+// bubbling `change` event both runtime modules listen for.
+func setFilesFor(inputID, name, mimeType string) string {
+	return `(function(){
+		var input = document.getElementById('` + inputID + `');
+		var dt = new DataTransfer();
+		dt.items.add(new File(['x'], ` + jsQuote(name) + `, { type: '` + mimeType + `' }));
+		input.files = dt.files;
+		input.dispatchEvent(new Event('change', { bubbles: true }));
+	})()`
+}
+
+// TestUploadFilenameRenderedAsText pins that a hostile FILENAME lands in
+// the DOM as text, never as markup, on both upload surfaces:
+//
+//   - fileupload.js render() builds the list with li.textContent = name
+//   - dropzone.js updateFilename() writes .ui-dropzone__filename via
+//     textContent, and updatePreviews() sets img.alt (attribute) + a
+//     data: URL from FileReader — no HTML sink.
+//
+// The payload is a full element with an onerror handler and a quote
+// breakout prefix; if any of these paths ever switches to innerHTML /
+// insertAdjacentHTML, the browser parses the element, src=x 404s, and the
+// canary fires. The text assertions additionally pin that the raw name is
+// DISPLAYED (the user must see their real filename), so a fix cannot
+// pass by silently dropping the name.
+func TestUploadFilenameRenderedAsText(t *testing.T) {
+	g := startGadgetServer(t, `[]`, uploadFilenamePage)
+	ctx := newSeedBrowserCtx(t)
+
+	var fuText, fuEls, dzText, dzAlt, canary, prevCount string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(g.Srv.URL+"/"),
+		chromedp.WaitVisible(`#f1`, chromedp.ByID),
+		// Let the marker scan idle-load both the fileupload and
+		// dropzone modules (same budget the other module e2e tests use).
+		chromedp.Sleep(700*time.Millisecond),
+
+		// Hostile filenames: element + onerror + quote breakout, once
+		// as a non-image (fileupload list path) and once as an image
+		// (dropzone preview path).
+		chromedp.Evaluate(setFilesFor("f1", `<img src=x onerror="window.__fuXSS=1">.txt`, "text/plain"), nil),
+		chromedp.Evaluate(setFilesFor("dz1", `"><img src=x onerror="window.__dzXSS=1">.png`, "image/png"), nil),
+		chromedp.Sleep(150*time.Millisecond),
+
+		// fileupload: the filename list must carry the payload as text.
+		chromedp.Evaluate(`document.querySelector('.ui-fileupload__filename').textContent`, &fuText),
+		chromedp.Evaluate(`String(document.querySelectorAll('.ui-fileupload__filename img, .ui-fileupload__filename script, .ui-fileupload__filename iframe, .ui-fileupload__filename svg').length)`, &fuEls),
+		// dropzone: .ui-dropzone__filename text + the preview img's alt.
+		chromedp.Evaluate(`document.querySelector('.ui-dropzone__filename').textContent`, &dzText),
+		chromedp.Evaluate(`(document.querySelector('.ui-dropzone__previews img')||{}).alt || ''`, &dzAlt),
+		chromedp.Evaluate(`String(document.querySelectorAll('.ui-dropzone__previews img').length)`, &prevCount),
+		// Neither onerror may have executed.
+		chromedp.Evaluate(`String(window.__fuXSS || window.__dzXSS || 'clean')`, &canary),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	wantFU := `<img src=x onerror="window.__fuXSS=1">.txt`
+	if !strings.Contains(fuText, wantFU) {
+		t.Errorf("fileupload: hostile filename not displayed as literal text — textContent = %q", fuText)
+	}
+	if fuEls != "0" {
+		t.Errorf("fileupload: filename region parsed %s element(s) out of the file name — HTML sink on the filename path", fuEls)
+	}
+	wantDZ := `"><img src=x onerror="window.__dzXSS=1">.png`
+	if !strings.Contains(dzText, wantDZ) {
+		t.Errorf("dropzone: hostile filename not displayed as literal text — textContent = %q", dzText)
+	}
+	if prevCount != "1" {
+		t.Errorf("dropzone: expected 1 preview img for the image file, got %s", prevCount)
+	}
+	if !strings.Contains(dzAlt, wantDZ) {
+		t.Errorf("dropzone: preview alt does not carry the raw filename (alt = %q)", dzAlt)
+	}
+	if canary != "clean" {
+		t.Errorf("XSS: onerror executed from a filename — canary = %s", canary)
+	}
+}
+
+// jsQuote renders a Go string as a JS string literal (the payload
+// contains both quote styles, so build it via JSON encoding).
+func jsQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// TestFileUploadZoneInjectedAfterLoadGetsWired pins the MutationObserver
+// scanner path for fileupload zones. wireFileUploads is called with each
+// INSERTED node as root; a zone inserted as that node itself (island /
+// RPC innerHTML swap) is not its own descendant, so the scanner must
+// test the root element too. Observable without the fix: the zone is
+// never wired, the change listener is never attached, and the filename
+// list never renders.
+func TestFileUploadZoneInjectedAfterLoadGetsWired(t *testing.T) {
+	g := startGadgetServer(t, `[]`, uploadFilenamePage)
+	ctx := newSeedBrowserCtx(t)
+
+	var injText, injBound string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(g.Srv.URL+"/"),
+		chromedp.WaitVisible(`#f1`, chromedp.ByID),
+		// Both modules loaded + initial zones wired.
+		chromedp.Sleep(700*time.Millisecond),
+
+		// Island-swap shape: fill an element that is ALREADY in the
+		// document (how sse.js and rpc signal swaps apply island HTML:
+		// el.innerHTML = html). Appending a fresh wrapper and filling
+		// it in the same task would hand the observer a wrapper-record
+		// whose descendants include the zone — a different, working
+		// path that hides the gap this test pins.
+		chromedp.Evaluate(`document.getElementById('injhost').innerHTML = '<div class="ui-fileupload__zone" data-fui-fileupload>' +
+			'<input type="file" id="f9" name="g">' +
+			'<p class="ui-fileupload__filename" aria-live="polite"></p></div>'`, nil),
+		chromedp.Evaluate(setFilesFor("f9", `injected.txt`, "text/plain"), nil),
+		chromedp.Sleep(150*time.Millisecond),
+		chromedp.Evaluate(`String(document.getElementById('f9').closest('[data-fui-fileupload]').__fuiWired === true)`, &injBound),
+		chromedp.Evaluate(`document.getElementById('f9').closest('[data-fui-fileupload]').querySelector('.ui-fileupload__filename').textContent`, &injText),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if injBound != "true" {
+		t.Errorf("injected fileupload zone was not wired — __fuiWired = %s, want true (the MutationObserver scanner passes the inserted zone itself as root; it is not its own descendant)", injBound)
+	}
+	if !strings.Contains(injText, "injected.txt") {
+		t.Errorf("injected zone is dead: filename textContent = %q, want it to list injected.txt", injText)
+	}
+}

--- a/core-ui/widget/theme/page.go
+++ b/core-ui/widget/theme/page.go
@@ -60,7 +60,7 @@ func PageCSS(t style.Theme) string {
 			"background", "{colors.background}",
 			"color", "{colors.text}",
 			"font-family", "{fonts.body}",
-			"font-size", "16px",
+			"font-size", "{typography.base}",
 			"line-height", "1.5",
 			"-webkit-font-smoothing", "antialiased",
 		).
@@ -127,7 +127,7 @@ func PageCSS(t style.Theme) string {
 		Set(
 			"text-transform", "uppercase",
 			"letter-spacing", "0.08em",
-			"font-size", "0.75rem",
+			"font-size", "{typography.xs}",
 			"font-weight", "700",
 			"color", "{colors.text}",
 			"margin", "0 0 {spacing.sm}",
@@ -135,7 +135,7 @@ func PageCSS(t style.Theme) string {
 		End()
 	ss.Rule(".kiln-display").Set("font-size", "3rem", "font-weight", "700").End()
 	ss.Rule(".kiln-title").Set("font-size", "2.25rem", "font-weight", "700").End()
-	ss.Rule(".kiln-h2").Set("font-size", "1.5rem", "font-weight", "700").End()
+	ss.Rule(".kiln-h2").Set("font-size", "{typography.2xl}", "font-weight", "700").End()
 
 	// Hero.
 	ss.Rule(".kiln-hero").
@@ -224,7 +224,7 @@ func PageCSS(t style.Theme) string {
 			"border", "1px solid {colors.border}",
 			"border-radius", "999px",
 			"padding", "4px 10px",
-			"font-size", "0.75rem",
+			"font-size", "{typography.xs}",
 			"font-weight", "600",
 			"color", "{colors.text-muted}",
 		).
@@ -236,7 +236,7 @@ func PageCSS(t style.Theme) string {
 	// Quote.
 	ss.Rule(".kiln-quote").
 		Set(
-			"font-size", "1.5rem",
+			"font-size", "{typography.2xl}",
 			"line-height", "1.5",
 			"color", "{colors.text}",
 			"font-weight", "500",

--- a/core-ui/widget/theme/page_test.go
+++ b/core-ui/widget/theme/page_test.go
@@ -72,3 +72,44 @@ func head(s string, n int) string {
 	}
 	return s[:n]
 }
+
+// A font size set from a token must follow that token when it is swapped.
+//
+// The rules used to hardcode the values: `.kiln-eyebrow` said "0.75rem"
+// where the theme declares XS as exactly that, `.kiln-h2` said "1.5rem"
+// against XXL, and `body.kiln-app` said "16px" against Base. The colors in
+// the same file already went through {colors.*}, so the mechanism was
+// present and the sizes simply bypassed it — the package doc promises "a
+// single token swap re-skins the whole app", and these rules did not move.
+//
+// This asserts the PROPERTY rather than the spelling: change the token's
+// value and the emitted CSS must change with it. Asserting that
+// "var(--text-xs)" appears somewhere would pass just as well against a
+// rule that never reads it.
+func TestPageCSSFontSizesFollowTypographyTokens(t *testing.T) {
+	base := theme.PageCSS(theme.PageTheme())
+	for _, lit := range []string{`font-size: 0.75rem`, `font-size: 1.5rem`, `font-size: 16px`} {
+		if strings.Contains(base, lit) {
+			t.Errorf("emitted CSS still hardcodes %q; it maps exactly onto a declared typography token", lit)
+		}
+	}
+
+	swapped := theme.PageTheme()
+	swapped.Typography.XS = style.FontSize{Name: "xs", Value: "0.1rem"}
+	swapped.Typography.XXL = style.FontSize{Name: "2xl", Value: "9.9rem"}
+	swapped.Typography.Base = style.FontSize{Name: "base", Value: "5.5rem"}
+	got := theme.PageCSS(swapped)
+
+	for _, want := range []string{"0.1rem", "9.9rem", "5.5rem"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("swapping a typography token did not reach the emitted CSS: %q absent", want)
+		}
+	}
+	// And the old values must be gone from the declarations they came from,
+	// or the swap only added a variable nothing reads.
+	for _, gone := range []string{"--text-xs: 0.75rem", "--text-2xl: 1.5rem"} {
+		if strings.Contains(got, gone) {
+			t.Errorf("token declaration %q survived the swap", gone)
+		}
+	}
+}

--- a/core/markdown/dos_security_test.go
+++ b/core/markdown/dos_security_test.go
@@ -184,23 +184,40 @@ func TestMarkdown_DistinctBacktickRunLengthsBounded(t *testing.T) {
 	// Absolute backstop: ~1 MB of adversarial runs renders in budget.
 	renderWithin(t, "distinct-length backtick runs", distinctRuns(1414), 1500*time.Millisecond)
 
-	// Machine-independent assertion: quadrupling the input (k ×4 → n ×4)
-	// must cost ≈4×, not the 8× of O(n^1.5).
-	if testing.Short() {
-		t.Skip("timing test")
-	}
-	var prev time.Duration
-	for i, k := range []int{350, 700, 1400} {
-		start := time.Now()
-		_ = RenderHTML(distinctRuns(k))
-		elapsed := time.Since(start)
-		t.Logf("k=%d n=%d took %v", k, 4*k*k, elapsed)
-		if i > 0 && prev > 0 {
-			ratio := float64(elapsed) / float64(prev)
-			if ratio > 6 {
-				t.Fatalf("SECURITY: [markdown] render time grew %.1fx on a 4x input — super-linear (distinct-length unmatched backtick runs)", ratio)
-			}
-		}
-		prev = elapsed
-	}
+	// What is NOT guarded here, stated plainly rather than pretended.
+	//
+	// The absolute backstop above is the whole gate. There is no scaling
+	// assertion for this shape, because two attempts at one were each worse
+	// than none:
+	//
+	//  1. A ratio ladder (k = 350, 700, 1400) passed here at 1.46x then
+	//     3.45x and FAILED on CI at 4.8x then 10x on identical code. What
+	//     the large step measures on a shared runner is the allocator, not
+	//     the parser. This repo already carries two tickets for flaky
+	//     blocking checks; a third is not an improvement.
+	//     (That ladder also logged "n = 4k²" while distinctRuns(k) is
+	//     ≈ k²/2 bytes — it overstated its own inputs 8x, which is why it
+	//     looked like it was exercising 7.84 MB when k=1400 is ~1 MB.)
+	//
+	//  2. Normalising against a benign render of the same length in the
+	//     same process fixes the machine-dependence but is not sensitive:
+	//     replacing the run index with a linear scan — the exact regression
+	//     it would exist to catch — moved the adversarial render from
+	//     0.47x to 1.12x of benign. Any ceiling loose enough to survive CI
+	//     is far too loose to catch that.
+	//
+	// The residual is second-order: K distinct run lengths need ≈K²/2 bytes
+	// and cost one scan each, so it is O(n^1.5) in the pre-index code, not
+	// quadratic. At the sizes a real document reaches, that is milliseconds
+	// either way — which is exactly why wall-clock cannot separate them, and
+	// also why it is not urgent.
+	//
+	// Reference numbers on an M4 Pro at n≈982 KB, for comparing a future
+	// regression against rather than guessing:
+	//
+	//	pre-fix (per-position tail rescan)  552 ms
+	//	whole-run skip only                 ~6.8x growth per 4x input
+	//	with the run index                  1.1 ms   (benign text: 2.4 ms)
+	//
+	// A gate for this wants an operation counter, not a clock.
 }

--- a/core/markdown/dos_security_test.go
+++ b/core/markdown/dos_security_test.go
@@ -141,11 +141,46 @@ func TestMarkdown_UnpairedBacktickTailBounded(t *testing.T) {
 // the assertion, independent of machine speed: doubling the input must not
 // quadruple the render time. Timing-ratio tests are coarse, so the ratio
 // threshold is generous (linear ≈ 2×, quadratic = 4×).
+//
+// The sizes moved up 32× when the code-span fix landed, and the reason is
+// worth keeping: the fix made this path about 100× faster, and the old
+// 8–64 KiB ladder then ran entirely under 200 µs, where a ratio measures
+// the scheduler rather than the algorithm. It failed CI at
+// 33 µs → 55 µs → 225 µs — "4.1× growth" that is 170 µs of noise. A test
+// can be outgrown by the code it guards.
+//
+// At 256 KiB and up the work is back above the clock's reach. Measured
+// after the fix (M4 Pro, best of 5): 256 KiB 730 µs, 1 MiB 3.30 ms,
+// 4 MiB 12.2 ms — clean 4× per 4× step.
+//
+// Verified against the real pre-fix implementation rather than a mutation.
+// That distinction cost two wrong attempts and is worth recording: undoing
+// the whole-run skip leaves the run index in place (still O(n log n), test
+// passes), and replacing the index lookup with a "linear scan" scans RUNS,
+// not tail bytes, so it stays linear too. Neither reproduces the old cost
+// model, because the fix changed findCodeEnd's shape rather than its
+// constant. Restoring core/markdown/inline.go from before the fix does:
+//
+//	run=262144 took 41.2s
+//	run=524288 took 2m47s   → 4.1× on a 2× input, FAIL
+//
+// The firstShotCeiling below exists because of those numbers: without it a
+// regression takes ~3.5 minutes to surface, since the ratio needs two
+// measurements and the second is the expensive one. The ceiling is ~2700×
+// the correct time at this size, so only a genuine complexity change trips
+// it, and it aborts in ~40s instead.
 func TestMarkdown_UnpairedBacktickTailScaling(t *testing.T) {
 	if testing.Short() {
 		t.Skip("timing test")
 	}
-	sizes := []int{8 * 1024, 16 * 1024, 32 * 1024, 64 * 1024}
+	// A quadratic regression spends 41s on the FIRST size, so waiting for
+	// the ratio means waiting for the second one too. Correct is ~1 ms
+	// here; this ceiling is roughly 2700× that, far outside anything a slow
+	// or loaded runner produces and far inside the 41s a real regression
+	// takes.
+	const firstShotCeiling = 3 * time.Second
+
+	sizes := []int{256 * 1024, 512 * 1024, 1024 * 1024, 2048 * 1024}
 	var prev time.Duration
 	for i, sz := range sizes {
 		in := "a" + strings.Repeat("`", sz) + strings.Repeat("x", sz)
@@ -153,6 +188,9 @@ func TestMarkdown_UnpairedBacktickTailScaling(t *testing.T) {
 		_ = RenderHTML(in)
 		elapsed := time.Since(start)
 		t.Logf("run=%d tail=%d took %v", sz, sz, elapsed)
+		if i == 0 && elapsed > firstShotCeiling {
+			t.Fatalf("SECURITY: [markdown] %d-byte run+tail took %v, over the %v ceiling — a linear renderer needs about a millisecond here, so this is a complexity regression, not a slow machine", sz, elapsed, firstShotCeiling)
+		}
 		if i > 0 && prev > 0 {
 			ratio := float64(elapsed) / float64(prev)
 			if ratio > 3.5 {

--- a/core/markdown/dos_security_test.go
+++ b/core/markdown/dos_security_test.go
@@ -1,6 +1,7 @@
 package markdown
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -220,4 +221,37 @@ func TestMarkdown_DistinctBacktickRunLengthsBounded(t *testing.T) {
 	//	with the run index                  1.1 ms   (benign text: 2.4 ms)
 	//
 	// A gate for this wants an operation counter, not a clock.
+}
+
+// TestMarkdown_GiantBacktickRunNoInt32Wrap pins that offsets into a block
+// are not narrowed to int32 on the way into the backtick-run index.
+// buildBacktickRuns stored starts and lengths as int32 while Render imposes
+// no document-size limit, so a block over math.MaxInt32 wrapped them: a
+// single backtick run of 2^31+2 made lens negative, findCodeEnd returned a
+// negative "open", and the caller sliced input[i+open:end] — a panic in the
+// render goroutine, the same crash class TestMarkdown_MalformedTableNoPanic
+// pins. Offsets stay int end to end now; this test holds that line.
+//
+// The input is a >2 GiB allocation, so the test opts in via
+// MARKDOWN_BIGINPUT=1 rather than running in every suite (the green path
+// is one linear pass plus one bulk write; measured 2.1s and a 6.2 GiB
+// peak RSS on a 48 GB M4 Pro). The leading 'x' keeps the line off the
+// fence classifier: a line beginning with ``` is a fence and never
+// reaches the inline path.
+func TestMarkdown_GiantBacktickRunNoInt32Wrap(t *testing.T) {
+	if os.Getenv("MARKDOWN_BIGINPUT") == "" {
+		t.Skip("allocates a >2 GiB block; opt in with MARKDOWN_BIGINPUT=1")
+	}
+	runLen := 1<<31 + 2
+	input := "x" + strings.Repeat("`", runLen)
+	doc := Render(input)
+	got := string(doc.HTML)
+	// The giant run has no same-length closer, so CommonMark leaves it
+	// literal text: one paragraph, escaped (backticks need no escaping).
+	if !strings.HasPrefix(got, "<p>x``") || !strings.HasSuffix(got, "```</p>\n") {
+		t.Fatalf("render mangled the giant run: prefix %q suffix %q", got[:16], got[len(got)-16:])
+	}
+	if want := len("<p>x") + runLen + len("</p>\n"); len(got) != want {
+		t.Fatalf("len(doc.HTML) = %d, want %d", len(got), want)
+	}
 }

--- a/core/markdown/dos_security_test.go
+++ b/core/markdown/dos_security_test.go
@@ -277,7 +277,7 @@ func TestMarkdown_DistinctBacktickRunLengthsBounded(t *testing.T) {
 // fence classifier: a line beginning with ``` is a fence and never
 // reaches the inline path.
 func TestMarkdown_GiantBacktickRunNoInt32Wrap(t *testing.T) {
-	if os.Getenv("MARKDOWN_BIGINPUT") == "" {
+	if os.Getenv("MARKDOWN_BIGINPUT") != "1" {
 		t.Skip("allocates a >2 GiB block; opt in with MARKDOWN_BIGINPUT=1")
 	}
 	runLen := 1<<31 + 2

--- a/core/markdown/dos_security_test.go
+++ b/core/markdown/dos_security_test.go
@@ -96,3 +96,111 @@ func TestMarkdown_NestedInlineBounded(t *testing.T) {
 	nestedEm := strings.Repeat("*", n) + "x" + strings.Repeat("*", n)
 	renderWithin(t, "nested emphasis", nestedEm, 1500*time.Millisecond)
 }
+
+// TestMarkdown_UnpairedBacktickTailBounded pins linear cost for an unpaired
+// backtick run followed by a long non-backtick tail.
+//
+// renderInlineDepth's '`' branch called findCodeEnd(input, i) at EVERY
+// position of a run that has no closer. findCodeEnd counts the remaining
+// run (open), starts scanning at i+open — i.e. at the END of the run — and
+// then walks the whole tail looking for a matching run that does not exist.
+// It fails, the main loop advanced by ONE byte, and the next position of
+// the same run rescanned the same tail. A run of L backticks followed by a
+// tail of T non-backtick bytes costs L×T: quadratic. (Fixed by consuming
+// the whole unmatched run; see the '`' case in renderInlineDepth for why
+// the emphasis branch's noCloser memo cannot be reused here.)
+//
+// A line BEGINNING with ``` is a fence and never reaches the inline path,
+// so the attack prefixes one ordinary character. Attack input is one line,
+// so it is one paragraph, one renderInline call.
+//
+// Measured before the fix existed (M4 Pro):
+//
+//	run=32000 tail=32000 (64 KiB) → 639 ms   (2.6 ms at 4 KiB, 4× each doubling)
+//
+// A 1 MiB request body would hold the render goroutine for minutes.
+func TestMarkdown_UnpairedBacktickTailBounded(t *testing.T) {
+	// Happy path: a paired code span still renders.
+	if got := string(RenderHTML("a `code` b")); !strings.Contains(got, "<code>code</code>") {
+		t.Fatalf("expected inline code to render, got: %s", got)
+	}
+	// And an unpaired run still renders literally, not dropped.
+	if got := string(RenderHTML("a `` unclosed")); strings.Contains(got, "<code>") {
+		t.Fatalf("unpaired backticks must not open a code span: %s", got)
+	}
+
+	// Attack: 48 KiB run + 48 KiB tail ≈ 96 KiB on one line. Quadratic
+	// behaviour costs well over the budget (≈3.6 s measured); a linear
+	// renderer finishes in single-digit milliseconds.
+	attack := "a" + strings.Repeat("`", 48*1024) + strings.Repeat("x", 48*1024)
+	renderWithin(t, "unpaired backtick run + tail", attack, 1500*time.Millisecond)
+}
+
+// TestMarkdown_UnpairedBacktickTailScaling makes the super-linearity itself
+// the assertion, independent of machine speed: doubling the input must not
+// quadruple the render time. Timing-ratio tests are coarse, so the ratio
+// threshold is generous (linear ≈ 2×, quadratic = 4×).
+func TestMarkdown_UnpairedBacktickTailScaling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing test")
+	}
+	sizes := []int{8 * 1024, 16 * 1024, 32 * 1024, 64 * 1024}
+	var prev time.Duration
+	for i, sz := range sizes {
+		in := "a" + strings.Repeat("`", sz) + strings.Repeat("x", sz)
+		start := time.Now()
+		_ = RenderHTML(in)
+		elapsed := time.Since(start)
+		t.Logf("run=%d tail=%d took %v", sz, sz, elapsed)
+		if i > 0 && prev > 0 {
+			ratio := float64(elapsed) / float64(prev)
+			if ratio > 3.5 {
+				t.Fatalf("SECURITY: [markdown] render time grew %.1fx on a 2x input — super-linear (unpaired backtick run + tail, findCodeEnd rescans the tail per run position)", ratio)
+			}
+		}
+		prev = elapsed
+	}
+}
+
+// TestMarkdown_DistinctBacktickRunLengthsBounded pins the second-order
+// shape: many backtick runs of DISTINCT lengths (1, 2, 3, … K), none with
+// a same-length closer. Skipping the whole unmatched run (the fix for the
+// single-run quadratic above) still leaves one full-tail scan per distinct
+// length: K runs need K(K+1)/2 bytes, so K scans over ~K²/2 bytes cost
+// O(n^1.5) — measured 552 ms on a 1 MB document. The backtick-run index
+// (buildBacktickRuns) turns closer lookups into binary searches so this
+// shape is linear too. A leading '*' also drives findClosingDelim's
+// code-span skipping across the same runs.
+func TestMarkdown_DistinctBacktickRunLengthsBounded(t *testing.T) {
+	distinctRuns := func(k int) string {
+		var sb strings.Builder
+		sb.WriteString("*")
+		for l := 1; l <= k; l++ {
+			sb.WriteString(strings.Repeat("`", l))
+			sb.WriteString("x")
+		}
+		return sb.String()
+	}
+	// Absolute backstop: ~1 MB of adversarial runs renders in budget.
+	renderWithin(t, "distinct-length backtick runs", distinctRuns(1414), 1500*time.Millisecond)
+
+	// Machine-independent assertion: quadrupling the input (k ×4 → n ×4)
+	// must cost ≈4×, not the 8× of O(n^1.5).
+	if testing.Short() {
+		t.Skip("timing test")
+	}
+	var prev time.Duration
+	for i, k := range []int{350, 700, 1400} {
+		start := time.Now()
+		_ = RenderHTML(distinctRuns(k))
+		elapsed := time.Since(start)
+		t.Logf("k=%d n=%d took %v", k, 4*k*k, elapsed)
+		if i > 0 && prev > 0 {
+			ratio := float64(elapsed) / float64(prev)
+			if ratio > 6 {
+				t.Fatalf("SECURITY: [markdown] render time grew %.1fx on a 4x input — super-linear (distinct-length unmatched backtick runs)", ratio)
+			}
+		}
+		prev = elapsed
+	}
+}

--- a/core/markdown/dos_security_test.go
+++ b/core/markdown/dos_security_test.go
@@ -180,14 +180,40 @@ func TestMarkdown_UnpairedBacktickTailScaling(t *testing.T) {
 	// takes.
 	const firstShotCeiling = 3 * time.Second
 
+	// Take the BEST of a few runs per size rather than one sample. A single
+	// shot on a shared runner measures whatever else the box was doing:
+	// CI produced 10.92ms at 256 KiB then 7.29ms at 512 KiB — the larger
+	// input FASTER than the smaller one — and the inflated first sample
+	// then made the next ratio read 3.7x. The minimum is the right
+	// estimator for "how fast can this go": noise only ever adds time, so
+	// the floor is the signal and everything above it is the machine.
+	const samples = 3
+	// Bails as soon as one sample is already over the ceiling: a quadratic
+	// regression spends ~41s per render here, and sampling it three times
+	// would triple the time to surface a failure the first sample already
+	// proves.
+	best := func(in string) time.Duration {
+		lo := time.Duration(1 << 62)
+		for i := 0; i < samples; i++ {
+			start := time.Now()
+			_ = RenderHTML(in)
+			d := time.Since(start)
+			if d < lo {
+				lo = d
+			}
+			if d > firstShotCeiling {
+				return d
+			}
+		}
+		return lo
+	}
+
 	sizes := []int{256 * 1024, 512 * 1024, 1024 * 1024, 2048 * 1024}
 	var prev time.Duration
 	for i, sz := range sizes {
 		in := "a" + strings.Repeat("`", sz) + strings.Repeat("x", sz)
-		start := time.Now()
-		_ = RenderHTML(in)
-		elapsed := time.Since(start)
-		t.Logf("run=%d tail=%d took %v", sz, sz, elapsed)
+		elapsed := best(in)
+		t.Logf("run=%d tail=%d best-of-%d %v", sz, sz, samples, elapsed)
 		if i == 0 && elapsed > firstShotCeiling {
 			t.Fatalf("SECURITY: [markdown] %d-byte run+tail took %v, over the %v ceiling — a linear renderer needs about a millisecond here, so this is a complexity regression, not a slow machine", sz, elapsed, firstShotCeiling)
 		}

--- a/core/markdown/inline.go
+++ b/core/markdown/inline.go
@@ -210,17 +210,20 @@ func findClosingDelim(runs *backtickRuns, s string, start int, delim byte, run i
 type backtickRuns struct {
 	// start/lens list each maximal run's start offset and full length, in
 	// document order. byLen maps a run length to the ascending starts of
-	// all runs with that length.
-	start []int32
-	lens  []int32
-	byLen map[int32][]int32
+	// all runs with that length. All three are int: Render caps no
+	// document size, so an int32 offset wraps on a block over
+	// math.MaxInt32 — a negative "open" reaches the caller and slices
+	// out of range (pinned by TestMarkdown_GiantBacktickRunNoInt32Wrap).
+	start []int
+	lens  []int
+	byLen map[int][]int
 }
 
 // buildBacktickRuns makes the index for s. Callers only build it when s
 // contains a backtick (strings.IndexByte gate), keeping backtick-free
 // blocks on the fast path.
 func buildBacktickRuns(s string) *backtickRuns {
-	b := &backtickRuns{byLen: make(map[int32][]int32)}
+	b := &backtickRuns{byLen: make(map[int][]int)}
 	for i := 0; i < len(s); {
 		if s[i] != '`' {
 			i++
@@ -230,10 +233,10 @@ func buildBacktickRuns(s string) *backtickRuns {
 		for j < len(s) && s[j] == '`' {
 			j++
 		}
-		l := int32(j - i)
-		b.start = append(b.start, int32(i))
+		l := j - i
+		b.start = append(b.start, i)
 		b.lens = append(b.lens, l)
-		b.byLen[l] = append(b.byLen[l], int32(i))
+		b.byLen[l] = append(b.byLen[l], i)
 		i = j
 	}
 	return b
@@ -246,15 +249,15 @@ func buildBacktickRuns(s string) *backtickRuns {
 // a backtick of a block this index was built for; mid-run positions use
 // the remaining suffix as the opener, the same rule a linear scan had.
 func (b *backtickRuns) findCodeEnd(i int) (end, open int) {
-	r := sort.Search(len(b.start), func(k int) bool { return b.start[k] > int32(i) }) - 1
+	r := sort.Search(len(b.start), func(k int) bool { return b.start[k] > i }) - 1
 	// Callers only query at backticks, so run r contains i.
-	open = int(b.start[r]+b.lens[r]) - i
-	starts := b.byLen[int32(open)]
-	k := sort.Search(len(starts), func(k int) bool { return starts[k] >= int32(i+open) })
+	open = b.start[r] + b.lens[r] - i
+	starts := b.byLen[open]
+	k := sort.Search(len(starts), func(k int) bool { return starts[k] >= i+open })
 	if k == len(starts) {
 		return -1, open
 	}
-	return int(starts[k]), open
+	return starts[k], open
 }
 
 // parseLink parses [text](url) starting at the '[' at position i.

--- a/core/markdown/inline.go
+++ b/core/markdown/inline.go
@@ -1,6 +1,7 @@
 package markdown
 
 import (
+	"sort"
 	"strings"
 	"unicode"
 )
@@ -36,6 +37,14 @@ func renderInlineDepth(input string, depth int) string {
 	// region), so we skip the rescan. This turns the unmatched-emphasis
 	// case from O(n^2) into O(n), a CPU-DoS guard.
 	var noCloser map[int]bool
+	// runs indexes the block's maximal backtick runs so code-span closer
+	// lookups are binary searches instead of tail scans. Built only when
+	// the block contains a backtick at all; see backtickRuns for why a
+	// scan-per-lookup is not just slow but a CPU-DoS on adversarial input.
+	var runs *backtickRuns
+	if strings.IndexByte(input, '`') >= 0 {
+		runs = buildBacktickRuns(input)
+	}
 	i := 0
 	for i < len(input) {
 		ch := input[i]
@@ -44,16 +53,26 @@ func renderInlineDepth(input string, depth int) string {
 			sb.WriteString(escapeHTML(string(input[i+1])))
 			i += 2
 		case ch == '`':
-			end := findCodeEnd(input, i)
-			if end > i {
+			end, open := runs.findCodeEnd(i)
+			if end >= 0 {
 				sb.WriteString("<code>")
-				sb.WriteString(escapeHTML(input[i+1 : end]))
+				sb.WriteString(escapeHTML(input[i+open : end]))
 				sb.WriteString("</code>")
-				i = end + 1
+				i = end + open
 				continue
 			}
-			sb.WriteString("`")
-			i++
+			// Unmatched run: the WHOLE run is literal text (CommonMark:
+			// a backtick string not closed by a matching run is literal).
+			// Consume the entire run, never one byte at a time. The next
+			// position of the same run would re-run findCodeEnd for a
+			// SHORTER length over the same tail, costing run × tail on
+			// adversarial input (measured 639 ms on a 64 KiB document
+			// before this skip). The emphasis branch's noCloser memo
+			// cannot be reused here: its key is the run length, and each
+			// successive position of a backtick run scans for a different
+			// length, so a memo keyed that way never hits.
+			sb.WriteString(input[i : i+open])
+			i += open
 		case ch == '!' && i+1 < len(input) && input[i+1] == '[':
 			alt, url, end, ok := parseLink(input, i+1)
 			if ok {
@@ -85,7 +104,7 @@ func renderInlineDepth(input string, depth int) string {
 			key := int(delim)<<2 | run
 			closeIdx := -1
 			if noCloser == nil || !noCloser[key] {
-				closeIdx = findClosingDelim(input, i+run, delim, run)
+				closeIdx = findClosingDelim(runs, input, i+run, delim, run)
 				if closeIdx < 0 {
 					if noCloser == nil {
 						noCloser = make(map[int]bool, 4)
@@ -144,15 +163,24 @@ func scanRun(s string, i int, delim byte) (byte, int) {
 // findClosingDelim looks for a matching delimiter run after position start.
 // CommonMark has a more complex flanking rule; we use a simple "next run of
 // the same length" search which works for everyday docs.
-func findClosingDelim(s string, start int, delim byte, run int) int {
+func findClosingDelim(runs *backtickRuns, s string, start int, delim byte, run int) int {
 	i := start
 	for i < len(s) {
 		if s[i] == '`' {
-			end := findCodeEnd(s, i)
-			if end > i {
-				i = end + 1
+			end, open := runs.findCodeEnd(i)
+			if end >= 0 {
+				i = end + open
 				continue
 			}
+			// Unmatched code-span opener: skip the entire run so the walk
+			// does not call findCodeEnd again from every backtick of the
+			// same run — each call would rescan the tail for a shorter
+			// length, the same run × tail blowup the main loop guards
+			// against. Skipping the closing run entirely (end + open, not
+			// end + 1) also stops the walk from re-entering a matched
+			// span's closing run mid-run.
+			i += open
+			continue
 		}
 		if s[i] == delim {
 			n := 0
@@ -170,29 +198,63 @@ func findClosingDelim(s string, start int, delim byte, run int) int {
 	return -1
 }
 
-// findCodeEnd returns the index of the closing backtick run that matches the
-// opening run starting at i. -1 if unbalanced.
-func findCodeEnd(s string, i int) int {
-	open := 0
-	for i+open < len(s) && s[i+open] == '`' {
-		open++
-	}
-	j := i + open
-	for j < len(s) {
-		if s[j] != '`' {
-			j++
+// backtickRuns indexes the maximal backtick runs of one block so that
+// code-span closer lookups are binary searches instead of forward scans.
+//
+// A scan-per-lookup is not merely slow, it is a CPU-DoS ladder: after the
+// whole-run skip in the caller, every DISTINCT run length can still fail
+// once, and each failure walks the remaining input. Runs of lengths
+// 1..K fit in ~K²/2 bytes, so K failing scans over that cost O(n·√n) —
+// measured 552 ms on a 1 MB document built as runs of 1..1414 backticks.
+// With the index, a lookup is O(log n) and the shape is linear.
+type backtickRuns struct {
+	// start/lens list each maximal run's start offset and full length, in
+	// document order. byLen maps a run length to the ascending starts of
+	// all runs with that length.
+	start []int32
+	lens  []int32
+	byLen map[int32][]int32
+}
+
+// buildBacktickRuns makes the index for s. Callers only build it when s
+// contains a backtick (strings.IndexByte gate), keeping backtick-free
+// blocks on the fast path.
+func buildBacktickRuns(s string) *backtickRuns {
+	b := &backtickRuns{byLen: make(map[int32][]int32)}
+	for i := 0; i < len(s); {
+		if s[i] != '`' {
+			i++
 			continue
 		}
-		n := 0
-		for j+n < len(s) && s[j+n] == '`' {
-			n++
+		j := i + 1
+		for j < len(s) && s[j] == '`' {
+			j++
 		}
-		if n == open {
-			return j
-		}
-		j += n
+		l := int32(j - i)
+		b.start = append(b.start, int32(i))
+		b.lens = append(b.lens, l)
+		b.byLen[l] = append(b.byLen[l], int32(i))
+		i = j
 	}
-	return -1
+	return b
+}
+
+// findCodeEnd returns the start index of the closing backtick run that
+// matches the opening run at i, together with that opening run's length
+// open (the matching closing run has the same length, so callers can skip
+// past both runs in full). end is -1 if no matching run exists. i must be
+// a backtick of a block this index was built for; mid-run positions use
+// the remaining suffix as the opener, the same rule a linear scan had.
+func (b *backtickRuns) findCodeEnd(i int) (end, open int) {
+	r := sort.Search(len(b.start), func(k int) bool { return b.start[k] > int32(i) }) - 1
+	// Callers only query at backticks, so run r contains i.
+	open = int(b.start[r]+b.lens[r]) - i
+	starts := b.byLen[int32(open)]
+	k := sort.Search(len(starts), func(k int) bool { return starts[k] >= int32(i+open) })
+	if k == len(starts) {
+		return -1, open
+	}
+	return int(starts[k]), open
 }
 
 // parseLink parses [text](url) starting at the '[' at position i.

--- a/core/markdown/markdown_test.go
+++ b/core/markdown/markdown_test.go
@@ -55,6 +55,29 @@ func TestParagraphAndInline(t *testing.T) {
 	}
 }
 
+// TestCodeSpanBacktickRuns pins multi-backtick code spans and the
+// unmatched-run rule. An opening run of N backticks closes only on a run
+// of exactly N; the span content excludes the whole opening run, and an
+// unmatched run is literal in its entirety (CommonMark 6.8: "a backtick
+// string that is not closed by a matching backtick string is literal").
+// Before this was pinned, content was sliced input[i+1:end], which only
+// fits a single-backtick opener: an input of a, two backticks, a, two
+// backticks, b rendered with an opener fragment inside the code element
+// and a stray closing-run backtick bleeding into the text after it.
+func TestCodeSpanBacktickRuns(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"``a``b", "<p><code>a</code>b</p>\n"},
+		{"a ``code with `inside` span`` b", "<p>a <code>code with `inside` span</code> b</p>\n"},
+		{"x ```y`` z", "<p>x ```y`` z</p>\n"},
+		{"a `` unclosed", "<p>a `` unclosed</p>\n"},
+	}
+	for _, c := range cases {
+		if got := string(RenderHTML(c.in)); got != c.want {
+			t.Errorf("code span mismatch for %q:\n got: %q\nwant: %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestFencedCodeEscapesHTML(t *testing.T) {
 	got := string(RenderHTML("```go\nfmt.Println(\"<hi>\")\n```\n"))
 	if !strings.Contains(got, `<pre tabindex="0"><code class="language-go">`) {

--- a/core/middleware/idempotency.go
+++ b/core/middleware/idempotency.go
@@ -29,8 +29,12 @@ const IdempotencyKeyHeader = "Idempotency-Key"
 //   - replay non-nil, ok=true: a cached response already exists for this
 //     key and fingerprint; the middleware should write replay back and
 //     skip the downstream handler.
-//   - replay nil, ok=true: the caller is the first writer for this key.
-//     It must call Finish exactly once with the captured response.
+//   - replay nil, ok=false, err=nil: the caller is the first writer for
+//     this key. It must call Finish exactly once with the captured
+//     response. (Both shipped stores return ok=false here, and the
+//     middleware's replay branch is `ok && replay != nil`, so ok=false is
+//     the contract. This line used to say ok=true, which no implementation
+//     and no caller has ever agreed with.)
 //   - ok=false, err=ErrFingerprintMismatch: same key was used previously
 //     with a different request fingerprint. The middleware responds 422.
 //   - ok=false, err=ErrInFlight: another request with the same key is

--- a/core/middleware/timeout.go
+++ b/core/middleware/timeout.go
@@ -269,6 +269,26 @@ func RouteTimeoutFromContext(ctx context.Context) (RouteTimeout, bool) {
 // replaces d for this request; a negative Budget skips the deadline
 // entirely. When the deadline fires on a buffered response, a structured
 // warning names the method, path, matched pattern, and budget.
+// handlerAlreadyFinished reports whether the handler closed done before the
+// deadline branch ran.
+//
+// It exists as a named function rather than an inline select so the
+// tie-break has a test seam. The race it settles cannot be reproduced from
+// outside — a select picks randomly only when both channels are ready at the
+// instant it is evaluated, and producing that overlap needs the middleware
+// goroutine descheduled across the deadline, which nothing outside the
+// runtime can arrange. So the RACE has no deterministic test, but the
+// DECISION does, and a decision nobody can make fail is the same untested
+// guard either way.
+func handlerAlreadyFinished(done <-chan struct{}) bool {
+	select {
+	case <-done:
+		return true
+	default:
+		return false
+	}
+}
+
 func Timeout(d time.Duration) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -404,14 +424,12 @@ func Timeout(d time.Duration) Middleware {
 				// The r.Context().Done() case above needs no equivalent:
 				// the client is gone, and delivering or abandoning both
 				// write to a socket nobody is reading.
-				select {
-				case <-done:
+				if handlerAlreadyFinished(done) {
 					if childPanic != nil {
 						panic(childPanic)
 					}
 					tw.finish()
 					return
-				default:
 				}
 				if abandon(context.DeadlineExceeded) {
 					// Name the route, not just the path: "why does this

--- a/core/middleware/timeout.go
+++ b/core/middleware/timeout.go
@@ -289,6 +289,27 @@ func handlerAlreadyFinished(done <-chan struct{}) bool {
 	}
 }
 
+// handlerBeatTheDeadline reports whether the handler finished, and finished
+// INSIDE its budget.
+//
+// The second half is the whole point. A closed done proves the handler is no
+// longer running; it says nothing about when it stopped. Delivering on a
+// closed channel alone hands a 200 to a handler that overran by any amount,
+// as long as this goroutine happened to be descheduled past its finish — the
+// deadline would then bound nothing whenever the scheduler was slow, which
+// is exactly when a deadline matters.
+//
+// finishedAt is written before close(done) and read only after receiving on
+// it, so the channel orders the two without a lock.
+func handlerBeatTheDeadline(done <-chan struct{}, finishedAt *time.Time, deadline time.Time) bool {
+	select {
+	case <-done:
+		return !finishedAt.After(deadline)
+	default:
+		return false
+	}
+}
+
 func Timeout(d time.Duration) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -340,11 +361,22 @@ func Timeout(d time.Duration) Middleware {
 			// because the parent's defer recover lives in a different
 			// goroutine.
 			var childPanic any
+			// finishedAt records when the handler returned, so the deadline
+			// branch can tell "finished inside the budget, and this
+			// goroutine was late to notice" from "finished after the
+			// deadline, while this goroutine was late". A closed done says
+			// only that the handler is no longer running; it does not say
+			// when it stopped, and the two cases deserve opposite answers.
+			// Written before close(done) and read only after it, which
+			// orders the two without a lock.
+			var finishedAt time.Time
+			deadline := time.Now().Add(effective)
 			go func() {
 				defer func() {
 					if v := recover(); v != nil {
 						childPanic = v
 					}
+					finishedAt = time.Now()
 					close(done)
 				}()
 				next.ServeHTTP(tw, r.WithContext(ctx))
@@ -424,7 +456,7 @@ func Timeout(d time.Duration) Middleware {
 				// The r.Context().Done() case above needs no equivalent:
 				// the client is gone, and delivering or abandoning both
 				// write to a socket nobody is reading.
-				if handlerAlreadyFinished(done) {
+				if handlerBeatTheDeadline(done, &finishedAt, deadline) {
 					if childPanic != nil {
 						panic(childPanic)
 					}

--- a/core/middleware/timeout.go
+++ b/core/middleware/timeout.go
@@ -281,6 +281,20 @@ func Timeout(d time.Duration) Middleware {
 				}
 				effective = rt.Budget
 			}
+			// Same rule for the constructor's own duration as for a route
+			// budget, and for the same reason: zero means no deadline, as
+			// it does in net/http. Without this, time.NewTimer(0) fires
+			// before the handler can finish and every request 504s — so
+			// `Timeout(cfg.RequestTimeout)` with the field unset turned
+			// the whole surface off rather than leaving it untimed. The
+			// framework's own wiring guards it (app.go only installs the
+			// middleware when RequestTimeout > 0), which is why nothing
+			// in-repo tripped it; a direct caller of the core API had no
+			// such cover.
+			if effective <= 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
 			ctx := newTimeoutCtx(r.Context())
 			// End-of-request cleanup: release the propagation callback
 			// and anyone still selecting on ctx.Done(). A context that
@@ -378,6 +392,27 @@ func Timeout(d time.Duration) Middleware {
 				// written for parity, observed by no one.
 				abandon(r.Context().Err())
 			case <-timer.C:
+				// A select whose cases are BOTH ready picks between them
+				// uniformly at random. When the handler closes done just
+				// inside the budget but this goroutine is descheduled past
+				// the deadline, that coin flip discards a finished response
+				// and 504s a request that succeeded — visible only under
+				// load, which is where a spurious 504 costs the most.
+				// The handler winning is the answer the client should get,
+				// so re-check done before abandoning.
+				//
+				// The r.Context().Done() case above needs no equivalent:
+				// the client is gone, and delivering or abandoning both
+				// write to a socket nobody is reading.
+				select {
+				case <-done:
+					if childPanic != nil {
+						panic(childPanic)
+					}
+					tw.finish()
+					return
+				default:
+				}
 				if abandon(context.DeadlineExceeded) {
 					// Name the route, not just the path: "why does this
 					// endpoint 504" starts from this line. Streaming

--- a/core/middleware/timeout_zero_test.go
+++ b/core/middleware/timeout_zero_test.go
@@ -163,6 +163,38 @@ func TestTimeoutDeadlineRaceProbe(t *testing.T) {
 	t.Logf("iterations=%d proven misfires=%d genuine overruns=%d", iters, misfires, overruns)
 }
 
+// The tie-break itself, at the seam.
+//
+// The RACE has no deterministic test (see the probe above). The DECISION
+// does, and that is the part that can regress: if handlerAlreadyFinished
+// stops reporting a closed done, the deadline branch discards finished
+// responses again. Removing the `case <-done` arm fails this.
+func TestHandlerAlreadyFinishedReportsAClosedDone(t *testing.T) {
+	closed := make(chan struct{})
+	close(closed)
+	if !handlerAlreadyFinished(closed) {
+		t.Error("a closed done must report the handler finished; the deadline branch would 504 a completed response")
+	}
+
+	open := make(chan struct{})
+	if handlerAlreadyFinished(open) {
+		t.Error("an open done must not report the handler finished; the deadline would never fire")
+	}
+
+	// Must not block on an open channel — the deadline path has to make
+	// progress whether or not the handler is done.
+	returned := make(chan bool, 1)
+	go func() { returned <- handlerAlreadyFinished(make(chan struct{})) }()
+	select {
+	case got := <-returned:
+		if got {
+			t.Error("an open done reported finished")
+		}
+	case <-time.After(time.Second):
+		t.Error("handlerAlreadyFinished blocked on an open done")
+	}
+}
+
 // The deadline still wins when the handler really did overrun, so the fix
 // above is a tie-break and not a disarm.
 func TestTimeoutStillAbandonsAnOverrunHandler(t *testing.T) {

--- a/core/middleware/timeout_zero_test.go
+++ b/core/middleware/timeout_zero_test.go
@@ -1,0 +1,191 @@
+package middleware
+
+// Two ways Timeout could 504 a request that did not time out.
+//
+// Both were found auditing #136's "never-looked" list. Neither is reachable
+// through the framework's own wiring — app.go installs the middleware only
+// when RequestTimeout > 0, and the deadline race needs the middleware
+// goroutine descheduled across the boundary — which is exactly why the
+// existing suite was green over both.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+// A zero duration means "no deadline" in net/http, and this file's own
+// route-budget path already reads it that way ("a negative Budget skips the
+// deadline entirely"). The constructor did not: time.NewTimer(0) fires
+// before the handler can run, so EVERY request 504d.
+//
+// The trap is a config field left unset — `Timeout(cfg.RequestTimeout)`
+// then turns the surface off rather than leaving it untimed, and it fails
+// closed on every request rather than loudly at startup.
+func TestTimeoutZeroOrNegativeMeansNoDeadline(t *testing.T) {
+	for _, d := range []time.Duration{0, -time.Second} {
+		t.Run(d.String(), func(t *testing.T) {
+			var served int
+			h := Timeout(d)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				served++
+				// Long enough that any live deadline of d would fire.
+				time.Sleep(20 * time.Millisecond)
+				w.WriteHeader(http.StatusOK)
+			}))
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("Timeout(%v) returned %d, want 200: a non-positive duration means no deadline, as it does for a route budget and in net/http", d, rec.Code)
+			}
+			if served != 1 {
+				t.Errorf("handler ran %d times, want 1", served)
+			}
+		})
+	}
+
+	// The route-override path, whose behaviour the constructor now matches.
+	// If these ever disagree again, the same value means two things in one
+	// file, which is how this got missed.
+	t.Run("route budget agrees", func(t *testing.T) {
+		h := Timeout(time.Minute)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req = req.WithContext(WithRouteTimeout(req.Context(), RouteTimeout{Budget: 0}))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("RouteTimeout{Budget:0} returned %d, want 200", rec.Code)
+		}
+	})
+
+	// The guard must not disarm a real deadline.
+	t.Run("a positive duration still times out", func(t *testing.T) {
+		h := Timeout(10 * time.Millisecond)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(2 * time.Second)
+			w.WriteHeader(http.StatusOK)
+		}))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+		if rec.Code != http.StatusGatewayTimeout {
+			t.Errorf("a hung handler under a 10ms budget returned %d, want 504", rec.Code)
+		}
+	})
+}
+
+// The deadline branch re-checks done before abandoning, because a select
+// whose cases are both ready picks between them at random. When the handler
+// RETURNS just inside the budget but the middleware goroutine is descheduled
+// past the deadline, that coin flip discards a finished response.
+//
+// This is a demonstration, not a regression gate, and the fix ships WITHOUT
+// a test that catches its removal. Both halves of that are worth stating.
+//
+// No deterministic version exists. A select picks randomly only when both
+// channels are ready at the moment it is *evaluated*; enter it earlier and
+// it blocks and wakes on the first one. Producing the overlap needs the
+// middleware goroutine descheduled across the deadline, which nothing
+// outside the runtime can arrange.
+//
+// And the occurrence is unconfirmed HERE. The hazard is certain — the Go
+// spec makes the ready-vs-ready choice uniform, so the branch is reachable
+// by construction — but with the re-check removed this probe found
+// 0 misfires in 4000 iterations under 10 CPU burners (~50 genuine overruns
+// per 2000, so the deadline was firing plenty). An audit worker reported
+// ~2 per 2000 on the same shape; that result is not reproduced here.
+// The one-line tie-break is kept because it cannot make anything worse and
+// the branch is reachable, not because a failure was observed.
+//
+// If you are reading this while chasing a spurious 504: run
+//
+//	GOFASTR_TIMEOUT_RACE_PROBE=1 go test ./core/middleware/ -run DeadlineRace
+//
+// under load, and note the instrument's one trap — the 504 path returns
+// while the handler is still running, so reading its elapsed time straight
+// after ServeHTTP reads zero for exactly the requests under test. Counting
+// those as overruns makes the probe blind to what it is looking for. That
+// is what the `finished` channel below is for; the first draft omitted it
+// and confidently reported 0 in 4000.
+func TestTimeoutDeadlineRaceProbe(t *testing.T) {
+	if os.Getenv("GOFASTR_TIMEOUT_RACE_PROBE") == "" {
+		t.Skip("load-dependent probe; set GOFASTR_TIMEOUT_RACE_PROBE=1")
+	}
+	const (
+		budget = 3 * time.Millisecond
+		work   = 2 * time.Millisecond
+		iters  = 2000
+	)
+	var misfires, overruns int
+	for i := 0; i < iters; i++ {
+		var mu sync.Mutex
+		var elapsed time.Duration
+		// The 504 path returns while the handler goroutine is still
+		// running, so reading elapsed straight after ServeHTTP reads zero
+		// for exactly the requests under test — and classifying those as
+		// overruns makes the probe blind to the thing it is looking for.
+		// (First draft did that and reported 0 misfires in 4000.)
+		finished := make(chan struct{})
+
+		h := Timeout(budget)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			time.Sleep(work)
+			w.WriteHeader(http.StatusOK)
+			mu.Lock()
+			elapsed = time.Since(start)
+			mu.Unlock()
+			close(finished)
+		}))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+		select {
+		case <-finished:
+		case <-time.After(time.Second):
+			t.Fatalf("iteration %d: handler never finished", i)
+		}
+		mu.Lock()
+		e := elapsed
+		mu.Unlock()
+		switch {
+		case rec.Code == http.StatusOK:
+		case e >= budget:
+			overruns++ // handler genuinely missed its budget
+		default:
+			misfires++
+			t.Errorf("handler returned in %v, inside the %v budget, and the client got 504", e, budget)
+		}
+	}
+	t.Logf("iterations=%d proven misfires=%d genuine overruns=%d", iters, misfires, overruns)
+}
+
+// The deadline still wins when the handler really did overrun, so the fix
+// above is a tie-break and not a disarm.
+func TestTimeoutStillAbandonsAnOverrunHandler(t *testing.T) {
+	released := make(chan struct{})
+	h := Timeout(10 * time.Millisecond)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-released
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		close(released)
+		t.Fatal("the middleware never returned for a hung handler")
+	}
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Errorf("hung handler returned %d, want 504", rec.Code)
+	}
+	close(released)
+	_ = context.Canceled
+}

--- a/core/middleware/timeout_zero_test.go
+++ b/core/middleware/timeout_zero_test.go
@@ -169,6 +169,50 @@ func TestTimeoutDeadlineRaceProbe(t *testing.T) {
 // does, and that is the part that can regress: if handlerAlreadyFinished
 // stops reporting a closed done, the deadline branch discards finished
 // responses again. Removing the `case <-done` arm fails this.
+// The tie-break must deliver only for a handler that finished INSIDE its
+// budget. A closed done alone would hand a 200 to a handler that overran by
+// any amount whenever this goroutine was descheduled past its finish — the
+// deadline would then bound nothing precisely when the scheduler is slow,
+// which is when it matters. Reviewed onto the PR that introduced the
+// tie-break; the first version checked only the channel.
+func TestHandlerBeatTheDeadlineComparesFinishTime(t *testing.T) {
+	deadline := time.Now()
+
+	t.Run("finished inside the budget is delivered", func(t *testing.T) {
+		done := make(chan struct{})
+		close(done)
+		fin := deadline.Add(-10 * time.Millisecond)
+		if !handlerBeatTheDeadline(done, &fin, deadline) {
+			t.Error("a handler that returned before the deadline must be delivered, not 504'd")
+		}
+	})
+
+	t.Run("finished after the deadline is not", func(t *testing.T) {
+		done := make(chan struct{})
+		close(done)
+		fin := deadline.Add(10 * time.Millisecond)
+		if handlerBeatTheDeadline(done, &fin, deadline) {
+			t.Error("a handler that overran its budget must still 504; delivering it makes the deadline bound nothing whenever this goroutine is descheduled")
+		}
+	})
+
+	t.Run("exactly on the deadline is delivered", func(t *testing.T) {
+		done := make(chan struct{})
+		close(done)
+		fin := deadline
+		if !handlerBeatTheDeadline(done, &fin, deadline) {
+			t.Error("finishing exactly at the deadline is not overrunning it")
+		}
+	})
+
+	t.Run("still running is never delivered", func(t *testing.T) {
+		var fin time.Time
+		if handlerBeatTheDeadline(make(chan struct{}), &fin, deadline) {
+			t.Error("an open done reported finished; the deadline would never fire")
+		}
+	})
+}
+
 func TestHandlerAlreadyFinishedReportsAClosedDone(t *testing.T) {
 	closed := make(chan struct{})
 	close(closed)

--- a/core/moduleproto/cancel_test.go
+++ b/core/moduleproto/cancel_test.go
@@ -1,0 +1,202 @@
+package moduleproto
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// module.cancel contract (issue #356). The two halves of this package used
+// to disagree about what CancelParams.RequestID is: methods.go called it
+// "what module.cancel references" (the proxy's "<module>-<counter>"
+// correlation id) while the child keyed its cancel registry by inbound
+// frame id and parsed RequestID with fmt.Sscanf("%d"). Together that made
+// module.cancel a silent no-op on the proxy path — the production shape
+// "notes-42" failed the decimal scan outright, so a client that aborted a
+// slow proxied request left the child burning CPU/DB until its own
+// deadline — and turned "1-anything" into a misroute that cancelled an
+// UNRELATED frame. The fix (audit record, 2026-09): the supervisor sends
+// the frame id [Peer.CallWithID] assigned, and the child parse is a strict
+// full-string decimal. The tests here pin both halves.
+
+// TestModuleCancelCancelsByFrameID pins the production shape end to end:
+// the originator cancels by the frame id CallWithID reported, and the
+// serving handler's context is aborted. This replaces the audit proof
+// TestModuleCancelAcceptsProductionRequestID, which pinned the same
+// workflow against the OLD mint ("<module>-<counter>") and was red from
+// the day it was written.
+func TestModuleCancelCancelsByFrameID(t *testing.T) {
+	host, child, _, _, cleanup := newPeerPair(t, 0)
+	defer cleanup()
+
+	cancelled := make(chan struct{}, 1)
+	if err := child.Handle("hang.until.cancelled", func(ctx context.Context, _ json.RawMessage) (any, error) {
+		select {
+		case <-ctx.Done():
+			cancelled <- struct{}{}
+			return nil, ctx.Err()
+		case <-time.After(5 * time.Second):
+			return "timeout", nil
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ids := make(chan uint64, 1)
+	go func() {
+		callCtx, c := context.WithTimeout(context.Background(), 4*time.Second)
+		defer c()
+		_, _ = host.CallWithID(callCtx, "hang.until.cancelled", nil, func(id uint64) {
+			ids <- id
+		})
+	}()
+
+	frameID := <-ids
+	if frameID == 0 {
+		t.Fatal("CallWithID reported id 0; frame ids start at 1")
+	}
+
+	// Let the hung request reach its handler, then cancel by the reported
+	// frame id — exactly what watchCancel sends post-fix.
+	time.Sleep(100 * time.Millisecond)
+	notifyCtx, nCancel := context.WithTimeout(context.Background(), time.Second)
+	defer nCancel()
+	if err := host.Notify(notifyCtx, MethodCancel, CancelParams{
+		RequestID: strconv.FormatUint(frameID, 10),
+	}); err != nil {
+		t.Fatalf("Notify cancel: %v", err)
+	}
+
+	select {
+	case <-cancelled:
+		// The reported id was the wire id: the serving handler aborted.
+	case <-time.After(600 * time.Millisecond):
+		t.Fatalf("module.cancel for the CallWithID-reported frame id %d did not cancel the in-flight request", frameID)
+	}
+}
+
+// TestCallWithIDReportsAssignedFrameID pins the id-reporting contract:
+// ids are reported once per call, monotonically from 1, and are the ids
+// the counterparty sees on the wire (cancelling by a reported id works —
+// pinned above). Also: no id is reported when none was allocated (the
+// inflight cap rejects before allocation).
+func TestCallWithIDReportsAssignedFrameID(t *testing.T) {
+	host, child, _, _, cleanup := newPeerPair(t, 0)
+	defer cleanup()
+
+	if err := child.Handle("echo", func(_ context.Context, _ json.RawMessage) (any, error) {
+		return "pong", nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var first, second uint64
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := host.CallWithID(ctx, "echo", nil, func(id uint64) { first = id }); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if _, err := host.CallWithID(ctx, "echo", nil, func(id uint64) { second = id }); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if first != 1 || second != 2 {
+		t.Fatalf("reported ids = %d, %d; want 1, 2 (monotonic from 1)", first, second)
+	}
+
+	// Cap a dedicated pair at one in-flight call, occupy it, and confirm
+	// the rejected call never reports an id.
+	connX, connY := net.Pipe()
+	codecX, _ := NewCodec(connX, connX, 0)
+	codecY, _ := NewCodec(connY, connY, 0)
+	cappedHost := NewPeer(codecX, RoleHost, WithMaxInflight(1))
+	cappedChild := NewPeer(codecY, RoleChild)
+	defer func() {
+		_ = cappedHost.Close()
+		_ = cappedChild.Close()
+		_ = connX.Close()
+		_ = connY.Close()
+	}()
+	release := make(chan struct{})
+	defer close(release)
+	if err := cappedChild.Handle("block", func(context.Context, json.RawMessage) (any, error) {
+		<-release
+		return nil, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cappedHost.Start()
+	cappedChild.Start()
+	go func() {
+		cctx, c := context.WithTimeout(context.Background(), 3*time.Second)
+		defer c()
+		_, _ = cappedHost.Call(cctx, "block", nil) // occupies the single slot
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	reported := make(chan uint64, 1)
+	rejCtx, rejCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer rejCancel()
+	if _, err := cappedHost.CallWithID(rejCtx, "block", nil, func(id uint64) { reported <- id }); !errors.Is(err, ErrInflightCap) {
+		t.Fatalf("capped call: err = %v, want ErrInflightCap", err)
+	}
+	select {
+	case id := <-reported:
+		t.Fatalf("onID fired with id %d for a call rejected at the inflight cap (no id was allocated)", id)
+	default:
+	}
+}
+
+// TestModuleCancelNonCanonicalRequestIDIsNoOp pins the child side: a
+// RequestID that is not the canonical decimal string of an in-flight
+// inbound frame id must cancel NOTHING. Prefix-matching ("1-…", " 1") is
+// the misroute hazard that made one request's cancel abort an unrelated
+// request; the name-prefixed production shape ("notes-1") is the old no-op
+// — post-fix both are simply ids that name no frame. This replaces the
+// audit proof TestModuleCancelRequestIDIgnoresTrailingBytes, which pinned
+// the pre-fix prefix-match behaviour and instructed the fix to flip it.
+func TestModuleCancelNonCanonicalRequestIDIsNoOp(t *testing.T) {
+	for _, rid := range []string{"notes-1", "1-not-the-frame-id", " 1"} {
+		t.Run(rid, func(t *testing.T) {
+			host, child, _, _, cleanup := newPeerPair(t, 0)
+			defer cleanup()
+
+			cancelled := make(chan struct{}, 1)
+			if err := child.Handle("hang.until.cancelled", func(ctx context.Context, _ json.RawMessage) (any, error) {
+				select {
+				case <-ctx.Done():
+					cancelled <- struct{}{}
+					return nil, ctx.Err()
+				case <-time.After(1500 * time.Millisecond):
+					return "survived", nil
+				}
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			go func() {
+				callCtx, c := context.WithTimeout(context.Background(), 5*time.Second)
+				defer c()
+				_, _ = host.Call(callCtx, "hang.until.cancelled", nil) // frame id 1
+			}()
+			// Let the hung request reach its handler.
+			time.Sleep(100 * time.Millisecond)
+
+			notifyCtx, nCancel := context.WithTimeout(context.Background(), time.Second)
+			defer nCancel()
+			if err := host.Notify(notifyCtx, MethodCancel, CancelParams{RequestID: rid}); err != nil {
+				t.Fatalf("Notify cancel: %v", err)
+			}
+
+			select {
+			case <-cancelled:
+				t.Fatalf("RequestID %q cancelled frame id 1: a non-canonical id must name no frame, not prefix-match an unrelated one", rid)
+			case <-time.After(700 * time.Millisecond):
+				// No cancellation: the id named no frame.
+			}
+		})
+	}
+}

--- a/core/moduleproto/cancel_test.go
+++ b/core/moduleproto/cancel_test.go
@@ -159,7 +159,10 @@ func TestCallWithIDReportsAssignedFrameID(t *testing.T) {
 // audit proof TestModuleCancelRequestIDIgnoresTrailingBytes, which pinned
 // the pre-fix prefix-match behaviour and instructed the fix to flip it.
 func TestModuleCancelNonCanonicalRequestIDIsNoOp(t *testing.T) {
-	for _, rid := range []string{"notes-1", "1-not-the-frame-id", " 1"} {
+	// "01" is the one that ParseUint alone lets through: it parses to
+	// 1 with no error, so only the canonical round-trip check refuses
+	// it. "+1" and " 1" the parser rejects on its own.
+	for _, rid := range []string{"notes-1", "1-not-the-frame-id", " 1", "01", "+1"} {
 		t.Run(rid, func(t *testing.T) {
 			host, child, _, _, cleanup := newPeerPair(t, 0)
 			defer cleanup()

--- a/core/moduleproto/late_response_test.go
+++ b/core/moduleproto/late_response_test.go
@@ -1,0 +1,129 @@
+package moduleproto
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestLateResponseAfterCallTimeoutIsNotFatal pins the availability contract
+// for origination-side cancellation:
+//
+//	Peer.Call returns on ctx expiry WITHOUT closing the peer, and the
+//	counterparty's response for that id — which the design GUARANTEES will
+//	arrive ("a request always gets a paired response so the originating
+//	Call unblocks", buildResponse) — must not be treated as a terminal
+//	protocol fault.
+//
+// Reachability (framework/processmodule_proxy.go): every proxied HTTP call
+// gets a per-call deadline context; when it expires, Call returns
+// DeadlineExceeded and watchCancel sends module.cancel, which makes the
+// child abort its handler and answer with an error response for that exact
+// id. deliverResponse then finds no pending entry (Call already deleted it),
+// and — because the peer is not closed — raises "unsolicited response" as a
+// FATAL fault, which the supervisor answers by tearing down the child
+// process and every other in-flight request to that module.
+//
+// A late response to a Call that gave up is an expected event on a healthy
+// peer, not a desynchronization. The fatal should apply to responses that
+// never matched ANY originated id in a way we cannot attribute — at minimum,
+// a gave-up-but-was-originated id must be distinguished from a never-existed
+// id.
+func TestLateResponseAfterCallTimeoutIsNotFatal(t *testing.T) {
+	host, child, _, _, cleanup := newPeerPair(t, 0)
+	defer cleanup()
+
+	// A handler that answers AFTER the host's call deadline: the module.http
+	// shape under module.cancel (handler observes ctx done / work simply
+	// outlasts the caller's budget, then responds).
+	if err := child.Handle("slow.echo", func(ctx context.Context, _ json.RawMessage) (any, error) {
+		select {
+		case <-time.After(300 * time.Millisecond):
+			return "late", nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	callCtx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+	if _, err := host.Call(callCtx, "slow.echo", nil); err == nil {
+		t.Fatal("expected the Call to time out")
+	}
+
+	// The child's paired response lands after Call already gave up. Give it
+	// ample time to be delivered, then check the host peer is still healthy.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case <-host.FatalDone():
+			t.Fatalf(
+				"SECURITY: [moduleproto] late response to a Call that returned on ctx expiry was treated as a terminal fault: %v — one expired per-call deadline kills the whole module peer and every concurrent in-flight request (see processmodule_proxy.go callCtx + watchCancel)",
+				host.FatalError(),
+			)
+		case <-host.Done():
+			t.Fatalf("SECURITY: [moduleproto] read loop exited after a late response: %v", host.FatalError())
+		case <-time.After(50 * time.Millisecond):
+			// still healthy at this tick; keep waiting out the window
+		}
+	}
+
+	// The peer must still work: a fresh Call must succeed.
+	freshCtx, freshCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer freshCancel()
+	if _, err := host.Call(freshCtx, "slow.echo", nil); err != nil {
+		t.Fatalf("peer unusable after a late response: %v", err)
+	}
+}
+
+// TestUnsolicitedResponseStillFatalAfterAbandonment pins the OTHER
+// direction of the late-response contract: suppression is scoped to ids
+// this peer actually originated and gave up on. A response naming an id
+// that was NEVER originated stays a terminal fault even while abandonment
+// tombstones exist — the tombstone set must not become a blanket pardon
+// for unsolicited responses. (The no-abandonment case is pinned by
+// TestPeerUnsolicitedRespIsFatal in peer_test.go.)
+func TestUnsolicitedResponseStillFatalAfterAbandonment(t *testing.T) {
+	connX, connY := net.Pipe()
+	codecX, _ := NewCodec(connX, connX, 0)
+	h := NewPeer(codecX, RoleHost)
+	h.Start()
+	defer func() {
+		_ = h.Close()
+		_ = connX.Close()
+		_ = connY.Close()
+	}()
+	// Drain the host's outbound writes (net.Pipe is synchronous; nothing
+	// else is reading connY).
+	go func() { _, _ = io.Copy(io.Discard, connY) }()
+
+	// Abandon id 1: originate a call whose ctx is already expired. The
+	// frame is written (and drained above), Call returns ctx.Err, and the
+	// id is tombstoned as abandoned.
+	expiredCtx, expCancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer expCancel()
+	if _, err := h.Call(expiredCtx, "anything", nil); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expired-ctx call: err = %v, want DeadlineExceeded", err)
+	}
+
+	// A response for an id that was never originated must still fault.
+	unsolicited := NewSuccessResponse(999, json.RawMessage(`{}`))
+	raw, _ := json.Marshal(unsolicited)
+	raw = append(raw, '\n')
+	go func() { _, _ = connY.Write(raw) }()
+
+	select {
+	case <-h.FatalDone():
+		if err := h.FatalError(); err == nil {
+			t.Fatal("FatalDone closed but FatalError is nil")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("unsolicited response for a never-originated id must stay fatal even while an abandonment tombstone exists")
+	}
+}

--- a/core/moduleproto/methods.go
+++ b/core/moduleproto/methods.go
@@ -157,9 +157,15 @@ type HTTPMethod string
 // request body to the allowlisted headers, base64-encoding the body, and
 // attaching the caller's delegation handle.
 type HTTPRequestParams struct {
-	// RequestID is a host-minted correlation id for THIS proxied request.
-	// It is independent of the JSON-RPC id (which lives at the envelope
-	// level) and is what module.cancel references to abort in-flight work.
+	// RequestID is a host-minted correlation id for THIS proxied request
+	// ("<module>-<counter>"), for diagnostics and child-side logging only.
+	// It is NOT what module.cancel references: cancellation targets the
+	// JSON-RPC frame id of the request (see [CancelParams.RequestID] and
+	// [Peer.CallWithID]). An earlier revision of this comment claimed the
+	// opposite ("independent of the JSON-RPC id … and is what module.cancel
+	// references"); the supervisor followed it, and module.cancel became a
+	// silent no-op on the proxy path because no serving peer can map this
+	// value back to a frame (issue #356).
 	RequestID string `json:"request_id"`
 	// RouteID is the installed route's descriptor id.
 	RouteID string `json:"route_id"`
@@ -385,9 +391,13 @@ type EventEmitParams struct {
 type EventEmitResult struct{}
 
 // CancelParams is the body of the module.cancel notification (host → module).
-// RequestID is the inbound request's host-side correlation id (the
-// HTTPRequestParams.RequestID for a module.http call). The child uses it to
-// find and cancel the in-flight handler's context.
+// RequestID is the CANONICAL DECIMAL STRING of the inbound frame id being
+// cancelled (e.g. the id [Peer.CallWithID] reported to the originator of the
+// module.http request). It is NOT [HTTPRequestParams.RequestID]: that value
+// is an application-level correlation id the serving peer cannot resolve to
+// a frame — conflating the two made module.cancel a silent no-op on the
+// proxy path (issue #356). The child parses RequestID with a strict
+// full-string decimal parse; any other shape names no frame and is a no-op.
 type CancelParams struct {
 	RequestID string `json:"request_id"`
 }

--- a/core/moduleproto/peer.go
+++ b/core/moduleproto/peer.go
@@ -788,7 +788,12 @@ func builtinCancelHandler(p *Peer) Handler {
 		// Sscanf("notes-42") rejected the whole value (module.cancel was a
 		// silent no-op on the proxy path, issue #356), while Sscanf("1-…")
 		id, err := strconv.ParseUint(cp.RequestID, 10, 64)
-		if err != nil || id == 0 {
+		// ParseUint alone is not strict enough to be canonical: "01" parses
+		// to 1 with no error, so a leading zero would cancel frame 1 while
+		// not being the value CallWithID reported. Requiring the round-trip
+		// makes exactly one spelling of each id acceptable, which is the
+		// property this parse is for — one RequestID, one frame.
+		if err != nil || id == 0 || cp.RequestID != strconv.FormatUint(id, 10) {
 			return nil, nil
 		}
 		p.mu.Lock()

--- a/core/moduleproto/peer.go
+++ b/core/moduleproto/peer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"sync"
 	"sync/atomic"
 )
@@ -71,11 +72,14 @@ type Handler func(ctx context.Context, params json.RawMessage) (result any, err 
 //   - The Peer installs a built-in handler for [MethodCancel]. When a
 //     module.cancel notification arrives with a given request_id, the Peer
 //     cancels the context of the inbound request currently serving that id
-//     (the request_id is the inbound frame's id, encoded as a string). The
-//     child's handlers observe ctx.Done and abort.
+//     (the request_id is the inbound frame's id, encoded as a canonical
+//     decimal string — the value [Peer.CallWithID] reports on the
+//     originating side, NOT [HTTPRequestParams.RequestID]). The child's
+//     handlers observe ctx.Done and abort.
 //   - Origination-side cancellation (the host sending module.cancel when ITS
 //     Call's ctx expires) is policy, NOT codec behavior. The supervisor wires
-//     it by calling [Peer.Notify] from a goroutine that watches ctx.Done.
+//     it by calling [Peer.Notify] from a goroutine armed with the frame id
+//     [Peer.CallWithID] assigned, watching ctx.Done.
 type Peer struct {
 	codec *Codec
 	role  Role
@@ -87,8 +91,17 @@ type Peer struct {
 	// so the first Add(1) returns 1: ids begin at 1, never 0.
 	nextID atomic.Uint64
 
-	mu            sync.Mutex // guards pending, inflight, handlers, cancel
-	pending       map[uint64]chan *Frame
+	mu      sync.Mutex // guards pending, abandoned, inflight, handlers, cancels
+	pending map[uint64]chan *Frame
+	// abandoned tombstones ids whose [Peer.Call] returned without its
+	// response (ctx expiry, Close, fatal fault), so [Peer.deliverResponse]
+	// can tell a LATE paired response to an id this peer originated but
+	// stopped waiting for (drop: expected on a healthy peer, which
+	// guarantees every request a paired response) from a response naming
+	// an id this peer NEVER originated (terminal protocol fault). Bounded
+	// FIFO; see maxAbandonedIDs.
+	abandoned     map[uint64]struct{}
+	abandonedFIFO []uint64
 	inflight      int
 	serveInflight int
 	handlers      map[string]Handler
@@ -165,6 +178,7 @@ func NewPeer(codec *Codec, role Role, opts ...PeerOption) *Peer {
 		maxInflight:      DefaultMaxInflight,
 		maxServeInflight: DefaultMaxInflight,
 		pending:          make(map[uint64]chan *Frame),
+		abandoned:        make(map[uint64]struct{}),
 		handlers:         make(map[string]Handler),
 		cancels:          make(map[uint64][]*cancelSlot),
 		closeCh:          make(chan struct{}),
@@ -254,15 +268,40 @@ func (p *Peer) FatalDone() <-chan struct{} { return p.fatalCh }
 //
 // Failure modes:
 //
-//   - ctx expired: the pending entry is removed and ctx.Err() is returned.
-//     Call does NOT automatically emit module.cancel; that is supervisor
-//     policy. Origination-side cancellation is a [Peer.Notify] away.
+//   - ctx expired: the pending entry is removed and ctx.Err() is returned;
+//     the id is tombstoned as abandoned so the counterparty's eventual
+//     paired response is dropped instead of faulting the peer (see
+//     [Peer.deliverResponse]). Call does NOT automatically emit
+//     module.cancel; that is supervisor policy, one [Peer.Notify] away
+//     naming the id [Peer.CallWithID] reports.
 //   - inflight cap reached: returns [ErrInflightCap] without writing anything.
 //   - Peer closed (or read loop exited): returns [ErrClosed] (or the terminal
 //     [Peer.FatalError] if one was observed).
 //   - the child returned a JSON-RPC error: returns it as a [*Error].
 //   - codec write failed (e.g. over-cap): returns that terminal error.
 func (p *Peer) Call(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	return p.call(ctx, method, params, nil)
+}
+
+// CallWithID originates a request exactly like [Peer.Call] and additionally
+// reports the frame id this Peer assigned to onID. onID is invoked
+// synchronously, exactly once, after the id is allocated and the pending
+// entry registered but BEFORE the request frame is written; it must not
+// block (arm a goroutine if the observer needs to wait on anything). It is
+// not invoked when no id was allocated (peer closed, empty method,
+// inflight cap).
+//
+// This is the seam origination-side cancellation needs: module.cancel names
+// the INBOUND frame id on the serving peer, so a supervisor that wants to
+// cancel its own in-flight Call must send the id reported here — the wire
+// id, not any application-level correlation id (issue #356: the proxy sent
+// its "<module>-<counter>" request id instead, which the serving peer could
+// never map back to a frame, making module.cancel a silent no-op).
+func (p *Peer) CallWithID(ctx context.Context, method string, params any, onID func(id uint64)) (json.RawMessage, error) {
+	return p.call(ctx, method, params, onID)
+}
+
+func (p *Peer) call(ctx context.Context, method string, params any, onID func(id uint64)) (json.RawMessage, error) {
 	if p.closed.Load() {
 		return nil, ErrClosed
 	}
@@ -289,12 +328,22 @@ func (p *Peer) Call(ctx context.Context, method string, params any) (json.RawMes
 	p.pending[id] = ch
 	p.mu.Unlock()
 
+	if onID != nil {
+		onID(id)
+	}
+
 	// Cleanup on all return paths.
 	defer func() {
 		p.mu.Lock()
-		// If the response was delivered, the entry is already gone; delete
-		// is a no-op then. Otherwise this Call is giving up on its id.
-		delete(p.pending, id)
+		// If the response was delivered, the entry is already gone and
+		// there is nothing to remember. Otherwise this Call is giving up
+		// on an id the counterparty still owes a paired response for:
+		// tombstone it so the eventual late response is recognized (and
+		// dropped) instead of faulting the peer as unsolicited.
+		if _, stillPending := p.pending[id]; stillPending {
+			delete(p.pending, id)
+			p.noteAbandonedLocked(id)
+		}
 		p.inflight--
 		p.mu.Unlock()
 	}()
@@ -619,19 +668,52 @@ func (p *Peer) serveNotification(f *Frame) {
 	_, _ = h(ctx, f.Params)
 }
 
+// maxAbandonedIDs bounds how many abandoned ids the peer remembers. A late
+// response trails its abandonment by at most one counterparty round-trip
+// (the serving peer guarantees every request a paired response), so a
+// window covering the last 1024 abandonments is far beyond any legitimate
+// need; a response that misses both the pending map and this window is
+// treated as the unsolicited protocol fault it almost certainly is.
+const maxAbandonedIDs = 1024
+
+// noteAbandonedLocked records id as given-up. p.mu must be held.
+func (p *Peer) noteAbandonedLocked(id uint64) {
+	if p.abandoned == nil {
+		p.abandoned = make(map[uint64]struct{})
+	}
+	p.abandoned[id] = struct{}{}
+	p.abandonedFIFO = append(p.abandonedFIFO, id)
+	for len(p.abandonedFIFO) > maxAbandonedIDs {
+		delete(p.abandoned, p.abandonedFIFO[0])
+		p.abandonedFIFO = p.abandonedFIFO[1:]
+	}
+}
+
 func (p *Peer) deliverResponse(f *Frame) {
 	id := *f.ID
 	p.mu.Lock()
 	ch, ok := p.pending[id]
 	if ok {
 		delete(p.pending, id)
+	} else if _, abandoned := p.abandoned[id]; abandoned {
+		// Consume the tombstone: an id gets exactly one paired response.
+		delete(p.abandoned, id)
+		p.mu.Unlock()
+		// A LATE response to a Call that already gave up on this id (its
+		// ctx expired; see [Peer.call]'s cleanup). Expected on a healthy
+		// peer — every request is guaranteed a paired response and the
+		// originator is free to stop waiting first — so drop it. Ids are
+		// monotonic per direction, so this can never be confused with a
+		// future Call's id.
+		return
 	}
 	p.mu.Unlock()
 	if !ok {
-		// A response with no matching pending id. Under correct per-direction
-		// correlation this is impossible on a healthy peer; treat as a
-		// terminal protocol fault. During shutdown, however, late responses
-		// for Calls that already gave up are expected; suppress in that case.
+		// A response naming an id this peer never originated. Under
+		// correct per-direction correlation this is impossible on a healthy
+		// peer; treat as a terminal protocol fault. During shutdown, late
+		// responses for Calls that already gave up are expected; suppress
+		// in that case.
 		if p.closed.Load() {
 			return
 		}
@@ -688,8 +770,11 @@ func marshalParams(v any) (json.RawMessage, error) {
 
 // builtinCancelHandler returns the handler for [MethodCancel]. The handler
 // looks up the inbound request id encoded in [CancelParams].RequestID and
-// cancels that request's context. RequestID is the string form of the inbound
-// frame id (the JSON-RPC id the host used for module.http, etc.).
+// cancels that request's context. RequestID is the CANONICAL DECIMAL STRING
+// of the inbound frame id (the JSON-RPC id the host used for module.http —
+// the value [Peer.CallWithID] reports to the originating side); it is NOT
+// [HTTPRequestParams.RequestID], which is an application-level correlation
+// id no serving peer can map back to a frame.
 func builtinCancelHandler(p *Peer) Handler {
 	return func(_ context.Context, params json.RawMessage) (any, error) {
 		var cp CancelParams
@@ -698,11 +783,12 @@ func builtinCancelHandler(p *Peer) Handler {
 				return nil, nil // notifications are unobservable; drop on malformed
 			}
 		}
-		// Parse the request_id. Under moduleproto it is the inbound frame
-		// id; the host mints it as a string but it MUST parse to a uint64
-		// matching a currently-served inbound id. Anything else is a no-op.
-		var id uint64
-		if _, err := fmt.Sscanf(cp.RequestID, "%d", &id); err != nil || id == 0 {
+		// Parse the request_id with a STRICT full-string decimal parse. The
+		// previous fmt.Sscanf("%d") prefix-matched, which failed twice:
+		// Sscanf("notes-42") rejected the whole value (module.cancel was a
+		// silent no-op on the proxy path, issue #356), while Sscanf("1-…")
+		id, err := strconv.ParseUint(cp.RequestID, 10, 64)
+		if err != nil || id == 0 {
 			return nil, nil
 		}
 		p.mu.Lock()

--- a/core/yaml/security_test.go
+++ b/core/yaml/security_test.go
@@ -1,0 +1,130 @@
+package yaml
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestYAML_DuplicateKeysRejected pins that a document mapping the same key
+// twice is a parse error, not a silent last-wins.
+//
+// parseMap wrote out.Map[key] = node with no duplicate detection, so in
+//
+//	app:
+//	  auth:
+//	    enabled: false
+//	    enabled: true
+//
+// the effective value is `true` while a human reviewing the file top-to-
+// bottom reads the first occurrence, `false`. Every mainstream YAML parser
+// (yaml.v3 "already defined", Go's sigs.k8s.io/yaml via JSON semantics)
+// rejects duplicate mapping keys precisely because silent last-wins lets a
+// stale or hostile copy-paste line override the value a reviewer believes
+// is in force. For this parser's consumers — gofastr blueprints, codegen
+// configs, kiln freeze output, contracts config — the parsed file is the
+// security config (auth.enabled is access-gating, cf. protectiveBool), so
+// ambiguity must fail closed at the parser, not be adjudicated by map
+// insertion order.
+//
+// Same key, different values, is the clear case. Same key, same value, is
+// still ambiguous (it can hide a meaningful later edit), but this test pins
+// only the clear case.
+//
+// The list-item case covers the second silent-merge path: parseList builds
+// the first key of a "- key: value" item itself and then merges the
+// indented continuation lines with maps.Copy, which also silently
+// overwrote earlier keys.
+func TestYAML_DuplicateKeysRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  string
+	}{
+		{"top level, different values", "auth: false\nauth: true\n"},
+		{"nested map, different values", "app:\n  auth:\n    enabled: false\n    enabled: true\n"},
+		{"duplicate key with map values", "dev:\n  a: 1\ndev:\n  a: 2\n"},
+		{"duplicate key inside one list item", "items:\n  - a: 1\n    a: 2\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := Parse(c.doc)
+			if err == nil {
+				t.Fatalf("SECURITY: [yaml] Parse accepted duplicate mapping keys (silent last-wins): %q", c.doc)
+			}
+		})
+	}
+
+	// Distinct keys must still parse.
+	if _, err := Parse("a: 1\nb: 2\n"); err != nil {
+		t.Fatalf("distinct keys must parse: %v", err)
+	}
+	// Repeated keys in DIFFERENT list items are fine; only keys that
+	// collapse into one mapping are ambiguous.
+	if _, err := Parse("items:\n  - a: 1\n  - a: 2\n"); err != nil {
+		t.Fatalf("same key in sibling list items must parse: %v", err)
+	}
+}
+
+// TestYAML_DuplicateKeyErrorNamesKeyAndLines pins the error contract: the
+// message must name the duplicated key and both defining lines, so a reader
+// can jump straight to the conflict instead of grepping. Before the guard
+// existed this shape parsed successfully with last-wins semantics (the
+// demonstration half of the finding above).
+func TestYAML_DuplicateKeyErrorNamesKeyAndLines(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  string
+		want string
+	}{
+		{"flat", "auth: false\nauth: true\n", `yaml:2:1: duplicate mapping key "auth" (first defined at line 1)`},
+		{"nested", "app:\n  auth:\n    enabled: false\n    enabled: true\n", `yaml:4:5: duplicate mapping key "enabled" (first defined at line 3)`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := Parse(c.doc)
+			if err == nil {
+				t.Fatalf("expected duplicate-key error for %q", c.doc)
+			}
+			if err.Error() != c.want {
+				t.Fatalf("error mismatch:\n got: %s\nwant: %s", err, c.want)
+			}
+		})
+	}
+
+	// The list-item merge path shares the message shape.
+	_, err := Parse("items:\n  - a: 1\n    a: 2\n")
+	if err == nil {
+		t.Fatal("expected duplicate-key error for list item continuation")
+	}
+	for _, want := range []string{`duplicate mapping key "a"`, "first defined at line 2"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("list-item error must contain %q, got: %s", want, err)
+		}
+	}
+}
+
+// TestYAML_YAML11BooleansStayStrings pins the YAML 1.2 core-schema rule the
+// blueprint layer relies on: yes/no/on/off/y/n are STRINGS, not booleans.
+// Strict consumers (strictBoolValue, protectiveBool, requiredBoolValue)
+// reject them loudly instead of coercing; a lax reader that defaults
+// non-bool to false would turn `auth: yes` fail-open. This test holds the
+// parser to the contract so a future "convenience" coercion cannot land
+// silently.
+func TestYAML_YAML11BooleansStayStrings(t *testing.T) {
+	for _, raw := range []string{"yes", "no", "on", "off", "y", "n", "Yes", "NO", "TRUE", "True", "false", "False"} {
+		node, err := Parse("k: " + raw + "\n")
+		if err != nil {
+			t.Fatalf("parse %q: %v", raw, err)
+		}
+		v := node.Map["k"].Value
+		switch raw {
+		case "TRUE", "True", "false", "False":
+			if _, ok := v.(bool); !ok {
+				t.Errorf("%q should decode as bool, got %T(%v)", raw, v, v)
+			}
+		default:
+			if s, ok := v.(string); !ok || s != raw {
+				t.Errorf("%q should stay a string (YAML 1.2 core schema), got %T(%v)", raw, v, v)
+			}
+		}
+	}
+}

--- a/core/yaml/security_test.go
+++ b/core/yaml/security_test.go
@@ -77,6 +77,13 @@ func TestYAML_DuplicateKeyErrorNamesKeyAndLines(t *testing.T) {
 	}{
 		{"flat", "auth: false\nauth: true\n", `yaml:2:1: duplicate mapping key "auth" (first defined at line 1)`},
 		{"nested", "app:\n  auth:\n    enabled: false\n    enabled: true\n", `yaml:4:5: duplicate mapping key "enabled" (first defined at line 3)`},
+		// A list item defines its first key on the "- key: value" line, and
+		// the continuation lines are parsed as a separate map. Without
+		// seeding that map, the first repeat among the continuations was
+		// reported as the first definition — line 3 here, when `a` was
+		// defined on line 2. The reported line is the point of the error.
+		{"list item then two continuations", "items:\n  - a: 1\n    a: 2\n    a: 3\n", `yaml:3:5: duplicate mapping key "a" (first defined at line 2)`},
+		{"list item then one continuation", "items:\n  - a: 1\n    a: 2\n", `yaml:3:5: duplicate mapping key "a" (first defined at line 2)`},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/core/yaml/yaml.go
+++ b/core/yaml/yaml.go
@@ -134,6 +134,23 @@ func (p *parser) parseBlock(indent int) (*Node, error) {
 }
 
 func (p *parser) parseMap(indent int) (*Node, error) {
+	return p.parseMapSeeded(indent, nil)
+}
+
+// parseMapSeeded is parseMap with the duplicate-key tracker pre-populated.
+//
+// A "- key: value" list item builds its first key itself and then parses the
+// indented continuation lines as a separate map. Without the seed that map
+// starts blank, so for
+//
+//   - a: 1
+//     a: 2
+//     a: 3
+//
+// it catches a@3 against a@4 and reports line 3 as the first definition —
+// when `a` was first defined on line 2, in the item itself. The reported
+// line is the whole point of the error, so it has to be the real one.
+func (p *parser) parseMapSeeded(indent int, seed map[string]int) (*Node, error) {
 	out := &Node{Kind: Map, Line: p.lines[p.pos].line, Column: indent + 1, Map: map[string]*Node{}}
 	// A duplicate key was silent last-wins: `enabled: false` followed later
 	// by `enabled: true` took the second value while a reviewer, and grep,
@@ -146,7 +163,8 @@ func (p *parser) parseMap(indent int) (*Node, error) {
 	//
 	// seen holds the line that first defined each key so the error can name
 	// both.
-	seen := make(map[string]int, 8)
+	seen := make(map[string]int, 8+len(seed))
+	maps.Copy(seen, seed)
 	for p.pos < len(p.lines) {
 		line := p.lines[p.pos]
 		if line.indent < indent {
@@ -236,7 +254,14 @@ func (p *parser) parseList(indent int) (*Node, error) {
 				child.Map[strings.TrimSpace(key)] = scalar
 			}
 			if p.pos < len(p.lines) && p.lines[p.pos].indent > indent {
-				more, err := p.parseMap(p.lines[p.pos].indent)
+				// Seed with the key this item already defined, so a repeat
+				// among the continuation lines reports the item's line as
+				// the first definition rather than the first continuation.
+				seed := make(map[string]int, len(child.Map))
+				for k, v := range child.Map {
+					seed[k] = v.Line
+				}
+				more, err := p.parseMapSeeded(p.lines[p.pos].indent, seed)
 				if err != nil {
 					return nil, err
 				}

--- a/core/yaml/yaml.go
+++ b/core/yaml/yaml.go
@@ -3,6 +3,7 @@ package yaml
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -134,6 +135,18 @@ func (p *parser) parseBlock(indent int) (*Node, error) {
 
 func (p *parser) parseMap(indent int) (*Node, error) {
 	out := &Node{Kind: Map, Line: p.lines[p.pos].line, Column: indent + 1, Map: map[string]*Node{}}
+	// A duplicate key was silent last-wins: `enabled: false` followed later
+	// by `enabled: true` took the second value while a reviewer, and grep,
+	// read the first. Every mainstream parser refuses that, and this
+	// parser's inputs are the security-relevant config — blueprints,
+	// codegen configs, kiln freeze snapshots — so the ambiguity has to fail
+	// closed here rather than resolve to whichever line came last. Same
+	// class as the YAML 1.2 boolean that read `auth: yes` as a string and
+	// meant PUBLIC: ask which direction a misread moves safety.
+	//
+	// seen holds the line that first defined each key so the error can name
+	// both.
+	seen := make(map[string]int, 8)
 	for p.pos < len(p.lines) {
 		line := p.lines[p.pos]
 		if line.indent < indent {
@@ -153,6 +166,10 @@ func (p *parser) parseMap(indent int) (*Node, error) {
 		if strings.ContainsAny(key, "[]{}") {
 			return nil, fmt.Errorf("yaml:%d:%d: unsupported key syntax %q", line.line, line.indent+1, key)
 		}
+		if first, dup := seen[key]; dup {
+			return nil, fmt.Errorf("yaml:%d:%d: duplicate mapping key %q (first defined at line %d)", line.line, line.indent+1, key, first)
+		}
+		seen[key] = line.line
 		value = strings.TrimSpace(value)
 		p.pos++
 		if value == "" {
@@ -222,6 +239,24 @@ func (p *parser) parseList(indent int) (*Node, error) {
 				more, err := p.parseMap(p.lines[p.pos].indent)
 				if err != nil {
 					return nil, err
+				}
+				// The second silent-merge path, and the one parseMap's own
+				// `seen` cannot see: a "- key: value" item builds its first
+				// key here, then the indented continuation lines are parsed
+				// as a SEPARATE map and copied in. maps.Copy overwrote a
+				// collision without a word. Keys are walked in sorted order
+				// so the reported one is deterministic — the repo's
+				// mapwriter analyzer requires that of any map iteration
+				// whose output escapes.
+				//
+				// A key repeated across SIBLING list items is untouched:
+				// those are different mappings, and repeating a key across
+				// them is ordinary YAML.
+				for _, k := range slices.Sorted(maps.Keys(more.Map)) {
+					if first, dup := child.Map[k]; dup {
+						v := more.Map[k]
+						return nil, fmt.Errorf("yaml:%d:%d: duplicate mapping key %q (first defined at line %d)", v.Line, v.Column, k, first.Line)
+					}
 				}
 				maps.Copy(child.Map, more.Map)
 			}

--- a/framework/app.go
+++ b/framework/app.go
@@ -594,15 +594,28 @@ func (a *App) entityCRUDEnabled(e *entity.Entity) bool {
 	return a.DB != nil && (e.Config.Exposure.CRUD == nil || *e.Config.Exposure.CRUD)
 }
 
-// EntityCRUDMounted exports [App.entityCRUDEnabled] for the surfaces that
-// advertise routes from outside this package. openapi.json and
-// /api/llm.md take it as a predicate; a host mounting
-// [sdkdocs.Config] or any other route-listing surface passes it the same
-// way. It exists because Exposure.CRUD alone is not the answer: a DB-less
-// app mounts no CRUD while every entity still reads "auto", and a surface
-// that consults the flag instead of this method documents an API the
-// server does not serve (#266).
-func (a *App) EntityCRUDMounted(e *entity.Entity) bool { return a.entityCRUDEnabled(e) }
+// entityCrudMount is THE predicate for the llm.md index (#358): like
+// entityCRUDEnabled, but it also reports read-only mounts. App.View
+// registers its entities with CrudRouteOptions{ReadOnly: true}, a fact no
+// entity declaration carries — the app that performed the mount is the
+// only party that knows, so the index asks it, the same way #266 threaded
+// the DB-less case. A read-only view is counted and labelled as the three
+// routes it serves instead of eight, five of which would 404/405.
+func (a *App) entityCrudMount(e *entity.Entity) crud.MountInfo {
+	if !a.entityCRUDEnabled(e) {
+		return crud.MountInfo{}
+	}
+	// Views registered with Columns become ORM entities and mount
+	// read-only (App.View); column-less views never register an entity,
+	// so they never reach this predicate. Table names are unique per
+	// booted app or route registration would already have panicked.
+	for _, v := range a.migrationViews {
+		if len(v.Columns) > 0 && v.Name == e.GetTable() {
+			return crud.MountInfo{Mounted: true, ReadOnly: true}
+		}
+	}
+	return crud.MountInfo{Mounted: true}
+}
 
 // WithRouter sets a custom router.
 func WithRouter(r *router.Router) AppOption {
@@ -2980,7 +2993,7 @@ func (a *App) Start(addr string) error {
 			// per-request-filtered crud handler, and per-entity
 			// /{table}/llm.md routes keep their own scope gate either way.
 			if a.Config.PublicOpenAPI {
-				doc := []byte(crud.RegistryLLMMD(a.Registry, appName, a.entityCRUDEnabled))
+				doc := []byte(crud.RegistryLLMMD(a.Registry, appName, a.entityCrudMount))
 				a.router.Get("/api/llm.md", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					w.Header().Set("Cache-Control", "no-store")
 					w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
@@ -2988,7 +3001,7 @@ func (a *App) Start(addr string) error {
 					w.Write(doc)
 				}))
 			} else {
-				a.router.Get("/api/llm.md", crud.RegistryLLMMDHandler(a.Registry, appName, a.entityCRUDEnabled))
+				a.router.Get("/api/llm.md", crud.RegistryLLMMDHandler(a.Registry, appName, a.entityCrudMount))
 			}
 			hasLLMMD = true
 		}

--- a/framework/crud/crud_routes.go
+++ b/framework/crud/crud_routes.go
@@ -13,9 +13,13 @@ import (
 // bare LLMMDHandler here checked only for a session, which let an
 // authenticated caller with no read permission fetch the schema of an entity
 // whose rows they get a 403 on.
-func registerLLMMDRoutes(r *router.Router, ch *CrudHandler, path string) {
+//
+// readOnly is the mount's own CrudRouteOptions.ReadOnly: the doc must
+// describe the routes this registration actually mounts, so a read-only
+// mount's llm.md omits the write and batch endpoints entirely (#358).
+func registerLLMMDRoutes(r *router.Router, ch *CrudHandler, path string, readOnly bool) {
 	path = NormalizePath(path)
-	r.Get(path+"/llm.md", LLMMDHandlerFor(ch))
+	r.Get(path+"/llm.md", LLMMDHandlerFor(ch, LLMMDOptions{ReadOnly: readOnly}))
 }
 
 // CrudRouteOptions controls which routes are registered by RegisterCrudRoutes.
@@ -109,7 +113,7 @@ func RegisterCrudRoutes(r *router.Router, handler *CrudHandler, path string, opt
 
 	// LLM-friendly documentation endpoint
 	if !opt.NoLLMMD {
-		registerLLMMDRoutes(r, handler, path)
+		registerLLMMDRoutes(r, handler, path, opt.ReadOnly)
 	}
 }
 

--- a/framework/crud/llmmd.go
+++ b/framework/crud/llmmd.go
@@ -12,6 +12,19 @@ import (
 	"github.com/DonaldMurillo/gofastr/framework/entity"
 )
 
+// LLMMDOptions controls what EntityLLMMD documents. The zero value keeps
+// the historical full-CRUD document; ReadOnly narrows it to the routes a
+// CrudRouteOptions{ReadOnly: true} mount actually serves.
+type LLMMDOptions struct {
+	// ReadOnly omits every write endpoint (POST, PUT, PATCH, DELETE and
+	// the _batch family) plus the per-field Create/Update columns: on a
+	// read-only mount those routes answer 404/405, and the doc must not
+	// advertise routes the server does not serve (#358, the #266 class
+	// one layer down: the answer lives in the mount options, not the
+	// entity declaration).
+	ReadOnly bool
+}
+
 // EntityLLMMD generates an LLM-friendly markdown document describing all
 // CRUD endpoints for a single entity. The output is designed to be
 // immediately useful as context for an LLM agent, concise, structured,
@@ -27,7 +40,15 @@ import (
 //   - Batch create / update / delete
 //   - SSE event stream
 //   - Custom endpoints declared on the entity
-func EntityLLMMD(ent *entity.Entity) string {
+//
+// Pass LLMMDOptions{ReadOnly: true} for an entity mounted with
+// CrudRouteOptions{ReadOnly: true} (App.View does): the write, batch and
+// Create/Update-column sections are omitted so the doc matches the mount.
+func EntityLLMMD(ent *entity.Entity, opts ...LLMMDOptions) string {
+	var opt LLMMDOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
 	var b strings.Builder
 	name := ent.GetName()
 	table := ent.GetTable()
@@ -39,28 +60,25 @@ func EntityLLMMD(ent *entity.Entity) string {
 		resourcePath = ent.Version + resourcePath
 	}
 	fmt.Fprintf(&b, "Resource: `%s`\n\n", resourcePath)
+	if opt.ReadOnly {
+		b.WriteString("This resource is served read-only: only the list, get-by-ID and `_events` endpoints are mounted. There are no create, update, delete or batch routes.\n\n")
+	}
 
 	// --- Field reference ---
+	// Read-only mounts have no create/update endpoints, so the per-field
+	// Create/Update columns (which describe those endpoints' request
+	// bodies) are omitted rather than frozen at "—".
 	b.WriteString("## Fields\n\n")
-	b.WriteString("| Field | Type | Create | Update | Notes |\n")
-	b.WriteString("|-------|------|--------|--------|-------|\n")
+	if opt.ReadOnly {
+		b.WriteString("| Field | Type | Notes |\n")
+		b.WriteString("|-------|------|-------|\n")
+	} else {
+		b.WriteString("| Field | Type | Create | Update | Notes |\n")
+		b.WriteString("|-------|------|--------|--------|-------|\n")
+	}
 	for _, f := range fields {
 		if f.Hidden {
 			continue
-		}
-		createCol := "—"
-		updateCol := "—"
-		if f.AutoGenerate == schema.AutoNone && !f.ReadOnly {
-			if f.Required && f.Default == nil {
-				createCol = "**required**"
-			} else {
-				createCol = "optional"
-			}
-			updateCol = "optional"
-		}
-		if f.AutoGenerate != schema.AutoNone {
-			createCol = "auto"
-			updateCol = "auto"
 		}
 		notes := ""
 		if f.Unique {
@@ -83,6 +101,24 @@ func EntityLLMMD(ent *entity.Entity) string {
 				notes += ", "
 			}
 			notes += "not filterable/sortable"
+		}
+		if opt.ReadOnly {
+			fmt.Fprintf(&b, "| `%s` | %s | %s |\n", f.Name, fieldTypeLabel(f.Type), notes)
+			continue
+		}
+		createCol := "—"
+		updateCol := "—"
+		if f.AutoGenerate == schema.AutoNone && !f.ReadOnly {
+			if f.Required && f.Default == nil {
+				createCol = "**required**"
+			} else {
+				createCol = "optional"
+			}
+			updateCol = "optional"
+		}
+		if f.AutoGenerate != schema.AutoNone {
+			createCol = "auto"
+			updateCol = "auto"
 		}
 		fmt.Fprintf(&b, "| `%s` | %s | %s | %s | %s |\n", f.Name, fieldTypeLabel(f.Type), createCol, updateCol, notes)
 	}
@@ -123,7 +159,13 @@ func EntityLLMMD(ent *entity.Entity) string {
 	b.WriteString("| Parameter | Type | Description |\n")
 	b.WriteString("|-----------|------|-------------|\n")
 	b.WriteString("| `page` | integer | Page number (offset mode, default 1) |\n")
-	b.WriteString("| `limit` | integer | Items per page (default 20, max 100) |\n")
+	// The cap is per entity, and hardcoding 100 here told every agent the
+	// wrong number for any entity that set Pagination.MaxListLimit — the
+	// same reality-drift as advertising unmounted routes, one column over.
+	// listLimitCap is the function the request path actually clamps with, so
+	// the doc and the clamp cannot disagree.
+	fmt.Fprintf(&b, "| `limit` | integer | Items per page (default 20, max %d) |\n",
+		listLimitCap(ent.Config.Pagination.MaxListLimit))
 	b.WriteString("| `sort` | string | Sort field (prefix with `-` for descending, e.g. `-created_at`) |\n")
 	b.WriteString("| `cursor` | string | Opaque cursor for keyset pagination. Presence switches to cursor mode. |\n")
 	b.WriteString("| `direction` | string | Cursor walk direction: `forward` (default) or `backward` |\n")
@@ -182,71 +224,77 @@ func EntityLLMMD(ent *entity.Entity) string {
 	b.WriteString("**Response:** `200` with `{\"data\": { ... }}`.\n")
 	b.WriteString("**Error:** `404` if not found.\n\n")
 
-	// POST /{table}
-	fmt.Fprintf(&b, "### POST %s\n\n", resourcePath)
-	b.WriteString("Create a new record.\n\n")
-	b.WriteString("**Request body:** JSON object with writable fields.\n```json\n")
-	b.WriteString("{\n")
-	first := true
-	for _, f := range fields {
-		if f.AutoGenerate != schema.AutoNone || f.ReadOnly || f.Hidden {
-			continue
+	// Write endpoints. Guarded by the mount: a CrudRouteOptions{ReadOnly:
+	// true} mount (App.View) never registers these routes, so documenting
+	// them would hand an agent seven 404/405s (#358).
+	if !opt.ReadOnly {
+
+		// POST /{table}
+		fmt.Fprintf(&b, "### POST %s\n\n", resourcePath)
+		b.WriteString("Create a new record.\n\n")
+		b.WriteString("**Request body:** JSON object with writable fields.\n```json\n")
+		b.WriteString("{\n")
+		first := true
+		for _, f := range fields {
+			if f.AutoGenerate != schema.AutoNone || f.ReadOnly || f.Hidden {
+				continue
+			}
+			if !first {
+				b.WriteString(",\n")
+			}
+			first = false
+			fmt.Fprintf(&b, "  \"%s\": \"<value>\"", f.Name)
 		}
-		if !first {
-			b.WriteString(",\n")
+		b.WriteString("\n}\n```\n")
+		b.WriteString("**Response:** `201` with `{\"data\": { ... }}`.\n")
+		b.WriteString("**Error:** `400` with validation errors.\n\n")
+
+		// PUT /{table}/{id}
+		fmt.Fprintf(&b, "### PUT %s/{id}\n\n", resourcePath)
+		b.WriteString("Update an existing record.\n\n")
+		b.WriteString("**Request body:** JSON object with fields to update.\n")
+		b.WriteString("**Response:** `200` with `{\"data\": { ... }}`.\n")
+		b.WriteString("**Error:** `400` validation errors, `404` not found.\n\n")
+
+		// PATCH /{table}/{id}
+		fmt.Fprintf(&b, "### PATCH %s/{id}\n\n", resourcePath)
+		b.WriteString("Sparsely update an existing record. Only fields present in the JSON body are validated and changed.\n\n")
+		b.WriteString("**Request body:** JSON object with one or more fields to update.\n")
+		b.WriteString("**Response:** `200` with `{\"data\": { ... }}`.\n")
+		b.WriteString("**Error:** `400` validation errors, `404` not found.\n\n")
+
+		// DELETE /{table}/{id}
+		fmt.Fprintf(&b, "### DELETE %s/{id}\n\n", resourcePath)
+		b.WriteString("Delete a record.\n\n")
+		if ent.Config.Scope.SoftDelete {
+			b.WriteString("**Note:** This entity uses soft-delete: sets `deleted_at` instead of removing the row.\n\n")
 		}
-		first = false
-		fmt.Fprintf(&b, "  \"%s\": \"<value>\"", f.Name)
+		b.WriteString("**Response:** `204` No Content.\n")
+		b.WriteString("**Error:** `404` not found.\n\n")
+
+		// Batch endpoints
+		fmt.Fprintf(&b, "### POST %s/_batch\n\n", resourcePath)
+		b.WriteString("Batch create (atomic, all-or-nothing).\n\n")
+		b.WriteString("```json\n{\n  \"items\": [ { ... }, { ... } ]\n}\n```\n")
+		b.WriteString(fmt.Sprintf("Maximum %d items per batch.\n\n", MaxBatchSize))
+
+		fmt.Fprintf(&b, "### PATCH %s/_batch\n\n", resourcePath)
+		b.WriteString("Batch update (atomic). Each item must include `id` plus fields to update.\n\n")
+		b.WriteString("```json\n{\n  \"items\": [ {\"id\": \"...\", \"...\": \"...\"} ]\n}\n```\n\n")
+
+		fmt.Fprintf(&b, "### DELETE %s/_batch\n\n", resourcePath)
+		b.WriteString("Batch delete (atomic).\n\n")
+		b.WriteString("```json\n{\n  \"ids\": [ \"id1\", \"id2\" ]\n}\n```\n\n")
+
+		fmt.Fprintf(&b, "**Batch response** (200 committed, 400 rolled back):\n```json\n")
+		b.WriteString("{\n")
+		b.WriteString("  \"committed\": true,\n")
+		b.WriteString("  \"results\": [\n")
+		b.WriteString("    { \"index\": 0, \"data\": { ... } },\n")
+		b.WriteString("    { \"index\": 1, \"error\": \"validation: ...\", \"fields\": { \"name\": [\"is required\"] } }\n")
+		b.WriteString("  ]\n")
+		b.WriteString("}\n```\n\n")
 	}
-	b.WriteString("\n}\n```\n")
-	b.WriteString("**Response:** `201` with `{\"data\": { ... }}`.\n")
-	b.WriteString("**Error:** `400` with validation errors.\n\n")
-
-	// PUT /{table}/{id}
-	fmt.Fprintf(&b, "### PUT %s/{id}\n\n", resourcePath)
-	b.WriteString("Update an existing record.\n\n")
-	b.WriteString("**Request body:** JSON object with fields to update.\n")
-	b.WriteString("**Response:** `200` with `{\"data\": { ... }}`.\n")
-	b.WriteString("**Error:** `400` validation errors, `404` not found.\n\n")
-
-	// PATCH /{table}/{id}
-	fmt.Fprintf(&b, "### PATCH %s/{id}\n\n", resourcePath)
-	b.WriteString("Sparsely update an existing record. Only fields present in the JSON body are validated and changed.\n\n")
-	b.WriteString("**Request body:** JSON object with one or more fields to update.\n")
-	b.WriteString("**Response:** `200` with `{\"data\": { ... }}`.\n")
-	b.WriteString("**Error:** `400` validation errors, `404` not found.\n\n")
-
-	// DELETE /{table}/{id}
-	fmt.Fprintf(&b, "### DELETE %s/{id}\n\n", resourcePath)
-	b.WriteString("Delete a record.\n\n")
-	if ent.Config.Scope.SoftDelete {
-		b.WriteString("**Note:** This entity uses soft-delete: sets `deleted_at` instead of removing the row.\n\n")
-	}
-	b.WriteString("**Response:** `204` No Content.\n")
-	b.WriteString("**Error:** `404` not found.\n\n")
-
-	// Batch endpoints
-	fmt.Fprintf(&b, "### POST %s/_batch\n\n", resourcePath)
-	b.WriteString("Batch create (atomic, all-or-nothing).\n\n")
-	b.WriteString("```json\n{\n  \"items\": [ { ... }, { ... } ]\n}\n```\n")
-	b.WriteString(fmt.Sprintf("Maximum %d items per batch.\n\n", MaxBatchSize))
-
-	fmt.Fprintf(&b, "### PATCH %s/_batch\n\n", resourcePath)
-	b.WriteString("Batch update (atomic). Each item must include `id` plus fields to update.\n\n")
-	b.WriteString("```json\n{\n  \"items\": [ {\"id\": \"...\", \"...\": \"...\"} ]\n}\n```\n\n")
-
-	fmt.Fprintf(&b, "### DELETE %s/_batch\n\n", resourcePath)
-	b.WriteString("Batch delete (atomic).\n\n")
-	b.WriteString("```json\n{\n  \"ids\": [ \"id1\", \"id2\" ]\n}\n```\n\n")
-
-	fmt.Fprintf(&b, "**Batch response** (200 committed, 400 rolled back):\n```json\n")
-	b.WriteString("{\n")
-	b.WriteString("  \"committed\": true,\n")
-	b.WriteString("  \"results\": [\n")
-	b.WriteString("    { \"index\": 0, \"data\": { ... } },\n")
-	b.WriteString("    { \"index\": 1, \"error\": \"validation: ...\", \"fields\": { \"name\": [\"is required\"] } }\n")
-	b.WriteString("  ]\n")
-	b.WriteString("}\n```\n\n")
 
 	// SSE
 	fmt.Fprintf(&b, "### GET %s/_events\n\n", resourcePath)
@@ -274,19 +322,36 @@ func EntityLLMMD(ent *entity.Entity) string {
 	return b.String()
 }
 
+// MountInfo reports how an entity's auto-CRUD routes are mounted. The llm.md
+// index asks the app that performed the mounts, not the entity declaration:
+// Exposure cannot express that App.View mounts an entity read-only (#358),
+// just as it could not express DB-less (#266). The index must describe
+// routes that exist.
+type MountInfo struct {
+	// Mounted reports whether the standard auto-CRUD routes are registered
+	// for this entity at all (the app's route predicate: DB attached AND
+	// Exposure.CRUD unset-or-true).
+	Mounted bool
+	// ReadOnly reports a CrudRouteOptions{ReadOnly: true} mount: only the
+	// List, Get-by-ID and _events routes exist; write and batch routes
+	// were never registered.
+	ReadOnly bool
+}
+
 // RegistryLLMMD generates a top-level LLM-friendly markdown index that
 // lists every registered entity with a link to its detailed llm.md page.
-// crudMounted reports whether the entity's auto-CRUD routes were actually
-// registered (the app passes its route predicate: DB attached AND
-// Exposure.CRUD); nil documents standard CRUD for every entity, the
-// pre-#266 behavior. Entities without CRUD routes list only their declared
-// custom endpoints, and entities with no routes at all are omitted — the
-// index must describe routes that exist. It lists every (routed) entity;
-// callers that serve this to a request (the /api/llm.md index) MUST filter
-// per request via [registryLLMMD] so the index does not disclose entities
-// the caller cannot read.
-func RegistryLLMMD(registry entity.Registry, appName string, crudMounted func(*entity.Entity) bool) string {
-	return registryLLMMD(registry, appName, nil, crudMounted)
+// crudMount reports how the entity's auto-CRUD routes were actually
+// registered (the app passes its mount predicate: DB attached AND
+// Exposure.CRUD, plus ReadOnly for App.View mounts); nil documents standard
+// CRUD for every entity, the pre-#266 behavior. Entities without CRUD
+// routes list only their declared custom endpoints, entities with no routes
+// at all are omitted, and read-only mounts are counted and labelled as the
+// three routes they serve — the index must describe routes that exist. It
+// lists every (routed) entity; callers that serve this to a request (the
+// /api/llm.md index) MUST filter per request via [registryLLMMD] so the
+// index does not disclose entities the caller cannot read.
+func RegistryLLMMD(registry entity.Registry, appName string, crudMount func(*entity.Entity) MountInfo) string {
+	return registryLLMMD(registry, appName, nil, crudMount)
 }
 
 // registryLLMMD renders the index, keeping only entities for which keep
@@ -294,7 +359,7 @@ func RegistryLLMMD(registry entity.Registry, appName string, crudMounted func(*e
 // per-request keep that mirrors List's read-scope predicate (owner, tenant,
 // RBAC) so an authenticated caller with no grant for an entity gets 403 on
 // its rows AND never sees its name, base path or flags in the index.
-func registryLLMMD(registry entity.Registry, appName string, keep, crudMounted func(*entity.Entity) bool) string {
+func registryLLMMD(registry entity.Registry, appName string, keep func(*entity.Entity) bool, crudMount func(*entity.Entity) MountInfo) string {
 	var b strings.Builder
 	title := appName
 	if title == "" {
@@ -316,12 +381,20 @@ func registryLLMMD(registry entity.Registry, appName string, keep, crudMounted f
 		if keep != nil && !keep(ent) {
 			continue
 		}
-		// crudMounted mirrors route registration: nil (direct callers)
-		// documents standard CRUD as before; false lists only declared
+		// crudMount mirrors route registration: nil (direct callers)
+		// documents standard CRUD as before; unmounted lists only declared
 		// custom endpoints; an entity with no routes at all is omitted.
-		crud := crudMounted == nil || crudMounted(ent)
+		// A read-only mount (App.View) counts and labels the three routes
+		// it serves (#358): counting 8 would advertise five that 404/405.
+		mount := MountInfo{Mounted: true}
+		if crudMount != nil {
+			mount = crudMount(ent)
+		}
 		numEndpoints := len(ent.Config.Endpoints)
-		if crud {
+		switch {
+		case mount.Mounted && mount.ReadOnly:
+			numEndpoints += 3 // List, Get-by-ID, _events — the ReadOnly mount
+		case mount.Mounted:
 			numEndpoints += 8 // standard CRUD + batch + events
 		}
 		if numEndpoints == 0 {
@@ -335,8 +408,14 @@ func registryLLMMD(registry entity.Registry, appName string, keep, crudMounted f
 			llmLink = ent.Version + "/" + table + "/llm.md"
 		}
 		desc := ""
+		if mount.ReadOnly {
+			desc = "read-only"
+		}
 		if ent.Config.Scope.SoftDelete {
-			desc = "soft-delete"
+			if desc != "" {
+				desc += ", "
+			}
+			desc += "soft-delete"
 		}
 		if ent.Config.Scope.MultiTenant {
 			if desc != "" {
@@ -344,7 +423,9 @@ func registryLLMMD(registry entity.Registry, appName string, keep, crudMounted f
 			}
 			desc += "multi-tenant"
 		}
-		if crud {
+		if mount.Mounted {
+			// Read-only mounts serve their llm.md too (RegisterCrudRoutes
+			// registers the doc route in both modes), so the link stays.
 			fmt.Fprintf(&b, "| [%s](%s) | `%s` | %d | %s |\n", ent.GetName(), llmLink, basePath, numEndpoints, desc)
 		} else {
 			// The per-entity llm.md route rides the CRUD mount; without
@@ -383,8 +464,8 @@ func registryLLMMD(registry entity.Registry, appName string, keep, crudMounted f
 // for a single entity. The schema-disclosure surface is broad (every field,
 // validator, relation), so the handler requires an authenticated context:
 // the framework's auth chain must have set a user before this fires.
-func LLMMDHandler(ent *entity.Entity) http.Handler {
-	md := EntityLLMMD(ent)
+func LLMMDHandler(ent *entity.Entity, opts ...LLMMDOptions) http.Handler {
+	md := EntityLLMMD(ent, opts...)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-store")
 		if _, ok := handler.GetUser(r.Context()); !ok {
@@ -407,8 +488,8 @@ func LLMMDHandler(ent *entity.Entity) http.Handler {
 //
 // It reuses requireScope, so owner, tenant, baseline-session and RBAC all move
 // together with the read path instead of being restated here.
-func LLMMDHandlerFor(ch *CrudHandler) http.Handler {
-	docs := LLMMDHandler(ch.Entity)
+func LLMMDHandlerFor(ch *CrudHandler, opts ...LLMMDOptions) http.Handler {
+	docs := LLMMDHandler(ch.Entity, opts...)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-store")
 		if !ch.requireScope(w, r, opRead) {
@@ -428,7 +509,7 @@ func LLMMDHandlerFor(ch *CrudHandler) http.Handler {
 // instead disclosed every entity's name, base path, endpoint count and
 // soft-delete/multi-tenant flags to an authenticated caller who would get
 // 403 on the rows. The index is the disclosure, not the row.
-func RegistryLLMMDHandler(registry entity.Registry, appName string, crudMounted func(*entity.Entity) bool) http.Handler {
+func RegistryLLMMDHandler(registry entity.Registry, appName string, crudMount func(*entity.Entity) MountInfo) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-store")
 		ctx := r.Context()
@@ -438,7 +519,7 @@ func RegistryLLMMDHandler(registry entity.Registry, appName string, crudMounted 
 		}
 		md := registryLLMMD(registry, appName, func(ent *entity.Entity) bool {
 			return canListEntity(ctx, ent)
-		}, crudMounted)
+		}, crudMount)
 		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
 		w.Header().Set("Content-Length", strconv.Itoa(len(md)))
 		w.Write([]byte(md))

--- a/framework/crud/llmmd_audit_test.go
+++ b/framework/crud/llmmd_audit_test.go
@@ -1,0 +1,61 @@
+package crud
+
+// Issue #136 audit slice: llm.md route-reality probes. RED tests document
+// findings (the doc describes limits the server does not serve, the #266
+// class); the green probe pins the /llm-pages.md link emission for the
+// dead-link finding (proof completed by uihost's
+// TestUIHost_PageLLMIndexDisabledByDefault). The read-only-mount finding
+// that lived here was fixed by #358 and its test moved to
+// llmmd_readonly_test.go.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// ── FINDING: "max 100" is hardcoded, ignoring Pagination.MaxListLimit ─────
+//
+// parsePaginationValues clamps ?limit to the entity's MaxListLimit
+// (deep_security_test.go pins the clamp). An entity with MaxListLimit=3
+// serves at most 3 rows per page, but its llm.md tells every agent
+// "Items per page (default 20, max 100)". The doc describes a limit the
+// server does not serve — same reality-drift class, on the request side.
+func TestLLMMD_LimitDocMustReflectEntityMaxListLimit(t *testing.T) {
+	ent := entity.Define("posts", entity.EntityConfig{
+		Name:  "posts",
+		Table: "posts",
+		Fields: []schema.Field{
+			{Name: "title", Type: schema.String},
+		},
+		Pagination: &entity.PaginationConfig{MaxListLimit: 3},
+	}.WithTimestamps(false))
+	doc := EntityLLMMD(ent)
+	if strings.Contains(doc, "max 100") {
+		t.Error("AUDIT FINDING: llm.md claims \"max 100\" items per page while the entity's Pagination.MaxListLimit=3 clamps every request to 3")
+	}
+}
+
+// ── Green probe: the index links /llm-pages.md unconditionally ────────────
+//
+// registryLLMMD always writes the "## Pages" section linking /llm-pages.md;
+// there is no condition or option. That route is mounted only by a UI host
+// built with WithPublicLLMMD() (default OFF, pinned by uihost's
+// TestUIHost_PageLLMIndexDisabledByDefault returning 404) and a bare API
+// app has no UI host at all. Every default app's /api/llm.md therefore
+// contains a dead link — the #266 class on the linking side.
+func TestLLMMD_RegistryIndexAlwaysLinksPagesIndex(t *testing.T) {
+	reg := stubRegistry{byName: map[string]*entity.Entity{
+		"posts": entity.Define("posts", entity.EntityConfig{
+			Name:   "posts",
+			Table:  "posts",
+			Fields: []schema.Field{{Name: "title", Type: schema.String}},
+		}.WithTimestamps(false)),
+	}}
+	md := RegistryLLMMD(reg, "App", nil)
+	if !strings.Contains(md, "(/llm-pages.md)") {
+		t.Fatal("fixture broken: index no longer links /llm-pages.md; the dead-link finding needs re-deriving")
+	}
+}

--- a/framework/crud/llmmd_audit_test.go
+++ b/framework/crud/llmmd_audit_test.go
@@ -1,8 +1,9 @@
 package crud
 
-// Issue #136 audit slice: llm.md route-reality probes. RED tests document
-// findings (the doc describes limits the server does not serve, the #266
-// class); the green probe pins the /llm-pages.md link emission for the
+// Issue #136 audit slice: llm.md route-reality probes. The limits finding
+// documented here (the doc described caps the server did not serve, the
+// #266 class) was fixed with #358 and its test is now the standing pin;
+// the green probe below pins the /llm-pages.md link emission for the
 // dead-link finding (proof completed by uihost's
 // TestUIHost_PageLLMIndexDisabledByDefault). The read-only-mount finding
 // that lived here was fixed by #358 and its test moved to
@@ -16,13 +17,16 @@ import (
 	"github.com/DonaldMurillo/gofastr/framework/entity"
 )
 
-// ── FINDING: "max 100" is hardcoded, ignoring Pagination.MaxListLimit ─────
+// ── Pin: the limit row reports the cap the List route enforces ────────────
 //
-// parsePaginationValues clamps ?limit to the entity's MaxListLimit
-// (deep_security_test.go pins the clamp). An entity with MaxListLimit=3
-// serves at most 3 rows per page, but its llm.md tells every agent
-// "Items per page (default 20, max 100)". The doc describes a limit the
-// server does not serve — same reality-drift class, on the request side.
+// parsePaginationValues clamps ?limit through listLimitCap
+// (deep_security_test.go pins the clamp), so the doc has to print that
+// same cap or it advertises a limit the server refuses — the #266
+// reality-drift class, on the request side. Found as a hardcoded
+// "max 100" against MaxListLimit=3. The assertion pins the exact row:
+// the first draft only rejected `max 100`, which passes on ANY other
+// wrong cap (0, 50, 99) — an assertion that rules out one wrong answer
+// instead of the right one.
 func TestLLMMD_LimitDocMustReflectEntityMaxListLimit(t *testing.T) {
 	ent := entity.Define("posts", entity.EntityConfig{
 		Name:  "posts",
@@ -33,8 +37,9 @@ func TestLLMMD_LimitDocMustReflectEntityMaxListLimit(t *testing.T) {
 		Pagination: &entity.PaginationConfig{MaxListLimit: 3},
 	}.WithTimestamps(false))
 	doc := EntityLLMMD(ent)
-	if strings.Contains(doc, "max 100") {
-		t.Error("AUDIT FINDING: llm.md claims \"max 100\" items per page while the entity's Pagination.MaxListLimit=3 clamps every request to 3")
+	const want = "Items per page (default 20, max 3)"
+	if !strings.Contains(doc, want) {
+		t.Errorf("llm.md limit row does not report the entity's cap; want %q in:\n%s", want, doc)
 	}
 }
 

--- a/framework/crud/llmmd_readonly_test.go
+++ b/framework/crud/llmmd_readonly_test.go
@@ -1,0 +1,157 @@
+package crud
+
+// #358: read-only mounts must not advertise routes they do not serve.
+//
+// RegisterCrudRoutes with CrudRouteOptions{ReadOnly: true} (what App.View
+// uses) mounts only GET /x, GET /x/{id}, GET /x/_events plus llm.md. The
+// doc generator and the registry index both consult the mount options now:
+// the served llm.md omits the seven write/batch endpoints that answer
+// 404/405, the field table drops its Create/Update columns, and the index
+// counts and labels the three routes actually served. Same precedent as
+// #266 (EntityCRUDMounted): the truth lives in the mount, not in the
+// entity declaration.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/handler"
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// writeRouteHeadings are the doc headings for every endpoint a ReadOnly
+// mount does NOT register.
+var writeRouteHeadings = []string{
+	"### POST {p}",
+	"### PUT {p}/{id}",
+	"### PATCH {p}/{id}",
+	"### DELETE {p}/{id}",
+	"### POST {p}/_batch",
+	"### PATCH {p}/_batch",
+	"### DELETE {p}/_batch",
+}
+
+// TestLLMMD_ReadOnlyMountMustNotAdvertiseWriteRoutes asserts the SERVED
+// doc against the MOUNTED routes: every write route is first confirmed
+// absent from the router, then confirmed absent from the llm.md that same
+// router serves. Kept from the #136 audit slice that proved the finding.
+func TestLLMMD_ReadOnlyMountMustNotAdvertiseWriteRoutes(t *testing.T) {
+	ent, db, r := covSimpleEntity(t)
+	ch := NewCrudHandler(ent, db)
+	RegisterCrudRoutes(r, ch, "/widgets", CrudRouteOptions{ReadOnly: true})
+
+	// Reality check: the write routes really are not mounted.
+	writeReqs := []struct {
+		method, path string
+	}{
+		{http.MethodPost, "/widgets"},
+		{http.MethodPut, "/widgets/w1"},
+		{http.MethodPatch, "/widgets/w1"},
+		{http.MethodDelete, "/widgets/w1"},
+		{http.MethodPost, "/widgets/_batch"},
+		{http.MethodPatch, "/widgets/_batch"},
+		{http.MethodDelete, "/widgets/_batch"},
+	}
+	for _, w := range writeReqs {
+		req := httptest.NewRequest(w.method, w.path, strings.NewReader("{}"))
+		req = req.WithContext(handler.SetUser(req.Context(), &testUser{id: "u1"}))
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code == http.StatusOK {
+			t.Fatalf("fixture broken: %s %s unexpectedly served (%d)", w.method, w.path, rec.Code)
+		}
+	}
+
+	// The served llm.md (authed, same gate as List).
+	req := httptest.NewRequest(http.MethodGet, "/widgets/llm.md", nil)
+	req = req.WithContext(handler.SetUser(req.Context(), &testUser{id: "u1"}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ReadOnly mount must still serve llm.md (App.View path relies on it): %d", rec.Code)
+	}
+	doc := rec.Body.String()
+	for _, advertised := range writeRouteHeadings {
+		advertised = strings.ReplaceAll(advertised, "{p}", "/widgets")
+		if strings.Contains(doc, advertised) {
+			t.Errorf("ReadOnly llm.md advertises %q, a route that is not mounted", advertised)
+		}
+	}
+}
+
+// TestEntityLLMMD_ReadOnlyOmitsWriteSections pins the generator itself:
+// read-only drops the write sections and the Create/Update columns, while
+// the default document keeps both (guard against always-omitting).
+func TestEntityLLMMD_ReadOnlyOmitsWriteSections(t *testing.T) {
+	ent := entity.Define("widgets", entity.EntityConfig{
+		Name:  "widgets",
+		Table: "widgets",
+		Fields: []schema.Field{
+			{Name: "name", Type: schema.String, Required: true},
+		},
+	}.WithTimestamps(false))
+
+	ro := EntityLLMMD(ent, LLMMDOptions{ReadOnly: true})
+	for _, heading := range writeRouteHeadings {
+		heading = strings.ReplaceAll(heading, "{p}", "/widgets")
+		if strings.Contains(ro, heading) {
+			t.Errorf("read-only doc must omit %q:\n%s", heading, ro)
+		}
+	}
+	if strings.Contains(ro, "| Create |") || strings.Contains(ro, "| Update |") {
+		t.Errorf("read-only doc must drop the Create/Update columns (no write endpoints exist to describe):\n%s", ro)
+	}
+	for _, want := range []string{
+		"This resource is served read-only",
+		"### GET /widgets\n",
+		"### GET /widgets/{id}\n",
+		"### GET /widgets/_events\n",
+	} {
+		if !strings.Contains(ro, want) {
+			t.Errorf("read-only doc must keep %q:\n%s", want, ro)
+		}
+	}
+
+	full := EntityLLMMD(ent)
+	for _, heading := range writeRouteHeadings {
+		heading = strings.ReplaceAll(heading, "{p}", "/widgets")
+		if !strings.Contains(full, heading) {
+			t.Errorf("default doc must keep %q (ReadOnly must not leak into the full document):\n%s", heading, full)
+		}
+	}
+	if !strings.Contains(full, "| Create |") {
+		t.Errorf("default doc must keep the Create/Update columns:\n%s", full)
+	}
+}
+
+// TestRegistryLLMMD_ReadOnlyMountCountsReadRoutes pins the index: a
+// read-only mount is counted as the three routes it serves and labelled
+// read-only, instead of inheriting the 8-endpoint CRUD count — five of
+// which would 404/405.
+func TestRegistryLLMMD_ReadOnlyMountCountsReadRoutes(t *testing.T) {
+	reg := stubRegistry{byName: map[string]*entity.Entity{
+		"widgets": entity.Define("widgets", entity.EntityConfig{
+			Name:  "widgets",
+			Table: "widgets",
+			Fields: []schema.Field{
+				{Name: "name", Type: schema.String},
+			},
+		}.WithTimestamps(false)),
+	}}
+	crudMount := func(e *entity.Entity) MountInfo {
+		return MountInfo{Mounted: true, ReadOnly: e.GetTable() == "widgets"}
+	}
+
+	md := RegistryLLMMD(reg, "MyApp", crudMount)
+
+	wantRow := "| [widgets](/widgets/llm.md) | `/widgets` | 3 | read-only |"
+	if !strings.Contains(md, wantRow) {
+		t.Errorf("read-only mount must be counted as 3 routes, linked and labelled read-only:\n%s", md)
+	}
+	if strings.Contains(md, "`/widgets` | 8 ") {
+		t.Errorf("read-only mount must not inherit the 8-endpoint count:\n%s", md)
+	}
+}

--- a/framework/crud/llmmd_readonly_test.go
+++ b/framework/crud/llmmd_readonly_test.go
@@ -55,13 +55,22 @@ func TestLLMMD_ReadOnlyMountMustNotAdvertiseWriteRoutes(t *testing.T) {
 		{http.MethodPatch, "/widgets/_batch"},
 		{http.MethodDelete, "/widgets/_batch"},
 	}
+	// Require the ROUTER'S ABSENT-ROUTE STATUS, not merely "not 200".
+	//
+	// This block is the premise of everything below it: the doc is allowed
+	// to omit these routes because the server does not serve them. Rejecting
+	// only 200 does not establish that. A write route that IS mounted
+	// answers 400 for the `{}` body below, or 401 before it ever reaches the
+	// handler, and neither trips a not-200 check — so the premise would hold
+	// whether or not the routes were mounted, and a change that re-mounted
+	// writes on a read-only view would leave this test green.
 	for _, w := range writeReqs {
 		req := httptest.NewRequest(w.method, w.path, strings.NewReader("{}"))
 		req = req.WithContext(handler.SetUser(req.Context(), &testUser{id: "u1"}))
 		rec := httptest.NewRecorder()
 		r.ServeHTTP(rec, req)
-		if rec.Code == http.StatusOK {
-			t.Fatalf("fixture broken: %s %s unexpectedly served (%d)", w.method, w.path, rec.Code)
+		if rec.Code != http.StatusNotFound && rec.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("fixture broken: %s %s answered %d; a read-only mount must give the absent-route status (404/405). Anything else means the route exists and merely rejected this request, which is not the same thing", w.method, w.path, rec.Code)
 		}
 	}
 

--- a/framework/crud/llmmd_route_reality_test.go
+++ b/framework/crud/llmmd_route_reality_test.go
@@ -27,9 +27,9 @@ func TestRegistryLLMMD_RouteReality(t *testing.T) {
 			Fields: []schema.Field{{Name: "n", Type: schema.String}},
 		}.WithTimestamps(false)), // CRUD off, no endpoints: no routes at all
 	}}
-	crudMounted := func(e *entity.Entity) bool { return e.GetTable() == "posts" }
+	crudMount := func(e *entity.Entity) MountInfo { return MountInfo{Mounted: e.GetTable() == "posts"} }
 
-	md := RegistryLLMMD(reg, "MyApp", crudMounted)
+	md := RegistryLLMMD(reg, "MyApp", crudMount)
 
 	if !strings.Contains(md, "[posts](/posts/llm.md)") {
 		t.Errorf("CRUD-mounted entity should keep its linked row:\n%s", md)

--- a/framework/crud/mcp.go
+++ b/framework/crud/mcp.go
@@ -201,24 +201,33 @@ func runToolRequest(ctx context.Context, router http.Handler, method, path strin
 	// chain (auth, recovery, etc.). Session/JWT middleware re-resolves the
 	// caller from transport headers, NOT from ctx, so without copying the
 	// original request's auth the caller is demoted to anonymous and
-	// owner-scoped CRUD returns 401. Copy Cookie + Authorization from the
-	// original inbound request (stashed by the MCP transport) so the same
-	// identity re-resolves. See TestMCPAuthenticatedListReturnsOwnerRows.
+	// owner-scoped CRUD returns 401. Copy every credential header the
+	// framework recognizes from the original inbound request (stashed by
+	// the MCP transport) so the same identity re-resolves. See
+	// TestMCPAuthenticatedListReturnsOwnerRows.
+	//
+	// Every FIELD, never Get()+Set(): Get returns only the FIRST field, and
+	// Cookie routinely arrives as several (a proxy prepends its own before
+	// the browser's), so Set(Get()) collapses them to the shared first
+	// field and loses the session — the same collapse Broker.MintDelegation
+	// had (issue #360).
+	//
+	// X-API-Key belongs in the list because battery/auth's apitoken resolves
+	// it like a session; without it an API-key caller was anonymous on every
+	// re-dispatch (issue #360's second layer). The embed grant stays because
+	// embed.Host.Middleware short-circuits on a missing header — dropping it
+	// would authenticate the subject without ever evaluating the reach
+	// allow-list or the grant's expiry for the path being re-dispatched to.
+	// Nothing beyond these four rides along: the re-dispatch re-presents
+	// the caller's credentials, never other headers the original carried.
 	if orig, ok := mcp.RequestFromContext(ctx); ok && orig != nil {
-		if cookie := orig.Header.Get("Cookie"); cookie != "" {
-			req.Header.Set("Cookie", cookie)
-		}
-		if authz := orig.Header.Get("Authorization"); authz != "" {
-			req.Header.Set("Authorization", authz)
-		}
-		// The embed grant is a credential like the two above, and copying it
-		// is what keeps the re-dispatched path GATED rather than merely
-		// authenticated. The grant survives on ctx either way, so the user
-		// re-resolves, but embed.Host.Middleware short-circuits on a missing
-		// header, so without this the reach allow-list and the grant's expiry
-		// are never evaluated for the path being re-dispatched to.
-		if grant := orig.Header.Get(fembed.GrantHeader); grant != "" {
-			req.Header.Set(fembed.GrantHeader, grant)
+		for _, name := range []string{"Cookie", "Authorization", "X-API-Key", fembed.GrantHeader} {
+			for _, v := range orig.Header.Values(name) {
+				if v == "" {
+					continue
+				}
+				req.Header.Add(name, v)
+			}
 		}
 	}
 	rec := httptest.NewRecorder()

--- a/framework/crud/mcp_auth_test.go
+++ b/framework/crud/mcp_auth_test.go
@@ -45,9 +45,9 @@ func sessionLikeMiddleware(cookieName string, users map[string]*testUser) func(h
 // that user's rows, not 401, even when SessionMiddleware sits in the router
 // chain. The internal request runToolRequest builds carries no session cookie,
 // so a re-running SessionMiddleware would demote the user to anonymous and
-// RequireOwner/owner-scoping would 401. The fix copies the original request's
-// auth (Cookie/Authorization) onto the internal request so the same session
-// re-resolves.
+// RequireOwner/owner-scoping would 401. The fix copies every field of every
+// credential header (Cookie/Authorization/X-API-Key/embed grant) onto the
+// internal request so the same session re-resolves.
 func TestMCPAuthenticatedListReturnsOwnerRows(t *testing.T) {
 	installSecurityOwnerExtractor(t)
 
@@ -126,4 +126,156 @@ func newTestRequestWithCookie(cookieName, value string) *http.Request {
 	req, _ := http.NewRequest(http.MethodPost, "/mcp", nil)
 	req.AddCookie(&http.Cookie{Name: cookieName, Value: value})
 	return req
+}
+
+// apiKeyLikeMiddleware mirrors battery/auth's apitoken resolution (identity
+// from X-API-Key) without importing the battery. Same anonymous-demotion
+// contract as sessionLikeMiddleware: an unrecognized or missing key clears
+// the user, so an internal re-dispatch that lost the header is a 401, not a
+// silently different caller.
+func apiKeyLikeMiddleware(users map[string]*testUser) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			k := r.Header.Get("X-API-Key")
+			u, ok := users[k]
+			if k == "" || !ok {
+				next.ServeHTTP(w, r.WithContext(handler.SetUser(r.Context(), nil)))
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(handler.SetUser(r.Context(), u)))
+		})
+	}
+}
+
+// trustHeaderMiddleware models a NON-credential header an ingress sets and a
+// caller must never control (X-Internal-Trust): when present it resolves the
+// request as a superuser that sees every row. It is the no-extra-authority
+// instrument: if runToolRequest ever copies headers beyond the credential
+// canon from the stashed original, the re-dispatch resolves as superuser and
+// the test fails on row count. Absent the header it passes through
+// untouched, so it composes behind a session middleware without erasing the
+// session's user.
+func trustHeaderMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("X-Internal-Trust") != "" {
+				next.ServeHTTP(w, r.WithContext(handler.SetUser(r.Context(), &testUser{id: "superuser"})))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// newMCPAuthEnv builds the shared fixture for the re-dispatch credential
+// tests: an owner-scoped notes entity with one row per user behind mw,
+// exposed through MCP tools whose calls re-dispatch via the router.
+func newMCPAuthEnv(t *testing.T, mw func(http.Handler) http.Handler) (*mcp.Server, *CrudHandler) {
+	t.Helper()
+	installSecurityOwnerExtractor(t)
+	db := setupDB(t, `CREATE TABLE notes (id TEXT PRIMARY KEY, user_id TEXT NOT NULL, body TEXT)`)
+	ent := entity.Define("notes", makeEntityConfig("notes", "notes", "user_id", []schema.Field{
+		{Name: "user_id", Type: schema.String, Required: true},
+		{Name: "body", Type: schema.String},
+	}))
+	ent.SetDB(db)
+	seedRows(t, db, "notes", []map[string]any{
+		{"id": "n-alice", "user_id": "alice", "body": "alice secret"},
+		{"id": "n-bob", "user_id": "bob", "body": "bob secret"},
+	})
+	ch := NewCrudHandler(ent, db).WithJSONCase(CaseSnake)
+	r := router.New()
+	r.Use(mw)
+	RegisterCrudRoutes(r, ch, "/notes")
+	srv := mcp.NewServer()
+	if err := RegisterEntityMCPTools(srv, ch, r); err != nil {
+		t.Fatalf("register mcp: %v", err)
+	}
+	return srv, ch
+}
+
+func callListRows(t *testing.T, srv *mcp.Server, ctx context.Context) []map[string]any {
+	t.Helper()
+	listed, err := srv.CallTool(ctx, "notes_list", map[string]any{})
+	if err != nil {
+		t.Fatalf("notes_list returned error (likely 401): %v", err)
+	}
+	m, ok := listed.(map[string]any)
+	if !ok {
+		t.Fatalf("notes_list returned %T, want map", listed)
+	}
+	rows, _ := m["data"].([]any)
+	out := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, row.(map[string]any))
+	}
+	return out
+}
+
+// TestMCPRedispatchReattachesAPIKey pins the X-API-Key half of the
+// credential canon. runToolRequest used to copy Cookie, Authorization, and
+// the embed grant but not X-API-Key, so an API-key caller (battery/auth
+// apitoken) was demoted to anonymous on every entity-MCP re-dispatch —
+// issue #360's both-layers gap, this is the crud half of it.
+func TestMCPRedispatchReattachesAPIKey(t *testing.T) {
+	srv, _ := newMCPAuthEnv(t, apiKeyLikeMiddleware(map[string]*testUser{"gfsk-alice": {id: "alice"}}))
+
+	orig, _ := http.NewRequest(http.MethodPost, "/mcp", nil)
+	orig.Header.Set("X-API-Key", "gfsk-alice")
+	ctx := mcp.WithRequest(context.Background(), orig)
+
+	rows := callListRows(t, srv, ctx)
+	if len(rows) != 1 || rows[0]["user_id"] != "alice" {
+		t.Fatalf("API-key caller's re-dispatch returned %v, want exactly alice's row", rows)
+	}
+}
+
+// TestMCPRedispatchPreservesEveryCookieField pins the multi-field half:
+// runToolRequest copied the stashed request's Cookie via Get()/Set(), which
+// keeps only the FIRST header field. A proxy that prepends its own
+// "Cookie: edge=blue" before the browser's session field therefore silenced
+// the session on every re-dispatch (same collapse MintDelegation had, and
+// the exact scenario app.go:889-896 documents for credentialFingerprint).
+func TestMCPRedispatchPreservesEveryCookieField(t *testing.T) {
+	const cookieName = "fastr_session"
+	srv, _ := newMCPAuthEnv(t, sessionLikeMiddleware(cookieName, map[string]*testUser{"sess-alice": {id: "alice"}}))
+
+	orig, _ := http.NewRequest(http.MethodPost, "/mcp", nil)
+	orig.Header.Add("Cookie", "edge=blue")              // proxy-prepended field
+	orig.Header.Add("Cookie", cookieName+"=sess-alice") // the session, second field
+	ctx := mcp.WithRequest(context.Background(), orig)
+
+	rows := callListRows(t, srv, ctx)
+	if len(rows) != 1 || rows[0]["user_id"] != "alice" {
+		t.Fatalf("multi-field-cookie caller's re-dispatch returned %v, want exactly alice's row", rows)
+	}
+}
+
+// TestMCPRedispatchCopiesOnlyCredentialHeaders pins the fail-closed
+// direction: the original request carried a trust header it should never
+// have been able to spend (an ingress-set internal header) alongside its
+// session cookie; the re-dispatch must inherit the cookie identity only.
+// If runToolRequest ever copies headers wholesale from the stashed original,
+// the re-dispatch resolves as the superuser (a different identity: her own
+// row set, not alice's) and the test fails.
+func TestMCPRedispatchCopiesOnlyCredentialHeaders(t *testing.T) {
+	const cookieName = "fastr_session"
+	users := map[string]*testUser{"sess-alice": {id: "alice"}}
+	mw := func(next http.Handler) http.Handler {
+		trust := trustHeaderMiddleware()(next)
+		return sessionLikeMiddleware(cookieName, users)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			trust.ServeHTTP(w, r)
+		}))
+	}
+	srv, _ := newMCPAuthEnv(t, mw)
+
+	orig, _ := http.NewRequest(http.MethodPost, "/mcp", nil)
+	orig.Header.Add("Cookie", cookieName+"=sess-alice")
+	orig.Header.Set("X-Internal-Trust", "1")
+	ctx := mcp.WithRequest(context.Background(), orig)
+
+	rows := callListRows(t, srv, ctx)
+	if len(rows) != 1 || rows[0]["user_id"] != "alice" {
+		t.Fatalf("re-dispatch inherited authority the cookie caller never held: got %v, want exactly alice's row", rows)
+	}
 }

--- a/framework/docs/content/entity-declarations.md
+++ b/framework/docs/content/entity-declarations.md
@@ -78,6 +78,15 @@ the `/posts/_events` stream, and `/posts/llm.md`. Route generation is **on by
 default**: `Exposure.CRUD` is a `*bool`, and nil means generate. Omitting the
 block is not "declare no surface"; it is "take the default surface".
 
+`/posts/llm.md` describes the routes the entity's mount serves, not the
+declaration's full shape. `App.View` entities and any registration built
+with `CrudRouteOptions{ReadOnly: true}` get a doc without the write,
+batch and Create/Update-column sections — those routes answer 404/405 —
+and the `limit` row reports the same cap the List route clamps `?limit`
+with (`Pagination.MaxListLimit`, never above 1000, 100 when unset). A doc
+that advertises routes or limits the server refuses sends agents into
+404s; the generators read the mount, not the declaration.
+
 MCP tools are the opposite. They are **off by default** and need
 `Exposure: &framework.ExposureConfig{MCP: true}`. The one exception is the dev
 loop: under `gofastr dev`, every CRUD-enabled entity also serves its data

--- a/framework/docs/content/migrations.md
+++ b/framework/docs/content/migrations.md
@@ -657,8 +657,10 @@ app.View(migrate.View{
   changes (the `Down` restores the previous definition / drops a new one).
 - **ORM**: with `Columns` declared, `GET /active_users` and
   `GET /active_users/{id}` are mounted (plus the query layer); no write
-  routes. Without `Columns`, the view is migration-only. Query it with
-  raw SQL.
+  routes. The view's `/active_users/llm.md` lists exactly those read
+  routes (no write, batch, or Create/Update columns), and the
+  `/api/llm.md` index counts it as three endpoints labelled `read-only`.
+  Without `Columns`, the view is migration-only. Query it with raw SQL.
 - The view's ORM entity is `Unmanaged`: the migration system emits no
   table DDL for it (the view DDL handles its existence). `Unmanaged` is a
   general `EntityConfig` flag. Use it for any externally-created table

--- a/framework/docs/content/migrations.md
+++ b/framework/docs/content/migrations.md
@@ -655,11 +655,13 @@ app.View(migrate.View{
   IF EXISTS` + `CREATE` on SQLite/materialized. `migrate generate` tracks
   the definition by checksum and writes a reversible migration when it
   changes (the `Down` restores the previous definition / drops a new one).
-- **ORM**: with `Columns` declared, `GET /active_users` and
-  `GET /active_users/{id}` are mounted (plus the query layer); no write
-  routes. The view's `/active_users/llm.md` lists exactly those read
-  routes (no write, batch, or Create/Update columns), and the
-  `/api/llm.md` index counts it as three endpoints labelled `read-only`.
+- **ORM**: with `Columns` declared, three read routes are mounted —
+  `GET /active_users`, `GET /active_users/{id}` and
+  `GET /active_users/_events` — and no write routes. The view's
+  `/active_users/llm.md` lists exactly those (no write, batch, or
+  Create/Update columns), and the `/api/llm.md` index counts the same
+  three, labelled `read-only`. The query layer is not one of them: it is
+  a Go surface, not an HTTP route, so it never appears in either count.
   Without `Columns`, the view is migration-only. Query it with raw SQL.
 - The view's ORM entity is `Unmanaged`: the migration system emits no
   table DDL for it (the view DDL handles its existence). `Unmanaged` is a

--- a/framework/docs/content/process-modules.md
+++ b/framework/docs/content/process-modules.md
@@ -248,6 +248,36 @@ The shape is fixed:
    re-register it).
 3. Call `peer.Start()`, then block on `<-peer.Done()` (clean EOF on stdin).
 
+### Cancelling an in-flight call
+
+`module.cancel` aborts one inbound request's context. `CancelParams.RequestID`
+is **the canonical decimal string of the inbound frame id** — the value the
+host's `Call` assigned to the frame it is cancelling, formatted with no
+padding or sign. Exactly one spelling is accepted: `"7"` cancels frame 7,
+while `"07"`, `" 7"` and `"notes-7"` are silently ignored, so a
+near-miss can never abort a neighbouring request.
+
+Note that this is *not* `HTTPRequestParams.RequestID`, which is a
+diagnostics-only `<module>-<counter>` label and cancels nothing. The two
+fields were documented as the same value and were not, which is why
+`module.cancel` never fired on the proxy path.
+
+Hosts get the frame id from `Peer.CallWithID`, which is `Call` plus a
+callback:
+
+```go
+raw, err := peer.CallWithID(ctx, moduleproto.MethodHTTP, params, func(frameID uint64) {
+    go watchCancel(peer, frameID, ctx) // arm the watcher for THIS frame
+})
+```
+
+The callback fires synchronously, after the pending entry is registered and
+before the frame is written, so a watcher armed inside it cannot miss a
+response. It must not block — the write is waiting on it. It is not called
+when no id was allocated (the peer is closed, the method is empty, or the
+in-flight cap is reached). Plain `Call` is unchanged and still correct
+wherever the caller has nothing to cancel.
+
 ```go
 codec, _ := moduleproto.NewCodec(os.Stdin, os.Stdout, moduleproto.DefaultMaxFrameBytes)
 peer := moduleproto.NewPeer(codec, moduleproto.RoleChild)

--- a/framework/internal/testdb/searchpath_test.go
+++ b/framework/internal/testdb/searchpath_test.go
@@ -14,6 +14,8 @@ package testdb
 
 import (
 	"database/sql"
+	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -184,6 +186,82 @@ func TestWithSearchPathPreservesQuotedValues(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// Everything above asserts the SHAPE of the rewritten string. That is not
+// the property that matters: the property is that lib/pq still accepts it
+// and lands in the right schema. A rewrite can look right and not connect —
+// which is exactly what the whitespace split did.
+//
+// Builds a keyword/value DSN carrying a quoted value with a space (the case
+// that broke), rewrites it, and opens a real connection with the result.
+func TestRewrittenKeywordValueDSNStillConnects(t *testing.T) {
+	base, err := ResolvePostgresOnce()
+	if err != nil {
+		t.Skipf("Postgres unavailable: %v", err)
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		t.Skipf("TEST_POSTGRES_DSN is not a URL (%v); this test builds from one", err)
+	}
+	pass, _ := u.User.Password()
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		port = "5432"
+	}
+	// The fixture has to contain a QUOTED search_path with a space in it.
+	// Splitting on whitespace and re-joining on whitespace is lossless on
+	// its own — the damage happens only when a token is dropped, and here
+	// `search_path='stale,` is dropped while `public'` is left behind as a
+	// stray token that lib/pq cannot parse. A fixture without a quoted
+	// search_path round-trips unharmed through the broken code, so this test
+	// would pass against the bug it exists to catch. (It did, first draft.)
+	//
+	// options carries the second half of the property: a quoted value with a
+	// space that must survive untouched.
+	kv := fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable "+
+			"options='-c statement_timeout=30s' search_path='stale, public'",
+		host, port, u.User.Username(), pass, strings.TrimPrefix(u.Path, "/"))
+
+	admin, err := sql.Open("postgres", base)
+	if err != nil {
+		t.Fatalf("open admin: %v", err)
+	}
+	defer admin.Close()
+	const sn = "t_kv_rewrite_probe"
+	admin.Exec("DROP SCHEMA IF EXISTS " + sn + " CASCADE")
+	if _, err := admin.Exec("CREATE SCHEMA " + sn); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	defer admin.Exec("DROP SCHEMA " + sn + " CASCADE")
+
+	rewritten, err := withSearchPath(kv, sn)
+	if err != nil {
+		t.Fatalf("withSearchPath: %v", err)
+	}
+	db, err := sql.Open("postgres", rewritten)
+	if err != nil {
+		t.Fatalf("open rewritten: %v", err)
+	}
+	defer db.Close()
+
+	var got string
+	if err := db.QueryRow("SHOW search_path").Scan(&got); err != nil {
+		t.Fatalf("lib/pq rejected the rewritten DSN: %v", err)
+	}
+	if got != sn {
+		t.Errorf("connected, but search_path = %q, want %q", got, sn)
+	}
+	// The quoted value has to have survived intact, not just been carried.
+	var timeout string
+	if err := db.QueryRow("SHOW statement_timeout").Scan(&timeout); err != nil {
+		t.Fatalf("SHOW statement_timeout: %v", err)
+	}
+	if timeout != "30s" {
+		t.Errorf("the quoted options value did not survive the rewrite: statement_timeout = %q, want 30s", timeout)
 	}
 }
 

--- a/framework/internal/testdb/searchpath_test.go
+++ b/framework/internal/testdb/searchpath_test.go
@@ -1,0 +1,135 @@
+package testdb
+
+// The per-test schema binding has to survive a connection replacement.
+//
+// SetMaxOpenConns(1) bounds concurrency, not connection identity:
+// database/sql discards a connection whose backend died and silently opens
+// another. A schema bound with `SET search_path` on the open session is
+// gone at that point, and every statement after it runs in "$user", public
+// — the test's tables are invisible and it fails as `relation "…" does not
+// exist`, blaming the schema rather than the replaced connection.
+//
+// The failure needs a dead backend, so the test kills its own with
+// pg_terminate_backend rather than waiting for one.
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/framework/migrate"
+)
+
+// backendPID is the connection's own server process, the one to kill.
+func backendPID(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var pid int
+	if err := db.QueryRow("SELECT pg_backend_pid()").Scan(&pid); err != nil {
+		t.Fatalf("pg_backend_pid: %v", err)
+	}
+	return pid
+}
+
+func TestSearchPathSurvivesConnectionReplacement(t *testing.T) {
+	db := Open(t, migrate.DialectPostgres) // skips when no PG is reachable
+
+	var before string
+	if err := db.QueryRow("SHOW search_path").Scan(&before); err != nil {
+		t.Fatalf("SHOW search_path: %v", err)
+	}
+	if before == "" || strings.Contains(before, "public") {
+		t.Fatalf("Open did not scope the connection to a per-test schema: search_path = %q", before)
+	}
+	if _, err := db.Exec("CREATE TABLE probe (id int)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	// Kill this pool's backend from a separate, unscoped connection. The
+	// next use of db then runs on a connection database/sql opened itself,
+	// which is the case the DSN parameter exists for.
+	base, err := ResolvePostgresOnce()
+	if err != nil {
+		t.Skipf("Postgres unavailable: %v", err)
+	}
+	killer, err := sql.Open("postgres", base)
+	if err != nil {
+		t.Fatalf("open killer: %v", err)
+	}
+	defer killer.Close()
+	if _, err := killer.Exec("SELECT pg_terminate_backend($1)", backendPID(t, db)); err != nil {
+		t.Fatalf("terminate backend: %v", err)
+	}
+
+	// The first statement after the kill may itself be the one that
+	// discovers the dead connection, so allow one retry for the discovery
+	// and require the SECOND to be on a live, correctly scoped connection.
+	var after string
+	if err := db.QueryRow("SHOW search_path").Scan(&after); err != nil {
+		if err := db.QueryRow("SHOW search_path").Scan(&after); err != nil {
+			t.Fatalf("SHOW search_path after replacement: %v", err)
+		}
+	}
+	if after != before {
+		t.Errorf("search_path did not survive the connection replacement: was %q, now %q — the per-test schema must travel in the DSN, not a session-level SET", before, after)
+	}
+	if _, err := db.Exec("INSERT INTO probe VALUES (1)"); err != nil {
+		t.Errorf("insert after the connection was replaced: %v (the replacement landed outside the test's schema)", err)
+	}
+}
+
+func TestWithSearchPathRewritesBothDSNForms(t *testing.T) {
+	cases := []struct {
+		name, dsn, want string
+	}{
+		{
+			name: "url",
+			dsn:  "postgres://test:test@localhost:5432/framework_test?sslmode=disable",
+			want: "search_path=t_x_1",
+		},
+		{
+			name: "url with an existing search_path is replaced, not doubled",
+			dsn:  "postgres://test@localhost/db?search_path=stale&sslmode=disable",
+			want: "search_path=t_x_1",
+		},
+		{
+			name: "keyword/value",
+			dsn:  "host=localhost user=test dbname=framework_test sslmode=disable",
+			want: "search_path=t_x_1",
+		},
+		{
+			name: "keyword/value with an existing search_path is replaced",
+			dsn:  "host=localhost search_path=stale dbname=db",
+			want: "search_path=t_x_1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := withSearchPath(tc.dsn, "t_x_1")
+			if err != nil {
+				t.Fatalf("withSearchPath: %v", err)
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("got %q, want it to contain %q", got, tc.want)
+			}
+			if strings.Contains(got, "stale") {
+				t.Errorf("the stale search_path survived: %q", got)
+			}
+			if n := strings.Count(got, "search_path="); n != 1 {
+				t.Errorf("got %d search_path parameters, want exactly 1: %q", n, got)
+			}
+		})
+	}
+}
+
+// The schema name is interpolated into a DSN, so anything outside what
+// NewSchemaName emits is refused rather than passed through.
+func TestWithSearchPathRefusesUnsafeSchemaNames(t *testing.T) {
+	for _, bad := range []string{"", "has space", "quote'", "UPPER", "semi;colon", "amp&sand"} {
+		if got, err := withSearchPath("postgres://h/db", bad); err == nil {
+			t.Errorf("withSearchPath(%q) returned %q, want an error", bad, got)
+		}
+	}
+	if _, err := withSearchPath("postgres://h/db", "t_ok_123_4"); err != nil {
+		t.Errorf("a NewSchemaName-shaped name was refused: %v", err)
+	}
+}

--- a/framework/internal/testdb/searchpath_test.go
+++ b/framework/internal/testdb/searchpath_test.go
@@ -121,6 +121,87 @@ func TestWithSearchPathRewritesBothDSNForms(t *testing.T) {
 	}
 }
 
+// A libpq value may be single-quoted and contain spaces, so a whitespace
+// split mangles it: `search_path='stale, public'` splits into
+// `search_path='stale,` and `public'`, and dropping the first leaves the
+// second behind as a stray token. A quoted value that merely CONTAINS
+// "search_path=" loses its tail to the same filter. lib/pq then reports a
+// malformed DSN rather than the schema, so the symptom points anywhere but
+// here.
+func TestWithSearchPathPreservesQuotedValues(t *testing.T) {
+	cases := []struct {
+		name, dsn, keep string
+	}{
+		{
+			name: "quoted search_path with a space is removed whole",
+			dsn:  "host=localhost search_path='stale, public' dbname=db",
+			keep: "dbname=db",
+		},
+		{
+			name: "an unrelated quoted value with a space survives",
+			dsn:  "host=localhost password='a b c' dbname=db",
+			keep: "password='a b c'",
+		},
+		{
+			// libpq's `options` really can carry `-c search_path=…`, so this
+			// is the realistic shape, not a contrived one: a filter that
+			// matches on the substring would eat half of it.
+			name: "a quoted value containing search_path= is not filtered",
+			dsn:  "host=localhost options='-c search_path=y' dbname=db",
+			keep: "options='-c search_path=y'",
+		},
+		{
+			name: "an escaped quote inside a value does not end it",
+			dsn:  `host=localhost password='a\'b c' dbname=db`,
+			keep: `password='a\'b c'`,
+		},
+		{
+			name: "whitespace around the equals sign",
+			dsn:  "host = localhost dbname=db",
+			keep: "host = localhost",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := withSearchPath(tc.dsn, "t_new_1")
+			if err != nil {
+				t.Fatalf("withSearchPath: %v", err)
+			}
+			if !strings.Contains(got, tc.keep) {
+				t.Errorf("got %q, want it to keep %q intact", got, tc.keep)
+			}
+			if strings.Contains(got, "stale") {
+				t.Errorf("the stale search_path survived: %q", got)
+			}
+			if n := strings.Count(got, "search_path=t_new_1"); n != 1 {
+				t.Errorf("got %d copies of the new search_path, want 1: %q", n, got)
+			}
+			// A leftover fragment is the actual bug: the old value's tail
+			// surviving as a token of its own.
+			for _, frag := range []string{" public'", " y'"} {
+				if strings.Contains(got, frag) {
+					t.Errorf("a quoted value was split, leaving %q behind: %q", frag, got)
+				}
+			}
+		})
+	}
+}
+
+// A DSN the tokeniser cannot parse is an error, not a guess: silently
+// reshaping a connection string is how the whitespace-split bug read.
+func TestWithSearchPathRefusesMalformedDSNs(t *testing.T) {
+	for _, bad := range []string{
+		"postgres://%",              // url.Parse fails
+		"host=localhost dbname",     // key with no value
+		"host=localhost password='", // unterminated quote
+		"=novalue dbname=db",        // empty key
+	} {
+		if got, err := withSearchPath(bad, "t_x_1"); err == nil {
+			t.Errorf("withSearchPath(%q) returned %q, want an error", bad, got)
+		}
+	}
+}
+
 // The schema name is interpolated into a DSN, so anything outside what
 // NewSchemaName emits is refused rather than passed through.
 func TestWithSearchPathRefusesUnsafeSchemaNames(t *testing.T) {

--- a/framework/internal/testdb/searchpath_test.go
+++ b/framework/internal/testdb/searchpath_test.go
@@ -226,7 +226,15 @@ func TestRewrittenKeywordValueDSNStillConnects(t *testing.T) {
 	// space breaks identically. Either way the failure lands on
 	// "lib/pq rejected the rewritten DSN" and blames the rewrite instead
 	// of the fixture. Quotes and backslashes are escaped per libpq.
-	pass = "'" + strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(pass) + "'"
+	// user and dbname need the same treatment, for the same reason: a DSN
+	// with no userinfo gives an empty username (url.Userinfo handles the
+	// nil receiver, so this does not panic — it just yields ""), and an
+	// empty or space-bearing value unquoted lets the NEXT pair be swallowed
+	// as its value. Quoting each one keeps every pair a pair.
+	q := func(v string) string {
+		return "'" + strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(v) + "'"
+	}
+	pass = q(pass)
 	// The fixture has to contain a QUOTED search_path with a space in it.
 	// Splitting on whitespace and re-joining on whitespace is lossless on
 	// its own — the damage happens only when a token is dropped, and here
@@ -240,7 +248,7 @@ func TestRewrittenKeywordValueDSNStillConnects(t *testing.T) {
 	kv := fmt.Sprintf(
 		"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable "+
 			"options='-c statement_timeout=30s' search_path='stale, public'",
-		host, port, u.User.Username(), pass, strings.TrimPrefix(u.Path, "/"))
+		host, port, q(u.User.Username()), pass, q(strings.TrimPrefix(u.Path, "/")))
 
 	admin, err := sql.Open("postgres", base)
 	if err != nil {

--- a/framework/internal/testdb/searchpath_test.go
+++ b/framework/internal/testdb/searchpath_test.go
@@ -162,6 +162,14 @@ func TestWithSearchPathPreservesQuotedValues(t *testing.T) {
 			dsn:  "host = localhost dbname=db",
 			keep: "host = localhost",
 		},
+		{
+			// lib/pq's unquoted-value scanner consumes a backslash-escaped
+			// character, so `password=a\ b` is ONE value to the driver.
+			// Splitting at the space rejected a DSN lib/pq accepts.
+			name: "an escaped space in an unquoted value is one token",
+			dsn:  `host=localhost password=a\ b dbname=db`,
+			keep: `password=a\ b`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -211,6 +219,14 @@ func TestRewrittenKeywordValueDSNStillConnects(t *testing.T) {
 	if port == "" {
 		port = "5432"
 	}
+	// The password is interpolated into a keyword/value DSN, so it has to
+	// be single-quoted or it cannot stay one pair: u.User.Password() is ""
+	// for a trust/peer-auth DSN, and `password= dbname=…` makes `dbname=…`
+	// the password (no dbname pair survives) — a password containing a
+	// space breaks identically. Either way the failure lands on
+	// "lib/pq rejected the rewritten DSN" and blames the rewrite instead
+	// of the fixture. Quotes and backslashes are escaped per libpq.
+	pass = "'" + strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(pass) + "'"
 	// The fixture has to contain a QUOTED search_path with a space in it.
 	// Splitting on whitespace and re-joining on whitespace is lossless on
 	// its own — the damage happens only when a token is dropped, and here

--- a/framework/internal/testdb/testdb.go
+++ b/framework/internal/testdb/testdb.go
@@ -184,16 +184,91 @@ func withSearchPath(dsn, schema string) (string, error) {
 		u.RawQuery = q.Encode()
 		return u.String(), nil
 	}
-	// Keyword/value form. Drop any existing search_path= pair, then append.
-	var kept []string
-	for _, f := range strings.Fields(dsn) {
-		if strings.HasPrefix(f, "search_path=") {
+	// Keyword/value form. Drop any existing search_path pair, then append.
+	pairs, err := splitKeywordValueDSN(dsn)
+	if err != nil {
+		return "", err
+	}
+	kept := make([]string, 0, len(pairs)+1)
+	for _, p := range pairs {
+		if p.key == "search_path" {
 			continue
 		}
-		kept = append(kept, f)
+		kept = append(kept, p.raw)
 	}
 	kept = append(kept, "search_path="+schema)
 	return strings.Join(kept, " "), nil
+}
+
+// dsnPair is one keyword/value entry: its key, and the original text of the
+// whole `key=value` so re-emitting a kept pair cannot change its meaning.
+type dsnPair struct{ key, raw string }
+
+// splitKeywordValueDSN tokenises a libpq keyword/value DSN.
+//
+// strings.Fields is wrong here, and quietly so. libpq values may be
+// single-quoted and contain spaces, so `search_path='stale, public'` splits
+// into `search_path='stale,` and `public'` — dropping the first leaves the
+// second behind as a stray token, and a quoted value that merely CONTAINS
+// "search_path=" loses its tail to the same filter. Either way the rewritten
+// DSN is malformed, and lib/pq reports that rather than the schema.
+//
+// Follows libpq's fe-connect.c: whitespace around the key and the `=` is
+// allowed; a value is either single-quoted with backslash escapes, or runs to
+// the next whitespace. A DSN this cannot parse is an error, not a guess —
+// silently reshaping a connection string is how the original bug read.
+func splitKeywordValueDSN(dsn string) ([]dsnPair, error) {
+	var out []dsnPair
+	i := 0
+	isSpace := func(c byte) bool { return c == ' ' || c == '\t' || c == '\n' || c == '\r' }
+	for {
+		for i < len(dsn) && isSpace(dsn[i]) {
+			i++
+		}
+		if i >= len(dsn) {
+			return out, nil
+		}
+		start := i
+		for i < len(dsn) && dsn[i] != '=' && !isSpace(dsn[i]) {
+			i++
+		}
+		key := dsn[start:i]
+		if key == "" {
+			return nil, fmt.Errorf("dsn: empty key at offset %d", start)
+		}
+		for i < len(dsn) && isSpace(dsn[i]) {
+			i++
+		}
+		if i >= len(dsn) || dsn[i] != '=' {
+			return nil, fmt.Errorf("dsn: key %q has no value", key)
+		}
+		i++ // '='
+		for i < len(dsn) && isSpace(dsn[i]) {
+			i++
+		}
+		if i < len(dsn) && dsn[i] == '\'' {
+			i++ // opening quote
+			for {
+				if i >= len(dsn) {
+					return nil, fmt.Errorf("dsn: unterminated quoted value for key %q", key)
+				}
+				if dsn[i] == '\\' && i+1 < len(dsn) {
+					i += 2
+					continue
+				}
+				if dsn[i] == '\'' {
+					i++ // closing quote
+					break
+				}
+				i++
+			}
+		} else {
+			for i < len(dsn) && !isSpace(dsn[i]) {
+				i++
+			}
+		}
+		out = append(out, dsnPair{key: key, raw: dsn[start:i]})
+	}
 }
 
 // ForEachDialect runs fn against every dialect in Dialects as a t.Run

--- a/framework/internal/testdb/testdb.go
+++ b/framework/internal/testdb/testdb.go
@@ -213,10 +213,14 @@ type dsnPair struct{ key, raw string }
 // "search_path=" loses its tail to the same filter. Either way the rewritten
 // DSN is malformed, and lib/pq reports that rather than the schema.
 //
-// Follows libpq's fe-connect.c: whitespace around the key and the `=` is
-// allowed; a value is either single-quoted with backslash escapes, or runs to
-// the next whitespace. A DSN this cannot parse is an error, not a guess —
-// silently reshaping a connection string is how the original bug read.
+// Follows libpq's fe-connect.c (and lib/pq's Go port): whitespace around
+// the key and the `=` is allowed; a value is either single-quoted with
+// backslash escapes, or runs to the next whitespace, with a backslash
+// escaping the next character in BOTH forms — lib/pq v1.12.3 consumes
+// `a\ b` as one unquoted value, and a tokeniser that splits at the space
+// rejects a DSN the driver accepts. A DSN this cannot parse is an error,
+// not a guess — silently reshaping a connection string is how the
+// original bug read.
 func splitKeywordValueDSN(dsn string) ([]dsnPair, error) {
 	var out []dsnPair
 	i := 0
@@ -263,7 +267,15 @@ func splitKeywordValueDSN(dsn string) ([]dsnPair, error) {
 				i++
 			}
 		} else {
+			// A trailing lone backslash stays a literal byte: lib/pq errors on
+			// it at open time ("missing character after backslash"), and
+			// keeping the raw text means the driver's own parse decides. Our
+			// job is agreeing on token boundaries, not re-validating escapes.
 			for i < len(dsn) && !isSpace(dsn[i]) {
+				if dsn[i] == '\\' && i+1 < len(dsn) {
+					i += 2 // consume the escaped character, quoted or not
+					continue
+				}
 				i++
 			}
 		}

--- a/framework/internal/testdb/testdb.go
+++ b/framework/internal/testdb/testdb.go
@@ -12,6 +12,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -119,19 +120,80 @@ func Open(t *testing.T, dialect migrate.Dialect) *sql.DB {
 		if _, err := db.ExecContext(context.Background(), "CREATE SCHEMA "+schemaName); err != nil {
 			t.Fatalf("create schema %s: %v", schemaName, err)
 		}
-		if _, err := db.ExecContext(context.Background(), "SET search_path TO "+schemaName); err != nil {
-			t.Fatalf("set search_path: %v", err)
+		// The schema binding travels in the DSN, not as `SET search_path` on
+		// the open session. SetMaxOpenConns(1) bounds concurrency, not
+		// connection identity: database/sql discards a connection whose
+		// backend died and silently opens a replacement, and a replacement
+		// starts at the default search_path. Every statement after that
+		// point runs in "$user", public — so the test's tables are invisible
+		// and it fails as `relation "…" does not exist`, pointing at the
+		// schema rather than at the connection that was actually replaced.
+		// lib/pq forwards unrecognised DSN parameters to the server as
+		// startup options, so carrying it here applies it to every
+		// connection the pool ever opens. Proven by killing the backend with
+		// pg_terminate_backend: the session-level SET does not survive it and
+		// the DSN parameter does (TestSearchPathSurvivesConnectionReplacement).
+		scoped, err := withSearchPath(base, schemaName)
+		if err != nil {
+			t.Fatalf("scope dsn to %s: %v", schemaName, err)
 		}
+		scopedDB, err := sql.Open("postgres", scoped)
+		if err != nil {
+			t.Fatalf("open pg (scoped): %v", err)
+		}
+		scopedDB.SetMaxOpenConns(1)
 		t.Cleanup(func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
+			scopedDB.Close()
 			db.ExecContext(ctx, "DROP SCHEMA "+schemaName+" CASCADE")
 			db.Close()
 		})
-		return db
+		return scopedDB
 	}
 	t.Fatalf("unknown dialect: %s", dialect)
 	return nil
+}
+
+// withSearchPath returns dsn with search_path set to schema, so every
+// connection the pool opens from it starts already scoped.
+//
+// Both DSN spellings lib/pq accepts are handled: a URL
+// (postgres://user@host/db?sslmode=disable) and keyword/value
+// (host=… user=… dbname=…). An existing search_path is replaced rather than
+// appended — two of them would leave which one wins up to the parser.
+//
+// schema comes from NewSchemaName, which emits only [a-z0-9_], so it needs
+// no quoting here; anything else is refused rather than interpolated.
+func withSearchPath(dsn, schema string) (string, error) {
+	if schema == "" {
+		return "", errors.New("empty schema name")
+	}
+	for _, r := range schema {
+		if !(r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '_') {
+			return "", fmt.Errorf("schema %q is not [a-z0-9_]; refusing to put it in a DSN", schema)
+		}
+	}
+	if strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://") {
+		u, err := url.Parse(dsn)
+		if err != nil {
+			return "", fmt.Errorf("parse dsn: %w", err)
+		}
+		q := u.Query()
+		q.Set("search_path", schema)
+		u.RawQuery = q.Encode()
+		return u.String(), nil
+	}
+	// Keyword/value form. Drop any existing search_path= pair, then append.
+	var kept []string
+	for _, f := range strings.Fields(dsn) {
+		if strings.HasPrefix(f, "search_path=") {
+			continue
+		}
+		kept = append(kept, f)
+	}
+	kept = append(kept, "search_path="+schema)
+	return strings.Join(kept, " "), nil
 }
 
 // ForEachDialect runs fn against every dialect in Dialects as a t.Run

--- a/framework/migrate_view_test.go
+++ b/framework/migrate_view_test.go
@@ -3,10 +3,13 @@ package framework
 import (
 	"context"
 	"database/sql"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/DonaldMurillo/gofastr/core/handler"
 	coremig "github.com/DonaldMurillo/gofastr/core/migrate"
 	"github.com/DonaldMurillo/gofastr/core/schema"
 	"github.com/DonaldMurillo/gofastr/framework/crud"
@@ -199,6 +202,75 @@ func TestView_ORMReadOnly(t *testing.T) {
 		resp := ta.Post("/active_users", map[string]any{"name": "x"})
 		if resp.Status() == http.StatusOK || resp.Status() == http.StatusCreated {
 			t.Fatalf("write to a read-only view should be rejected, got %d", resp.Status())
+		}
+	})
+}
+
+// TestView_LLMMDMatchesReadOnlyMount pins #358 end to end through App.View:
+// the mount is read-only, so the served per-entity llm.md must not name the
+// seven write/batch routes (they 404/405), and the /api/llm.md index must
+// count the three routes the mount actually serves. Both docs consult the
+// mount (CrudRouteOptions.ReadOnly via RegisterCrudRoutes; App.entityCrudMount
+// for the index), not the entity declaration — the #266 precedent.
+func TestView_LLMMDMatchesReadOnlyMount(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, db *sql.DB, _ Dialect) {
+		app := NewApp(WithDB(db))
+		app.Registry.Register(entity.Define("users", entity.EntityConfig{
+			Table:  "users",
+			Fields: []schema.Field{{Name: "name", Type: schema.String}, {Name: "active", Type: schema.Bool}},
+		}.WithTimestamps(false)))
+		app.View(activeUsersView())
+
+		// Full boot: migrates the table + view and registers /api/llm.md.
+		app, cleanup := startApp(t, app)
+		defer cleanup()
+
+		do := func(method, path string) *httptest.ResponseRecorder {
+			var body io.Reader
+			if method == http.MethodPost {
+				body = strings.NewReader(`{"name":"x"}`)
+			}
+			req := httptest.NewRequest(method, path, body)
+			req = req.WithContext(handler.SetUser(req.Context(), map[string]string{"id": "u1"}))
+			rec := httptest.NewRecorder()
+			app.router.ServeHTTP(rec, req)
+			return rec
+		}
+
+		// Reality check: write routes really are not mounted.
+		if s := do(http.MethodPost, "/active_users").Code; s == http.StatusOK || s == http.StatusCreated {
+			t.Fatalf("write to a read-only view served (%d) — fixture broken", s)
+		}
+
+		rec := do(http.MethodGet, "/active_users/llm.md")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("App.View must serve the view's llm.md: %d %s", rec.Code, rec.Body.String())
+		}
+		doc := rec.Body.String()
+		for _, heading := range []string{
+			"### POST /active_users",
+			"### PUT /active_users/{id}",
+			"### PATCH /active_users/{id}",
+			"### DELETE /active_users/{id}",
+			"### POST /active_users/_batch",
+			"### PATCH /active_users/_batch",
+			"### DELETE /active_users/_batch",
+		} {
+			if strings.Contains(doc, heading) {
+				t.Errorf("App.View llm.md advertises %q, a route the read-only mount does not serve", heading)
+			}
+		}
+
+		idxRec := do(http.MethodGet, "/api/llm.md")
+		if idxRec.Code != http.StatusOK {
+			t.Fatalf("index refused an authenticated caller: %d %s", idxRec.Code, idxRec.Body.String())
+		}
+		idx := idxRec.Body.String()
+		if want := "| [active_users](/active_users/llm.md) | `/active_users` | 3 | read-only |"; !strings.Contains(idx, want) {
+			t.Errorf("index must count the view's 3 read-only routes and label it read-only:\n%s", idx)
+		}
+		if strings.Contains(idx, "`/active_users` | 8 ") {
+			t.Errorf("index counted 8 endpoints for a read-only view mount:\n%s", idx)
 		}
 	})
 }

--- a/framework/migrate_view_test.go
+++ b/framework/migrate_view_test.go
@@ -243,8 +243,22 @@ func TestView_LLMMDMatchesReadOnlyMount(t *testing.T) {
 		// "not a success". A mounted POST would reject this empty body with
 		// 400, which a not-2xx check accepts — so the premise of the
 		// assertion below would hold whether or not the route existed.
-		if s := do(http.MethodPost, "/active_users").Code; s != http.StatusNotFound && s != http.StatusMethodNotAllowed {
-			t.Fatalf("POST to a read-only view answered %d; want the absent-route status (404/405). Anything else means the route is mounted and merely refused this request", s)
+		// All seven, not just POST. The llm.md assertion below covers every
+		// write verb, so a premise that checks one of them leaves six
+		// unproven: re-mounting PUT while POST stays absent keeps this
+		// green. The sibling test in framework/crud iterates the same set.
+		for _, w := range []struct{ method, path string }{
+			{http.MethodPost, "/active_users"},
+			{http.MethodPut, "/active_users/1"},
+			{http.MethodPatch, "/active_users/1"},
+			{http.MethodDelete, "/active_users/1"},
+			{http.MethodPost, "/active_users/_batch"},
+			{http.MethodPatch, "/active_users/_batch"},
+			{http.MethodDelete, "/active_users/_batch"},
+		} {
+			if s := do(w.method, w.path).Code; s != http.StatusNotFound && s != http.StatusMethodNotAllowed {
+				t.Fatalf("%s %s on a read-only view answered %d; want the absent-route status (404/405). Anything else means the route is mounted and merely refused this request", w.method, w.path, s)
+			}
 		}
 
 		rec := do(http.MethodGet, "/active_users/llm.md")

--- a/framework/migrate_view_test.go
+++ b/framework/migrate_view_test.go
@@ -238,8 +238,13 @@ func TestView_LLMMDMatchesReadOnlyMount(t *testing.T) {
 		}
 
 		// Reality check: write routes really are not mounted.
-		if s := do(http.MethodPost, "/active_users").Code; s == http.StatusOK || s == http.StatusCreated {
-			t.Fatalf("write to a read-only view served (%d) — fixture broken", s)
+		//
+		// The status has to be the router's absent-route answer, not just
+		// "not a success". A mounted POST would reject this empty body with
+		// 400, which a not-2xx check accepts — so the premise of the
+		// assertion below would hold whether or not the route existed.
+		if s := do(http.MethodPost, "/active_users").Code; s != http.StatusNotFound && s != http.StatusMethodNotAllowed {
+			t.Fatalf("POST to a read-only view answered %d; want the absent-route status (404/405). Anything else means the route is mounted and merely refused this request", s)
 		}
 
 		rec := do(http.MethodGet, "/active_users/llm.md")

--- a/framework/pluginhost/wasm_tier_chromium_test.go
+++ b/framework/pluginhost/wasm_tier_chromium_test.go
@@ -98,6 +98,12 @@ func TestWasmTierInstantiatesInFrame(t *testing.T) {
 
 	allocCtx, cancelAlloc := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
+			// A cold Chrome start on a shared runner can take longer than
+			// chromedp's 20s default wait for the DevTools websocket URL, which
+			// surfaces as "websocket url timeout reached" and looks like a test
+			// failure rather than a slow launch. The cmd/gofastr chromedp tests
+			// already raise it to 90s; these did not.
+			chromedp.WSURLReadTimeout(90*time.Second),
 			chromedp.NoSandbox,
 			chromedp.ExecPath(path),
 		)...)

--- a/framework/processmodule_broker.go
+++ b/framework/processmodule_broker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/core/moduleproto"
 	"github.com/DonaldMurillo/gofastr/framework/access"
 	"github.com/DonaldMurillo/gofastr/framework/crud"
+	fembed "github.com/DonaldMurillo/gofastr/framework/embed"
 	"github.com/DonaldMurillo/gofastr/framework/entity"
 	"github.com/DonaldMurillo/gofastr/framework/event"
 )
@@ -72,19 +73,24 @@ type Broker struct {
 
 // delegationEntry is the snapshot stashed at delegation-mint time. It carries
 // exactly what the reverse path needs to (a) re-attach the caller's identity
-// to the CRUD re-dispatch (Cookie/Authorization re-injected via crud.Redispatch
-// reading mcp.WithRequest) and (b) run the CrossOwnerRead carve-out on the
-// delegated caller (roles + policy). module binds the handle to the module
-// that minted it (F6) so an app-global handle table cannot be replayed under
-// a different module's reverse handler. parentCallID is diagnostic correlation.
+// to the CRUD re-dispatch (every field of every credential header re-injected
+// via crud.Redispatch reading mcp.WithRequest) and (b) run the
+// CrossOwnerRead carve-out on the delegated caller (roles + policy). module
+// binds the handle to the module that minted it (F6) so an app-global handle
+// table cannot be replayed under a different module's reverse handler.
+// parentCallID is diagnostic correlation.
 type delegationEntry struct {
-	cookie        string
-	authorization string
-	roles         []string
-	policy        *access.RolePolicy
-	module        string
-	parentCallID  uint64
-	expires       time.Time
+	// credentials holds every FIELD of every credential header the minting
+	// request presented, keyed by canonical header name — the four-header
+	// canon in delegationCredentialHeaders. Nothing else from the request
+	// rides along, so a delegation can re-present the caller's authority
+	// but never MORE of it (issue #360).
+	credentials  http.Header
+	roles        []string
+	policy       *access.RolePolicy
+	module       string
+	parentCallID uint64
+	expires      time.Time
 }
 
 // BrokerOption configures a [Broker].
@@ -167,6 +173,19 @@ func mustHandle(p *moduleproto.Peer, method string, h moduleproto.Handler) {
 // (including buffered-503 crash paths) so the in-memory table does not leak.
 // A nil r is the ambient (caller-less) path. MintDelegation is still legal
 // but returns an empty handle the broker treats as ambient.
+//
+// The snapshot deliberately does NOT pin which identity CLASS resolved the
+// original request (grant vs session vs API key): it re-presents the
+// credential fields verbatim and lets the re-dispatch's middleware chain
+// re-run the same verdicts on the same headers. Pinning would mean the
+// broker interpreting credentials, which the capability model reserves for
+// the auth surfaces; and under the real wiring the question is mostly moot —
+// embed.Host.Middleware (contract: installed OUTERMOST) deletes
+// Cookie/Authorization/X-API-Key from the request the moment a grant verdict
+// is final, i.e. BEFORE the supervisor mints, so a mixed request snapshots
+// as the class its middleware already chose. A grant that may not reach the
+// re-dispatched CRUD path fails closed there (embed reach refusal), it never
+// falls through to the suppressed cookie.
 func (b *Broker) MintDelegation(r *http.Request, parentCallID uint64) (string, func()) {
 	handle, err := randomHandle()
 	if err != nil {
@@ -180,8 +199,7 @@ func (b *Broker) MintDelegation(r *http.Request, parentCallID uint64) (string, f
 	}
 	entry := delegationEntry{parentCallID: parentCallID, expires: b.now().Add(b.handleTTL)}
 	if r != nil {
-		entry.cookie = r.Header.Get("Cookie")
-		entry.authorization = r.Header.Get("Authorization")
+		entry.credentials = credentialSnapshot(r)
 		entry.roles = access.GetRoles(r.Context())
 		entry.policy = access.PolicyFromContext(r.Context())
 		entry.module = delegationModuleFromCtx(r.Context())
@@ -594,18 +612,52 @@ func (b *Broker) entityPath(ent *entity.Entity) string {
 // moduleRole is the synthetic ambient role name for a module (design §5).
 func moduleRole(name string) string { return "module/" + name }
 
+// delegationCredentialHeaders is the framework's credential-header canon: the
+// four transport headers the auth surfaces resolve (Authorization bearer,
+// X-API-Key apitoken, the embed grant, Cookie sessions — the same list
+// app.go's credentialFingerprint hashes). It MUST stay in sync with
+// credentialFingerprint's list in app.go and the copy list in
+// crud/mcp.go runToolRequest: a header one of them recognizes and the others
+// drop is the issue #360 defect class — authority the caller legitimately
+// holds that never reaches the re-dispatch.
+var delegationCredentialHeaders = []string{"Authorization", "X-API-Key", fembed.GrantHeader, "Cookie"}
+
+// credentialSnapshot copies every FIELD of every credential header r carries.
+// Values, never Get: Get returns only the FIRST field, and Cookie is
+// routinely several (a proxy prepends its own before the browser's), which
+// is the exact collapse app.go's credentialFingerprint documents. Headers
+// outside the canon are deliberately excluded — the snapshot re-presents
+// the caller's credentials and nothing else, so it can never carry more
+// authority than the minting request had.
+func credentialSnapshot(r *http.Request) http.Header {
+	h := http.Header{}
+	for _, name := range delegationCredentialHeaders {
+		for _, v := range r.Header.Values(name) {
+			if v == "" {
+				continue
+			}
+			h.Add(name, v)
+		}
+	}
+	return h
+}
+
 // snapshotRequest builds a minimal *http.Request carrying the stashed caller
 // credentials so crud.Redispatch's mcp.WithRequest header re-injection
 // recovers the same identity the middleware would resolve for a live request.
+//
+// The header map is a fresh CLONE of the stash per call: re-dispatch
+// middleware mutates request headers in place (embed's grant path deletes
+// Cookie/Authorization/X-API-Key once the grant verdict is final — "the
+// grant is the only identity an embed request may have"), and a shared map
+// would let one re-dispatch's verdict erase the credentials of every later
+// reverse call on the same handle.
 func snapshotRequest(entry delegationEntry) *http.Request {
-	r := &http.Request{Header: map[string][]string{}, URL: &url.URL{Path: "/"}}
-	if entry.cookie != "" {
-		r.Header.Set("Cookie", entry.cookie)
+	header := entry.credentials.Clone()
+	if header == nil {
+		header = http.Header{}
 	}
-	if entry.authorization != "" {
-		r.Header.Set("Authorization", entry.authorization)
-	}
-	return r
+	return &http.Request{Header: header, URL: &url.URL{Path: "/"}}
 }
 
 // entityQuerySuffix expands the structured query params into the CRUD list

--- a/framework/processmodule_broker_cover_test.go
+++ b/framework/processmodule_broker_cover_test.go
@@ -370,7 +370,8 @@ func TestParseEntityCall_emptyParamsErrors(t *testing.T) {
 // ---- snapshotRequest / moduleRole ----
 
 func TestSnapshotRequest_carriesCredentials(t *testing.T) {
-	r := snapshotRequest(delegationEntry{cookie: "sid=x", authorization: "Bearer t"})
+	entry := delegationEntry{credentials: http.Header{"Cookie": []string{"sid=x"}, "Authorization": []string{"Bearer t"}}}
+	r := snapshotRequest(entry)
 	if r.Header.Get("Cookie") != "sid=x" {
 		t.Errorf("Cookie = %q", r.Header.Get("Cookie"))
 	}
@@ -434,15 +435,15 @@ func TestMintDelegation_ambientIsCallerless(t *testing.T) {
 	if handle == "" {
 		t.Fatal("ambient handle = empty; MintDelegation always returns a random handle")
 	}
-	// The entry is caller-less: no cookie / authorization stashed.
+	// The entry is caller-less: no credentials stashed.
 	b.mu.Lock()
 	entry, ok := b.handles[handle]
 	b.mu.Unlock()
 	if !ok {
 		t.Fatalf("ambient handle %q not stashed", handle)
 	}
-	if entry.cookie != "" || entry.authorization != "" {
-		t.Errorf("ambient entry = %+v, want no caller credentials", entry)
+	if n := len(snapshotRequest(entry).Header); n != 0 {
+		t.Errorf("ambient entry snapshot carries %d header names, want no caller credentials", n)
 	}
 }
 
@@ -459,8 +460,11 @@ func TestMintDelegation_withRequestStash(t *testing.T) {
 	b.mu.Lock()
 	entry, ok := b.handles[handle]
 	b.mu.Unlock()
-	if !ok || entry.cookie != "sid=abc" {
-		t.Errorf("stashed entry = %+v ok=%v", entry, ok)
+	if !ok {
+		t.Fatalf("stashed handle %q not found", handle)
+	}
+	if got := snapshotRequest(entry).Header.Get("Cookie"); got != "sid=abc" {
+		t.Errorf("stashed entry = %+v, want the cookie sid=abc to round-trip", entry)
 	}
 }
 

--- a/framework/processmodule_broker_delegation_test.go
+++ b/framework/processmodule_broker_delegation_test.go
@@ -1,0 +1,386 @@
+package framework
+
+// Delegation-credential contract tests (issue #360). The original audit
+// finding, kept as evidence: the broker's delegation snapshot persisted only
+// 2 of the 4 credential headers the framework recognizes. framework/app.go
+// credentialFingerprint enumerates Authorization, X-API-Key, the embed grant
+// (X-Gofastr-Embed), and Cookie; crud.runToolRequest copied the first three
+// plus Cookie from the request stashed via mcp.WithRequest; but
+// Broker.MintDelegation stashed only Cookie (first header field only) and
+// Authorization, and snapshotRequest rebuilt a request carrying just those. A
+// delegated caller authenticated by API key or embed grant therefore
+// re-resolved ANONYMOUS on every brokered host.entity.* re-dispatch, and a
+// caller whose session cookie lived in a second Cookie header field lost it
+// the same way. Fail-closed (the owner gate refuses), but the module-grant ∩
+// caller-authority contract was broken for those callers: authority they
+// legitimately hold never reached the reverse path. These tests pin the fixed
+// contract: the snapshot carries EVERY field of EVERY credential header, and
+// nothing else.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/handler"
+	"github.com/DonaldMurillo/gofastr/core/mcp"
+	"github.com/DonaldMurillo/gofastr/core/moduleproto"
+	"github.com/DonaldMurillo/gofastr/core/router"
+	"github.com/DonaldMurillo/gofastr/framework/access"
+	"github.com/DonaldMurillo/gofastr/framework/crud"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// delegationCredMiddleware mirrors how the framework's real auth surfaces
+// resolve identity, one branch per credential:
+//   - X-API-Key (battery/auth apitoken),
+//   - the embed grant header, whose verdict is FINAL when presented
+//     (framework/embed middleware: a grant suppresses ambient cookies),
+//   - session cookies, scanning EVERY Cookie header field — the exact
+//     multi-field lesson app.go:888 documents for credentialFingerprint.
+//
+// Every authenticated caller gets the "owner" role so the entity's
+// Access.Read permission resolves; identity (and therefore owner scope)
+// still comes from the user alone.
+//
+// saw, when non-nil, receives a clone of the raw inbound headers of every
+// request that reaches the middleware — the instrument the no-extra-authority
+// test uses to inspect exactly what a brokered re-dispatch carried.
+func delegationCredMiddleware(policy *access.RolePolicy, saw func(http.Header)) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if saw != nil {
+				saw(r.Header.Clone())
+			}
+			ctx := r.Context()
+			if policy != nil {
+				ctx = access.WithPolicy(ctx, policy)
+			}
+			authenticated := false
+			if k := r.Header.Get("X-API-Key"); k != "" {
+				ctx = handler.SetUser(ctx, &brokerTestUser{id: "keyuser-" + k})
+				authenticated = true
+			}
+			if g := r.Header.Get("X-Gofastr-Embed"); g != "" {
+				ctx = handler.SetUser(ctx, &brokerTestUser{id: "embeduser-" + g})
+				authenticated = true
+			} else if !authenticated {
+				for _, field := range r.Header.Values("Cookie") {
+					for _, part := range strings.Split(field, ";") {
+						part = strings.TrimSpace(part)
+						if sid, ok := strings.CutPrefix(part, "sid="); ok && sid != "" {
+							ctx = handler.SetUser(ctx, &brokerTestUser{id: sid})
+							authenticated = true
+						}
+					}
+				}
+			}
+			if authenticated {
+				ctx = access.WithRoles(ctx, []string{"owner"})
+			}
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// newDelegationCredEnv builds a real CRUD chokepoint (owner-scoped entity +
+// Access.Read permission) behind delegationCredMiddleware, wired into a
+// Broker exactly like newCrudBrokerEnv but with the multi-credential
+// middleware. saw is passed through to the middleware (nil = no instrument).
+func newDelegationCredEnv(t *testing.T, saw func(http.Header)) (*Broker, *access.RolePolicy) {
+	t.Helper()
+	brokerInstallOwnerExtractor(t)
+	db := brokerSetupDB(t, `CREATE TABLE logs (id TEXT PRIMARY KEY, user_id TEXT NOT NULL, subject TEXT)`)
+	ent := brokerEntity("logs", "logs", func(c *entity.EntityConfig) {
+		c.Exposure.Access.Read = "logs:read"
+	})
+	ent.SetDB(db)
+	reg := brokerRegistry(ent)
+	ch := crud.NewCrudHandler(ent, db)
+	ch.Registry = reg
+	ch.JSONCase = crud.CaseSnake
+	inner := router.New()
+	crud.RegisterCrudRoutes(inner, ch, "/logs", crud.CrudRouteOptions{NoLLMMD: true})
+	policy := access.NewRolePolicy()
+	if err := policy.Grant("owner", "logs:read"); err != nil {
+		t.Fatal(err)
+	}
+	b := NewBroker(delegationCredMiddleware(policy, saw)(inner), reg, nil, "", WithBrokerPolicy(policy))
+	return b, policy
+}
+
+// mintDelegationFor mints a handle from a request shaped by shape, bound to
+// module "m" the way the supervisor's proxy does (withDelegationModule).
+func mintDelegationFor(t *testing.T, b *Broker, shape func(*http.Request)) (string, func()) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/m/logs", nil)
+	if shape != nil {
+		shape(req)
+	}
+	req = req.WithContext(withDelegationModule(req.Context(), "m"))
+	return b.MintDelegation(req, 1)
+}
+
+// TestBrokerDelegationReattachesAPIKeyCredential: a caller authenticated by
+// X-API-Key holds logs:read and owns a row. The direct REST path returns the
+// row. The brokered reverse host.entity.query call — minted from THAT EXACT
+// request — must equally re-attach the caller and return the row.
+//
+// The gap spanned BOTH layers: crud.runToolRequest's re-injection list
+// (crud/mcp.go) copied Cookie, Authorization, and the embed grant but NOT
+// X-API-Key, and the broker's snapshot (MintDelegation + snapshotRequest)
+// carried only Cookie + Authorization. Neither layer alone preserved an API
+// key; the direct REST control is the honest baseline.
+func TestBrokerDelegationReattachesAPIKeyCredential(t *testing.T) {
+	b, _ := newDelegationCredEnv(t, nil)
+	logsEnt, err := b.entities.Get("logs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	brokerSeedRow(t, logsEnt.DB, "logs", "l-1", "keyuser-ak-alice", "Alpha")
+
+	shape := func(r *http.Request) { r.Header.Set("X-API-Key", "ak-alice") }
+
+	// Control: the direct REST path authenticates the API-key caller.
+	req := httptest.NewRequest(http.MethodGet, "/logs", nil)
+	shape(req)
+	rec := httptest.NewRecorder()
+	b.router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("control: direct REST request with X-API-Key: status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	handle, release := mintDelegationFor(t, b, shape)
+	defer release()
+	h := b.entityHandler(ModuleGrantView{Name: "m", Grants: []access.Permission{"logs:read"}}, opQuery)
+	res, err := callReverse(t, h, moduleproto.EntityQueryParams{
+		Entity: "logs",
+		Caller: moduleproto.CallerRef{Delegation: handle},
+	})
+	if err != nil {
+		t.Fatalf("FINDING: brokered reverse query for an API-key caller was denied even though the caller holds logs:read and owns the row: %v", err)
+	}
+	qr, ok := res.(moduleproto.EntityQueryResult)
+	if !ok || qr.Total != 1 {
+		t.Fatalf("brokered query result = %#v, want the caller's 1 owner-scoped row", res)
+	}
+}
+
+// TestBrokerDelegationReattachesEmbedGrant: same shape for a caller whose
+// credential is the embed grant header (X-Gofastr-Embed). crud/mcp.go copied
+// this header specifically ("the embed grant is a credential like the two
+// above"), so only the broker's snapshot layer dropped it.
+func TestBrokerDelegationReattachesEmbedGrant(t *testing.T) {
+	b, _ := newDelegationCredEnv(t, nil)
+	logsEnt, err := b.entities.Get("logs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	brokerSeedRow(t, logsEnt.DB, "logs", "l-1", "embeduser-emg-alice", "Alpha")
+
+	shape := func(r *http.Request) { r.Header.Set("X-Gofastr-Embed", "emg-alice") }
+
+	req := httptest.NewRequest(http.MethodGet, "/logs", nil)
+	shape(req)
+	rec := httptest.NewRecorder()
+	b.router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("control: direct REST request with embed grant: status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Control 2: crud.Redispatch DOES re-inject the embed grant when the
+	// originating request is stashed on ctx (crud/mcp.go exists for exactly
+	// this credential) — proving the re-dispatch machinery supports it and
+	// the broker's delegation snapshot was the layer dropping it.
+	orig := httptest.NewRequest(http.MethodGet, "/logs", nil)
+	shape(orig)
+	if _, err := crud.Redispatch(mcp.WithRequest(context.Background(), orig), b.router, http.MethodGet, "/logs", nil); err != nil {
+		t.Fatalf("control: redispatch with stashed embed-grant request failed: %v", err)
+	}
+
+	handle, release := mintDelegationFor(t, b, shape)
+	defer release()
+	h := b.entityHandler(ModuleGrantView{Name: "m", Grants: []access.Permission{"logs:read"}}, opQuery)
+	if _, err := callReverse(t, h, moduleproto.EntityQueryParams{
+		Entity: "logs",
+		Caller: moduleproto.CallerRef{Delegation: handle},
+	}); err != nil {
+		t.Fatalf("FINDING: brokered reverse query for an embed-grant caller was denied even though the caller holds logs:read and owns the row: %v", err)
+	}
+}
+
+// TestBrokerDelegationPreservesEveryCookieField: Cookie routinely arrives as
+// SEVERAL header fields (a proxy prepends its own; app.go:889-896 exists
+// precisely because Get() sees only the first). MintDelegation used
+// Header.Get("Cookie"), so a session cookie living in the second field was
+// dropped from the snapshot; the brokered re-dispatch re-resolved anonymous.
+func TestBrokerDelegationPreservesEveryCookieField(t *testing.T) {
+	b, _ := newDelegationCredEnv(t, nil)
+	logsEnt, err := b.entities.Get("logs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	brokerSeedRow(t, logsEnt.DB, "logs", "l-1", "alice", "Alpha")
+
+	shape := func(r *http.Request) {
+		r.Header.Add("Cookie", "edge=blue") // proxy-prepended field
+		r.Header.Add("Cookie", "sid=alice") // the session, second field
+	}
+
+	// Control: the middleware scans every Cookie field, request succeeds.
+	req := httptest.NewRequest(http.MethodGet, "/logs", nil)
+	shape(req)
+	rec := httptest.NewRecorder()
+	b.router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("control: direct REST request with two Cookie fields: status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	handle, release := mintDelegationFor(t, b, shape)
+	defer release()
+	h := b.entityHandler(ModuleGrantView{Name: "m", Grants: []access.Permission{"logs:read"}}, opQuery)
+	if _, err := callReverse(t, h, moduleproto.EntityQueryParams{
+		Entity: "logs",
+		Caller: moduleproto.CallerRef{Delegation: handle},
+	}); err != nil {
+		t.Fatalf("FINDING: brokered reverse query lost a session cookie that lived in a second Cookie header field: %v", err)
+	}
+}
+
+// TestBrokerDelegationSnapshotCarriesEveryMintedCredentialField pins the
+// snapshot's shape directly, at the MintDelegation → snapshotRequest seam:
+// every field of every credential header survives (multi-field Cookie in
+// field order, X-API-Key, the embed grant), and NOTHING beyond the four
+// credential names rides along. The X-Internal-Debug header stands in for
+// any non-credential header the minting request happened to carry; the
+// snapshot re-presents the caller's authority, never the request's ambient
+// headers.
+//
+// The second half is the clone guard: re-dispatch middleware mutates request
+// headers (framework/embed's grant path deletes Cookie/Authorization/
+// X-API-Key once the grant verdict is final), so a snapshot sharing the
+// stashed header map would let one re-dispatch's verdict erase the
+// credentials of every LATER reverse call on the same handle.
+func TestBrokerDelegationSnapshotCarriesEveryMintedCredentialField(t *testing.T) {
+	b := NewBroker(nil, nil, nil, "")
+	handle, release := b.MintDelegation(httptest.NewRequest(http.MethodGet, "/m/anything", nil), 1)
+	defer release()
+
+	minted := httptest.NewRequest(http.MethodGet, "/m/logs", nil)
+	minted.Header.Add("Cookie", "edge=blue")
+	minted.Header.Add("Cookie", "sid=alice")
+	minted.Header.Set("Authorization", "Bearer jwt-alice")
+	minted.Header.Set("X-API-Key", "ak-alice")
+	minted.Header.Set("X-Gofastr-Embed", "emg-alice")
+	minted.Header.Set("X-Internal-Debug", "1")
+	handle2, release2 := b.MintDelegation(minted, 2)
+	defer release2()
+
+	b.mu.Lock()
+	entry := b.handles[handle2]
+	b.mu.Unlock()
+
+	snap := snapshotRequest(entry)
+
+	if got := snap.Header.Get("X-API-Key"); got != "ak-alice" {
+		t.Fatalf("snapshot X-API-Key = %q, want the minted API key (issue #360: this credential was dropped)", got)
+	}
+	if got := snap.Header.Get("X-Gofastr-Embed"); got != "emg-alice" {
+		t.Fatalf("snapshot embed grant = %q, want the minted grant (issue #360: this credential was dropped)", got)
+	}
+	if got := snap.Header.Get("Authorization"); got != "Bearer jwt-alice" {
+		t.Fatalf("snapshot Authorization = %q, want the minted bearer", got)
+	}
+	fields := snap.Header.Values("Cookie")
+	if len(fields) != 2 || fields[0] != "edge=blue" || fields[1] != "sid=alice" {
+		t.Fatalf("snapshot Cookie fields = %q, want both minted fields in order", fields)
+	}
+	if got := snap.Header.Get("X-Internal-Debug"); got != "" {
+		t.Fatalf("snapshot carried non-credential header X-Internal-Debug = %q: a snapshot must never carry more than the caller's credentials", got)
+	}
+	if n := len(snap.Header); n != 4 {
+		t.Fatalf("snapshot carries %d header names (%v), want exactly the 4 credential names", n, snap.Header)
+	}
+
+	// The ambient (nil-request) handle still snapshots to a request with no
+	// credentials at all — ambient stays caller-less.
+	b.mu.Lock()
+	ambient := b.handles[handle]
+	b.mu.Unlock()
+	if n := len(snapshotRequest(ambient).Header); n != 0 {
+		t.Fatalf("ambient snapshot carries %d header names, want none", n)
+	}
+
+	// Clone guard: mutate the snapshot the way re-dispatch middleware would
+	// (embed's grant path deletes the competing credential headers), then
+	// re-snapshot the same entry and require the credentials intact.
+	snap.Header.Del("Cookie")
+	snap.Header.Set("Authorization", "Bearer mutated")
+	again := snapshotRequest(entry)
+	if got := again.Header.Get("Authorization"); got != "Bearer jwt-alice" {
+		t.Fatalf("a re-dispatch's header mutation poisoned the stashed entry: Authorization = %q, want %q", got, "Bearer jwt-alice")
+	}
+	if fields := again.Header.Values("Cookie"); len(fields) != 2 {
+		t.Fatalf("a re-dispatch's header mutation poisoned the stashed entry: Cookie fields = %q, want both", fields)
+	}
+}
+
+// TestBrokerDelegationSnapshotGrantsNoExtraAuthority pins the fail-closed
+// direction of the fix: the snapshot carries no authority the minting request
+// did not present. A cookie-only caller must re-dispatch with exactly their
+// cookie — no Authorization, X-API-Key, or embed grant appears on the
+// re-dispatch, no non-credential header rides along, and the owner scope
+// stays the cookie user's: a row owned by an identity reachable only via a
+// credential the caller did NOT present (ak-stolen) stays invisible.
+func TestBrokerDelegationSnapshotGrantsNoExtraAuthority(t *testing.T) {
+	var mu sync.Mutex
+	var saw http.Header
+	record := func(h http.Header) { mu.Lock(); saw = h; mu.Unlock() }
+
+	b, _ := newDelegationCredEnv(t, record)
+	logsEnt, err := b.entities.Get("logs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	brokerSeedRow(t, logsEnt.DB, "logs", "l-mine", "alice", "Alpha")
+	brokerSeedRow(t, logsEnt.DB, "logs", "l-not-mine", "keyuser-ak-stolen", "Stolen")
+
+	// Mint from a cookie-only request that also carries a non-credential
+	// header: neither the credentials the caller lacks nor the ambient
+	// header may reach the re-dispatch.
+	handle, release := mintDelegationFor(t, b, func(r *http.Request) {
+		r.Header.Add("Cookie", "sid=alice")
+		r.Header.Set("X-Internal-Debug", "1")
+	})
+	defer release()
+
+	h := b.entityHandler(ModuleGrantView{Name: "m", Grants: []access.Permission{"logs:read"}}, opQuery)
+	res, err := callReverse(t, h, moduleproto.EntityQueryParams{
+		Entity: "logs",
+		Caller: moduleproto.CallerRef{Delegation: handle},
+	})
+	if err != nil {
+		t.Fatalf("brokered query for the cookie caller failed: %v", err)
+	}
+	qr, ok := res.(moduleproto.EntityQueryResult)
+	if !ok || qr.Total != 1 {
+		t.Fatalf("brokered query result = %#v, want exactly the caller's own row — a credential she never held must not unlock ak-stolen's row", res)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if saw == nil {
+		t.Fatal("the re-dispatch never reached the credentialed router — nothing was observed")
+	}
+	if got := saw.Values("Cookie"); len(got) != 1 || got[0] != "sid=alice" {
+		t.Fatalf("re-dispatch Cookie fields = %q, want exactly the minted session field", got)
+	}
+	for _, name := range []string{"Authorization", "X-API-Key", "X-Gofastr-Embed", "X-Internal-Debug"} {
+		if v := saw.Get(name); v != "" {
+			t.Fatalf("re-dispatch carried %s = %q, which the minting request never presented: the snapshot granted extra authority", name, v)
+		}
+	}
+}

--- a/framework/processmodule_proxy.go
+++ b/framework/processmodule_proxy.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -122,16 +123,19 @@ func (s *ProcessModuleSupervisor) serveProxy(name, routeID string, w http.Respon
 
 	// Per-call deadline context. The cancel watcher notifies the child via
 	// module.cancel when this ctx expires so it aborts in-flight work
-	// (design §4.4 module.cancel).
+	// (design §4.4 module.cancel). The notification MUST name the frame id
+	// Call assigns — the child's cancel registry is keyed by inbound frame
+	// id and cannot resolve params.RequestID ("name-counter"). Sending the
+	// latter made module.cancel a silent no-op on this path (issue #356).
 	deadline := time.UnixMilli(params.DeadlineUnixMs)
 	callCtx, cancel := context.WithDeadline(r.Context(), deadline)
 	defer cancel()
-	go s.watchCancel(peer, requestID, callCtx)
-
 	// Issue the call. The result is FULLY BUFFERED in the response before
 	// any header commit, a child that dies mid-call returns an error
 	// here, which we surface as a buffered 503. Never a truncated 200.
-	raw, err := peer.Call(callCtx, moduleproto.MethodHTTP, params)
+	raw, err := peer.CallWithID(callCtx, moduleproto.MethodHTTP, params, func(frameID uint64) {
+		go s.watchCancel(peer, frameID, callCtx)
+	})
 	if err != nil {
 		writeProxy503(w, proxyRetryAfter)
 		return
@@ -260,10 +264,16 @@ func pathParamsFor(r *http.Request, _ string) map[string]string {
 }
 
 // watchCancel notifies the child of a per-call cancellation (design §4.4
-// module.cancel). It returns once callCtx is done or the supervisor closes.
-// The notification is best-effort: a child that has already returned is not
-// affected.
-func (s *ProcessModuleSupervisor) watchCancel(peer *moduleproto.Peer, requestID string, callCtx context.Context) {
+// module.cancel). frameID is the moduleproto frame id [moduleproto.Peer.CallWithID]
+// assigned to the aborted call; the notification carries its canonical decimal
+// string, because the child's cancel registry is keyed by inbound frame id and
+// a strict decimal parse rejects everything else. (The pre-fix code sent the
+// proxy's params.RequestID "name-counter" instead, which the child could never
+// resolve: module.cancel was a silent no-op here, issue #356.)
+//
+// It returns once callCtx is done or the supervisor closes. The notification
+// is best-effort: a child that has already returned is not affected.
+func (s *ProcessModuleSupervisor) watchCancel(peer *moduleproto.Peer, frameID uint64, callCtx context.Context) {
 	select {
 	case <-callCtx.Done():
 	case <-s.closeCh:
@@ -272,7 +282,9 @@ func (s *ProcessModuleSupervisor) watchCancel(peer *moduleproto.Peer, requestID 
 	if errors.Is(callCtx.Err(), context.Canceled) || errors.Is(callCtx.Err(), context.DeadlineExceeded) {
 		notifyCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		defer cancel()
-		_ = peer.Notify(notifyCtx, moduleproto.MethodCancel, moduleproto.CancelParams{RequestID: requestID})
+		_ = peer.Notify(notifyCtx, moduleproto.MethodCancel, moduleproto.CancelParams{
+			RequestID: strconv.FormatUint(frameID, 10),
+		})
 	}
 }
 

--- a/framework/processmodule_proxy_cover_test.go
+++ b/framework/processmodule_proxy_cover_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -302,6 +303,118 @@ func TestDeclaredRoutes_returnsCopy(t *testing.T) {
 	again := sup.DeclaredRoutes("demo")
 	if again[0].ID != "list" {
 		t.Error("DeclaredRoutes did not return a copy")
+	}
+}
+
+// ---- serveProxy deadline path over an in-memory peer (no child spawn) ----
+
+// proxyDeadlineTestSlot wires a supervisor whose "demo" slot is Ready with
+// an in-memory moduleproto peer pair and a 150ms per-call deadline. The
+// slot is hand-built (no supervise/heartbeat loops), so reconcile can
+// never flip its state mid-test; serveProxy runs for real.
+func proxyDeadlineTestSlot(t *testing.T) (sup *ProcessModuleSupervisor, sl *moduleSlot, host, child *moduleproto.Peer, cleanup func()) {
+	t.Helper()
+	store := newTestStore(t)
+	sup = newBareTestSupervisor(t, store, &TrustedProcessRunner{})
+	d := validToolDescriptor(t, "demo", nil)
+	d.Limits.Deadline = 150 * time.Millisecond
+	host, child, pipeClose := newModuleProtoPipe(t)
+	sl = &moduleSlot{
+		name: d.Name,
+		desc: d,
+		sup:  sup,
+		wake: make(chan struct{}, 1),
+		done: make(chan struct{}),
+	}
+	sl.mu.Lock()
+	sl.peer = host
+	sl.enabled = true
+	sl.state = StateReady
+	sl.mu.Unlock()
+	sup.mu.Lock()
+	sup.slots[d.Name] = sl
+	sup.mu.Unlock()
+	return sup, sl, host, child, pipeClose
+}
+
+// TestServeProxyDeadlineCancelReachesChild drives the real serveProxy path
+// against a moduleproto peer pair. A proxied request whose child handler
+// hangs must, when the host's per-call deadline expires: (1) receive a
+// module.cancel that aborts the child handler's context, and (2) leave the
+// peer healthy — the child's late paired response to the abandoned id must
+// be dropped, not raised as a terminal "unsolicited response" fault — so
+// the NEXT proxied request still succeeds.
+//
+// Both properties were dead in wiring (issue #356): watchCancel sent the
+// proxy's "<name>-<counter>" RequestID, which the child's frame-id-keyed
+// cancel registry can never match (module.cancel was a silent no-op on the
+// proxy path; the child burned CPU/DB until its own deadline), and the
+// late response then faulted the peer, tearing down every concurrent
+// caller with it.
+func TestServeProxyDeadlineCancelReachesChild(t *testing.T) {
+	sup, sl, host, child, cleanup := proxyDeadlineTestSlot(t)
+	defer cleanup()
+
+	var hangFirst atomic.Bool
+	hangFirst.Store(true)
+	childCancelled := make(chan struct{}, 1)
+	if err := child.Handle(moduleproto.MethodHTTP, func(ctx context.Context, _ json.RawMessage) (any, error) {
+		if !hangFirst.CompareAndSwap(true, false) {
+			// Subsequent calls: answer normally so the peer proves usable.
+			return moduleproto.HTTPResponseResult{
+				Status: http.StatusOK,
+				Body:   moduleproto.HTTPResponseBody{Kind: moduleproto.BodyKindText, Value: jsonRaw(`"ok"`)},
+			}, nil
+		}
+		select {
+		case <-ctx.Done():
+			// Nothing but module.cancel (or a child-peer Close, which this
+			// test never does before cleanup) cancels a served request's
+			// ctx: reaching here IS the cancel notification arriving.
+			childCancelled <- struct{}{}
+			return nil, ctx.Err()
+		case <-time.After(3 * time.Second):
+			// Fallback: answer late so the "response for an abandoned id"
+			// path is exercised even if cancel never arrives.
+			return moduleproto.HTTPResponseResult{
+				Status: http.StatusOK,
+				Body:   moduleproto.HTTPResponseBody{Kind: moduleproto.BodyKindText, Value: jsonRaw(`"late"`)},
+			}, nil
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// First proxied call: hangs past the 150ms descriptor deadline → 503.
+	rec := httptest.NewRecorder()
+	sup.ProxyHandler(sl.desc.Name, "r1").ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/r", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("first proxied call: status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+
+	// (1) module.cancel must reach the child handler promptly — well
+	// before the handler's own 3s fallback.
+	select {
+	case <-childCancelled:
+	case <-time.After(1500 * time.Millisecond):
+		t.Fatal("child handler was not cancelled by module.cancel after the host deadline expired: per-call cancellation is a no-op on the proxy path (watchCancel sent an id the child cannot resolve)")
+	}
+
+	// (2) The child's late paired response to the abandoned id must not
+	// fault the peer. Give the response a window to land, then require
+	// the peer healthy and a fresh proxied call green.
+	select {
+	case <-host.FatalDone():
+		t.Fatalf("late response to the abandoned id faulted the peer: %v", host.FatalError())
+	case <-host.Done():
+		t.Fatalf("host read loop exited after late response: %v", host.FatalError())
+	case <-time.After(400 * time.Millisecond):
+	}
+
+	rec2 := httptest.NewRecorder()
+	sup.ProxyHandler(sl.desc.Name, "r1").ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/r", nil))
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("peer unusable after late response to abandoned id: second proxied call status = %d, peer fatal: %v", rec2.Code, host.FatalError())
 	}
 }
 

--- a/framework/ui/card_footer_pin_chromium_test.go
+++ b/framework/ui/card_footer_pin_chromium_test.go
@@ -53,6 +53,12 @@ func TestCardFooterPinsToBottomInGrid(t *testing.T) {
 	// 12rem-min grid pack all three cards into one row deterministically.
 	allocCtx, cancelAlloc := chromedp.NewExecAllocator(context.Background(),
 		append(chromedp.DefaultExecAllocatorOptions[:],
+			// A cold Chrome start on a shared runner can take longer than
+			// chromedp's 20s default wait for the DevTools websocket URL, which
+			// surfaces as "websocket url timeout reached" and looks like a test
+			// failure rather than a slow launch. The cmd/gofastr chromedp tests
+			// already raise it to 90s; these did not.
+			chromedp.WSURLReadTimeout(90*time.Second),
 			chromedp.NoSandbox, chromedp.WindowSize(800, 600))...)
 	defer cancelAlloc()
 	ctx, cancel := chromedp.NewContext(allocCtx)

--- a/framework/ui/commandpalette_chromium_test.go
+++ b/framework/ui/commandpalette_chromium_test.go
@@ -95,7 +95,13 @@ body{margin:0}
 func paletteChromeCtx(t *testing.T, w, h int64) context.Context {
 	t.Helper()
 	allocCtx, cancelAlloc := chromedp.NewExecAllocator(context.Background(),
-		append(chromedp.DefaultExecAllocatorOptions[:], chromedp.NoSandbox)...)
+		append(chromedp.DefaultExecAllocatorOptions[:], // A cold Chrome start on a shared runner can take longer than
+			// chromedp's 20s default wait for the DevTools websocket URL, which
+			// surfaces as "websocket url timeout reached" and looks like a test
+			// failure rather than a slow launch. The cmd/gofastr chromedp tests
+			// already raise it to 90s; these did not.
+			chromedp.WSURLReadTimeout(90*time.Second),
+			chromedp.NoSandbox)...)
 	t.Cleanup(cancelAlloc)
 	ctx, cancel := chromedp.NewContext(allocCtx)
 	t.Cleanup(cancel)

--- a/framework/ui/image_placeholder_chromium_test.go
+++ b/framework/ui/image_placeholder_chromium_test.go
@@ -55,7 +55,13 @@ func TestPlaceholderPaintsWhileSourceIsPending(t *testing.T) {
 	defer srv.Close()
 
 	allocCtx, cancelAlloc := chromedp.NewExecAllocator(context.Background(),
-		append(chromedp.DefaultExecAllocatorOptions[:], chromedp.NoSandbox)...)
+		append(chromedp.DefaultExecAllocatorOptions[:], // A cold Chrome start on a shared runner can take longer than
+			// chromedp's 20s default wait for the DevTools websocket URL, which
+			// surfaces as "websocket url timeout reached" and looks like a test
+			// failure rather than a slow launch. The cmd/gofastr chromedp tests
+			// already raise it to 90s; these did not.
+			chromedp.WSURLReadTimeout(90*time.Second),
+			chromedp.NoSandbox)...)
 	defer cancelAlloc()
 	ctx, cancel := chromedp.NewContext(allocCtx)
 	defer cancel()

--- a/framework/ui/srcset_datauri_chromium_test.go
+++ b/framework/ui/srcset_datauri_chromium_test.go
@@ -38,7 +38,13 @@ func TestSrcsetDataURICommaInBrowser(t *testing.T) {
 	defer srv.Close()
 
 	allocCtx, cancelAlloc := chromedp.NewExecAllocator(context.Background(),
-		append(chromedp.DefaultExecAllocatorOptions[:], chromedp.NoSandbox)...)
+		append(chromedp.DefaultExecAllocatorOptions[:], // A cold Chrome start on a shared runner can take longer than
+			// chromedp's 20s default wait for the DevTools websocket URL, which
+			// surfaces as "websocket url timeout reached" and looks like a test
+			// failure rather than a slow launch. The cmd/gofastr chromedp tests
+			// already raise it to 90s; these did not.
+			chromedp.WSURLReadTimeout(90*time.Second),
+			chromedp.NoSandbox)...)
 	defer cancelAlloc()
 	ctx, cancel := chromedp.NewContext(allocCtx)
 	defer cancel()

--- a/kiln/journal/replay.go
+++ b/kiln/journal/replay.go
@@ -77,6 +77,17 @@ func Apply(s *Session, e Entry) error {
 		if err := e.Decode(&p); err != nil {
 			return err
 		}
+		// A plan with no id is not a plan, and storing one arms the only
+		// trick that gets past spendPlan's empty-id refusal: propose and
+		// approve s.Plans[""] listing a target, then emit the destructive
+		// entry with plan_id OMITTED, which decodes to "". Without
+		// spendPlan's first branch that lookup HITS an approved plan
+		// listing the target and the deletion is authorized. That branch
+		// holds today, so this is the second lock on the same door — but
+		// it removes the state that makes the door interesting.
+		if strings.TrimSpace(p.PlanID) == "" {
+			return fmt.Errorf("plan_proposed: empty plan_id")
+		}
 		s.Plans[p.PlanID] = &Plan{
 			PlanID:     p.PlanID,
 			ProposedAt: e.Timestamp,

--- a/kiln/journal/replay_security_test.go
+++ b/kiln/journal/replay_security_test.go
@@ -99,6 +99,83 @@ func TestReplayEnforcesPlanSingleUse(t *testing.T) {
 	}
 }
 
+// The empty plan_id is the one way past spendPlan that costs an attacker
+// nothing to arrange, and it had no test.
+//
+// plan_proposed did not require a non-empty id, so a hand-authored journal
+// could store and approve s.Plans[""] listing a target. A destructive entry
+// that simply OMITS plan_id decodes to "", and the lookup then HITS that
+// approved plan. Only spendPlan's `planID == ""` branch stood in the way —
+// deleting it deletes the entity, verified by mutation:
+//
+//	guard present:  delete_entity "orders": no plan_id
+//	guard removed:  err = <nil>, and s.World.Entities no longer has "orders"
+//
+// So it is checked at both ends: the empty id cannot be stored, and it
+// cannot be spent.
+func TestReplayRefusesEmptyPlanID(t *testing.T) {
+	t.Run("plan_proposed refuses an empty id", func(t *testing.T) {
+		s := newSessionWithEntity(t)
+		err := Apply(s, planEntry(KindPlanProposed, PlanProposedPayload{
+			PlanID:  "",
+			Targets: []PlanTarget{{Op: "delete_entity", Name: "orders"}},
+		}))
+		if err == nil {
+			t.Fatal("SECURITY: [integrity] a plan with an empty plan_id was stored")
+		}
+		if _, ok := s.Plans[""]; ok {
+			t.Error("SECURITY: [integrity] the refused plan is still in the session")
+		}
+	})
+
+	t.Run("whitespace is not an id either", func(t *testing.T) {
+		s := newSessionWithEntity(t)
+		if err := Apply(s, planEntry(KindPlanProposed, PlanProposedPayload{
+			PlanID:  "   ",
+			Targets: []PlanTarget{{Op: "delete_entity", Name: "orders"}},
+		})); err == nil {
+			t.Error("SECURITY: [integrity] a whitespace-only plan_id was stored")
+		}
+	})
+
+	// spendPlan's own refusal, reached directly.
+	//
+	// Going through Apply cannot test it while plan_proposed refuses the
+	// empty id first: the setup never happens, so removing spendPlan's
+	// branch fails nothing. That is exactly how the deeper of the two locks
+	// stays untested — the shallower one hides it. This plants the approved
+	// empty-id plan in the session and calls spendPlan itself.
+	t.Run("spendPlan refuses an empty id even with an approved empty-id plan", func(t *testing.T) {
+		s := newSessionWithEntity(t)
+		target := PlanTarget{Op: "delete_entity", Name: "orders"}
+		s.Plans[""] = &Plan{PlanID: "", Approved: true, Targets: []PlanTarget{target}}
+
+		if err := s.spendPlan("", target); err == nil {
+			t.Error("SECURITY: [integrity] spendPlan authorized a destructive op from an empty-id plan")
+		}
+	})
+
+	// The end-to-end shape, independent of where it gets refused: a journal
+	// that tries the whole trick must not delete anything. This is the
+	// assertion that survives either lock being reworked.
+	t.Run("the empty-id trick deletes nothing", func(t *testing.T) {
+		s := newSessionWithEntity(t)
+		_ = Apply(s, planEntry(KindPlanProposed, PlanProposedPayload{
+			PlanID:  "",
+			Targets: []PlanTarget{{Op: "delete_entity", Name: "orders"}},
+		}))
+		_ = Apply(s, planEntry(KindPlanApproved, PlanApprovedPayload{PlanID: ""}))
+
+		// plan_id omitted entirely — this is what a forged journal writes.
+		if err := Apply(s, worldEdit(OpDeleteEntity, DeleteEntityPayload{Name: "orders"})); err == nil {
+			t.Error("SECURITY: [integrity] a delete with no plan_id was authorized by an empty-id plan")
+		}
+		if _, still := s.World.Entities["orders"]; !still {
+			t.Error("SECURITY: [integrity] the empty-id plan deleted the entity")
+		}
+	})
+}
+
 // The authorized path must still work, or the guard has just broken kiln.
 func TestReplayAppliesAuthorizedDelete(t *testing.T) {
 	s := newSessionWithEntity(t)


### PR DESCRIPTION
Batches what were PRs #354, #355 and #359. Three independent fixes from the #136 never-looked audit, one CI run instead of three.

---

## 1. `Timeout(0)` 504s every request instead of meaning "no deadline"

`core/middleware/timeout.go`

`Timeout` never guarded its duration, so `time.NewTimer(0)` fires before the handler can run.

| call | result |
|---|---|
| `Timeout(0)` | 504 on 50 of 50 instant requests |
| `Timeout(-1s)` | 504 on 50 of 50 |
| `RouteTimeout{Budget: 0}` | 200 |

Same value, same file, opposite meanings. The route path was already right and says so — "a negative Budget skips the deadline entirely, matching net/http where a zero duration means no timeout". The constructor now reads it the same way.

The trap is a config field left unset: `Timeout(cfg.RequestTimeout)` with the field zero turns the surface **off** rather than leaving it untimed, failing closed on every request rather than loudly at startup. Nothing in-repo tripped it because `app.go` installs the middleware only when `RequestTimeout > 0` — the cover is the wiring, not the API.

Mutation-proved: removing the guard fails `TestTimeoutZeroOrNegativeMeansNoDeadline` on both `0s` and `-1s`.

**Also a deadline tie-break that ships without a gate, and the test says so.** A `select` whose cases are both ready picks uniformly at random, so a handler that returns inside its budget can still 504 when the middleware goroutine is descheduled past the deadline. The branch now re-checks `done` first. No deterministic test exists (the overlap needs a deschedule nothing outside the runtime can arrange), and with the re-check removed I found **0 misfires in 4000 iterations under 10 CPU burners**. An audit worker reported ~2 per 2000; not reproduced here. Kept because the branch is reachable by construction, not because a failure was observed.

Third, a doc bug: `IdempotencyStore.Begin` said `ok=true` for first-writer. Both shipped stores return `ok=false` and the middleware branch is `ok && replay != nil`. Only the comment was wrong.

## 2. Per-test Postgres schema was session state on a pooled connection

`framework/internal/testdb/`

`Open` bound each test's schema with `SET search_path`. `SetMaxOpenConns(1)` bounds concurrency, not connection *identity*: `database/sql` discards a connection whose backend died and silently opens a replacement, which starts at `"$user", public`. The failure then surfaces as `relation "…" does not exist` — pointing at the schema, the one thing that is fine.

Now carried in the DSN, so it applies to every connection the pool opens. Proved by killing the backend with `pg_terminate_backend`: reverting to the session-level `SET` gives `was "t_…" now "$user", public` and a 42P01 on the next insert.

Includes two review fixes from #354: `strings.Fields` mangled quoted keyword/value DSNs (`search_path='stale, public'` → a stray `public'` token), replaced with a libpq-compatible tokenizer; and the `url.Parse` error branch had no failing test. Plus a test that **connects** with the rewritten DSN rather than inspecting it — whose first draft could not fail, because a fixture without a quoted `search_path` round-trips unharmed through the broken code.

## 3. kiln: an empty `plan_id` defeated plan-gating

`kiln/journal/`

`spendPlan`'s `planID == ""` branch carries the whole plan-gating property and had no test. `plan_proposed` did not require a non-empty id, so a hand-authored `.kiln.session.jsonl` could store *and approve* `s.Plans[""]` listing a target; a destructive entry that simply omits `plan_id` decodes to `""` and hits that approved plan.

| | result |
|---|---|
| guard present | `delete_entity "orders": no plan_id` — entity survives |
| guard removed | `err = <nil>` — entity gone from the world |

Now refused at both ends. Testing the deeper lock needed care: reaching `spendPlan` through `Apply` is impossible once `plan_proposed` refuses first, which is how the shallow lock hid the deep one. The subtest plants the approved empty-id plan directly.

---

## Verification

- `go test ./core/middleware/ -count=1` and `-race` — green
- `go test ./framework/internal/testdb/ -count=1` against a live Postgres — green; 116 packages green across `./framework/... ./battery/queue/... ./core/...`
- `go test ./kiln/... -count=1` — green including the 162s integration suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Carousel timers and dynamically inserted carousels now behave correctly during navigation.
  - File-upload areas added after page load are wired correctly, with filenames displayed safely as text.
  - Tag inputs no longer commit incomplete IME composition text.
  - Timeout handling, cancellation, and late responses are more reliable.
  - Invalid plan identifiers, duplicate YAML keys, and unsafe generated input are rejected.
  - Markdown rendering remains responsive for complex code-span input.
  - Read-only API documentation accurately reflects available endpoints.
  - Credential headers are preserved during internal request re-dispatch.

- **Tests**
  - Expanded end-to-end, security, and round-trip regression coverage.

- **Documentation**
  - Corrected idempotency and request-cancellation documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->