### PR TITLE
fix(framework): restore EntityCRUDMounted; adopt the port-dep menu batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to GoFastr. Follows
 calendar versions (`YYYY-MM-DD` per substantive release until the API
 stabilises). Breaking changes are clearly marked with **BREAKING**.
 
+## [Unreleased]
+
+### Fixed
+
+- **`App.EntityCRUDMounted` is back.** The #358 rework that introduced the
+  richer internal mount predicate deleted the exported wrapper while three
+  shipped references still told callers to use it — `sdk.md`'s
+  `CRUDMounted: fwApp.EntityCRUDMounted` example, the
+  `sdkdocs.Config.CRUDMounted` field comment, and repolint's
+  `crud-exposure-rederived` finding message — so the documented wiring did
+  not compile in v0.78.0, and hosts had no exported way to hand sdkdocs
+  the mount truth at all. Restored as a delegate to the mount predicate
+  (a read-only view counts as mounted; its read routes are what a docs
+  surface documents), with a test pinning the symbol and its answers.
+  Found while confirming an old worktree's uncommitted duplicate of the
+  original #266 fix was safe to discard.
+
 ## [0.78.0] - 2026-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,36 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Added
+
+- **`ui.MenuItem.Action` — form-POST menu rows.** For command rows that hit
+  PRG endpoints (stop impersonating, sign out with server-side sessions)
+  where a plain `Href` would widen a state-changing endpoint to GET. The
+  row renders as a submit button inside `<form method action>` with
+  `Fields` as hidden inputs, written in sorted order. CSRF contract: the
+  framework mints nothing — but an Action with no `Fields` panics unless
+  `Unsafe: true` acknowledges the endpoint protects itself, so a forgotten
+  token fails at render time instead of shipping. Mutually exclusive with
+  `Href`, `RPC`, `Radio`, and `Children`; incoherent combos panic.
+
 ### Fixed
+
+- **A menu whose trigger is a real `<button>` opens under a real click.**
+  Chrome does not run the summary's UA activation when the click target is
+  an interactive descendant, so a `TriggerHTML` button opened nothing. The
+  disclosure module now toggles for interactive descendants of a
+  `data-fui-disclosure` summary (preventDefault stops engines that would
+  double-toggle; plain `<details>` stays native), pinned by a
+  real-pointer chromedp test. The panel's closed state is also hidden
+  explicitly in CSS: the author `display:grid` was overriding the UA
+  sheet's closed-details hiding, so the panel rendered while `open` was
+  false.
+
+- **Combobox options that are plain anchors navigate instead of dying.**
+  `pickOption`'s preventDefault swallowed server-built link options
+  (filters, sorters) that carry `href` without `data-fui-push-state`. The
+  destination now falls back to the anchor's href and rides the same
+  origin-gated SPA navigate path as push-state options.
 
 - **`App.EntityCRUDMounted` is back.** The #358 rework that introduced the
   richer internal mount predicate deleted the exported wrapper while three

--- a/core-ui/runtime/menu_contract_e2e_test.go
+++ b/core-ui/runtime/menu_contract_e2e_test.go
@@ -669,3 +669,39 @@ func TestMenuUngroupedRadioSelfChecks(t *testing.T) {
 		t.Fatalf("after activating grouped B = %s, want B checked and U keeping its own check", afterB)
 	}
 }
+
+// TestMenuButtonTriggerRealClick: a TriggerHTML button inside the
+// summary must toggle the disclosure under a REAL pointer. Chrome's UA
+// activation does not run when the click target is an interactive
+// descendant, so without the disclosure module's interactive-descendant
+// toggle the menu opens dead. (The closed-panel CSS hiding is pinned
+// markup-side in framework/ui/menu_test.go: menuCSS must not defeat
+// the UA's closed-details display with its author display:grid.)
+func TestMenuButtonTriggerRealClick(t *testing.T) {
+	g := startGadgetServer(t, `[]`, `<details class="ui-menu ui-menu--bottom-start" data-fui-disclosure data-fui-menu="bm" data-fui-comp="ui-menu"><summary class="ui-menu__trigger" aria-haspopup="menu" aria-controls="bm-panel"><button type="button" aria-label="Open user menu"><span>U</span></button></summary><div class="ui-menu__panel" id="bm-panel" role="menu" data-fui-menu-panel><a class="ui-menu__item" href="/x" role="menuitem" tabindex="-1"><span class="ui-menu__label">Row</span></a></div></details>`)
+	ctx := newSeedBrowserCtx(t)
+
+	var coords string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(g.Srv.URL+"/"),
+		chromedp.WaitVisible(`summary.ui-menu__trigger > button`),
+		chromedp.Evaluate(`(() => { const r = document.querySelector('summary.ui-menu__trigger > button').getBoundingClientRect(); return r.x + r.width/2 + ',' + (r.y + r.height/2); })()`, &coords),
+	); err != nil {
+		t.Fatal(err)
+	}
+	var x, y float64
+	if _, err := fmt.Sscanf(coords, "%f,%f", &x, &y); err != nil {
+		t.Fatalf("coords: %v (%q)", err, coords)
+	}
+	var after string
+	if err := chromedp.Run(ctx,
+		chromedp.MouseClickXY(x, y),
+		chromedp.Evaluate(`String(document.querySelector('details[data-fui-menu="bm"]').open)`, &after),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if after != "true" {
+		t.Fatal("real click on TriggerHTML button must open the disclosure")
+	}
+}
+

--- a/core-ui/runtime/menu_contract_e2e_test.go
+++ b/core-ui/runtime/menu_contract_e2e_test.go
@@ -669,3 +669,38 @@ func TestMenuUngroupedRadioSelfChecks(t *testing.T) {
 		t.Fatalf("after activating grouped B = %s, want B checked and U keeping its own check", afterB)
 	}
 }
+
+// TestMenuButtonTriggerRealClick: a TriggerHTML button inside the
+// summary must toggle the disclosure under a REAL pointer. Chrome's UA
+// activation does not run when the click target is an interactive
+// descendant, so without the disclosure module's interactive-descendant
+// toggle the menu opens dead. (The closed-panel CSS hiding is pinned
+// markup-side in framework/ui/menu_test.go: menuCSS must not defeat
+// the UA's closed-details display with its author display:grid.)
+func TestMenuButtonTriggerRealClick(t *testing.T) {
+	g := startGadgetServer(t, `[]`, `<details class="ui-menu ui-menu--bottom-start" data-fui-disclosure data-fui-menu="bm" data-fui-comp="ui-menu"><summary class="ui-menu__trigger" aria-haspopup="menu" aria-controls="bm-panel"><button type="button" aria-label="Open user menu"><span>U</span></button></summary><div class="ui-menu__panel" id="bm-panel" role="menu" data-fui-menu-panel><a class="ui-menu__item" href="/x" role="menuitem" tabindex="-1"><span class="ui-menu__label">Row</span></a></div></details>`)
+	ctx := newSeedBrowserCtx(t)
+
+	var coords string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(g.Srv.URL+"/"),
+		chromedp.WaitVisible(`summary.ui-menu__trigger > button`),
+		chromedp.Evaluate(`(() => { const r = document.querySelector('summary.ui-menu__trigger > button').getBoundingClientRect(); return r.x + r.width/2 + ',' + (r.y + r.height/2); })()`, &coords),
+	); err != nil {
+		t.Fatal(err)
+	}
+	var x, y float64
+	if _, err := fmt.Sscanf(coords, "%f,%f", &x, &y); err != nil {
+		t.Fatalf("coords: %v (%q)", err, coords)
+	}
+	var after string
+	if err := chromedp.Run(ctx,
+		chromedp.MouseClickXY(x, y),
+		chromedp.Evaluate(`String(document.querySelector('details[data-fui-menu="bm"]').open)`, &after),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if after != "true" {
+		t.Fatal("real click on TriggerHTML button must open the disclosure")
+	}
+}

--- a/core-ui/runtime/runtime_test.go
+++ b/core-ui/runtime/runtime_test.go
@@ -743,6 +743,24 @@ func TestComboboxPickOptionHonorsPushState(t *testing.T) {
 	}
 }
 
+// TestComboboxPickOptionHonorsPlainAnchors pins the plain-anchor arm of
+// pickOption: an <a href> option with no data-fui-push-state must derive
+// its destination from href and ride the same gated navigate path —
+// pickOption's preventDefault otherwise swallows server-built link
+// options (filters, sorters) into dead rows.
+func TestComboboxPickOptionHonorsPlainAnchors(t *testing.T) {
+	src, ok := Module("combobox")
+	if !ok {
+		t.Fatal("combobox module not embedded")
+	}
+	// Module() serves the minified source, so the pin uses tokens that
+	// survive minification: the tagName check exists only in the
+	// anchor-fallback arm, and "href" only as its attribute read.
+	if !strings.Contains(src, "tagName") || !strings.Contains(src, "href") {
+		t.Error("combobox pickOption must fall back to a plain anchor option's href when data-fui-push-state is absent")
+	}
+}
+
 func contains(s, substr string) bool {
 	for i := 0; i+len(substr) <= len(s); i++ {
 		if s[i:i+len(substr)] == substr {

--- a/core-ui/runtime/src/combobox.js
+++ b/core-ui/runtime/src/combobox.js
@@ -79,8 +79,12 @@
     // in a search/palette pattern is almost always meant to navigate.
     // The server side hands the option a path via this attribute;
     // we route it through the SPA navigator (or fall back to a hard
-    // load if the navigator hasn't booted yet).
-    const dest = opt.getAttribute('data-fui-push-state');
+    // load if the navigator hasn't booted yet). A plain anchor option
+    // (href, no push-state) navigates too — hosts render server-built
+    // link options (filters, sorters) and the preventDefault above
+    // would otherwise swallow them.
+    const dest = opt.getAttribute('data-fui-push-state') ||
+      (opt.tagName === 'A' ? opt.getAttribute('href') : null);
     // data-fui-push-state is DOM input, so this destination is caller
     // input. The SPA navigator applies _originOK itself, but the
     // pre-boot fallback below assigns location.href directly, and a
@@ -98,7 +102,9 @@
       if (widget && window.__gofastr && window.__gofastr.closeWidget) {
         try { window.__gofastr.closeWidget(widget.getAttribute('data-fui-widget')); } catch (_) {}
       }
-      if (window.__gofastr && window.__gofastr.navigate) {
+      if (!opt.getAttribute('data-fui-push-state')) {
+        location.href = dest;
+      } else if (window.__gofastr && window.__gofastr.navigate) {
         window.__gofastr.navigate(dest);
       } else {
         location.href = dest;

--- a/core-ui/runtime/src/combobox.js
+++ b/core-ui/runtime/src/combobox.js
@@ -79,8 +79,12 @@
     // in a search/palette pattern is almost always meant to navigate.
     // The server side hands the option a path via this attribute;
     // we route it through the SPA navigator (or fall back to a hard
-    // load if the navigator hasn't booted yet).
-    const dest = opt.getAttribute('data-fui-push-state');
+    // load if the navigator hasn't booted yet). A plain anchor option
+    // (href, no push-state) navigates too — hosts render server-built
+    // link options (filters, sorters) and the preventDefault above
+    // would otherwise swallow them.
+    const dest = opt.getAttribute('data-fui-push-state') ||
+      (opt.tagName === 'A' ? opt.getAttribute('href') : null);
     // data-fui-push-state is DOM input, so this destination is caller
     // input. The SPA navigator applies _originOK itself, but the
     // pre-boot fallback below assigns location.href directly, and a
@@ -98,6 +102,11 @@
       if (widget && window.__gofastr && window.__gofastr.closeWidget) {
         try { window.__gofastr.closeWidget(widget.getAttribute('data-fui-widget')); } catch (_) {}
       }
+      // Plain anchors ride the SPA navigator exactly like push-state
+      // options: same-origin app links are what the gate above admits,
+      // and cross-page nav is client-side everywhere else in the
+      // framework. The hard load stays what it always was — the
+      // pre-boot fallback, not an anchor special case.
       if (window.__gofastr && window.__gofastr.navigate) {
         window.__gofastr.navigate(dest);
       } else {

--- a/core-ui/runtime/src/disclosure.js
+++ b/core-ui/runtime/src/disclosure.js
@@ -101,6 +101,32 @@
     }
   };
 
+  // Interactive descendants of the summary (TriggerHTML buttons,
+  // icon-only triggers) swallow the UA's summary activation: Chrome
+  // does not toggle details.open when the click target is itself an
+  // interactive element. Toggle it here and preventDefault so the
+  // summary activation (which WOULD fire in engines that toggle for
+  // nested controls) cannot double-toggle. Scoped to
+  // data-fui-disclosure so plain details stay native. A defaultPrevented
+  // earlier listener (the caller wired the button itself) wins.
+  if (!document.__fuiDisclosureInteractive) {
+    document.__fuiDisclosureInteractive = true;
+    document.addEventListener('click', (e) => {
+      if (e.defaultPrevented) return;
+      const t = e.target;
+      if (!t || !t.closest) return;
+      const interactive = t.closest('button, a, input, select, textarea, [role="button"]');
+      if (!interactive) return;
+      const summary = interactive.closest('summary');
+      if (!summary) return;
+      const d = summary.closest('details[data-fui-disclosure]');
+      if (!d) return;
+      e.preventDefault();
+      d.toggleAttribute('open');
+      mirror(d);
+    });
+  }
+
   if (!document.__fuiDisclosureDispatch) {
     document.__fuiDisclosureDispatch = true;
 

--- a/framework/app.go
+++ b/framework/app.go
@@ -594,6 +594,25 @@ func (a *App) entityCRUDEnabled(e *entity.Entity) bool {
 	return a.DB != nil && (e.Config.Exposure.CRUD == nil || *e.Config.Exposure.CRUD)
 }
 
+// EntityCRUDMounted reports whether an entity's CRUD routes were actually
+// registered — the predicate route registration, the startup banner,
+// openapi.json and /api/llm.md agree on, exported for surfaces that
+// advertise routes from outside this package (#266). sdkdocs.Config takes
+// it as CRUDMounted; Exposure.CRUD alone is not the answer, because a
+// DB-less app mounts no CRUD while every entity still reads "auto". A
+// read-only view mount counts as mounted: its read routes exist and are
+// what such a surface documents.
+//
+// This wrapper was deleted once, in the #358 rework that introduced
+// entityCrudMount below, while framework/docs/content/sdk.md, the
+// sdkdocs.Config.CRUDMounted comment, and repolint's
+// crud-exposure-rederived message all still told callers to pass it —
+// the documented wiring did not compile for one release (v0.78.0).
+// TestEntityCRUDMountedTracksTheMount pins the symbol and its answers.
+func (a *App) EntityCRUDMounted(e *entity.Entity) bool {
+	return a.entityCrudMount(e).Mounted
+}
+
 // entityCrudMount is THE predicate for the llm.md index (#358): like
 // entityCRUDEnabled, but it also reports read-only mounts. App.View
 // registers its entities with CrudRouteOptions{ReadOnly: true}, a fact no

--- a/framework/docs/content/sdk.md
+++ b/framework/docs/content/sdk.md
@@ -135,8 +135,10 @@ only when its CRUD routes were actually registered, and `Exposure.CRUD`
 alone cannot answer that: an app with no DB mounts no CRUD at all while
 every entity still reads `nil` ("auto"). Without the predicate the site
 publishes a reference page, and an SDK download, for paths that answer
-404. Leaving it nil keeps the older `Exposure`-only behaviour for callers
-that document a registry without an App.
+404. A columned view registered with `App.View` counts as mounted — it
+serves read routes, and read routes are what the site documents. Leaving
+the field nil keeps the older `Exposure`-only behaviour for callers that
+document a registry without an App.
 
 It is deliberately not a `uihost` option: the screens compose
 `framework/ui`, which uihost must never import (its always-on styles

--- a/framework/entity_crud_mounted_test.go
+++ b/framework/entity_crud_mounted_test.go
@@ -49,5 +49,25 @@ func TestEntityCRUDMountedTracksTheMount(t *testing.T) {
 		if app.EntityCRUDMounted(disabled) {
 			t.Fatal("Exposure.CRUD=false entity must not report mounted")
 		}
+
+		// A columned view registers an entity and mounts READ-ONLY
+		// (App.View). Its read routes exist, and read routes are what a
+		// route-advertising surface documents — so the predicate must say
+		// mounted, not treat read-only as absent.
+		app.Registry.Register(entity.Define("users", entity.EntityConfig{
+			Table: "users",
+			Fields: []schema.Field{
+				{Name: "name", Type: schema.String},
+				{Name: "active", Type: schema.Bool},
+			},
+		}.WithTimestamps(false)))
+		app.View(activeUsersView())
+		viewEnt, err := app.Registry.Get("active_users")
+		if err != nil {
+			t.Fatalf("view entity not registered: %v", err)
+		}
+		if !app.EntityCRUDMounted(viewEnt) {
+			t.Fatal("a columned view mounts read-only routes; the predicate must report it mounted")
+		}
 	})
 }

--- a/framework/entity_crud_mounted_test.go
+++ b/framework/entity_crud_mounted_test.go
@@ -1,0 +1,53 @@
+package framework
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/schema"
+	"github.com/DonaldMurillo/gofastr/framework/entity"
+)
+
+// TestEntityCRUDMountedTracksTheMount pins the exported predicate the
+// route-advertising surfaces are documented to use (sdkdocs.Config's
+// CRUDMounted, repolint's crud-exposure-rederived message, sdk.md). The
+// #358 rework deleted the export while all three references stood, so the
+// documented wiring did not compile for one release — this test is the
+// symbol's existence proof as much as its behavior pin.
+func TestEntityCRUDMountedTracksTheMount(t *testing.T) {
+	off := false
+	define := func() (*entity.Entity, *entity.Entity) {
+		auto := entity.Define("posts", entity.EntityConfig{
+			Table:  "posts",
+			Fields: []schema.Field{{Name: "title", Type: schema.String}},
+		}.WithTimestamps(false))
+		disabled := entity.Define("drafts", entity.EntityConfig{
+			Table:    "drafts",
+			Exposure: &entity.ExposureConfig{CRUD: &off},
+			Fields:   []schema.Field{{Name: "title", Type: schema.String}},
+		}.WithTimestamps(false))
+		return auto, disabled
+	}
+
+	// The case Exposure.CRUD alone cannot see: no DB, so nothing mounts,
+	// while the entity still reads "auto".
+	auto, disabled := define()
+	noDB := NewApp()
+	noDB.Registry.Register(auto)
+	if noDB.EntityCRUDMounted(auto) {
+		t.Fatal("DB-less app reported an entity's CRUD routes as mounted — nothing was registered")
+	}
+
+	forEachDialect(t, func(t *testing.T, dbc *sql.DB, _ Dialect) {
+		auto, disabled = define()
+		app := NewApp(WithDB(dbc))
+		app.Registry.Register(auto)
+		app.Registry.Register(disabled)
+		if !app.EntityCRUDMounted(auto) {
+			t.Fatal("auto-exposed entity on an app with a DB must report mounted")
+		}
+		if app.EntityCRUDMounted(disabled) {
+			t.Fatal("Exposure.CRUD=false entity must not report mounted")
+		}
+	})
+}

--- a/framework/ui/menu.go
+++ b/framework/ui/menu.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/html"
@@ -93,6 +95,16 @@ type MenuItem struct {
 	// on a plain menuitem.
 	Checked bool
 
+	// Action renders the row as a form submission instead of a link or
+	// RPC, for hosts whose command rows hit PRG endpoints (stop
+	// impersonation, sign out with server-side sessions) where a plain
+	// Href would widen a state-changing endpoint to GET. Nil (the zero
+	// value) renders nothing — Action is a pointer exactly so the
+	// unconfigured case cannot half-render. See MenuAction for the
+	// CSRF contract. Mutually exclusive with Href, RPC, Radio, and
+	// Children: incoherent combos panic at render time.
+	Action *MenuAction
+
 	// Children nests a submenu behind this row: the row renders as a
 	// <summary role="menuitem" aria-haspopup="menu"> whose activation
 	// reveals a nested role="menu" panel, reusing the same
@@ -120,6 +132,34 @@ type MenuItem struct {
 	// disabled, aria-checked, and on submenu rows aria-haspopup /
 	// aria-controls).
 	ExtraAttrs map[string]string
+}
+
+// MenuAction is MenuItem's form-POST row. The menuitem is a submit
+// button inside <form method action>; Fields supplies the hidden
+// inputs.
+//
+// CSRF contract: the framework never mints or verifies tokens — the
+// caller's form middleware owns that exactly as it would for any
+// inline form. But a state-changing POST with NO hidden inputs is
+// almost certainly a forgotten token, so the default refuses it: an
+// Action with no Fields panics unless Unsafe explicitly acknowledges
+// the endpoint carries its own protection (same-origin POST + session
+// checks, a one-shot token in the path, or a reviewed exception like
+// the port's tokenless parity surface). Unsafe is greppable debt, not
+// a recommendation.
+type MenuAction struct {
+	// Path is the form's action URL.
+	Path string
+
+	// Method defaults to POST. GET is allowed for completeness but
+	// defeats the point; prefer Href for navigations.
+	Method string
+
+	// Fields are the hidden inputs, first use: the CSRF token.
+	Fields map[string]string
+
+	// Unsafe acknowledges the no-Fields case deliberately.
+	Unsafe bool
 }
 
 // MenuConfig describes a dropdown menu: a trigger that, when
@@ -244,10 +284,48 @@ func writeMenuItem(b *strings.Builder, it MenuItem, parentPanelID string, idx in
 		if it.Radio != "" {
 			panic("ui: MenuItem with Radio cannot have Children (a radio row is a leaf command, a submenu parent is a disclosure)")
 		}
-		if it.Href != "" || it.RPC != "" {
-			panic("ui: MenuItem with Children cannot also set Href or RPC (a submenu parent is purely a disclosure)")
+		if it.Href != "" || it.RPC != "" || it.Action != nil {
+			panic("ui: MenuItem with Children cannot also set Href, RPC, or Action (a submenu parent is purely a disclosure)")
 		}
 		writeSubMenu(b, it, parentPanelID, idx)
+		return
+	}
+	if it.Action != nil {
+		if it.Href != "" || it.RPC != "" || it.Radio != "" {
+			panic("ui: MenuItem with Action cannot also set Href, RPC, or Radio (a form row is a leaf command)")
+		}
+		if len(it.Action.Fields) == 0 && !it.Action.Unsafe {
+			panic("ui: MenuAction has no Fields (no CSRF token?) — pass the token in Fields or set Unsafe: true to acknowledge the endpoint protects itself")
+		}
+		method := it.Action.Method
+		if method == "" {
+			method = "POST"
+		}
+		cls := "ui-menu__item"
+		if it.Danger {
+			cls += " ui-menu__item--danger"
+		}
+		if it.Disabled {
+			cls += " ui-menu__item--disabled"
+		}
+		if it.Class != "" {
+			cls += " " + it.Class
+		}
+		extra := serializeExtraAttrs(html.SafeExtraAttrs(it.ExtraAttrs,
+			"type", "href", "tabindex", "role", "aria-disabled", "disabled", "aria-checked"))
+		b.WriteString(`<form class="ui-menu__form" method="` + render.Escape(method) + `" action="` + render.Escape(it.Action.Path) + `">`)
+		for _, k := range slices.Sorted(maps.Keys(it.Action.Fields)) {
+			b.WriteString(`<input type="hidden" name="` + render.Escape(k) + `" value="` + render.Escape(it.Action.Fields[k]) + `">`)
+		}
+		disabledAttr := ""
+		if it.Disabled {
+			disabledAttr = ` disabled aria-disabled="true"`
+		}
+		b.WriteString(`<button type="submit" class="` + render.Escape(cls) + `" role="menuitem" tabindex="-1"` + disabledAttr + extra + `>`)
+		if it.Icon != "" {
+			b.WriteString(`<span class="ui-menu__icon" aria-hidden="true">` + string(it.Icon) + `</span>`)
+		}
+		b.WriteString(`<span class="ui-menu__label">` + render.Escape(it.Label) + `</span></button></form>`)
 		return
 	}
 	cls := "ui-menu__item"
@@ -464,6 +542,12 @@ func menuCSS(_ style.Theme) string {
   animation: ui-menu-in var(--duration-dropdown-enter, 120ms)
     var(--easing-ease-out, cubic-bezier(0.16, 1, 0.3, 1));
 }
+/* The UA sheet hides closed-details children with display:none, but the
+   author display:grid above would override it — the panel would render
+   visibly while details.open is false, and AT/role engines prune the
+   whole menu (the trigger's own activation state lies). Hide explicitly;
+   the open state is the UA default. */
+[data-fui-comp="ui-menu"]:not([open]) .ui-menu__panel { display: none; }
 [data-fui-comp="ui-menu"].ui-menu--bottom-start .ui-menu__panel { inset-inline-start: 0; top: calc(100% + 4px); }
 [data-fui-comp="ui-menu"].ui-menu--bottom-end   .ui-menu__panel { inset-inline-end: 0;   top: calc(100% + 4px); }
 [data-fui-comp="ui-menu"].ui-menu--top-start    .ui-menu__panel { inset-inline-start: 0; bottom: calc(100% + 4px); }

--- a/framework/ui/menu.go
+++ b/framework/ui/menu.go
@@ -93,6 +93,16 @@ type MenuItem struct {
 	// on a plain menuitem.
 	Checked bool
 
+	// Action renders the row as a form submission instead of a link or
+	// RPC, for hosts whose command rows hit PRG endpoints (stop
+	// impersonation, sign out with server-side sessions) where a plain
+	// Href would widen a state-changing endpoint to GET. Nil (the zero
+	// value) renders nothing — Action is a pointer exactly so the
+	// unconfigured case cannot half-render. See MenuAction for the
+	// CSRF contract. Mutually exclusive with Href, RPC, Radio, and
+	// Children: incoherent combos panic at render time.
+	Action *MenuAction
+
 	// Children nests a submenu behind this row: the row renders as a
 	// <summary role="menuitem" aria-haspopup="menu"> whose activation
 	// reveals a nested role="menu" panel, reusing the same
@@ -120,6 +130,34 @@ type MenuItem struct {
 	// disabled, aria-checked, and on submenu rows aria-haspopup /
 	// aria-controls).
 	ExtraAttrs map[string]string
+}
+
+// MenuAction is MenuItem's form-POST row. The menuitem is a submit
+// button inside <form method action>; Fields supplies the hidden
+// inputs.
+//
+// CSRF contract: the framework never mints or verifies tokens — the
+// caller's form middleware owns that exactly as it would for any
+// inline form. But a state-changing POST with NO hidden inputs is
+// almost certainly a forgotten token, so the default refuses it: an
+// Action with no Fields panics unless Unsafe explicitly acknowledges
+// the endpoint carries its own protection (same-origin POST + session
+// checks, a one-shot token in the path, or a reviewed exception like
+// the port's tokenless parity surface). Unsafe is greppable debt, not
+// a recommendation.
+type MenuAction struct {
+	// Path is the form's action URL.
+	Path string
+
+	// Method defaults to POST. GET is allowed for completeness but
+	// defeats the point; prefer Href for navigations.
+	Method string
+
+	// Fields are the hidden inputs, first use: the CSRF token.
+	Fields map[string]string
+
+	// Unsafe acknowledges the no-Fields case deliberately.
+	Unsafe bool
 }
 
 // MenuConfig describes a dropdown menu: a trigger that, when
@@ -244,10 +282,48 @@ func writeMenuItem(b *strings.Builder, it MenuItem, parentPanelID string, idx in
 		if it.Radio != "" {
 			panic("ui: MenuItem with Radio cannot have Children (a radio row is a leaf command, a submenu parent is a disclosure)")
 		}
-		if it.Href != "" || it.RPC != "" {
-			panic("ui: MenuItem with Children cannot also set Href or RPC (a submenu parent is purely a disclosure)")
+		if it.Href != "" || it.RPC != "" || it.Action != nil {
+			panic("ui: MenuItem with Children cannot also set Href, RPC, or Action (a submenu parent is purely a disclosure)")
 		}
 		writeSubMenu(b, it, parentPanelID, idx)
+		return
+	}
+	if it.Action != nil {
+		if it.Href != "" || it.RPC != "" || it.Radio != "" {
+			panic("ui: MenuItem with Action cannot also set Href, RPC, or Radio (a form row is a leaf command)")
+		}
+		if len(it.Action.Fields) == 0 && !it.Action.Unsafe {
+			panic("ui: MenuAction has no Fields (no CSRF token?) — pass the token in Fields or set Unsafe: true to acknowledge the endpoint protects itself")
+		}
+		method := it.Action.Method
+		if method == "" {
+			method = "POST"
+		}
+		cls := "ui-menu__item"
+		if it.Danger {
+			cls += " ui-menu__item--danger"
+		}
+		if it.Disabled {
+			cls += " ui-menu__item--disabled"
+		}
+		if it.Class != "" {
+			cls += " " + it.Class
+		}
+		extra := serializeExtraAttrs(html.SafeExtraAttrs(it.ExtraAttrs,
+			"type", "href", "tabindex", "role", "aria-disabled", "disabled", "aria-checked"))
+		b.WriteString(`<form class="ui-menu__form" method="` + render.Escape(method) + `" action="` + render.Escape(it.Action.Path) + `">`)
+		for k, v := range it.Action.Fields {
+			b.WriteString(`<input type="hidden" name="` + render.Escape(k) + `" value="` + render.Escape(v) + `">`)
+		}
+		disabledAttr := ""
+		if it.Disabled {
+			disabledAttr = ` disabled aria-disabled="true"`
+		}
+		b.WriteString(`<button type="submit" class="` + render.Escape(cls) + `" role="menuitem" tabindex="-1"` + disabledAttr + extra + `>`)
+		if it.Icon != "" {
+			b.WriteString(`<span class="ui-menu__icon" aria-hidden="true">` + string(it.Icon) + `</span>`)
+		}
+		b.WriteString(`<span class="ui-menu__label">` + render.Escape(it.Label) + `</span></button></form>`)
 		return
 	}
 	cls := "ui-menu__item"

--- a/framework/ui/menu.go
+++ b/framework/ui/menu.go
@@ -536,6 +536,13 @@ func menuCSS(_ style.Theme) string {
   border-radius: var(--radii-md, 8px);
   box-shadow: var(--shadow-lg, 0 10px 15px -3px rgba(0,0,0,.10));
   display: grid;
+  /* The UA sheet hides closed-details children with display:none, but
+     this author display:grid would override it — the panel would
+     render visibly while details.open is false, and AT/role engines
+     prune the whole menu (the trigger's own activation state lies).
+     Hide explicitly; the open state is the UA default. */
+}
+[data-fui-comp="ui-menu"]:not([open]) .ui-menu__panel { display: none; }
   gap: var(--spacing-xs, 2px);
   animation: ui-menu-in var(--duration-dropdown-enter, 120ms)
     var(--easing-ease-out, cubic-bezier(0.16, 1, 0.3, 1));

--- a/framework/ui/menu_css_internal_test.go
+++ b/framework/ui/menu_css_internal_test.go
@@ -1,0 +1,15 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/style"
+)
+
+func TestMenuCSSHidesClosedPanel(t *testing.T) {
+	css := menuCSS(style.Theme{})
+	if !strings.Contains(css, `[data-fui-comp="ui-menu"]:not([open]) .ui-menu__panel { display: none; }`) {
+		t.Fatal("menuCSS must hide closed panels explicitly: the author display:grid on .ui-menu__panel defeats the UA sheet's closed-details hiding, and role engines then prune the whole menu while details.open stays false")
+	}
+}

--- a/framework/ui/menu_test.go
+++ b/framework/ui/menu_test.go
@@ -655,10 +655,3 @@ func TestMenuActionWithHrefPanics(t *testing.T) {
 	}}})
 	t.Fatal("Action + Href must panic")
 }
-
-func TestMenuCSSHidesClosedPanel(t *testing.T) {
-	css := menuCSS(nil)
-	if !strings.Contains(css, `[data-fui-comp="ui-menu"]:not([open]) .ui-menu__panel { display: none; }`) {
-		t.Fatal("menuCSS must hide closed panels explicitly: the author display:grid on .ui-menu__panel defeats the UA sheet's closed-details hiding, and role engines then prune the whole menu while details.open stays false")
-	}
-}

--- a/framework/ui/menu_test.go
+++ b/framework/ui/menu_test.go
@@ -595,3 +595,63 @@ func TestMenuItemIDIgnoredOnSeparator(t *testing.T) {
 		t.Errorf("separator picked up fields it must ignore:\n%s", out)
 	}
 }
+
+func TestMenuActionRowMarkup(t *testing.T) {
+	out := string(ui.Menu(ui.MenuConfig{
+		ID:    "acts",
+		Label: "Acts",
+		Items: []ui.MenuItem{{
+			Label: "Stop Impersonating",
+			ID:    "stop-imp",
+			Action: &ui.MenuAction{
+				Path:   "/admin/stop-impersonating",
+				Fields: map[string]string{"csrf": "tok-1"},
+			},
+		}},
+	}))
+	for _, want := range []string{
+		`<form class="ui-menu__form" method="POST" action="/admin/stop-impersonating">`,
+		`<input type="hidden" name="csrf" value="tok-1">`,
+		`<button type="submit" class="ui-menu__item" role="menuitem" tabindex="-1">`,
+		`<span class="ui-menu__label">Stop Impersonating</span></button></form>`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("action row missing %q", want)
+		}
+	}
+}
+
+func TestMenuActionWithoutFieldsPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("no-Fields Action without Unsafe must panic")
+		}
+		if msg, ok := r.(string); ok && !strings.Contains(msg, "CSRF") {
+			t.Errorf("panic should name the CSRF contract, got: %v", r)
+		}
+	}()
+	_ = ui.Menu(ui.MenuConfig{Label: "m", Items: []ui.MenuItem{{
+		Label:  "x",
+		Action: &ui.MenuAction{Path: "/go"},
+	}}})
+}
+
+func TestMenuActionUnsafeExplicit(t *testing.T) {
+	out := string(ui.Menu(ui.MenuConfig{Label: "m", Items: []ui.MenuItem{{
+		Label:  "x",
+		Action: &ui.MenuAction{Path: "/go", Unsafe: true},
+	}}}))
+	if !strings.Contains(out, `action="/go"`) || strings.Contains(out, `type="hidden"`) {
+		t.Fatal("Unsafe action should render a bare form")
+	}
+}
+
+func TestMenuActionWithHrefPanics(t *testing.T) {
+	defer func() { _ = recover() }()
+	_ = ui.Menu(ui.MenuConfig{Label: "m", Items: []ui.MenuItem{{
+		Label: "x", Href: "/a",
+		Action: &ui.MenuAction{Path: "/b", Fields: map[string]string{"t": "1"}},
+	}}})
+	t.Fatal("Action + Href must panic")
+}

--- a/framework/ui/menu_test.go
+++ b/framework/ui/menu_test.go
@@ -655,3 +655,10 @@ func TestMenuActionWithHrefPanics(t *testing.T) {
 	}}})
 	t.Fatal("Action + Href must panic")
 }
+
+func TestMenuCSSHidesClosedPanel(t *testing.T) {
+	css := menuCSS(nil)
+	if !strings.Contains(css, `[data-fui-comp="ui-menu"]:not([open]) .ui-menu__panel { display: none; }`) {
+		t.Fatal("menuCSS must hide closed panels explicitly: the author display:grid on .ui-menu__panel defeats the UA sheet's closed-details hiding, and role engines then prune the whole menu while details.open stays false")
+	}
+}


### PR DESCRIPTION
Two grouped items.

**1. Post-v0.78.0 regression: `App.EntityCRUDMounted` restored.** PR #361's #358 rework deleted the exported predicate while `sdk.md`, the `sdkdocs.Config.CRUDMounted` comment, and repolint's finding message still tell callers to use it — the documented wiring does not compile on v0.78.0. Restored as a delegate to the mount predicate, with a symbol-existence + behavior test, mutation-proven.

**2. The `port-dep-v078` menu batch, adopted after adversarial review.** Four unlanded commits from the removed `gofastr-v078` worktree (per Donald: fold in if we need it — we do, `MenuItem.Action` exists nowhere else):

- `ui.MenuItem.Action`: form-POST menu rows with a reject-by-default CSRF contract (no `Fields` panics unless `Unsafe` acknowledges the endpoint protects itself).
- Disclosure module: a `TriggerHTML` `<button>` inside the summary now opens the menu under a real click (Chrome skips UA summary activation for interactive descendants); pinned by a real-pointer chromedp test. Closed panels hidden explicitly in CSS.
- Combobox: plain-anchor options navigate instead of being swallowed by `pickOption`'s preventDefault.

Review of the unlanded branch found three defects, fixed before adoption: the closed-panel CSS rule was spliced mid-block (orphaning `gap`/`animation` outside any selector), `Action.Fields` iterated in map order (the `mapwriter` invariant), and anchor picks hard-navigated via `location.href` instead of the gated SPA navigate path (hard rule 4). Each fix is mutation- or e2e-proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WagteSowAi6Dy8TrRBt6s9