### PR TITLE
fix(crud): stop probing the live ambient tx; commit-queue held-back emissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,24 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Fixed
 
+- **Live-bus emissions for ambient-transaction writes no longer probe the
+  live `*sql.Tx`, and their Postgres confirm query actually parses.** A CRUD
+  write joined to `App.InTx` held its `entity.created`/`updated`/`deleted`
+  emission back by polling `SELECT 1` on the caller's transaction from a
+  goroutine until it reported done. That statement raced the caller's own
+  next statement on the transaction's single connection, and the interleaved
+  wire protocol crossed their results: the caller's `INSERT … RETURNING`
+  scanned `sql.ErrNoRows` (the intermittent `TestInTx_ComposesCommit`
+  failure, #353), and a well-formed confirm query came back as `pq: syntax
+  error at end of input`. Framework-owned transactions (`App.InTx`, crud's
+  own) now attach a `db.CommitQueue` to the transaction context and drain it
+  only after `Commit` succeeds, so held-back emissions fire without touching
+  the transaction and rollback drops them exactly. Separately, the fallback
+  confirm query for caller-owned transactions (`db.WithTx` around your own
+  `Begin`) was built with `?` placeholders, which Postgres rejects outright —
+  every such emission on Postgres was silently dropped as unconfirmable. It
+  now uses the `$N` placeholders the query builders emit everywhere else.
+
 - **Queue completions are fenced on the claim they were issued for.**
   `DBQueue` had no claim identity at all, and its `Nack` updated by bare job
   ID: a worker whose lease expired flipped the RE-CLAIMANT's live row to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,25 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   every such emission on Postgres was silently dropped as unconfirmable. It
   now uses the `$N` placeholders the query builders emit everywhere else.
 
+- **Immediate ambient-tx emissions no longer hand the live `*sql.Tx` to
+  bus subscribers.** The two `emitAfterAmbientTx` fallbacks that publish
+  right away (handler bound to a transaction; record with no extractable
+  primary key) passed the original context to `EmitAsync`, which hands it
+  to a goroutine per subscriber — so a subscriber following the documented
+  `db.TxFromContext` pattern got a live transaction in a goroutine running
+  beside the transaction's owner, the same one-connection statements race
+  as #353. The new `db.WithoutTx` masks the tx and its commit queue while
+  keeping tenant/owner identity, and both call sites use it (#367).
+
+- **The ui-quality eval's first screenshot no longer bills the browser
+  launch to its 45s capture budget.** chromedp launches Chrome lazily on
+  the first action, so shot one paid for the launch out of a budget meant
+  for the capture — CI died at ~45.04s with the whole budget gone at the
+  network-guard install while later shots used milliseconds (#342). The
+  first shot now gets 150s, past chromedp's own 90s websocket allowance;
+  every later shot keeps the tight 45s, and the guard diagnostic prints
+  whichever budget applied.
+
 - **crud's per-write transaction now rolls back when code inside it
   panics.** `App.InTx` has always carried a deferred rollback so a panic in
   `fn` cannot leak the pooled connection and its row locks; crud's own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,16 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   every such emission on Postgres was silently dropped as unconfirmable. It
   now uses the `$N` placeholders the query builders emit everywhere else.
 
+- **crud's per-write transaction now rolls back when code inside it
+  panics.** `App.InTx` has always carried a deferred rollback so a panic in
+  `fn` cannot leak the pooled connection and its row locks; crud's own
+  `inTx` — the wrapper every auto-CRUD write runs under — did not. A panic
+  from anything inside the write path (hook panics are recovered, but
+  nothing else is) unwound past both `Rollback` and `Commit` and pinned the
+  connection until the finalizer; with `SetMaxOpenConns(1)` that is the
+  whole pool. Found by the adversarial review of the ambient-tx fix;
+  proven by driving `inTx` with a panicking fn on a one-connection pool.
+
 - **Queue completions are fenced on the claim they were issued for.**
   `DBQueue` had no claim identity at all, and its `Nack` updated by bare job
   ID: a worker whose lease expired flipped the RE-CLAIMANT's live row to

--- a/evals/ui-quality/internal/evalrunner/capture.go
+++ b/evals/ui-quality/internal/evalrunner/capture.go
@@ -377,12 +377,11 @@ func captureCandidate(ctx context.Context, baseURL, blindDir string, scenario Sc
 			// after cancel closes the shared tab and makes every later shot fail
 			// with context canceled. Give each screenshot its own tab instead.
 			tab, closeTab := chromedp.NewContext(browser)
-			// Named so the diagnostic below cannot drift from it. Writing
+			// Named so the diagnostic below cannot drift from them. Writing
 			// "45s" into the message and the duration separately is how a
 			// number goes stale the first time someone tunes the budget.
-			const captureBudget = 45 * time.Second
-			captureCtx, cancel := context.WithTimeout(tab, captureBudget)
-			// #342: on the FIRST shot this budget starts before the browser
+			//
+			// #342: on the FIRST shot the budget starts before the browser
 			// exists. chromedp launches Chrome lazily on the first action,
 			// and the first action here is the guard's fetch.Enable — so a
 			// slow launch is billed to a budget meant for the capture, and
@@ -390,16 +389,26 @@ func captureCandidate(ctx context.Context, baseURL, blindDir string, scenario Sc
 			// startup. Later shots reuse that browser: a new tab inherits
 			// the running process, so their number is guard time only.
 			//
-			// On CI this fails at ~45.04s while a quiet local run is 3.3s
-			// and a CPU-saturated one is 7.5s, so the gap is far larger
-			// than contention explains and nobody has measured where it
-			// goes. Report the split rather than guess again: budgetUsed is
-			// how much of the budget was gone by the time the guard
-			// returned. A failure near the full budget is a launch problem;
-			// one far below it is not, and the two want opposite fixes.
-			// (Stated without the number on purpose — see the constant
-			// above. Writing it here is the drift that comment forbids,
-			// and this comment had it.)
+			// The diagnostic this block emits settled which fix applies:
+			// CI failed at ~45.04s of 45s — the whole budget gone at the
+			// guard, on the first shot — while a quiet local run is 3.3s
+			// and a CPU-saturated one 7.5s. That is a launch problem, so
+			// the first shot's allowance covers a slow launch and later
+			// shots stay tight. Attempts to instead move the launch out of
+			// the budget (chromedp.Run with no actions, warming the tab
+			// with about:blank) are recorded refuted on #342 — chromedp
+			// does not launch without a real action. 150s follows the
+			// pattern that fixed the chromium-ui flakes: chromedp's own
+			// websocket allowance is 90s (WSURLReadTimeout above), and a
+			// launch that outlives handshake plus session setup needs
+			// headroom past it, not a number tuned to a fast idle box.
+			const captureBudget = 45 * time.Second
+			const firstShotBudget = 150 * time.Second
+			budget := captureBudget
+			if shotIndex == 1 {
+				budget = firstShotBudget
+			}
+			captureCtx, cancel := context.WithTimeout(tab, budget)
 			guardStart := time.Now()
 			networkGuard, guardErr := newCandidateNetworkGuard(baseURL)
 			if guardErr == nil {
@@ -419,7 +428,7 @@ func captureCandidate(ctx context.Context, baseURL, blindDir string, scenario Sc
 					launchNote = "first shot, so this includes the browser launch"
 				}
 				issues = append(issues, fmt.Sprintf("%s %s: install network guard after %s of the %s budget (%s): %v",
-					page.Name, vp.ID, budgetUsed.Round(time.Millisecond), captureBudget, launchNote, guardErr))
+					page.Name, vp.ID, budgetUsed.Round(time.Millisecond), budget, launchNote, guardErr))
 				continue
 			}
 			emulationActions := []chromedp.Action{chromedp.EmulateReset()}

--- a/framework/ARCHITECTURE.md
+++ b/framework/ARCHITECTURE.md
@@ -537,6 +537,33 @@ into `db.WithTx` / `db.TxFromContext`. The previous private
 `contextWithTx` helper would have created a cycle when the methods
 ended up in different packages.
 
+### `db.CommitQueue` + `db.WithTxQueue`
+
+```go
+// framework/db/db.go
+type CommitQueue struct{ /* mutex, fns, drained */ }
+func (q *CommitQueue) Add(fn func())
+func (q *CommitQueue) RunAfterCommit()
+
+func WithTxQueue(ctx, tx) (context.Context, *CommitQueue)
+func CommitQueueFromContext(ctx) (*CommitQueue, bool)
+```
+
+Work that must run only if the transaction commits — live-bus event
+emissions staged by CRUD writes that joined the tx. The tx OWNER
+attaches the queue (`App.InTx` and crud's `inTx` both use `WithTxQueue`
+instead of bare `WithTx`), drains it after `Commit` returns nil, and
+drops it on every other exit path.
+
+This replaced a goroutine that polled `SELECT 1` on the live `*sql.Tx`
+to learn when it resolved: that statement races the owner's own
+statements on the transaction's single connection, and the interleaved
+wire protocol crossed their results (#353 — an `INSERT … RETURNING`
+scanning `sql.ErrNoRows`). The poll survives only for a caller-owned tx
+wrapped with bare `db.WithTx`, where there is nothing else that can
+learn the tx's fate; callers who own their transaction should prefer
+`WithTxQueue` and drain after commit themselves.
+
 ---
 
 ## Conventions established along the way

--- a/framework/crud/crud_api_security_test.go
+++ b/framework/crud/crud_api_security_test.go
@@ -411,6 +411,55 @@ func TestAmbientTxQueuePublishesOnDrainOnly(t *testing.T) {
 	}
 }
 
+// TestAmbientFallbackEmitsWithoutLiveTx pins #367: the two
+// emitAfterAmbientTx fallback branches (handler bound to a tx; record
+// with no extractable primary key) publish immediately, and EmitAsync
+// hands the context to a goroutine per subscriber. That context must NOT
+// still carry the live *sql.Tx — a subscriber following the documented
+// TxFromContext pattern would otherwise run statements on the
+// transaction's single connection beside its owner, the exact race the
+// commit queue removed from the framework paths.
+func TestAmbientFallbackEmitsWithoutLiveTx(t *testing.T) {
+	ch, dbc := covNotesHandler(t)
+	bus := event.NewEventBus()
+	ch.Events = bus
+
+	sawTx := make(chan bool, 8)
+	cancel := bus.Subscribe(event.EntityCreated, func(ctx context.Context, _ event.Event) error {
+		_, ok := db.TxFromContext(ctx)
+		sawTx <- ok
+		return nil
+	})
+	defer cancel()
+
+	tx, err := dbc.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	ctx := db.WithTx(context.Background(), tx)
+
+	// Branch 1: the handler itself is tx-bound, so there is no base
+	// connection to confirm against and the emission fires immediately.
+	txCh := *ch
+	txCh.DB = tx
+	txCh.EmitEvent(ctx, event.EntityCreated, map[string]any{"id": "r1", "title": "x"})
+
+	// Branch 2: no extractable primary key, same immediate publish.
+	ch.EmitEvent(ctx, event.EntityCreated, map[string]any{"title": "no id here"})
+
+	for i := 0; i < 2; i++ {
+		select {
+		case ok := <-sawTx:
+			if ok {
+				t.Fatal("SECURITY: [#367] a live *sql.Tx reached an async bus subscriber's context — statements from the subscriber goroutine interleave with the transaction owner's on one connection")
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("fallback emission %d never reached the subscriber", i+1)
+		}
+	}
+}
+
 // TestInTxRollsBackWhenFnPanics pins the deferred rollback in crud's inTx:
 // a panic inside fn must not leak the transaction's pooled connection.
 // (Hook panics are recovered into errors by the hook registry, so this

--- a/framework/crud/crud_api_security_test.go
+++ b/framework/crud/crud_api_security_test.go
@@ -365,3 +365,48 @@ func TestAmbientTxCommitEmitsEvents(t *testing.T) {
 		// Exactly once, as documented.
 	}
 }
+
+// TestAmbientTxQueuePublishesOnDrainOnly pins the commit-queue path the
+// framework-owned tx wrappers use (db.WithTxQueue): the emission for a
+// write joined to the tx is staged on the queue — NOT probed against the
+// live *sql.Tx, which raced the owner's own statements on the
+// transaction's single connection (#353) — and fires exactly when the
+// owner drains after commit.
+func TestAmbientTxQueuePublishesOnDrainOnly(t *testing.T) {
+	ch, dbc := covNotesHandler(t)
+	bus := event.NewEventBus()
+	ch.Events = bus
+
+	got := make(chan event.Event, 8)
+	cancel := bus.Subscribe(event.EntityCreated, func(_ context.Context, ev event.Event) error {
+		got <- ev
+		return nil
+	})
+	defer cancel()
+
+	tx, err := dbc.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, queue := db.WithTxQueue(context.Background(), tx)
+	if _, err := ch.CreateOne(ctx, map[string]any{"title": "queued"}); err != nil {
+		t.Fatalf("CreateOne: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Committed but not yet drained: the emission must still be held.
+	select {
+	case ev := <-got:
+		t.Fatalf("EntityCreated published before the tx owner drained the queue: %v", ev.Data)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	queue.RunAfterCommit()
+	select {
+	case <-got:
+	case <-time.After(2 * time.Second):
+		t.Fatal("EntityCreated not delivered after the queue drained")
+	}
+}

--- a/framework/crud/crud_api_security_test.go
+++ b/framework/crud/crud_api_security_test.go
@@ -410,3 +410,34 @@ func TestAmbientTxQueuePublishesOnDrainOnly(t *testing.T) {
 		t.Fatal("EntityCreated not delivered after the queue drained")
 	}
 }
+
+// TestInTxRollsBackWhenFnPanics pins the deferred rollback in crud's inTx:
+// a panic inside fn must not leak the transaction's pooled connection.
+// (Hook panics are recovered into errors by the hook registry, so this
+// drives inTx directly — the defer guards whatever future code panics
+// inside the closure.) App.InTx has carried the same guard, and the same
+// test, since it was written; crud's inTx did not.
+func TestInTxRollsBackWhenFnPanics(t *testing.T) {
+	ch, dbc := covNotesHandler(t)
+	dbc.SetMaxOpenConns(1)
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("panic did not propagate out of inTx")
+			}
+		}()
+		_ = ch.inTx(context.Background(), func(context.Context, *CrudHandler) error {
+			panic("boom inside the transaction")
+		})
+	}()
+
+	// Before the deferred rollback, the abandoned tx held the pool's only
+	// connection forever and this query blocked until the deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var n int
+	if err := dbc.QueryRowContext(ctx, "SELECT COUNT(*) FROM notes").Scan(&n); err != nil {
+		t.Fatalf("connection still held after a panicking fn: %v", err)
+	}
+}

--- a/framework/crud/crud_events.go
+++ b/framework/crud/crud_events.go
@@ -545,13 +545,18 @@ func (ch *CrudHandler) emitAfterAmbientTx(ctx context.Context, tx *sql.Tx, event
 	if !ok {
 		// The handler itself is bound to a transaction, so there is no
 		// independent connection to verify against. Nothing sensible to
-		// gate on; publish as before rather than silently dropping.
-		ch.Events.EmitAsync(ctx, event.Event{Type: eventType, Data: ch.eventData(ctx, record)})
+		// gate on; publish as before rather than silently dropping. The
+		// tx is masked first (#367): EmitAsync hands the context to a
+		// goroutine per subscriber, and a live *sql.Tx in a goroutine
+		// running beside the transaction's owner is the same
+		// one-connection statements race the commit queue exists to
+		// avoid. eventData reads identity values, which survive the mask.
+		ch.Events.EmitAsync(db.WithoutTx(ctx), event.Event{Type: eventType, Data: ch.eventData(ctx, record)})
 		return
 	}
 	id, ok := ch.recordPrimaryKey(record)
 	if !ok {
-		ch.Events.EmitAsync(ctx, event.Event{Type: eventType, Data: ch.eventData(ctx, record)})
+		ch.Events.EmitAsync(db.WithoutTx(ctx), event.Event{Type: eventType, Data: ch.eventData(ctx, record)})
 		return
 	}
 

--- a/framework/crud/crud_events.go
+++ b/framework/crud/crud_events.go
@@ -514,6 +514,23 @@ const ambientTxProbeTimeout = 2 * time.Minute
 // emitted VALUES as well: the row counts as landed only if the columns the
 // event announced are the columns the database now holds.
 func (ch *CrudHandler) emitAfterAmbientTx(ctx context.Context, tx *sql.Tx, eventType string, record any) {
+	if q, ok := db.CommitQueueFromContext(ctx); ok {
+		// The tx owner is framework code (App.InTx / crud's inTx): it
+		// drains this queue only after Commit succeeds and drops it on
+		// rollback, so the emission needs no probe and no row re-check.
+		// Probing is not an option on this path — a statement on the live
+		// *sql.Tx from a spawned goroutine races the owner's own
+		// statements on the transaction's single connection, and the
+		// interleaved wire protocol crossed their results (#353: an
+		// INSERT…RETURNING scanning sql.ErrNoRows, a well-formed query
+		// failing with a pq syntax error).
+		data := ch.eventData(ctx, record)
+		bus := ch.Events
+		q.Add(func() {
+			bus.EmitAsync(context.Background(), event.Event{Type: eventType, Data: data})
+		})
+		return
+	}
 	base, ok := ch.DB.(*sql.DB)
 	if !ok {
 		// The handler itself is bound to a transaction, so there is no
@@ -578,7 +595,11 @@ func landed(base *sql.DB, eventType, table, pk string, id any, match map[string]
 	if err != nil {
 		return false, err
 	}
-	where := []string{query.QuoteIdent(safePK) + " = ?"}
+	// $N placeholders, matching what core/query's builders emit for every
+	// dialect. Postgres rejects `?` outright — with it, this confirm query
+	// failed as `pq: syntax error at end of input` on every ambient-tx
+	// event, and the emission was dropped as unconfirmable.
+	where := []string{query.QuoteIdent(safePK) + " = $1"}
 	args := []any{id}
 	if eventType == event.EntityUpdated {
 		for _, col := range slices.Sorted(maps.Keys(match)) {
@@ -586,7 +607,8 @@ func landed(base *sql.DB, eventType, table, pk string, id any, match map[string]
 			if err != nil {
 				continue
 			}
-			where = append(where, query.QuoteIdent(safeCol)+" = ?")
+			where = append(where, fmt.Sprintf("%s = $%d",
+				query.QuoteIdent(safeCol), len(args)+1))
 			args = append(args, match[col])
 		}
 	}

--- a/framework/crud/crud_events.go
+++ b/framework/crud/crud_events.go
@@ -501,11 +501,21 @@ const ambientTxProbeTimeout = 2 * time.Minute
 // phantom write. The durable outbox lane never had this problem because
 // StageEvent writes inside the tx and rolls back with it.
 //
-// database/sql exposes no commit callback, and a committed and a rolled-back
-// Tx are indistinguishable afterwards (both report sql.ErrTxDone). So the
-// outcome is read from the database instead: once the transaction is done,
-// the write is re-checked against the base connection. That is the same
-// question a subscriber would ask, which makes it the right one to gate on.
+// Two mechanisms answer "did it commit?", split by who owns the tx:
+//
+//   - Framework-owned (App.InTx, crud's inTx): the owner attached a
+//     db.CommitQueue to the context and drains it only after Commit
+//     succeeds, so the emission is enqueued and the question never
+//     arises. No statement touches the live tx and no row re-check runs.
+//   - Caller-owned (db.WithTx around the caller's own Begin): database/sql
+//     exposes no commit callback, and a committed and a rolled-back Tx are
+//     indistinguishable afterwards (both report sql.ErrTxDone). So the
+//     outcome is read from the database: once the transaction is done, the
+//     write is re-checked against the base connection. That is the same
+//     question a subscriber would ask, which makes it the right one to
+//     gate on. The done-poll this requires races the owner's statements on
+//     the tx's connection (see CommitQueueFromContext), which is why every
+//     framework path uses the queue.
 //
 // "Re-checked" is per event kind, because row presence alone does not
 // answer it. A rolled-back CREATE leaves no row and a rolled-back DELETE

--- a/framework/crud/crud_events.go
+++ b/framework/crud/crud_events.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/DonaldMurillo/gofastr/core/handler"
@@ -490,6 +491,10 @@ const ambientTxProbeInterval = 5 * time.Millisecond
 // nobody committed is worse than a missing one.
 const ambientTxProbeTimeout = 2 * time.Minute
 
+// probeWarnOnce gates the once-per-process warning that the caller-owned
+// fallback below is probing a live transaction.
+var probeWarnOnce sync.Once
+
 // emitAfterAmbientTx holds a live-bus emission until the caller's ambient
 // transaction resolves, then publishes it only if the write actually landed.
 //
@@ -559,6 +564,18 @@ func (ch *CrudHandler) emitAfterAmbientTx(ctx context.Context, tx *sql.Tx, event
 		ch.Events.EmitAsync(db.WithoutTx(ctx), event.Event{Type: eventType, Data: ch.eventData(ctx, record)})
 		return
 	}
+
+	// Reaching here means a caller-owned transaction with no commit queue,
+	// so the outcome must be learned by probing the live tx — a statement
+	// that can interleave with the caller's own on the transaction's one
+	// connection. Scream once per process rather than racing silently;
+	// the caller can remove the probe entirely by switching to
+	// db.WithTxQueue and draining after Commit.
+	probeWarnOnce.Do(func() {
+		log.Printf("crud: a CRUD write joined a caller-owned transaction (db.WithTx with no commit queue); " +
+			"its lifecycle event is confirmed by polling the live *sql.Tx, which can race the owner's statements — " +
+			"prefer db.WithTxQueue + RunAfterCommit (see hooks-and-transactions docs)")
+	})
 
 	// Snapshot the payload now: it is built from the request context's
 	// tenant/owner identity, which will not be valid to read later.

--- a/framework/crud/tx.go
+++ b/framework/crud/tx.go
@@ -38,16 +38,26 @@ func (ch *CrudHandler) inTx(ctx context.Context, fn func(ctx context.Context, ch
 	txCh := *ch
 	txCh.DB = tx
 	txCtx, queue := db.WithTxQueue(ctx, tx)
+	// The deferred rollback guarantees the tx is closed on EVERY exit path,
+	// including a panicking hook inside fn: without it the panic unwinds
+	// past both Rollback and Commit and the pooled connection (plus any row
+	// locks) leaks until the finalizer. Mirrors App.InTx.
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
 	if err := fn(txCtx, &txCh); err != nil {
-		_ = tx.Rollback()
 		return err
 	}
 	if err := tx.Commit(); err != nil {
 		return err
 	}
+	committed = true
 	// Emissions staged inside the tx (e.g. a hook calling another entity's
 	// CreateOne with the tx context) fire only now, on confirmed commit;
-	// the rollback path above drops the queue.
+	// every other exit path drops the queue with the rollback.
 	queue.RunAfterCommit()
 	return nil
 }

--- a/framework/crud/tx.go
+++ b/framework/crud/tx.go
@@ -37,10 +37,17 @@ func (ch *CrudHandler) inTx(ctx context.Context, fn func(ctx context.Context, ch
 	}
 	txCh := *ch
 	txCh.DB = tx
-	txCtx := db.WithTx(ctx, tx)
+	txCtx, queue := db.WithTxQueue(ctx, tx)
 	if err := fn(txCtx, &txCh); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	// Emissions staged inside the tx (e.g. a hook calling another entity's
+	// CreateOne with the tx context) fire only now, on confirmed commit;
+	// the rollback path above drops the queue.
+	queue.RunAfterCommit()
+	return nil
 }

--- a/framework/db/db.go
+++ b/framework/db/db.go
@@ -53,25 +53,36 @@ type Beginner interface {
 // answers commit-vs-rollback exactly, where the probe had to re-derive it
 // from row state.
 type CommitQueue struct {
-	mu  sync.Mutex
-	fns []func()
+	mu      sync.Mutex
+	fns     []func()
+	drained bool
 }
 
 // Add queues fn to run after the owning transaction commits. Safe for
-// concurrent use.
+// concurrent use. An Add that arrives after the queue has drained runs fn
+// immediately: the drain only ever happens once Commit has succeeded, so
+// the work's precondition already holds, and appending to a list nothing
+// will read again would lose it silently.
 func (q *CommitQueue) Add(fn func()) {
 	q.mu.Lock()
+	if q.drained {
+		q.mu.Unlock()
+		fn()
+		return
+	}
 	q.fns = append(q.fns, fn)
 	q.mu.Unlock()
 }
 
-// RunAfterCommit runs and clears the queued work. The tx owner calls it
-// exactly once, after Commit returns nil; a rollback path simply drops the
-// queue, and the queued work never runs.
+// RunAfterCommit runs and clears the queued work, in Add order. The tx
+// owner calls it exactly once, after Commit returns nil; a rollback path
+// simply drops the queue, and the queued work never runs. Calling it again
+// is a no-op.
 func (q *CommitQueue) RunAfterCommit() {
 	q.mu.Lock()
 	fns := q.fns
 	q.fns = nil
+	q.drained = true
 	q.mu.Unlock()
 	for _, fn := range fns {
 		fn()
@@ -92,8 +103,15 @@ func WithTxQueue(ctx context.Context, tx *sql.Tx) (context.Context, *CommitQueue
 
 // CommitQueueFromContext returns the commit queue attached by the ambient
 // transaction's owner. A context carrying a tx but no queue means the
-// caller wrapped its own transaction with WithTx; emissions for those fall
-// back to observing the database after the tx resolves.
+// caller wrapped its own transaction with WithTx directly; emissions for
+// those fall back to POLLING the live *sql.Tx (a "SELECT 1" every few
+// milliseconds until it reports sql.ErrTxDone) and then re-checking the
+// row on the base connection. That probe statement can interleave with
+// the owner's own statements on the transaction's single connection —
+// the race #353 removed from every framework-owned path. There is no way
+// to passively learn a foreign transaction's fate, so callers who own
+// their tx should prefer WithTxQueue and drain the queue themselves after
+// a successful Commit.
 func CommitQueueFromContext(ctx context.Context) (*CommitQueue, bool) {
 	q, ok := ctx.Value(commitQueueKey{}).(*CommitQueue)
 	return q, ok

--- a/framework/db/db.go
+++ b/framework/db/db.go
@@ -7,6 +7,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"sync"
 )
 
 // Executor is the interface for database operations. Both *sql.DB and *sql.Tx
@@ -40,4 +41,60 @@ func WithTx(ctx context.Context, tx *sql.Tx) context.Context {
 // inTx skip nested begin attempts.
 type Beginner interface {
 	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+}
+
+// CommitQueue collects work that must run only after the transaction that
+// owns it commits. CRUD handlers queue live-bus emissions here instead of
+// probing the live *sql.Tx from a goroutine: a probe statement races the
+// owner's own statements on the transaction's single connection, and the
+// interleaved wire protocol hands each side the other's results — observed
+// as sql.ErrNoRows from an INSERT…RETURNING and as pq "syntax error at end
+// of input" from a well-formed query (#353). Draining after Commit also
+// answers commit-vs-rollback exactly, where the probe had to re-derive it
+// from row state.
+type CommitQueue struct {
+	mu  sync.Mutex
+	fns []func()
+}
+
+// Add queues fn to run after the owning transaction commits. Safe for
+// concurrent use.
+func (q *CommitQueue) Add(fn func()) {
+	q.mu.Lock()
+	q.fns = append(q.fns, fn)
+	q.mu.Unlock()
+}
+
+// RunAfterCommit runs and clears the queued work. The tx owner calls it
+// exactly once, after Commit returns nil; a rollback path simply drops the
+// queue, and the queued work never runs.
+func (q *CommitQueue) RunAfterCommit() {
+	q.mu.Lock()
+	fns := q.fns
+	q.fns = nil
+	q.mu.Unlock()
+	for _, fn := range fns {
+		fn()
+	}
+}
+
+// commitQueueKey is the context key for the owning transaction's queue.
+type commitQueueKey struct{}
+
+// WithTxQueue derives a context carrying both tx and a fresh CommitQueue,
+// returning the queue for the owner to drain. Framework-owned transactions
+// (App.InTx and crud's inTx) use this instead of WithTx, so emissions
+// staged inside the transaction fire only after it commits.
+func WithTxQueue(ctx context.Context, tx *sql.Tx) (context.Context, *CommitQueue) {
+	q := &CommitQueue{}
+	return context.WithValue(WithTx(ctx, tx), commitQueueKey{}, q), q
+}
+
+// CommitQueueFromContext returns the commit queue attached by the ambient
+// transaction's owner. A context carrying a tx but no queue means the
+// caller wrapped its own transaction with WithTx; emissions for those fall
+// back to observing the database after the tx resolves.
+func CommitQueueFromContext(ctx context.Context) (*CommitQueue, bool) {
+	q, ok := ctx.Value(commitQueueKey{}).(*CommitQueue)
+	return q, ok
 }

--- a/framework/db/db.go
+++ b/framework/db/db.go
@@ -37,6 +37,17 @@ func WithTx(ctx context.Context, tx *sql.Tx) context.Context {
 	return context.WithValue(ctx, txKey{}, tx)
 }
 
+// WithoutTx masks any ambient transaction (and its commit queue) in ctx,
+// keeping everything else — tenant, owner, request identity. Use it when
+// handing a context to a goroutine that outlives or runs beside the
+// transaction's owner: a *sql.Tx shares one connection, and a statement
+// from a second goroutine interleaves with the owner's on the wire (#353).
+// TxFromContext and CommitQueueFromContext report absent on the result.
+func WithoutTx(ctx context.Context) context.Context {
+	ctx = context.WithValue(ctx, txKey{}, nil)
+	return context.WithValue(ctx, commitQueueKey{}, nil)
+}
+
 // Beginner is satisfied by *sql.DB. *sql.Tx does not satisfy it, which lets
 // inTx skip nested begin attempts.
 type Beginner interface {

--- a/framework/db/db_test.go
+++ b/framework/db/db_test.go
@@ -56,6 +56,23 @@ func TestCommitQueueUndrainedNeverRuns(t *testing.T) {
 	}
 }
 
+func TestWithoutTxMasksTxAndQueue(t *testing.T) {
+	type otherKey struct{}
+	base := context.WithValue(context.Background(), otherKey{}, "kept")
+	ctx, _ := WithTxQueue(base, nil)
+
+	masked := WithoutTx(ctx)
+	if _, ok := TxFromContext(masked); ok {
+		t.Fatal("WithoutTx left the transaction visible")
+	}
+	if _, ok := CommitQueueFromContext(masked); ok {
+		t.Fatal("WithoutTx left the commit queue visible")
+	}
+	if masked.Value(otherKey{}) != "kept" {
+		t.Fatal("WithoutTx dropped an unrelated context value")
+	}
+}
+
 func TestWithTxQueueRoundTrip(t *testing.T) {
 	ctx, q := WithTxQueue(context.Background(), nil)
 	got, ok := CommitQueueFromContext(ctx)

--- a/framework/db/db_test.go
+++ b/framework/db/db_test.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -53,6 +55,43 @@ func TestCommitQueueUndrainedNeverRuns(t *testing.T) {
 	q.Add(func() { ran = true })
 	if ran {
 		t.Fatal("queued work ran without a drain")
+	}
+}
+
+// Adds racing the drain: whichever side of the transition each Add lands
+// on, its callback must run exactly once — queued-and-drained or run
+// immediately, never lost, never doubled. Meaningful under -race.
+func TestCommitQueueConcurrentAddsRunExactlyOnce(t *testing.T) {
+	const adders = 16
+	var q CommitQueue
+	var runs [adders]atomic.Int32
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < adders; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			q.Add(func() { runs[i].Add(1) })
+		}(i)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		q.RunAfterCommit()
+	}()
+	close(start)
+	wg.Wait()
+	// Callbacks queued before the drain ran inside RunAfterCommit; any
+	// that arrived after ran inline in their Add. Either way: exactly one
+	// run each, once all goroutines have joined.
+	q.RunAfterCommit() // second drain is a no-op; must not re-run anything
+	for i := 0; i < adders; i++ {
+		if n := runs[i].Load(); n != 1 {
+			t.Fatalf("callback %d ran %d times, want exactly 1", i, n)
+		}
 	}
 }
 

--- a/framework/db/db_test.go
+++ b/framework/db/db_test.go
@@ -1,0 +1,71 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCommitQueueDrainsInAddOrder(t *testing.T) {
+	var q CommitQueue
+	var got []int
+	for i := 0; i < 3; i++ {
+		i := i
+		q.Add(func() { got = append(got, i) })
+	}
+	if len(got) != 0 {
+		t.Fatalf("queued work ran before drain: %v", got)
+	}
+	q.RunAfterCommit()
+	if len(got) != 3 || got[0] != 0 || got[1] != 1 || got[2] != 2 {
+		t.Fatalf("drain ran %v, want [0 1 2] in Add order", got)
+	}
+}
+
+func TestCommitQueueSecondDrainIsANoOp(t *testing.T) {
+	var q CommitQueue
+	runs := 0
+	q.Add(func() { runs++ })
+	q.RunAfterCommit()
+	q.RunAfterCommit()
+	if runs != 1 {
+		t.Fatalf("work ran %d times across two drains, want exactly 1", runs)
+	}
+}
+
+// A late Add — the owner committed and drained while another goroutine was
+// still finishing a CRUD call — must not park work on a list nothing reads
+// again. The commit already succeeded, so the work runs immediately.
+func TestCommitQueueLateAddRunsImmediately(t *testing.T) {
+	var q CommitQueue
+	q.RunAfterCommit()
+	ran := false
+	q.Add(func() { ran = true })
+	if !ran {
+		t.Fatal("Add after drain neither queued-and-ran nor ran immediately — the emission is silently lost")
+	}
+}
+
+// A dropped queue (rollback path: the owner never drains) must never run
+// its work — that is the phantom-event guarantee.
+func TestCommitQueueUndrainedNeverRuns(t *testing.T) {
+	var q CommitQueue
+	ran := false
+	q.Add(func() { ran = true })
+	if ran {
+		t.Fatal("queued work ran without a drain")
+	}
+}
+
+func TestWithTxQueueRoundTrip(t *testing.T) {
+	ctx, q := WithTxQueue(context.Background(), nil)
+	got, ok := CommitQueueFromContext(ctx)
+	if !ok || got != q {
+		t.Fatalf("CommitQueueFromContext = %v, %v; want the queue WithTxQueue attached", got, ok)
+	}
+	if _, ok := CommitQueueFromContext(context.Background()); ok {
+		t.Fatal("bare context reported a commit queue")
+	}
+	if _, ok := TxFromContext(ctx); !ok {
+		t.Fatal("WithTxQueue did not also attach the tx")
+	}
+}

--- a/framework/docs/content/hooks-and-transactions.md
+++ b/framework/docs/content/hooks-and-transactions.md
@@ -181,6 +181,31 @@ on the provided `tx` is part of the same unit. Without an ambient
 transaction (the normal HTTP path), each CRUD write opens and commits its
 own transaction as before.
 
+Lifecycle events for writes joined to the ambient transaction are held
+until it resolves and published only on commit; a rollback publishes
+nothing. Inside `App.InTx` this costs nothing extra — the transaction
+owner drains the held emissions right after a successful commit (a
+`db.CommitQueue` carried on the same context as the tx).
+
+If you open a transaction YOURSELF and wrap it with bare `db.WithTx`,
+the framework cannot see your commit, so it learns the outcome by
+polling the live `*sql.Tx` (a `SELECT 1` every few milliseconds until it
+reports done) and then re-checking the row. That poll shares the
+transaction's single connection with your own statements. Prefer
+`db.WithTxQueue`, and call `queue.RunAfterCommit()` after your `Commit`
+succeeds — that removes the poll entirely:
+
+```go
+tx, _ := dbc.Begin()
+ctx, queue := db.WithTxQueue(ctx, tx)
+if _, err := ordersCH.CreateOne(ctx, order); err != nil {
+    tx.Rollback() // held events are dropped with the queue
+    return err
+}
+if err := tx.Commit(); err != nil { return err }
+queue.RunAfterCommit() // events publish now, post-commit
+```
+
 ### Handling validation errors
 
 When an in-process `CreateOne` / `UpdateOne` / `UpsertOne` / batch call

--- a/framework/docs/content/hooks-and-transactions.md
+++ b/framework/docs/content/hooks-and-transactions.md
@@ -196,15 +196,30 @@ transaction's single connection with your own statements. Prefer
 succeeds — that removes the poll entirely:
 
 ```go
-tx, _ := dbc.Begin()
-ctx, queue := db.WithTxQueue(ctx, tx)
-if _, err := ordersCH.CreateOne(ctx, order); err != nil {
-    tx.Rollback() // held events are dropped with the queue
+tx, err := dbc.Begin()
+if err != nil {
     return err
 }
-if err := tx.Commit(); err != nil { return err }
+ctx, queue := db.WithTxQueue(ctx, tx)
+committed := false
+defer func() {
+    if !committed {
+        _ = tx.Rollback() // held events are dropped with the queue
+    }
+}()
+if _, err := ordersCH.CreateOne(ctx, order); err != nil {
+    return err
+}
+if err := tx.Commit(); err != nil {
+    return err
+}
+committed = true
 queue.RunAfterCommit() // events publish now, post-commit
 ```
+
+The deferred rollback matters: a panic between `Begin` and `Commit`
+otherwise keeps the pooled connection and any row locks until the
+finalizer. It is the same shape `App.InTx` uses internally.
 
 ### Handling validation errors
 

--- a/framework/tx.go
+++ b/framework/tx.go
@@ -51,7 +51,7 @@ func (a *App) InTx(ctx context.Context, fn func(ctx context.Context, tx *sql.Tx)
 			_ = tx.Rollback()
 		}
 	}()
-	txCtx := db.WithTx(ctx, tx)
+	txCtx, queue := db.WithTxQueue(ctx, tx)
 	if err := fn(txCtx, tx); err != nil {
 		return err
 	}
@@ -59,5 +59,9 @@ func (a *App) InTx(ctx context.Context, fn func(ctx context.Context, tx *sql.Tx)
 		return err
 	}
 	committed = true
+	// Work staged for after the commit (live-bus event emissions from CRUD
+	// operations that joined this tx) runs only now, on the confirmed-commit
+	// path. Error returns above drop the queue with the rollback.
+	queue.RunAfterCommit()
 	return nil
 }

--- a/framework/tx_events_test.go
+++ b/framework/tx_events_test.go
@@ -117,3 +117,50 @@ func TestForeignTxCommitDeliversEvents(t *testing.T) {
 		}
 	})
 }
+
+// TestForeignTxCommitDeliversUpdateEvents is the UPDATE arm of the foreign
+// path, and the positive pin the rollback arm cannot be: an update is
+// confirmed by matching the emitted values, so landed()'s WHERE gains a
+// column and its placeholder numbering goes past $1. The rollback test
+// alone cannot tell "dropped because values did not match" from "dropped
+// because the query errored" — this can: an off-by-one drops the event
+// and this times out.
+func TestForeignTxCommitDeliversUpdateEvents(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, dbc *sql.DB, _ Dialect) {
+		_, ch, _ := notesEventApp(t, dbc)
+
+		created, err := ch.CreateOne(context.Background(), map[string]any{"body": "original"})
+		if err != nil {
+			t.Fatalf("seed CreateOne: %v", err)
+		}
+		id, _ := created["id"].(string)
+		if id == "" {
+			t.Fatalf("seed row has no string id: %v", created)
+		}
+
+		bus := ch.Events
+		gotUpd := make(chan event.Event, 8)
+		cancel := bus.Subscribe(event.EntityUpdated, func(_ context.Context, ev event.Event) error {
+			gotUpd <- ev
+			return nil
+		})
+		defer cancel()
+
+		tx, err := dbc.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := db.WithTx(context.Background(), tx)
+		if _, err := ch.UpdateOne(ctx, id, map[string]any{"body": "edited"}); err != nil {
+			t.Fatalf("UpdateOne: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+		select {
+		case <-gotUpd:
+		case <-time.After(5 * time.Second):
+			t.Fatal("entity.updated not delivered after foreign tx commit — landed()'s value-match query failed or mismatched")
+		}
+	})
+}

--- a/framework/tx_events_test.go
+++ b/framework/tx_events_test.go
@@ -1,0 +1,119 @@
+package framework
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/crud"
+	"github.com/DonaldMurillo/gofastr/framework/db"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+	"github.com/DonaldMurillo/gofastr/framework/event"
+)
+
+// Live-bus emissions for CRUD writes joined to an ambient transaction. The
+// framework-owned path (App.InTx) resolves them through the commit queue
+// the tx owner drains — never by probing the live *sql.Tx, which raced the
+// owner's own statements on the transaction's single connection (#353).
+// The foreign-owner path (a caller's own tx wrapped with db.WithTx) still
+// observes the database after the tx resolves.
+
+// notesEventApp returns ONE handler with the bus attached — CrudHandler
+// builds a fresh handler per call, so the caller must reuse this one.
+func notesEventApp(t *testing.T, dbc *sql.DB) (*App, *crud.CrudHandler, chan event.Event) {
+	t.Helper()
+	app := NewApp(WithDB(dbc))
+	app.Registry.Register(entity.Define("notes", entity.EntityConfig{
+		Table:  "notes",
+		Fields: []schema.Field{{Name: "body", Type: schema.Text}},
+	}.WithTimestamps(false)))
+	if err := AutoMigrate(dbc, app.Registry); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	bus := event.NewEventBus()
+	ch := app.MustCrudHandler("notes")
+	ch.Events = bus
+	got := make(chan event.Event, 8)
+	cancel := bus.Subscribe(event.EntityCreated, func(_ context.Context, ev event.Event) error {
+		got <- ev
+		return nil
+	})
+	t.Cleanup(cancel)
+	return app, ch, got
+}
+
+// TestInTxCommitDeliversEvents pins the commit-queue path: a CreateOne
+// joined to App.InTx publishes entity.created once the InTx commits.
+func TestInTxCommitDeliversEvents(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, dbc *sql.DB, _ Dialect) {
+		app, ch, got := notesEventApp(t, dbc)
+
+		err := app.InTx(context.Background(), func(ctx context.Context, _ *sql.Tx) error {
+			_, e := ch.CreateOne(ctx, map[string]any{"body": "durable"})
+			return e
+		})
+		if err != nil {
+			t.Fatalf("InTx: %v", err)
+		}
+		select {
+		case <-got:
+		case <-time.After(2 * time.Second):
+			t.Fatal("entity.created not delivered after InTx commit")
+		}
+	})
+}
+
+// TestInTxRollbackWithholdsEvents pins the drop side of the same queue: a
+// CreateOne whose App.InTx rolls back publishes nothing.
+func TestInTxRollbackWithholdsEvents(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, dbc *sql.DB, _ Dialect) {
+		app, ch, got := notesEventApp(t, dbc)
+
+		boom := errors.New("boom")
+		err := app.InTx(context.Background(), func(ctx context.Context, _ *sql.Tx) error {
+			if _, e := ch.CreateOne(ctx, map[string]any{"body": "phantom"}); e != nil {
+				return e
+			}
+			return boom
+		})
+		if !errors.Is(err, boom) {
+			t.Fatalf("InTx: %v, want the rollback error", err)
+		}
+		select {
+		case ev := <-got:
+			t.Fatalf("entity.created published for a rolled-back write: %v", ev.Data)
+		case <-time.After(600 * time.Millisecond):
+		}
+	})
+}
+
+// TestForeignTxCommitDeliversEvents pins the fallback path for a caller
+// that opens its own transaction and wraps it with db.WithTx: the emission
+// is confirmed against the database after the tx resolves. On Postgres this
+// confirm query was built with `?` placeholders and failed as a syntax
+// error, so every such event was silently dropped.
+func TestForeignTxCommitDeliversEvents(t *testing.T) {
+	forEachDialect(t, func(t *testing.T, dbc *sql.DB, _ Dialect) {
+		_, ch, got := notesEventApp(t, dbc)
+
+		tx, err := dbc.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := db.WithTx(context.Background(), tx)
+		if _, err := ch.CreateOne(ctx, map[string]any{"body": "foreign"}); err != nil {
+			t.Fatalf("CreateOne: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+		select {
+		case <-got:
+		case <-time.After(5 * time.Second):
+			t.Fatal("entity.created not delivered after foreign tx commit")
+		}
+	})
+}


### PR DESCRIPTION
Fixes #353. Fixes #367. Fixes #342.

## The bug

`TestInTx_ComposesCommit/postgres` failed the CI race step three times
with `insert: sql: no rows in result set` — an `INSERT … RETURNING`
scanning an empty result inside a healthy transaction, which Postgres
does not do.

Reproduced under load (1 of 40 stress rounds of the InTx tests under
`-race` with the framework package churning beside them), then pinned:
`emitAfterAmbientTx` spawned a goroutine that polled `SELECT 1` **on the
caller's live `*sql.Tx`** to learn when the tx resolved. `database/sql`
serialises driver calls but not the wire protocol around an open result
set, so the probe's statement interleaved with the caller's next
statement on the transaction's single connection and their responses
crossed. The same repro run showed the second face of the crossed wire:
`pq: syntax error at end of input` from a well-formed query.

That syntax error exposed a second bug. The fallback confirm query
(`landed()`) was built with `?` placeholders — Postgres rejects them, and
"column 44" in the error is exactly the `?`. So on Postgres, every
ambient-transaction live-bus event was being dropped as unconfirmable,
always, silently.

## The fix

Framework-owned transactions (`App.InTx`, crud's `inTx`) attach a
`db.CommitQueue` to the transaction context. `emitAfterAmbientTx`
enqueues the emission; the owner drains the queue only after `Commit`
returns nil, and the rollback path drops it. No statement ever touches
the live tx, and commit-vs-rollback is answered exactly instead of
re-derived from row state — this is the "post-commit callback queue
drained by the tx owner" that `crud_api_security_test.go` prescribed in
its failure message.

The polling fallback survives only for a caller-owned tx wrapped with
`db.WithTx` directly, with its placeholders fixed to the `$N` the query
builders emit for every dialect.

## Proof

Each guard watched red, then green:

- drain removed → `TestInTxCommitDeliversEvents` fails
- drain added to the rollback path → `TestInTxRollbackWithholdsEvents` fails
- placeholders reverted to `?` → `TestForeignTxCommitDeliversEvents/postgres` fails

Stress: pre-fix 1/40 rounds reproduced the CI failure and the logs
carried a stream of "cannot confirm" drops; post-fix 0/40 and zero
drops, with the churn half running the full framework package under
`-race` twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9

---

**Grouped follow-ups on the same invariant** (added after the independent GLM review and the CodeRabbit round):

- **#367**: the two immediate-publish fallbacks in `emitAfterAmbientTx` handed the live-tx context to async bus subscribers — same one-connection race, one step removed. New `db.WithoutTx` masks the tx (identity values survive); a subscriber-side test proves the mask red/green.
- **#342**: the ui-quality capture billed the lazy browser launch to the first shot's 45s budget (CI died at ~45.04s at the guard install; the shipped diagnostic settled the reading). First shot now gets 150s, later shots keep 45s.
- crud's `inTx` gains the deferred rollback `App.InTx` always had (panicking fn leaked the pooled connection — proven on a one-connection pool).
- `framework/db` gets its first unit tests, including a 16-adds-vs-drain concurrency pin under `-race`; the caller-owned probe path now screams once per process and the docs steer to `WithTxQueue` with a panic-safe example.