### PR TITLE
examples: webmcp-remote-assist (#376), plus two framework defects it exposed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,7 @@ kiln-*
 /real-estate
 /spa
 /static-site
+/webmcp-remote-assist
 # Same race for cmd/<name>: `go build ./cmd/repolint` from the root drops a
 # 3.5MB binary at /repolint, which is neither a *-demo nor named above. A
 # review caught one sitting untracked. Enumerate the package dir, not the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,12 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   declared property types) and `Tool.OutputSchema` is preserved as
   documentation with no runtime validation. The bridge degrades safely:
   it forwards what `registerTool` accepts and the manifest keeps the
-  rest.
+  rest. The generated orientation tool carries the empty-object input
+  schema `Register` would have defaulted: it joins the manifest without
+  passing through `Register`, and Chromium's `registerTool` refuses a
+  null `inputSchema`, so the first real-browser mount found it absent
+  from `getTools()`; the package's Chromium test now registers and
+  executes it.
 - **`ui.Menu` takes a caller-owned trigger** (#369): `MenuConfig.TriggerElement`
   is the inline HTML of your own `<button>` (or `<a>`), rendered in a
   presentation wrapper beside a summary-less `<details>` that holds the
@@ -161,6 +166,31 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   WebRTC or media protocol layered on it. `WSConfig.ConnectionID` and
   `WebSocketConn.ConnectionID` (random when unset) correlate a client's
   reconnects in server logs.
+- **`examples/webmcp-remote-assist`: authenticated WebMCP plus WebRTC
+  remote support** (#376): one binary, one origin, two roles. A shared
+  sign-in key mints an HttpOnly support cookie; a one-time join link
+  trades for an operator cookie scoped to `/session`. The WebMCP bridge
+  ships only on signed-in support documents (`WithDocumentScope`, with
+  the manifest and script behind the same role check as the tool
+  endpoints), so leaving the console is a real navigation and the next
+  document carries no tools. The console's manual button and the
+  `send_instruction` / `clear_instruction` tools decode into one typed
+  command; `inspect_session` reads backend state so an agent verifies
+  delivery from the operator's acknowledgement, correlated with the
+  observer's invocation id, which the operator's copy of every event
+  never carries. Each session is a `stream.StateChannel`; every
+  relayed WebRTC signaling frame advances the session version too, so
+  a reconnect snapshot is never older than the events a page applied.
+  The camera is video-only and peer-to-peer: the server relays SDP and
+  ICE JSON, and the app's `Permissions-Policy` opens `camera=(self)`
+  while keeping the framework's `microphone=()`. Cross-site mutations
+  are refused the way `battery/auth` does it: `Sec-Fetch-Site` first,
+  a null `Origin` (a top-level same-origin form post) allowed. A
+  two-tab Chromium test with a fake camera covers discovery, the
+  shared command path, the acknowledgement, two server-side socket
+  drops (one with a mutation landing while the operator is offline,
+  which only the reconnect snapshot can deliver), and the hard
+  navigation out.
 - Probe tests kept from the #136 audit as regression pins: the pack
   encode/decode round-trip property over a randomized hostile corpus, the
   Levenshtein scaling benchmark, `Timeout`'s deterministic boundary and an

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ build-examples: csp-check embed-check $(DIST_DIR)
 	@SITE_VER=$$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//'); \
 	LDFLAGS=$$( [ -n "$$SITE_VER" ] && echo "-ldflags=-X=main.siteVersion=$$SITE_VER" ); \
 	for dir in examples/api-tour examples/blog examples/semantic-demo \
-	            examples/embed-demo examples/spa examples/static-site examples/site; do \
+	            examples/embed-demo examples/spa examples/static-site \
+	            examples/webmcp-remote-assist examples/site; do \
 		name=$$(basename $$dir); \
 		echo "  building $$name → $(DIST_DIR)/examples/$$name"; \
 		go build $$LDFLAGS -o $(DIST_DIR)/examples/$$name ./$$dir || exit 1; \

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,7 @@ Self-contained Go programs, run with `go run ./examples/<name>`:
 | `semantic-demo` | Semantic search with `battery/semantic`. |
 | `embed-demo` | Embeddable surfaces: an app and a customer's site on two origins. |
 | `processmodule-demo` | A process-isolated third-party module speaking the `moduleproto` protocol over stdio. The canonical [process-module](../framework/docs/content/process-modules.md) example and the child the go/no-go gate suite drives end to end. |
+| `webmcp-remote-assist` | Authenticated WebMCP + WebRTC remote support: support-only tool discovery, one typed command behind the manual button and the AI tools, role-filtered realtime state, peer-to-peer camera with server-side signaling only. |
 | `site` | The framework's live component gallery and reference docs site: every UI component rendered one per page, plus the hosted examples. Run with `go run ./examples/site` (or `./scripts/dev-watch.sh` for livereload). |
 
 ## Blueprint examples (declarative)

--- a/examples/webmcp-remote-assist/README.md
+++ b/examples/webmcp-remote-assist/README.md
@@ -1,0 +1,140 @@
+# webmcp-remote-assist
+
+One Go binary, one origin, two roles: a support console whose in-browser
+AI agent can guide an operator through a camera session.
+
+This is the reference example for three framework surfaces working
+together:
+
+- **Browser WebMCP** (`framework/experimental/webmcp`): server-declared
+  tools registered on `navigator.modelContext`, scoped to the support
+  documents, gated by the support role cookie.
+- **Sequenced realtime state** (`core/stream.StateChannel` + the
+  `ws` runtime module): one channel per session, per-role snapshots and
+  events, reconnects that rehydrate instead of resurrecting.
+- **WebRTC with GoFastr signaling**: offer/answer/ICE relayed over the
+  session's WebSocket; media never crosses the Go server.
+
+## Run it
+
+```bash
+go run ./examples/webmcp-remote-assist
+```
+
+Open <http://localhost:8090> (the framework's dev isolation may remap
+the port; the startup log names the real one).
+
+1. **Support sign in** with the key from the start-up log mints an
+   HttpOnly support cookie.
+2. **Create session** → the console opens with a one-time join link.
+3. Send the link to the operator (another browser, another machine).
+4. **Operator** opens it: the link trades for an operator cookie
+   (HttpOnly, `Path=/session`) and opens the operator page.
+5. Operator clicks **Share camera** (video only — no microphone is
+   ever requested). Support sees the feed peer-to-peer.
+6. Support sends instructions two ways that share one command path:
+   the visible form, and the `send_instruction` WebMCP tool an
+   in-browser agent can call.
+7. Operator reads the instruction and clicks **Mark as shown**;
+   support sees the acknowledgement correlated with the agent
+   invocation id when the command came from one.
+8. Leaving the console through the header nav is a real navigation:
+   the next document carries no support tools.
+
+To drive the WebMCP tools by hand, use a Chromium with
+`chrome://flags/#enable-webmcp-testing` (or automation with
+`--enable-blink-features=WebMCP`), then in the console on the support
+page:
+
+```js
+const mc = document.modelContext || navigator.modelContext;
+const tools = await mc.getTools();        // inspect_session, send_instruction, clear_instruction
+const t = tools.find(x => x.name === "inspect_session");
+JSON.parse(await mc.executeTool(t, JSON.stringify({ session: "..." })));
+```
+
+## The boundaries it exists to show
+
+| Boundary | Where |
+|---|---|
+| Discovery is authority | The manifest and bridge script are wrapped in the same role check as the tool endpoints (`WithAssetAuthorization`, `WithPageScope`). |
+| Marker ≠ authorization | `X-Gofastr-WebMCP: 1` attributes a call to the observer; the role cookie decides. Spoofing the header without the cookie is a 403. |
+| One typed command | `assistCommand` + `applyCommand` in `session.go`: the manual form, the two agent tools, and the ack all decode into it. |
+| Role filtering before serialization | `sessionSource.FilterEvent`: an offer is delivered to support only, an answer to the operator only; the invocation ref is stripped for the operator. |
+| Hard navigation out of capability pages | `WithDocumentScope("/support…")`: the host's SPA runtime turns the scope edge into a document boundary. |
+| No state resurrection | Snapshots and events share one sequence; `createSequencedReducer` applies only `sequence > applied`. The browser test drops the operator's socket server-side and asserts the cleared instruction stays cleared. |
+| Media bypasses the server | `static/app.js` does `getUserMedia({video, audio: false})` and WebRTC with empty `iceServers`; the Go server relays SDP/ICE JSON only. |
+| No microphone, enforced by the browser | The app's `Permissions-Policy` opens `camera=(self)` and keeps the framework's default `microphone=()`, so even a page script that asked for audio would be refused. |
+
+## What is demo-grade on purpose
+
+- **The support login is a shared key.** `ASSIST_SUPPORT_KEY` from the
+  environment, or a random one printed once at start. A real deployment
+  puts `battery/auth` (or equivalent) at `/support/login`; the cookie
+  shape and every downstream check stay the same.
+- **State is in RAM.** One process owns the session map and the
+  channels. Multi-replica means the session store moves to a database
+  and the channel fanout to a broker; the page code does not change.
+- **Sessions are short-lived** (10 minutes) and join links are
+  single-use. Both are enforced server-side and both render the same
+  410 recovery screen, so a caller cannot probe the difference.
+
+## Deployment notes
+
+- **HTTPS and WSS.** `getUserMedia` and WebMCP are secure-context APIs.
+  The pages build their WebSocket URL from the page scheme (`wss` under
+  HTTPS, `X-Forwarded-Proto` respected); terminate TLS at your proxy
+  and forward the upgrade headers for `/session/:id/ws` and
+  `/support/session/:id/ws`.
+- **STUN/TURN.** The example ships empty `iceServers` because its
+  browser test runs both peers on one machine. Real deployments need at
+  least a STUN server (`stun:stun.l.google.com:19302`) for NAT
+  traversal, and a TURN server if one side sits behind a symmetric NAT
+  or strict firewall — decide based on your users, not on the example.
+- **Cookies.** Both role cookies are `HttpOnly` and `SameSite=Lax`.
+  The support cookie is `Path=/` because the WebMCP assets live under
+  `/__gofastr/`, outside the `/support` tree; the operator cookie is
+  `Path=/session`, so it never rides on a support URL. `Secure` is
+  decided per request from TLS or `X-Forwarded-Proto`, so plain-HTTP
+  localhost works and a TLS deployment never sends the cookie in clear.
+- **Caching.** The WebMCP mount uses `WithPrivateAssets()`
+  (`Cache-Control: private, no-store`): the bridge and manifest are
+  requester-dependent, and a shared cache must never replay an
+  authenticated manifest to anonymous traffic. `app.js` is
+  hash-versioned and immutable.
+- **Browser/model compatibility.** WebMCP needs Chromium 146+ behind
+  `chrome://flags/#enable-webmcp-testing`, or the origin trial from
+  Chrome 149. On any browser without the API the bridge feature-detects
+  and does nothing; the manual controls keep working. Automation passes
+  `--enable-blink-features=WebMCP`.
+- **Safe logging.** The WebMCP observer (`WithObserver`) logs phase,
+  tool name, method, declared path, status, error class, duration, and
+  invocation id — never the input body, headers, or query string; tool
+  inputs are where secrets live. The browser side is the same posture:
+  `ws.js` never logs close reasons or payloads, and the page's
+  `window.__assist` debug state carries phases and envelope types only.
+  The host sends `Cache-Control: no-store` on every rendered page, so
+  instruction text and join links stay out of shared and history
+  caches; the example's tests pin that contract for the session pages.
+- **CSP note for third-party libraries.** The example loads one
+  external script (`app.js`) through the uihost script rail and uses no
+  `eval`. If you add a library that wants code generation (template
+  compilers, some WebRTC stats dashboards), run it inside a sandboxed
+  `iframe` or a worker with its own CSP — never by widening the host
+  document's `script-src` to `unsafe-eval`. Trusted host-page assets
+  (this example's `app.js`) and sandboxed iframe plugins are different
+  trust domains; treat them differently.
+
+## Tests
+
+```bash
+go test ./examples/webmcp-remote-assist/ -count=1          # HTTP + source level
+go test ./examples/webmcp-remote-assist/ -count=1 -run TestRemoteAssistFlow -v  # one Chrome, two tabs
+```
+
+The browser suite launches Chromium with fake media flags
+(`--use-fake-device-for-media-stream`,
+`--use-fake-ui-for-media-stream`) and `--enable-blink-features=WebMCP`,
+plays support and operator in two tabs of one browser, and covers
+discovery, the shared command path, the ack, server-side transport
+death with recovery, and the hard navigation out of the console.

--- a/examples/webmcp-remote-assist/README.md
+++ b/examples/webmcp-remote-assist/README.md
@@ -28,8 +28,10 @@ the port; the startup log names the real one).
    HttpOnly support cookie.
 2. **Create session** → the console opens with a one-time join link.
 3. Send the link to the operator (another browser, another machine).
-4. **Operator** opens it: the link trades for an operator cookie
-   (HttpOnly, `Path=/session`) and opens the operator page.
+4. **Operator** opens it: a confirmation page (fetching the link spends
+   nothing, so a chat preview cannot burn it) whose button trades the
+   token for an operator cookie (HttpOnly, `Path=/session`) and opens
+   the operator page.
 5. Operator clicks **Share camera** (video only — no microphone is
    ever requested). Support sees the feed peer-to-peer.
 6. Support sends instructions two ways that share one command path:
@@ -76,8 +78,9 @@ JSON.parse(await mc.executeTool(t, JSON.stringify({ session: "..." })));
   channels. Multi-replica means the session store moves to a database
   and the channel fanout to a broker; the page code does not change.
 - **Sessions are short-lived** (10 minutes) and join links are
-  single-use. Both are enforced server-side and both render the same
-  410 recovery screen, so a caller cannot probe the difference.
+  single-use: only the confirmation page's POST spends one. Both are
+  enforced server-side and both render the same 410 recovery screen,
+  so a caller cannot probe the difference.
 
 ## Deployment notes
 

--- a/examples/webmcp-remote-assist/browser_test.go
+++ b/examples/webmcp-remote-assist/browser_test.go
@@ -1,0 +1,350 @@
+package main
+
+// Browser end-to-end: one Chrome, two tabs, fake media, the real
+// WebMCP browser API. Covers the flow the docs describe end to end:
+// discovery on the support document only, one command path behind
+// both the manual button and the agent tool, the operator
+// acknowledgement, transport death without state resurrection, and
+// the hard navigation out of the capability-bearing page.
+//
+// Skips in -short mode. One browser for the whole suite: the tabs
+// share a cookie jar, and the roles stay separated by which page tree
+// each cookie is scoped to (see session.go).
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	cdpruntime "github.com/chromedp/cdproto/runtime"
+	"github.com/chromedp/chromedp"
+)
+
+var (
+	browserOnce sync.Once
+	browserRoot context.Context
+	browserErr  error
+)
+
+// assistBrowserCtx boots the shared browser with the flags the flow
+// needs: WebMCP exposed, fake camera device, fake grant UI.
+func assistBrowserCtx(t *testing.T) context.Context {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("browser E2E disabled in short mode")
+	}
+	browserOnce.Do(func() {
+		opts := append(chromedp.DefaultExecAllocatorOptions[:],
+			chromedp.Flag("headless", true),
+			chromedp.Flag("disable-gpu", true),
+			chromedp.Flag("no-sandbox", true),
+			// Exposes navigator.modelContext (Chromium 146+).
+			chromedp.Flag("enable-blink-features", "WebMCP"),
+			// getUserMedia without a real camera or permission dialog.
+			chromedp.Flag("use-fake-device-for-media-stream", true),
+			chromedp.Flag("use-fake-ui-for-media-stream", true),
+			chromedp.WSURLReadTimeout(90*time.Second),
+			chromedp.WindowSize(1280, 800),
+		)
+		allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), opts...)
+		root, cancel := chromedp.NewContext(allocCtx)
+		if err := chromedp.Run(root); err != nil {
+			browserErr = err
+			cancel()
+			allocCancel()
+			return
+		}
+		browserRoot = root
+	})
+	if browserErr != nil {
+		t.Fatalf("browser failed to start: %v", browserErr)
+	}
+	return browserRoot
+}
+
+func newTab(t *testing.T, browser context.Context) context.Context {
+	t.Helper()
+	tab, cancel := chromedp.NewContext(browser)
+	t.Cleanup(cancel)
+	ctx, tcancel := context.WithTimeout(tab, 150*time.Second)
+	t.Cleanup(tcancel)
+	return ctx
+}
+
+// evalAwait evaluates an expression, awaiting any promise it returns.
+func evalAwait(ctx context.Context, expr string, out *string) error {
+	return chromedp.Run(ctx, chromedp.Evaluate(expr, out,
+		func(p *cdpruntime.EvaluateParams) *cdpruntime.EvaluateParams {
+			return p.WithAwaitPromise(true)
+		}))
+}
+
+// execTool drives the real WebMCP browser API: find the tool handle
+// by name and hand it to executeTool with the input as a JSON string,
+// which resolves with the execute() result JSON-stringified (Chromium
+// 151 behavior, the shape the webmcp package's own browser test uses).
+func execTool(ctx context.Context, name, inputJSON string) (string, error) {
+	expr := fmt.Sprintf(`(async () => {
+		const mc = document.modelContext || navigator.modelContext;
+		const tools = await mc.getTools();
+		const tool = tools.find(t => t.name === %q);
+		if (!tool) return JSON.stringify({error: "not registered"});
+		return mc.executeTool(tool, JSON.stringify(%s));
+	})()`, name, inputJSON)
+	var raw string
+	if err := evalAwait(ctx, expr, &raw); err != nil {
+		return "", err
+	}
+	return raw, nil
+}
+
+// toolText unwraps the bridge's result envelope ({content:[{text}]},
+// JSON-stringified by executeTool) to the endpoint's response body.
+func toolText(t *testing.T, raw string) string {
+	t.Helper()
+	var res struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+		IsError bool `json:"isError"`
+	}
+	if err := json.Unmarshal([]byte(raw), &res); err != nil || len(res.Content) == 0 {
+		t.Fatalf("tool result envelope %q: %v", raw, err)
+	}
+	if res.IsError {
+		t.Fatalf("tool returned an error result: %s", res.Content[0].Text)
+	}
+	return res.Content[0].Text
+}
+
+const toolNamesExpr = `(async () =>
+	(await (document.modelContext || navigator.modelContext).getTools())
+		.map(t => t.name).sort().join(','))()`
+
+// pollExpr polls an (optionally async) string expression until it
+// equals want.
+func pollExpr(t *testing.T, ctx context.Context, expr, want string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var got string
+	for {
+		if err := evalAwait(ctx, expr, &got); err != nil {
+			t.Fatalf("poll: %v", err)
+		}
+		if got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("poll = %q, want %q (expr %s, deadline)", got, want, expr)
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+func waitReady(t *testing.T, ctx context.Context, sel string) {
+	t.Helper()
+	if err := chromedp.Run(ctx, chromedp.WaitVisible(sel, chromedp.ByQuery)); err != nil {
+		t.Fatalf("wait %s: %v", sel, err)
+	}
+}
+
+func clickSel(t *testing.T, ctx context.Context, sel string) {
+	t.Helper()
+	if err := chromedp.Run(ctx, chromedp.Click(sel, chromedp.ByQuery)); err != nil {
+		t.Fatalf("click %s: %v", sel, err)
+	}
+}
+
+func evalString(t *testing.T, ctx context.Context, expr string) string {
+	t.Helper()
+	var got string
+	if err := evalAwait(ctx, expr, &got); err != nil {
+		t.Fatalf("eval %s: %v", expr, err)
+	}
+	return got
+}
+
+// TestRemoteAssistFlow drives support and operator through one
+// session: fake camera over WebRTC, manual + agent commands sharing
+// one command path, the ack, transport death and recovery without
+// state resurrection, discovery boundaries, and the hard navigation
+// out of the console.
+func TestRemoteAssistFlow(t *testing.T) {
+	app := buildApp()
+	srv := httptest.NewServer(app.Router())
+	t.Cleanup(srv.Close)
+
+	browser := assistBrowserCtx(t)
+	support := newTab(t, browser)  // tab 1: support console
+	operator := newTab(t, browser) // tab 2: operator page
+
+	// ── 1. Landing: zero tools in the document ───────────────────
+	if err := chromedp.Run(support, chromedp.Navigate(srv.URL+"/")); err != nil {
+		t.Fatal(err)
+	}
+	pollExpr(t, support, toolNamesExpr, "", 15*time.Second)
+
+	// ── 2. Support signs in, creates a session ───────────────────
+	if err := chromedp.Run(support, chromedp.Navigate(srv.URL+"/support/login")); err != nil {
+		t.Fatal(err)
+	}
+	waitReady(t, support, `form[action="/support/login"] button[type=submit]`)
+	if err := chromedp.Run(support, chromedp.SetValue("#assist-support-key", assist.supportKey, chromedp.ByID)); err != nil {
+		t.Fatal(err)
+	}
+	clickSel(t, support, `form[action="/support/login"] button[type=submit]`)
+	waitReady(t, support, `form[action="/support/sessions"] button[type=submit]`)
+	clickSel(t, support, `form[action="/support/sessions"] button[type=submit]`)
+	waitReady(t, support, "#assist-root")
+
+	sid := evalString(t, support, `document.getElementById('assist-root').dataset.assistSession`)
+	joinURL := evalString(t, support, `document.getElementById('assist-join-link').value`)
+	if sid == "" || joinURL == "" {
+		t.Fatalf("session %q join %q", sid, joinURL)
+	}
+
+	// ── 3. Discovery: four tools on the console document ─────────
+	pollExpr(t, support, toolNamesExpr,
+		"clear_instruction,get_app_instructions,inspect_session,send_instruction", 15*time.Second)
+	pollExpr(t, support, `window.__assist.phase`, "hydrated", 15*time.Second)
+
+	// ── 4. Operator joins: one-time link, zero tools ─────────────
+	if err := chromedp.Run(operator, chromedp.Navigate(joinURL)); err != nil {
+		t.Fatal(err)
+	}
+	waitReady(t, operator, "#assist-share")
+	pollExpr(t, operator, toolNamesExpr, "", 15*time.Second)
+	pollExpr(t, operator, `window.__assist.phase`, "hydrated", 15*time.Second)
+
+	// Support sees the operator arrive.
+	pollExpr(t, support, `'' + !document.getElementById('assist-pill-op-on').hidden`, "true", 15*time.Second)
+
+	// ── 5. Camera: peer-to-peer, server sees only signaling ──────
+	clickSel(t, operator, "#assist-share")
+	pollExpr(t, operator, `window.__assist.pcState`, "connected", 30*time.Second)
+	pollExpr(t, support, `window.__assist.pcState`, "connected", 30*time.Second)
+	pollExpr(t, support, `'' + !!document.getElementById('assist-remote').srcObject`, "true", 15*time.Second)
+	pollExpr(t, support, `'' + !document.getElementById('assist-pill-media-on').hidden`, "true", 15*time.Second)
+
+	// The microphone never exists: the operator's stream is video-only.
+	pollExpr(t, operator,
+		`'' + (() => {
+			const v = document.getElementById('assist-local');
+			return !!v && !!v.srcObject
+				&& v.srcObject.getAudioTracks().length === 0
+				&& v.srcObject.getVideoTracks().length > 0;
+		})()`, "true", 15*time.Second)
+
+	// ── 6. Manual button and agent tool share one command path ────
+	if err := chromedp.Run(support, chromedp.SetValue("#assist-instruction-input",
+		"Turn the dial to three.", chromedp.ByID)); err != nil {
+		t.Fatal(err)
+	}
+	clickSel(t, support, `#assist-manual-form button[type=submit]`)
+	pollExpr(t, operator, `document.getElementById('assist-instruction-text').textContent`,
+		"Turn the dial to three.", 15*time.Second)
+
+	out, err := execTool(support, "send_instruction",
+		fmt.Sprintf(`{"session":%q,"instruction":"Now press the blue button."}`, sid))
+	if err != nil {
+		t.Fatalf("send_instruction: %v", err)
+	}
+	if !strings.Contains(out, "accepted") {
+		t.Fatalf("send_instruction result: %s", out)
+	}
+	pollExpr(t, operator, `document.getElementById('assist-instruction-text').textContent`,
+		"Now press the blue button.", 15*time.Second)
+	// The invocation ref is support-only correlation data.
+	pollExpr(t, support, `'' + document.getElementById('assist-invocation').textContent.includes('invocation')`,
+		"true", 15*time.Second)
+
+	// ── 7. Operator acknowledges the rendered instruction ─────────
+	clickSel(t, operator, `#assist-ack-form button[type=submit]`)
+	pollExpr(t, operator, `'' + !document.getElementById('assist-pill-ack-on').hidden`, "true", 15*time.Second)
+	pollExpr(t, support, `'' + !document.getElementById('assist-pill-ack-on').hidden`, "true", 15*time.Second)
+
+	// Verify delivery the honest way: the tool reads backend state.
+	inspect, err := execTool(support, "inspect_session", fmt.Sprintf(`{"session":%q}`, sid))
+	if err != nil {
+		t.Fatalf("inspect_session: %v", err)
+	}
+	if text := toolText(t, inspect); !strings.Contains(text, `"acked":true`) {
+		t.Fatalf("inspect_session after ack: %s", text)
+	}
+
+	// ── 8. Transport death cannot resurrect cleared state ────────
+	if _, err := execTool(support, "send_instruction",
+		fmt.Sprintf(`{"session":%q,"instruction":"Unplug the cable for ten seconds."}`, sid)); err != nil {
+		t.Fatal(err)
+	}
+	pollExpr(t, operator, `document.getElementById('assist-instruction-text').textContent`,
+		"Unplug the cable for ten seconds.", 15*time.Second)
+	if _, err := execTool(support, "clear_instruction", fmt.Sprintf(`{"session":%q}`, sid)); err != nil {
+		t.Fatal(err)
+	}
+	pollExpr(t, operator, `document.getElementById('assist-instruction-text').textContent`,
+		"No instruction yet.", 15*time.Second)
+
+	// Instruction envelopes applied so far; a reconnect that replayed
+	// stale state would grow this count.
+	appliedBefore := evalString(t, operator,
+		`'' + window.__assist.applied.filter(e => e.startsWith('instruction')).length`)
+
+	// Server drops the operator's socket: the page's ws module must
+	// classify, reconnect, and rehydrate — without resurrecting the
+	// cleared instruction, and without tearing down the healthy peer.
+	// Nothing changed while the socket was down, so the reconnect
+	// snapshot is not newer than the page's state; hydration must
+	// complete anyway.
+	if !assist.dropRoleSocket(sid, roleOperator) {
+		t.Fatal("no operator socket to drop")
+	}
+	pollExpr(t, operator, `'' + (window.__assist.generations >= 2)`, "true", 30*time.Second)
+	pollExpr(t, operator, `window.__assist.phase`, "hydrated", 30*time.Second)
+	pollExpr(t, operator, `document.getElementById('assist-instruction-text').textContent`,
+		"No instruction yet.", 15*time.Second)
+	appliedAfter := evalString(t, operator,
+		`'' + window.__assist.applied.filter(e => e.startsWith('instruction')).length`)
+	if appliedAfter != appliedBefore {
+		t.Fatalf("reconnect resurrected instruction state: %s -> %s", appliedBefore, appliedAfter)
+	}
+	// The media path is peer-to-peer: it survives the transport drop.
+	pollExpr(t, operator, `window.__assist.pcState`, "connected", 15*time.Second)
+
+	// Second drop, and a mutation lands while the operator is offline
+	// (the reconnect backoff is one second; the tool call takes
+	// milliseconds). The event is gone for good; only the reconnect
+	// snapshot can carry the new text. A snapshot whose sequence
+	// trailed the events the page had applied (the signaling frames
+	// relayed earlier consumed sequences too) would be refused as
+	// stale, and the page would keep showing the cleared slot.
+	if !assist.dropRoleSocket(sid, roleOperator) {
+		t.Fatal("no operator socket to drop (second)")
+	}
+	if _, err := execTool(support, "send_instruction",
+		fmt.Sprintf(`{"session":%q,"instruction":"Sent while you were offline."}`, sid)); err != nil {
+		t.Fatal(err)
+	}
+	pollExpr(t, operator, `'' + (window.__assist.generations >= 3)`, "true", 30*time.Second)
+	pollExpr(t, operator, `window.__assist.phase`, "hydrated", 30*time.Second)
+	pollExpr(t, operator, `document.getElementById('assist-instruction-text').textContent`,
+		"Sent while you were offline.", 15*time.Second)
+	appliedOffline := evalString(t, operator,
+		`'' + window.__assist.applied.filter(e => e.startsWith('instruction')).length`)
+	if appliedOffline != appliedBefore {
+		t.Fatalf("the missed instruction event was replayed: %s -> %s", appliedBefore, appliedOffline)
+	}
+
+	// ── 9. Leaving support is a hard navigation; tools retire ────
+	if err := chromedp.Run(support, chromedp.Evaluate(`window.__marker = 'support-doc'`, nil)); err != nil {
+		t.Fatal(err)
+	}
+	clickSel(t, support, `nav a[href="/"]`)
+	pollExpr(t, support, `'' + (typeof window.__marker)`, "undefined", 30*time.Second)
+	pollExpr(t, support, toolNamesExpr, "", 15*time.Second)
+}

--- a/examples/webmcp-remote-assist/browser_test.go
+++ b/examples/webmcp-remote-assist/browser_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -25,46 +24,35 @@ import (
 	"github.com/chromedp/chromedp"
 )
 
-var (
-	browserOnce sync.Once
-	browserRoot context.Context
-	browserErr  error
-)
-
-// assistBrowserCtx boots the shared browser with the flags the flow
-// needs: WebMCP exposed, fake camera device, fake grant UI.
+// assistBrowserCtx boots a browser for the test with the flags the flow
+// needs (WebMCP exposed, fake camera device, fake grant UI) and tears
+// it down with the test: both the allocator and the browser context
+// are cancelled from t.Cleanup, so no Chrome outlives the suite.
 func assistBrowserCtx(t *testing.T) context.Context {
 	t.Helper()
 	if testing.Short() {
 		t.Skip("browser E2E disabled in short mode")
 	}
-	browserOnce.Do(func() {
-		opts := append(chromedp.DefaultExecAllocatorOptions[:],
-			chromedp.Flag("headless", true),
-			chromedp.Flag("disable-gpu", true),
-			chromedp.Flag("no-sandbox", true),
-			// Exposes navigator.modelContext (Chromium 146+).
-			chromedp.Flag("enable-blink-features", "WebMCP"),
-			// getUserMedia without a real camera or permission dialog.
-			chromedp.Flag("use-fake-device-for-media-stream", true),
-			chromedp.Flag("use-fake-ui-for-media-stream", true),
-			chromedp.WSURLReadTimeout(90*time.Second),
-			chromedp.WindowSize(1280, 800),
-		)
-		allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), opts...)
-		root, cancel := chromedp.NewContext(allocCtx)
-		if err := chromedp.Run(root); err != nil {
-			browserErr = err
-			cancel()
-			allocCancel()
-			return
-		}
-		browserRoot = root
-	})
-	if browserErr != nil {
-		t.Fatalf("browser failed to start: %v", browserErr)
+	opts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.Flag("headless", true),
+		chromedp.Flag("disable-gpu", true),
+		chromedp.Flag("no-sandbox", true),
+		// Exposes navigator.modelContext (Chromium 146+).
+		chromedp.Flag("enable-blink-features", "WebMCP"),
+		// getUserMedia without a real camera or permission dialog.
+		chromedp.Flag("use-fake-device-for-media-stream", true),
+		chromedp.Flag("use-fake-ui-for-media-stream", true),
+		chromedp.WSURLReadTimeout(90*time.Second),
+		chromedp.WindowSize(1280, 800),
+	)
+	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), opts...)
+	t.Cleanup(allocCancel)
+	root, cancel := chromedp.NewContext(allocCtx)
+	t.Cleanup(cancel)
+	if err := chromedp.Run(root); err != nil {
+		t.Fatalf("browser failed to start: %v", err)
 	}
-	return browserRoot
+	return root
 }
 
 func newTab(t *testing.T, browser context.Context) context.Context {
@@ -213,10 +201,14 @@ func TestRemoteAssistFlow(t *testing.T) {
 		"clear_instruction,get_app_instructions,inspect_session,send_instruction", 15*time.Second)
 	pollExpr(t, support, `window.__assist.phase`, "hydrated", 15*time.Second)
 
-	// ── 4. Operator joins: one-time link, zero tools ─────────────
+	// ── 4. Operator joins: the link opens a confirmation page (a
+	// previewer fetching it spends nothing); the button's POST is
+	// the one-time exchange. Zero tools on the operator document.
 	if err := chromedp.Run(operator, chromedp.Navigate(joinURL)); err != nil {
 		t.Fatal(err)
 	}
+	waitReady(t, operator, `form[action^="/join/"] button[type=submit]`)
+	clickSel(t, operator, `form[action^="/join/"] button[type=submit]`)
 	waitReady(t, operator, "#assist-share")
 	pollExpr(t, operator, toolNamesExpr, "", 15*time.Second)
 	pollExpr(t, operator, `window.__assist.phase`, "hydrated", 15*time.Second)

--- a/examples/webmcp-remote-assist/main.go
+++ b/examples/webmcp-remote-assist/main.go
@@ -1,0 +1,460 @@
+// Package main is the reference example for authenticated WebMCP plus
+// WebRTC remote support: one Go binary, one origin, two roles.
+//
+// The boundaries it exists to teach:
+//
+//   - Support-only WebMCP discovery. The bridge rides the document
+//     script rail scoped to /support (webmcp.WithDocumentScope), the
+//     assets are authorization-wrapped (WithAssetAuthorization), and
+//     leaving the console is a real navigation, so a document never
+//     carries tools it should not.
+//   - Role cookies authorize. Every endpoint re-checks the support or
+//     operator cookie; the WebMCP marker header only attributes.
+//   - One typed command. The console's manual button and the
+//     send_instruction / clear_instruction tools decode into one
+//     assistCommand and share applyCommand.
+//   - Peer-to-peer media. getUserMedia (video, never audio) feeds an
+//     RTCPeerConnection whose SDP and ICE cross the server only as
+//     signaling frames on the session's WebSocket.
+//   - Sequenced realtime state. core/stream.StateChannel server-side,
+//     __gofastr.loadModule('ws') + createSequencedReducer in the
+//     browser, so a reconnect cannot resurrect stale instruction state.
+//
+// Run it:
+//
+//	go run ./examples/webmcp-remote-assist
+//
+// then open http://localhost:8090. README.md walks the whole flow.
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	uiapp "github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/core/middleware"
+	"github.com/DonaldMurillo/gofastr/core/render"
+	"github.com/DonaldMurillo/gofastr/core/router"
+	"github.com/DonaldMurillo/gofastr/framework"
+	"github.com/DonaldMurillo/gofastr/framework/experimental/webmcp"
+	"github.com/DonaldMurillo/gofastr/framework/ui"
+	"github.com/DonaldMurillo/gofastr/framework/ui/theme"
+	"github.com/DonaldMurillo/gofastr/framework/uihost"
+)
+
+//go:embed static/app.js
+var appJS []byte
+
+// assist is the example's store. One global, set in main; tests build
+// their own via buildApp and reset it per server.
+var assist *assistApp
+
+const listenAddr = ":8090"
+
+func main() {
+	fwApp := buildApp()
+	if os.Getenv("ASSIST_SUPPORT_KEY") == "" {
+		log.Printf("support sign-in key (set ASSIST_SUPPORT_KEY to choose one): %s", assist.supportKey)
+	}
+	log.Printf("webmcp-remote-assist listening on http://localhost%s", listenAddr)
+	if err := fwApp.Start(listenAddr); err != nil && err != http.ErrServerClosed {
+		log.Fatal(err)
+	}
+}
+
+// buildApp wires the site, the host, the routes, and the WebMCP mount,
+// without binding a port, so tests drive fwApp.Router() directly.
+func buildApp() *framework.App {
+	assist = newAssistApp()
+	site := uiapp.NewApp("remote-assist")
+	// The canonical theme: light and dark palettes from one token set,
+	// so the pages follow the operator's OS preference with no CSS here.
+	site.WithTheme(theme.Default())
+	layout := uiapp.NewLayout("main").WithHeader(&siteHeaderComponent{})
+	site.SetDefaultLayout(layout)
+
+	site.RegisterScreen(uiapp.NewScreen("/", &LandingScreen{}).WithTitle("Remote assist"), nil)
+	site.RegisterScreen(uiapp.NewScreen("/support/login", &SupportLoginScreen{}).WithTitle("Support sign in"), nil)
+	site.RegisterScreen(uiapp.NewScreen("/support", &SupportHomeScreen{}).WithTitle("Assist sessions"), nil)
+	site.RegisterScreen(uiapp.NewScreen("/support/session/{id}", &SupportConsoleScreen{}).WithTitle("Support console"), nil)
+	site.RegisterScreen(uiapp.NewScreen("/session/{id}", &OperatorScreen{}).WithTitle("Assist session"), nil)
+
+	host := uihost.New(site,
+		// Every dead end is the same branded page: unknown session,
+		// expired, spent join link. Callers never learn which.
+		uihost.WithNotFoundScreen(&SessionGoneScreen{}),
+	)
+
+	fwApp := framework.NewApp(
+		framework.WithConfig(framework.AppConfig{Name: "webmcp-remote-assist"}),
+		// The default Permissions-Policy denies the camera outright;
+		// the operator page needs it, so the policy opens camera to
+		// this origin only. The microphone stays denied at the header
+		// level: "no audio" is enforced by the browser, not just by
+		// the getUserMedia constraints in app.js.
+		framework.WithSecurityHeaders(middleware.SecurityHeadersConfig{
+			PermissionsPolicy: "geolocation=(), microphone=(), camera=(self)",
+		}),
+	)
+	// Route parameters before the guards that read them (ui-wiring:
+	// "Guards on dynamic screens"). Router.Use runs first-registered
+	// outermost; fwApp.Use appends.
+	fwApp.Use(host.RouteMatchMiddleware())
+	fwApp.Use(assist.guard(host))
+	fwApp.Mount(host)
+
+	rt := fwApp.Router()
+
+	// ── Auth and session pages ────────────────────────────────────
+	// Every write route lives in a group that carries its guard, so a
+	// route added later inherits it (the shape the contracts pipeline
+	// checks). The sign-in is the credential exchange itself: it mints
+	// nothing without the key and is same-origin checked.
+	rt.Post("/support/login", sameOrigin(assist.handleLogin())) //gofastr:allow(GOFASTR1902) the sign-in exchanges the key for the role cookie; it is the guard the other routes rely on
+	support := rt.Group("/support", sameOrigin, assist.requireSupport())
+	support.Post("/sessions", assist.handleCreateSession())
+	support.Post("/session/{id}/instruction", assist.handleManualForm(cmdInstruction))
+	support.Post("/session/{id}/clear", assist.handleManualForm(cmdClear))
+	operator := rt.Group("/session", sameOrigin, assist.requireOperator())
+	operator.Post("/{id}/ack", assist.handleAck())
+	rt.Get("/join/{token}", assist.handleJoin(host))
+
+	// ── Realtime: one channel per session, two role-scoped sockets ─
+	rt.Get("/support/session/{id}/ws", assist.handleWS(roleSupport))
+	rt.Get("/session/{id}/ws", assist.handleWS(roleOperator))
+
+	// ── The one browser script, served CSP-safe and hash-versioned,
+	// on the document rail for the session pages only ────────────────
+	rt.Get("/__assist/app.js", uihost.ScriptHandler(appJS))
+	if err := host.RegisterDocumentScript(uihost.ScriptURL("/__assist/app.js", appJS), assistDocScope); err != nil {
+		log.Fatalf("assist: register document script: %v", err)
+	}
+
+	// ── WebMCP: browser tools for the support role ────────────────
+	tools := webmcp.New(
+		webmcp.WithInstructions("Inspect before mutating. Send one instruction at a time; "+
+			"send_instruction replaces the previous one. An HTTP 200 means the command was "+
+			"accepted, not that the operator saw it: verify delivery from inspect_session's "+
+			"acked field, which the operator sets by acknowledging the rendered instruction."),
+		webmcp.WithObserver(assist.observeToolEvent),
+	)
+	group := tools.Group("assist",
+		webmcp.WithDescription("Remote assist controls for the signed-in support operator."),
+		webmcp.WithPreferredFirst("inspect_session"),
+	)
+	toolAuth := []router.Middleware{assist.requireSupport(), sameOrigin}
+	for _, decl := range []struct {
+		tool    webmcp.Tool
+		handler http.Handler
+	}{
+		{assist.inspectTool(), assist.handleInspect()},
+		{assist.sendTool(), assist.handleSend()},
+		{assist.clearTool(), assist.handleClearTool()},
+	} {
+		if err := group.Handle(rt, decl.tool, decl.handler, webmcp.WithHTTPMiddleware(toolAuth...)); err != nil {
+			log.Fatalf("assist: webmcp handle %s: %v", decl.tool.Name, err)
+		}
+	}
+	if _, err := tools.Mount(rt, host,
+		// The bridge exists only on support documents; entering or
+		// leaving /support is a real navigation (the host's SPA
+		// runtime turns the scope edge into a document boundary), so
+		// an operator page can never inherit live tools.
+		webmcp.WithDocumentScope(supportScope),
+		// Discovery is an authority surface: the manifest names every
+		// tool and endpoint, so the assets need the same role check
+		// the endpoints have. WithPageScope is defense in depth for a
+		// stray script tag; the cookie check is the decision.
+		webmcp.WithAssetAuthorization(assist.requireSupport()),
+		webmcp.WithPageScope(func(r *http.Request) bool { return assist.authorizeSupport(r) }),
+		webmcp.WithPrivateAssets(),
+		// Bounded bridge state (support, registered names, last
+		// status; never inputs or URLs) so the console can show
+		// whether the browser registered the tools.
+		webmcp.WithBridgeDebug(),
+	); err != nil {
+		log.Fatalf("assist: webmcp mount: %v", err)
+	}
+
+	return fwApp
+}
+
+// supportScope is the WebMCP document scope: the signed-in support
+// page tree. Written prefix-style so the concrete path
+// (/support/session/ab12) and the route pattern (/support/session/:id)
+// agree. The sign-in page sits under /support but is anonymous, so it
+// is outside the scope: a document with no role carries no bridge.
+func supportScope(path string) bool {
+	if path == "/support/login" {
+		return false
+	}
+	return path == "/support" || strings.HasPrefix(path, "/support/")
+}
+
+// assistDocScope is the app.js document scope: both session pages.
+// The operator page and the support console each need the WebSocket
+// client; the landing page, the sign-in page, and the join exchange
+// carry nothing.
+func assistDocScope(path string) bool {
+	return supportScope(path) || path == "/session" || strings.HasPrefix(path, "/session/")
+}
+
+// siteHeaderComponent is the shared chrome. Its nav link to "/" is the
+// visible way out of the console: crossing the document scope is a
+// full navigation, which is what retires the tools.
+type siteHeaderComponent struct{}
+
+func (h *siteHeaderComponent) Render() render.HTML {
+	return ui.SiteHeader(ui.SiteHeaderConfig{
+		Brand: ui.Link(ui.LinkConfig{Href: "/", Text: "Remote assist"}),
+		NavItems: []ui.SiteHeaderLink{
+			{Label: "Overview", Href: "/"},
+			{Label: "Support", Href: "/support"},
+		},
+	})
+}
+
+// guard answers role failures with real pages (ui-wiring's recovery
+// screen pattern): support pages redirect to the demo sign-in, the
+// operator page and every dead session render the one SessionGone
+// screen with 410. An unauthorized caller never learns whether a
+// session exists.
+func (a *assistApp) guard(host *uihost.UIHost) router.Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			m, ok := uiapp.MatchFromContext(r.Context())
+			if ok {
+				switch m.ScreenID() {
+				case "/support", "/support/session/:id":
+					if !a.authorizeSupport(r) {
+						http.Redirect(w, r, "/support/login", http.StatusSeeOther)
+						return
+					}
+					if m.ScreenID() == "/support/session/:id" && a.lookup(m.Param("id")) == nil {
+						host.RenderScreen(w, r, &SessionGoneScreen{}, uihost.ScreenResponse{Status: http.StatusGone})
+						return
+					}
+				case "/session/:id":
+					if !a.authorizeOperator(operatorCookie(r), m.Param("id")) || a.lookup(m.Param("id")) == nil {
+						host.RenderScreen(w, r, &SessionGoneScreen{}, uihost.ScreenResponse{Status: http.StatusGone})
+						return
+					}
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// handleLogin mints the support role cookie when the form carries the
+// sign-in key. Demo-only: a real app puts battery/auth here. The cookie
+// is HttpOnly and Path=/ — the WebMCP assets live under /__gofastr/,
+// outside the /support tree. A wrong key re-renders the sign-in page
+// rather than answering with a distinguishable error.
+func (a *assistApp) handleLogin() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil || !a.checkSupportKey(r.PostFormValue("key")) {
+			http.Redirect(w, r, "/support/login", http.StatusSeeOther)
+			return
+		}
+		http.SetCookie(w, &http.Cookie{
+			Name:     supportCookieName,
+			Value:    a.mintSupportCookie(),
+			Path:     "/",
+			HttpOnly: true,
+			Secure:   secureRequest(r),
+			SameSite: http.SameSiteLaxMode,
+			MaxAge:   int(cookieTTL.Seconds()),
+		})
+		http.Redirect(w, r, "/support", http.StatusSeeOther)
+	})
+}
+
+// handleCreateSession starts a session and opens its console.
+func (a *assistApp) handleCreateSession() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s := a.createSession()
+		http.Redirect(w, r, "/support/session/"+s.id, http.StatusSeeOther)
+	})
+}
+
+// handleManualForm is the console's visible button: form-encoded POST
+// decoded into the same assistCommand the AI tools use. It answers
+// 303 back to the console, which is correct for a plain form post and
+// harmless for app.js's fetch enhancement.
+func (a *assistApp) handleManualForm(kind string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sid := router.Param(r, "id")
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "invalid form", http.StatusBadRequest)
+			return
+		}
+		cmd := assistCommand{Session: sid, Kind: kind, Instruction: r.PostFormValue("instruction")}
+		if _, status, err := a.applyCommand(cmd); err != nil {
+			http.Error(w, err.Error(), status)
+			return
+		}
+		http.Redirect(w, r, "/support/session/"+sid, http.StatusSeeOther)
+	})
+}
+
+// handleAck records the operator's acknowledgement of the rendered
+// instruction and returns to the page. The operator group's
+// requireOperator middleware has already matched the cookie to {id}.
+func (a *assistApp) handleAck() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sid := router.Param(r, "id")
+		if _, status, err := a.applyCommand(assistCommand{Session: sid, Kind: cmdAck}); err != nil {
+			http.Error(w, err.Error(), status)
+			return
+		}
+		http.Redirect(w, r, "/session/"+sid, http.StatusSeeOther)
+	})
+}
+
+// handleJoin exchanges the one-time link for the operator cookie and
+// redirects to the operator page. A spent or unknown token renders the
+// same 410 screen a dead session does.
+func (a *assistApp) handleJoin(host *uihost.UIHost) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sid, cookieValue, ok := a.exchangeJoin(router.Param(r, "token"))
+		if !ok {
+			host.RenderScreen(w, r, &SessionGoneScreen{}, uihost.ScreenResponse{Status: http.StatusGone})
+			return
+		}
+		http.SetCookie(w, &http.Cookie{
+			Name:     operatorCookieName,
+			Value:    cookieValue,
+			Path:     "/session", // never rides on a support URL
+			HttpOnly: true,
+			Secure:   secureRequest(r),
+			SameSite: http.SameSiteLaxMode,
+			MaxAge:   int(sessionTTL.Seconds()),
+		})
+		http.Redirect(w, r, "/session/"+sid, http.StatusSeeOther)
+	})
+}
+
+// secureRequest reports whether the request arrived over TLS, directly
+// or through a proxy that says so, which is the same signal the
+// framework's CSRF middleware and battery/auth use to decide a cookie's
+// Secure flag per request: on plain-HTTP localhost the cookie works,
+// behind TLS it is never sent in clear.
+func secureRequest(r *http.Request) bool {
+	return r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+}
+
+// ── WebMCP tool declarations ─────────────────────────────────────
+
+func (a *assistApp) inspectTool() webmcp.Tool {
+	return webmcp.Tool{
+		Name:        "inspect_session",
+		Title:       "Inspect assist session",
+		Description: "Read the session's current state: instruction text, whether the operator acknowledged it, who is connected, and whether the video path is up. Inspect before mutating.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"session":{"type":"string","description":"session id from the console URL"}},"required":["session"]}`),
+		Method:      http.MethodGet,
+		Path:        "/support/api/inspect",
+		Examples: []webmcp.Example{{
+			Summary: "Check delivery of the last instruction",
+			Input:   json.RawMessage(`{"session":"ab12cd34"}`),
+		}},
+		ReadOnlyHint:         true,
+		UntrustedContentHint: true, // instruction text is user content
+	}
+}
+
+func (a *assistApp) sendTool() webmcp.Tool {
+	return webmcp.Tool{
+		Name:        "send_instruction",
+		Title:       "Send instruction",
+		Description: "Show one instruction on the operator's page. Replaces any previous instruction. Accepted (HTTP 200) is not delivered: the operator acknowledges the rendered text, visible via inspect_session.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"session":{"type":"string"},"instruction":{"type":"string","maxLength":500}},"required":["session","instruction"]}`),
+		Method:      http.MethodPost,
+		Path:        "/support/api/instruction",
+		Examples: []webmcp.Example{{
+			Summary: "Point at the restart control",
+			Input:   json.RawMessage(`{"session":"ab12cd34","instruction":"Press and hold the green restart button for three seconds."}`),
+		}},
+	}
+}
+
+func (a *assistApp) clearTool() webmcp.Tool {
+	return webmcp.Tool{
+		Name:        "clear_instruction",
+		Title:       "Clear instruction",
+		Description: "Remove the current instruction from the operator's page.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"session":{"type":"string"}},"required":["session"]}`),
+		Method:      http.MethodPost,
+		Path:        "/support/api/clear",
+	}
+}
+
+// ── WebMCP tool handlers ─────────────────────────────────────────
+//
+// Each decodes into assistCommand and calls applyCommand — the exact
+// path the manual form takes. The invocation ref (the marked call's
+// correlation id) rides along so the operator's acknowledgement can be
+// correlated with the agent command that earned it.
+
+func (a *assistApp) handleInspect() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s := a.lookup(r.URL.Query().Get("session"))
+		if s == nil {
+			writeJSON(w, http.StatusGone, map[string]any{"error": "session has ended"})
+			return
+		}
+		snap := a.snapshotFor(roleSupport, s)
+		writeJSON(w, http.StatusOK, snap)
+	})
+}
+
+func (a *assistApp) handleSend() http.Handler {
+	return a.toolCommandHandler(func(in toolInput) assistCommand {
+		return assistCommand{Session: in.Session, Kind: cmdInstruction, Instruction: in.Instruction}
+	})
+}
+
+func (a *assistApp) handleClearTool() http.Handler {
+	return a.toolCommandHandler(func(in toolInput) assistCommand {
+		return assistCommand{Session: in.Session, Kind: cmdClear}
+	})
+}
+
+type toolInput struct {
+	Session     string `json:"session"`
+	Instruction string `json:"instruction"`
+}
+
+func (a *assistApp) toolCommandHandler(build func(toolInput) assistCommand) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, 8<<10)
+		var in toolInput
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid JSON body"})
+			return
+		}
+		cmd := build(in)
+		cmd.Ref = invocationRef(r.Context())
+		snap, status, err := a.applyCommand(cmd)
+		if err != nil {
+			writeJSON(w, status, map[string]any{"error": err.Error()})
+			return
+		}
+		// Accepted, not delivered: the operator must still acknowledge.
+		// inspect_session's acked field is the verification path.
+		writeJSON(w, status, map[string]any{
+			"accepted": true, "session": snap.Session,
+			"verify": "call inspect_session and check acked",
+		})
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/examples/webmcp-remote-assist/main.go
+++ b/examples/webmcp-remote-assist/main.go
@@ -82,6 +82,7 @@ func buildApp() *framework.App {
 	site.RegisterScreen(uiapp.NewScreen("/support", &SupportHomeScreen{}).WithTitle("Assist sessions"), nil)
 	site.RegisterScreen(uiapp.NewScreen("/support/session/{id}", &SupportConsoleScreen{}).WithTitle("Support console"), nil)
 	site.RegisterScreen(uiapp.NewScreen("/session/{id}", &OperatorScreen{}).WithTitle("Assist session"), nil)
+	site.RegisterScreen(uiapp.NewScreen("/join/{token}", &JoinScreen{}).WithTitle("Join assist session"), nil)
 
 	host := uihost.New(site,
 		// Every dead end is the same branded page: unknown session,
@@ -121,7 +122,10 @@ func buildApp() *framework.App {
 	support.Post("/session/{id}/clear", assist.handleManualForm(cmdClear))
 	operator := rt.Group("/session", sameOrigin, assist.requireOperator())
 	operator.Post("/{id}/ack", assist.handleAck())
-	rt.Get("/join/{token}", assist.handleJoin(host))
+	// The join link's GET renders a confirmation page and spends
+	// nothing, so a link previewer (chat unfurls, mail scanners) cannot
+	// burn the one-time token; the page's POST is the exchange.
+	rt.Post("/join/{token}", sameOrigin(assist.handleJoin(host))) //gofastr:allow(GOFASTR1902) the join exchange is the operator's credential: the one-time token in the path is what it checks
 
 	// ── Realtime: one channel per session, two role-scoped sockets ─
 	rt.Get("/support/session/{id}/ws", assist.handleWS(roleSupport))
@@ -243,6 +247,13 @@ func (a *assistApp) guard(host *uihost.UIHost) router.Middleware {
 						host.RenderScreen(w, r, &SessionGoneScreen{}, uihost.ScreenResponse{Status: http.StatusGone})
 						return
 					}
+				case "/join/:token":
+					// A spent or unknown token is the same 410 as a dead
+					// session; the check consumes nothing.
+					if !a.joinOpen(m.Param("token")) {
+						host.RenderScreen(w, r, &SessionGoneScreen{}, uihost.ScreenResponse{Status: http.StatusGone})
+						return
+					}
 				}
 			}
 			next.ServeHTTP(w, r)
@@ -316,9 +327,10 @@ func (a *assistApp) handleAck() http.Handler {
 	})
 }
 
-// handleJoin exchanges the one-time link for the operator cookie and
-// redirects to the operator page. A spent or unknown token renders the
-// same 410 screen a dead session does.
+// handleJoin is the confirmation page's POST: it exchanges the one-time
+// token for the operator cookie and redirects to the operator page. A
+// spent or unknown token renders the same 410 screen a dead session
+// does.
 func (a *assistApp) handleJoin(host *uihost.UIHost) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sid, cookieValue, ok := a.exchangeJoin(router.Param(r, "token"))

--- a/examples/webmcp-remote-assist/main_test.go
+++ b/examples/webmcp-remote-assist/main_test.go
@@ -1,0 +1,676 @@
+package main
+
+// HTTP- and source-level tests for the example's boundaries. The
+// chromedp suite (browser_test.go) drives the same boundaries through
+// a real browser; these pin them without one.
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// newTestApp builds a fresh app + server, isolating every test's
+// state (the store is process-global so buildApp can reach it).
+// noRedirectClient reads 303s instead of following them.
+var noRedirectClient = &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+	return http.ErrUseLastResponse
+}}
+
+func newTestApp(t *testing.T) (*httptest.Server, *assistApp) {
+	t.Helper()
+	app := buildApp()
+	srv := httptest.NewServer(app.Router())
+	t.Cleanup(srv.Close)
+	return srv, assist
+}
+
+// supportLogin performs the demo sign-in with the boot-time key and
+// returns the cookie.
+func supportLogin(t *testing.T, srv *httptest.Server) *http.Cookie {
+	t.Helper()
+	resp, err := noRedirectClient.PostForm(srv.URL+"/support/login", url.Values{"key": {assist.supportKey}})
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	resp.Body.Close()
+	for _, c := range resp.Cookies() {
+		if c.Name == supportCookieName {
+			return c
+		}
+	}
+	t.Fatal("login set no support cookie")
+	return nil
+}
+
+// A wrong or missing key mints nothing and answers with the same
+// redirect as success, so the response does not say which it was.
+func TestLoginRequiresKey(t *testing.T) {
+	srv, _ := newTestApp(t)
+	for _, key := range []string{"", "wrong", assist.supportKey + "x"} {
+		resp, err := noRedirectClient.PostForm(srv.URL+"/support/login", url.Values{"key": {key}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusSeeOther || resp.Header.Get("Location") != "/support/login" {
+			t.Fatalf("key %q: %d -> %q, want 303 back to the sign-in", key, resp.StatusCode, resp.Header.Get("Location"))
+		}
+		if firstCookie(resp, supportCookieName) != nil {
+			t.Fatalf("key %q minted a support cookie", key)
+		}
+	}
+}
+
+// newSupportSession logs in and creates a session, returning the
+// session id and the one-time join path.
+func newSupportSession(t *testing.T, srv *httptest.Server, a *assistApp) (*http.Cookie, string) {
+	t.Helper()
+	cookie := supportLogin(t, srv)
+	resp, err := noRedirectClient.Do(withCookie(t, srv, cookie, "POST", "/support/sessions", nil))
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	defer resp.Body.Close()
+	loc := resp.Header.Get("Location")
+	id := strings.TrimPrefix(loc, "/support/session/")
+	if id == loc || id == "" {
+		t.Fatalf("create session redirected to %q", loc)
+	}
+	return cookie, id
+}
+
+func withCookie(t *testing.T, srv *httptest.Server, c *http.Cookie, method, path string, body io.Reader) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, srv.URL+path, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.AddCookie(c)
+	return req
+}
+
+// MarkerSpoof: the WebMCP marker header must never substitute for the
+// role cookie. A spoofed marker without the cookie is 403.
+func TestMarkerNeverAuthorizesToolCall(t *testing.T) {
+	srv, _ := newTestApp(t)
+	resp, err := srv.Client().Post(srv.URL+"/support/api/instruction",
+		"application/json", strings.NewReader(`{"session":"x","instruction":"spoof"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	req, _ := http.NewRequest("POST", srv.URL+"/support/api/instruction",
+		strings.NewReader(`{"session":"x","instruction":"spoof"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Gofastr-WebMCP", "1")
+	resp2, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp2.Body.Close()
+	if resp.StatusCode != http.StatusForbidden || resp2.StatusCode != http.StatusForbidden {
+		t.Fatalf("marker-spoofed call without cookie = %d/%d, want 403/403", resp.StatusCode, resp2.StatusCode)
+	}
+}
+
+// A real cookie without the marker works (manual path) and produces NO
+// invocation event: the marker attributes, it does not grant — and its
+// absence is not a refusal either.
+func TestUnmarkedCallWorksButIsNotInvocation(t *testing.T) {
+	srv, a := newTestApp(t)
+	cookie, id := newSupportSession(t, srv, a)
+	resp, err := srv.Client().Do(withCookie(t, srv, cookie, "POST", "/support/api/instruction",
+		strings.NewReader(`{"session":"`+id+`","instruction":"turn it off and on"}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("manual tool call = %d, want 200", resp.StatusCode)
+	}
+	for _, line := range a.toolEventLog() {
+		if strings.Contains(line, "invoke") {
+			t.Fatalf("unmarked call produced an invocation event: %q", line)
+		}
+	}
+}
+
+// The marked call is attributed: an invoke event with a correlation id.
+func TestMarkedCallRecordsInvocation(t *testing.T) {
+	srv, a := newTestApp(t)
+	cookie, id := newSupportSession(t, srv, a)
+	req, _ := http.NewRequest("POST", srv.URL+"/support/api/instruction",
+		strings.NewReader(`{"session":"`+id+`","instruction":"press restart"}`))
+	req.AddCookie(cookie)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Gofastr-WebMCP", "1")
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("marked call = %d, want 200", resp.StatusCode)
+	}
+	if resp.Header.Get("X-Gofastr-WebMCP-Invocation") == "" {
+		t.Fatal("marked call carries no invocation header")
+	}
+	found := false
+	for _, line := range a.toolEventLog() {
+		if strings.HasPrefix(line, "invoke send_instruction") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no invoke event for send_instruction in %v", a.toolEventLog())
+	}
+}
+
+// One typed command: the console's form-encoded POST and the tool's
+// JSON POST mutate the same state through the same applyCommand.
+func TestManualFormAndToolShareOneCommand(t *testing.T) {
+	srv, a := newTestApp(t)
+	cookie, id := newSupportSession(t, srv, a)
+
+	form := withCookie(t, srv, cookie, "POST", "/support/session/"+id+"/instruction",
+		strings.NewReader("instruction=press+the+green+button"))
+	form.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := noRedirectClient.Do(form)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("manual form = %d, want 303", resp.StatusCode)
+	}
+
+	snap := inspect(t, srv, cookie, id)
+	if snap.Instruction != "press the green button" {
+		t.Fatalf("after manual form, instruction = %q", snap.Instruction)
+	}
+
+	tool := withCookie(t, srv, cookie, "POST", "/support/api/clear",
+		strings.NewReader(`{"session":"`+id+`"}`))
+	tool.Header.Set("Content-Type", "application/json")
+	resp2, err := srv.Client().Do(tool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp2.Body.Close()
+	snap = inspect(t, srv, cookie, id)
+	if snap.Instruction != "" {
+		t.Fatalf("after tool clear, instruction = %q, want empty", snap.Instruction)
+	}
+}
+
+// The join link is single-use: first open trades it for the operator
+// cookie, second open renders the 410 recovery page.
+func TestJoinLinkIsSingleUse(t *testing.T) {
+	srv, a := newTestApp(t)
+	_, id := newSupportSession(t, srv, a)
+	join := "/join/" + a.lookup(id).joinToken
+
+	resp, err := noRedirectClient.Get(srv.URL + join)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("first join = %d, want 303 (body %q)", resp.StatusCode, body)
+	}
+
+	resp2, err := noRedirectClient.Get(srv.URL + join)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	page, _ := io.ReadAll(resp2.Body)
+	if resp2.StatusCode != http.StatusGone {
+		t.Fatalf("second join = %d, want 410", resp2.StatusCode)
+	}
+	if !strings.Contains(string(page), "assist session has ended") {
+		t.Fatalf("second join body is not the recovery screen")
+	}
+}
+
+// An operator cookie minted for session A authorizes nothing on
+// session B, and the operator page guard answers 410 with the same
+// recovery screen for a missing cookie and an unknown session.
+func TestOperatorCookieIsSessionScoped(t *testing.T) {
+	srv, a := newTestApp(t)
+	_, idA := newSupportSession(t, srv, a)
+	_, idB := newSupportSession(t, srv, a)
+
+	resp, err := noRedirectClient.Get(srv.URL + "/join/" + a.lookup(idB).joinToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	opCookie := firstCookie(resp, operatorCookieName)
+	if opCookie == nil {
+		t.Fatal("join set no operator cookie")
+	}
+
+	// Right session: 200.
+	req, _ := http.NewRequest("GET", srv.URL+"/session/"+idB, nil)
+	req.AddCookie(opCookie)
+	resp2, err := noRedirectClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("operator page with own cookie = %d, want 200", resp2.StatusCode)
+	}
+
+	// Wrong session and no cookie: both 410, same body.
+	req2, _ := http.NewRequest("GET", srv.URL+"/session/"+idA, nil)
+	req2.AddCookie(opCookie)
+	resp3, err := noRedirectClient.Do(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp3.Body.Close()
+	page, _ := io.ReadAll(resp3.Body)
+	if resp3.StatusCode != http.StatusGone || !strings.Contains(string(page), "assist session has ended") {
+		t.Fatalf("foreign session = %d, want 410 recovery", resp3.StatusCode)
+	}
+	resp4, err := noRedirectClient.Get(srv.URL + "/session/" + idB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp4.Body.Close()
+	if resp4.StatusCode != http.StatusGone {
+		t.Fatalf("operator page without cookie = %d, want 410", resp4.StatusCode)
+	}
+}
+
+// The operator's write route is guarded by the group middleware: no
+// cookie and a cookie for another session are both 403 before the
+// handler runs, and the right cookie acknowledges.
+func TestAckRequiresMatchingOperatorCookie(t *testing.T) {
+	srv, a := newTestApp(t)
+	_, idA := newSupportSession(t, srv, a)
+	_, idB := newSupportSession(t, srv, a)
+	resp, err := noRedirectClient.Get(srv.URL + "/join/" + a.lookup(idB).joinToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	opCookie := firstCookie(resp, operatorCookieName)
+	post := func(id string, c *http.Cookie) int {
+		req, _ := http.NewRequest("POST", srv.URL+"/session/"+id+"/ack", nil)
+		if c != nil {
+			req.AddCookie(c)
+		}
+		r, err := noRedirectClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		r.Body.Close()
+		return r.StatusCode
+	}
+	if got := post(idB, nil); got != http.StatusForbidden {
+		t.Fatalf("ack without cookie = %d, want 403", got)
+	}
+	if got := post(idA, opCookie); got != http.StatusForbidden {
+		t.Fatalf("ack on another session = %d, want 403", got)
+	}
+	if got := post(idB, opCookie); got != http.StatusSeeOther {
+		t.Fatalf("ack with own cookie = %d, want 303", got)
+	}
+	if !a.lookup(idB).acked {
+		t.Fatal("ack did not record")
+	}
+}
+
+// The bridge document scope: support pages carry the bridge tag, the
+// landing and operator pages carry nothing.
+func TestBridgeShipsOnlyOnSupportPages(t *testing.T) {
+	srv, a := newTestApp(t)
+	cookie, id := newSupportSession(t, srv, a)
+	join := "/join/" + a.lookup(id).joinToken
+
+	resp, err := noRedirectClient.Get(srv.URL + join)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	opCookie := firstCookie(resp, operatorCookieName)
+
+	for _, path := range []string{"/", "/support/login"} {
+		page := getPage(t, srv, path)
+		if strings.Contains(page, `src="/__gofastr/webmcp.js`) || strings.Contains(page, "data-fui-doc") {
+			t.Fatalf("%s carries a document-scoped script", path)
+		}
+	}
+
+	req, _ := http.NewRequest("GET", srv.URL+"/session/"+id, nil)
+	req.AddCookie(opCookie)
+	resp2, err := noRedirectClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opBody, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	// app.js IS document-scoped here (the operator page needs it);
+	// the WebMCP bridge must not be.
+	if strings.Contains(string(opBody), `src="/__gofastr/webmcp.js`) {
+		t.Fatal("operator page carries the WebMCP bridge")
+	}
+
+	console := getPage(t, srv, "/support/session/"+id, cookie)
+	if !strings.Contains(console, "data-fui-doc") {
+		t.Fatal("support console lacks the document-scoped bridge tag")
+	}
+	if !strings.Contains(console, "/__assist/app.js") {
+		t.Fatal("support console lacks app.js")
+	}
+}
+
+// The WebMCP asset routes require the support cookie: the manifest
+// names every tool, so discovery is gated like the endpoints.
+func TestManifestRequiresSupportRole(t *testing.T) {
+	srv, a := newTestApp(t)
+	cookie, _ := newSupportSession(t, srv, a)
+
+	resp, err := srv.Client().Get(srv.URL + "/__gofastr/webmcp/tools.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("anonymous manifest = %d, want 403", resp.StatusCode)
+	}
+
+	req, _ := http.NewRequest("GET", srv.URL+"/__gofastr/webmcp/tools.json", nil)
+	req.AddCookie(cookie)
+	resp2, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	body, _ := io.ReadAll(resp2.Body)
+	for _, name := range []string{"inspect_session", "send_instruction", "clear_instruction", "get_app_instructions"} {
+		if !strings.Contains(string(body), name) {
+			t.Fatalf("manifest lacks %q", name)
+		}
+	}
+}
+
+// A cross-site mutating request is refused even with a valid cookie
+// (the CSRF posture: the role cookie decides WHO, Fetch Metadata and
+// Origin decide WHERE FROM). Sec-Fetch-Site is authoritative: a
+// cross-site request is refused whatever Origin says, and a same-origin
+// one passes. Without Fetch Metadata the Origin host decides, and a
+// null Origin (a top-level same-origin form navigation) passes.
+func TestCrossSiteCommandRefused(t *testing.T) {
+	srv, a := newTestApp(t)
+	cookie, id := newSupportSession(t, srv, a)
+	cases := []struct {
+		name   string
+		sfs    string
+		origin string
+		want   int
+	}{
+		{"cross-site metadata", "cross-site", "", http.StatusForbidden},
+		{"cross-site metadata beats a matching origin", "cross-site", srv.URL, http.StatusForbidden},
+		{"same-origin metadata", "same-origin", "", http.StatusOK},
+		{"foreign origin, no metadata", "", "https://evil.example", http.StatusForbidden},
+		{"matching origin, no metadata", "", srv.URL, http.StatusOK},
+		{"null origin, no metadata", "", "null", http.StatusOK},
+		{"no headers at all", "", "", http.StatusOK},
+	}
+	for _, tc := range cases {
+		req, _ := http.NewRequest("POST", srv.URL+"/support/api/instruction",
+			strings.NewReader(`{"session":"`+id+`","instruction":"x"}`))
+		req.AddCookie(cookie)
+		req.Header.Set("Content-Type", "application/json")
+		if tc.sfs != "" {
+			req.Header.Set("Sec-Fetch-Site", tc.sfs)
+		}
+		if tc.origin != "" {
+			req.Header.Set("Origin", tc.origin)
+		}
+		resp, err := srv.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != tc.want {
+			t.Fatalf("%s: %d, want %d", tc.name, resp.StatusCode, tc.want)
+		}
+	}
+}
+
+// Every published event advances the session version, signaling
+// frames included: the channel assigns each event the next sequence,
+// and a snapshot whose sequence trailed the events a page had applied
+// would be refused by the page's reducer, leaving a reconnect
+// unhydrated.
+func TestSignalAdvancesSessionVersion(t *testing.T) {
+	_, a := newTestApp(t)
+	s := a.createSession()
+	src := sessionSource{app: a, id: s.id}
+	_, before := src.SnapshotFor(roleSupport)
+	if !a.relaySignal(s, roleOperator, signalMessage{To: roleSupport, Type: "offer", Data: json.RawMessage(`{}`)}) {
+		t.Fatal("offer to the peer was refused")
+	}
+	if a.relaySignal(s, roleOperator, signalMessage{To: roleOperator, Type: "offer", Data: json.RawMessage(`{}`)}) {
+		t.Fatal("offer addressed to the sender's own role was relayed")
+	}
+	_, after := src.SnapshotFor(roleSupport)
+	if after != before+1 {
+		t.Fatalf("session version %d -> %d after one relayed frame, want +1", before, after)
+	}
+}
+
+// The microphone is denied by the response header, not only by the
+// getUserMedia constraints: a page script that asked for audio would
+// be refused by the browser. The camera is open to this origin only.
+func TestMicrophoneDeniedByPolicy(t *testing.T) {
+	srv, _ := newTestApp(t)
+	resp, err := srv.Client().Get(srv.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	pp := resp.Header.Get("Permissions-Policy")
+	if !strings.Contains(pp, "microphone=()") || !strings.Contains(pp, "camera=(self)") {
+		t.Fatalf("Permissions-Policy = %q, want microphone denied and camera self", pp)
+	}
+}
+
+// A bad command reports why, not a generic status text.
+func TestBadRequestKeepsItsReason(t *testing.T) {
+	_, a := newTestApp(t)
+	s := a.createSession()
+	_, status, err := a.applyCommand(assistCommand{Session: s.id, Kind: cmdInstruction, Instruction: "   "})
+	if status != http.StatusBadRequest || err == nil || !strings.Contains(err.Error(), "1-500") {
+		t.Fatalf("blank instruction: %d %v", status, err)
+	}
+}
+
+// The session pages are per-role state (instruction text, the join
+// link) and must not enter shared or history caches. The host sends
+// Cache-Control: no-store on every rendered page; this pins the
+// contract the example relies on rather than adding a header of its
+// own.
+func TestSessionPagesAreNoStore(t *testing.T) {
+	srv, a := newTestApp(t)
+	cookie, id := newSupportSession(t, srv, a)
+	req, _ := http.NewRequest("GET", srv.URL+"/support/session/"+id, nil)
+	req.AddCookie(cookie)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if cc := resp.Header.Get("Cache-Control"); resp.StatusCode != http.StatusOK || !strings.Contains(cc, "no-store") {
+		t.Fatalf("console = %d Cache-Control %q", resp.StatusCode, cc)
+	}
+	resp, err = noRedirectClient.Get(srv.URL + "/join/" + a.lookup(id).joinToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	req2, _ := http.NewRequest("GET", srv.URL+"/session/"+id, nil)
+	req2.AddCookie(firstCookie(resp, operatorCookieName))
+	resp2, err := srv.Client().Do(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp2.Body.Close()
+	if cc := resp2.Header.Get("Cache-Control"); resp2.StatusCode != http.StatusOK || !strings.Contains(cc, "no-store") {
+		t.Fatalf("operator page = %d Cache-Control %q", resp2.StatusCode, cc)
+	}
+}
+
+// Source-level minimization: signaling is addressed, the invocation
+// ref is support-only, and a hidden event serializes nothing.
+func TestFilterEventMinimizesPerRole(t *testing.T) {
+	_, a := newTestApp(t)
+	s := a.createSession()
+	src := sessionSource{app: a, id: s.id}
+
+	offer := assistEvent{Kind: "signal", Signal: &signalMessage{From: roleOperator, To: roleSupport, Type: "offer", Data: json.RawMessage(`{"sdp":"v=0"}`)}}
+	if _, ok := src.FilterEvent(roleOperator, offer); ok {
+		t.Fatal("operator received its own offer back")
+	}
+	seen, ok := src.FilterEvent(roleSupport, offer)
+	if !ok {
+		t.Fatal("support did not receive the offer")
+	}
+	if _, ok := seen.(signalMessage); !ok {
+		t.Fatalf("offer payload type %T", seen)
+	}
+
+	a.applyCommand(assistCommand{Session: s.id, Kind: cmdInstruction, Instruction: "look left", Ref: "inv-123"})
+	if _, snapSeq := src.SnapshotFor(roleOperator); snapSeq == 0 {
+		t.Fatal("snapshot sequence is zero after a mutation")
+	}
+	opSnap, _ := src.SnapshotFor(roleOperator)
+	supSnap, _ := src.SnapshotFor(roleSupport)
+	if opSnap.Invocation != "" {
+		t.Fatalf("operator snapshot carries the invocation ref %q", opSnap.Invocation)
+	}
+	if supSnap.Invocation != "inv-123" {
+		t.Fatalf("support snapshot invocation = %q", supSnap.Invocation)
+	}
+
+	for _, ev := range []assistEvent{
+		{Kind: cmdAck, Acked: true, Ref: "inv-123"},
+		{Kind: cmdInstruction, Instruction: "look left", Ref: "inv-123"},
+		{Kind: cmdClear, Ref: "inv-123"},
+	} {
+		op, ok := src.FilterEvent(roleOperator, ev)
+		if !ok {
+			t.Fatalf("operator did not receive the %s event", ev.Kind)
+		}
+		if strings.Contains(mustJSON(t, op), "inv-123") {
+			t.Fatalf("operator %s payload carries the invocation ref: %s", ev.Kind, mustJSON(t, op))
+		}
+		sup, _ := src.FilterEvent(roleSupport, ev)
+		if !strings.Contains(mustJSON(t, sup), "inv-123") {
+			t.Fatalf("support %s payload lost the invocation ref: %s", ev.Kind, mustJSON(t, sup))
+		}
+	}
+}
+
+// A dead session answers 410 everywhere it is addressable.
+func TestDeadSessionIsGone(t *testing.T) {
+	srv, a := newTestApp(t)
+	cookie, id := newSupportSession(t, srv, a)
+	s := a.lookup(id)
+	a.mu.Lock()
+	a.dropLocked(s)
+	a.mu.Unlock()
+
+	req, _ := http.NewRequest("GET", srv.URL+"/support/session/"+id, nil)
+	req.AddCookie(cookie)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	page, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusGone || !strings.Contains(string(page), "assist session has ended") {
+		t.Fatalf("dead session console = %d, want 410 recovery", resp.StatusCode)
+	}
+	if code := inspectStatus(t, srv, cookie, id); code != http.StatusGone {
+		t.Fatalf("inspect on dead session = %d, want 410", code)
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────
+
+func getPage(t *testing.T, srv *httptest.Server, path string, cookies ...*http.Cookie) string {
+	t.Helper()
+	req, err := http.NewRequest("GET", srv.URL+path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return string(body)
+}
+
+func firstCookie(resp *http.Response, name string) *http.Cookie {
+	for _, c := range resp.Cookies() {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func inspect(t *testing.T, srv *httptest.Server, cookie *http.Cookie, id string) assistSnapshot {
+	t.Helper()
+	req, _ := http.NewRequest("GET", srv.URL+"/support/api/inspect?session="+id, nil)
+	req.AddCookie(cookie)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var snap assistSnapshot
+	if err := json.Unmarshal(body, &snap); err != nil {
+		t.Fatalf("inspect body: %v", err)
+	}
+	return snap
+}
+
+func inspectStatus(t *testing.T, srv *httptest.Server, cookie *http.Cookie, id string) int {
+	t.Helper()
+	req, _ := http.NewRequest("GET", srv.URL+"/support/api/inspect?session="+id, nil)
+	req.AddCookie(cookie)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	return resp.StatusCode
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/examples/webmcp-remote-assist/main_test.go
+++ b/examples/webmcp-remote-assist/main_test.go
@@ -208,34 +208,67 @@ func TestManualFormAndToolShareOneCommand(t *testing.T) {
 	}
 }
 
-// The join link is single-use: first open trades it for the operator
-// cookie, second open renders the 410 recovery page.
+// joinAs performs the confirmation page's POST for the token and
+// returns the operator cookie.
+func joinAs(t *testing.T, srv *httptest.Server, token string) *http.Cookie {
+	t.Helper()
+	resp, err := noRedirectClient.Post(srv.URL+"/join/"+token, "application/x-www-form-urlencoded", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("join POST = %d, want 303", resp.StatusCode)
+	}
+	c := firstCookie(resp, operatorCookieName)
+	if c == nil {
+		t.Fatal("join set no operator cookie")
+	}
+	return c
+}
+
+// The join link is single-use, and only its POST spends it: any number
+// of GETs (a chat unfurl, a mail scanner, the operator's own preview)
+// render the confirmation page and change nothing. The first POST
+// trades the token for the operator cookie; every request after that
+// renders the 410 recovery page.
 func TestJoinLinkIsSingleUse(t *testing.T) {
 	srv, a := newTestApp(t)
 	_, id := newSupportSession(t, srv, a)
-	join := "/join/" + a.lookup(id).joinToken
+	token := a.lookup(id).joinToken
+	join := "/join/" + token
 
-	resp, err := noRedirectClient.Get(srv.URL + join)
-	if err != nil {
-		t.Fatal(err)
+	for i := 0; i < 2; i++ {
+		resp, err := noRedirectClient.Get(srv.URL + join)
+		if err != nil {
+			t.Fatal(err)
+		}
+		page, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK || !strings.Contains(string(page), `action="`+join+`"`) {
+			t.Fatalf("GET #%d = %d, want 200 with the confirmation form", i+1, resp.StatusCode)
+		}
+		if firstCookie(resp, operatorCookieName) != nil {
+			t.Fatalf("GET #%d minted an operator cookie", i+1)
+		}
 	}
-	body, _ := io.ReadAll(resp.Body)
-	resp.Body.Close()
-	if resp.StatusCode != http.StatusSeeOther {
-		t.Fatalf("first join = %d, want 303 (body %q)", resp.StatusCode, body)
+	if !a.joinOpen(token) {
+		t.Fatal("GET consumed the token")
 	}
 
-	resp2, err := noRedirectClient.Get(srv.URL + join)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp2.Body.Close()
-	page, _ := io.ReadAll(resp2.Body)
-	if resp2.StatusCode != http.StatusGone {
-		t.Fatalf("second join = %d, want 410", resp2.StatusCode)
-	}
-	if !strings.Contains(string(page), "assist session has ended") {
-		t.Fatalf("second join body is not the recovery screen")
+	joinAs(t, srv, token)
+
+	for _, method := range []string{"POST", "GET"} {
+		req, _ := http.NewRequest(method, srv.URL+join, nil)
+		resp, err := noRedirectClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		page, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusGone || !strings.Contains(string(page), "assist session has ended") {
+			t.Fatalf("%s after the exchange = %d, want 410 recovery", method, resp.StatusCode)
+		}
 	}
 }
 
@@ -247,15 +280,7 @@ func TestOperatorCookieIsSessionScoped(t *testing.T) {
 	_, idA := newSupportSession(t, srv, a)
 	_, idB := newSupportSession(t, srv, a)
 
-	resp, err := noRedirectClient.Get(srv.URL + "/join/" + a.lookup(idB).joinToken)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp.Body.Close()
-	opCookie := firstCookie(resp, operatorCookieName)
-	if opCookie == nil {
-		t.Fatal("join set no operator cookie")
-	}
+	opCookie := joinAs(t, srv, a.lookup(idB).joinToken)
 
 	// Right session: 200.
 	req, _ := http.NewRequest("GET", srv.URL+"/session/"+idB, nil)
@@ -298,12 +323,7 @@ func TestAckRequiresMatchingOperatorCookie(t *testing.T) {
 	srv, a := newTestApp(t)
 	_, idA := newSupportSession(t, srv, a)
 	_, idB := newSupportSession(t, srv, a)
-	resp, err := noRedirectClient.Get(srv.URL + "/join/" + a.lookup(idB).joinToken)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp.Body.Close()
-	opCookie := firstCookie(resp, operatorCookieName)
+	opCookie := joinAs(t, srv, a.lookup(idB).joinToken)
 	post := func(id string, c *http.Cookie) int {
 		req, _ := http.NewRequest("POST", srv.URL+"/session/"+id+"/ack", nil)
 		if c != nil {
@@ -336,20 +356,15 @@ func TestBridgeShipsOnlyOnSupportPages(t *testing.T) {
 	srv, a := newTestApp(t)
 	cookie, id := newSupportSession(t, srv, a)
 	join := "/join/" + a.lookup(id).joinToken
-
-	resp, err := noRedirectClient.Get(srv.URL + join)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp.Body.Close()
-	opCookie := firstCookie(resp, operatorCookieName)
-
-	for _, path := range []string{"/", "/support/login"} {
+	// Anonymous documents carry no document-scoped script at all; the
+	// join page is checked before its POST spends the token.
+	for _, path := range []string{"/", "/support/login", join} {
 		page := getPage(t, srv, path)
 		if strings.Contains(page, `src="/__gofastr/webmcp.js`) || strings.Contains(page, "data-fui-doc") {
 			t.Fatalf("%s carries a document-scoped script", path)
 		}
 	}
+	opCookie := joinAs(t, srv, a.lookup(id).joinToken)
 
 	req, _ := http.NewRequest("GET", srv.URL+"/session/"+id, nil)
 	req.AddCookie(opCookie)
@@ -487,6 +502,41 @@ func TestMicrophoneDeniedByPolicy(t *testing.T) {
 	}
 }
 
+// The status pills render the state at load: a reload of the console
+// after an acknowledgement shows "acknowledged" before any script
+// runs, with its counterpart hidden.
+func TestPillsRenderStateAtLoad(t *testing.T) {
+	srv, a := newTestApp(t)
+	cookie, id := newSupportSession(t, srv, a)
+	if _, _, err := a.applyCommand(assistCommand{Session: id, Kind: cmdInstruction, Instruction: "hold"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := a.applyCommand(assistCommand{Session: id, Kind: cmdAck}); err != nil {
+		t.Fatal(err)
+	}
+	page := getPage(t, srv, "/support/session/"+id, cookie)
+	on := openingTag(t, page, "assist-pill-ack-on")
+	off := openingTag(t, page, "assist-pill-ack-off")
+	if strings.Contains(on, " hidden") || !strings.Contains(off, " hidden") {
+		t.Fatalf("after ack:\n on  %s\n off %s\nwant the on-pill visible and the off-pill hidden", on, off)
+	}
+}
+
+// openingTag returns the opening tag that carries id="<id>".
+func openingTag(t *testing.T, page, id string) string {
+	t.Helper()
+	i := strings.Index(page, `id="`+id+`"`)
+	if i < 0 {
+		t.Fatalf("no element with id %q", id)
+	}
+	start := strings.LastIndex(page[:i], "<")
+	end := strings.Index(page[i:], ">")
+	if start < 0 || end < 0 {
+		t.Fatalf("malformed tag around id %q", id)
+	}
+	return page[start : i+end+1]
+}
+
 // A bad command reports why, not a generic status text.
 func TestBadRequestKeepsItsReason(t *testing.T) {
 	_, a := newTestApp(t)
@@ -515,13 +565,8 @@ func TestSessionPagesAreNoStore(t *testing.T) {
 	if cc := resp.Header.Get("Cache-Control"); resp.StatusCode != http.StatusOK || !strings.Contains(cc, "no-store") {
 		t.Fatalf("console = %d Cache-Control %q", resp.StatusCode, cc)
 	}
-	resp, err = noRedirectClient.Get(srv.URL + "/join/" + a.lookup(id).joinToken)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp.Body.Close()
 	req2, _ := http.NewRequest("GET", srv.URL+"/session/"+id, nil)
-	req2.AddCookie(firstCookie(resp, operatorCookieName))
+	req2.AddCookie(joinAs(t, srv, a.lookup(id).joinToken))
 	resp2, err := srv.Client().Do(req2)
 	if err != nil {
 		t.Fatal(err)

--- a/examples/webmcp-remote-assist/screens.go
+++ b/examples/webmcp-remote-assist/screens.go
@@ -1,0 +1,354 @@
+package main
+
+// screens.go renders every page from framework/ui components: no CSS
+// and no hand-rolled structural markup live here. Live values (the
+// current instruction, presence, media state) render BOTH states
+// server-side; static/app.js toggles `hidden` and sets textContent, so
+// the design system owns every pixel and the script only moves state.
+//
+// Each session page carries one config carrier, #assist-root, whose
+// data-assist-* attributes tell app.js the session id, the role, and
+// that page's WebSocket endpoint. That is the whole page-to-script
+// contract: CSP-safe (no inline JS), and nothing a page doesn't
+// declare reaches the script.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/core-ui/component"
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
+	"github.com/DonaldMurillo/gofastr/core/render"
+	"github.com/DonaldMurillo/gofastr/framework/ui"
+)
+
+// assistRoot renders the #assist-root config carrier around the page
+// body. app.js refuses to boot without it.
+func assistRoot(attrs map[string]string, children ...render.HTML) render.HTML {
+	data := map[string]string{"assist-root": ""}
+	for k, v := range attrs {
+		data["assist-"+k] = v
+	}
+	return html.Div(html.DivConfig{ID: "assist-root", ExtraAttrs: html.DataAttrs(data)}, children...)
+}
+
+// videoTag renders a <video> element, hidden until a stream is
+// attached (app.js clears the attribute when it sets srcObject). A leaf
+// semantic tag, not layout: the design system has no media component,
+// and none is needed — the element ships no styling of its own.
+func videoTag(id string) render.HTML {
+	return render.Tag("video", map[string]string{
+		"id": id, "autoplay": "", "muted": "", "playsinline": "", "hidden": "",
+	})
+}
+
+// pillPair renders two StatusPills where exactly one is visible;
+// app.js flips the hidden attribute as state changes.
+func pillPair(id string, off, on string) render.HTML {
+	return ui.Cluster(ui.ClusterConfig{Gap: ui.GapSM},
+		ui.StatusPill(ui.StatusPillConfig{ID: id + "-off", Dot: true, Label: off, ExtraAttrs: html.Attrs{"data-assist-live": ""}}),
+		ui.StatusPill(ui.StatusPillConfig{ID: id + "-on", Dot: true, Label: on, ExtraAttrs: html.Attrs{"hidden": "", "data-assist-live": ""}}),
+	)
+}
+
+// LandingScreen is the public page: no role, no tools, no bridge.
+type LandingScreen struct{}
+
+func (s *LandingScreen) ScreenTitle() string { return "Remote assist" }
+func (s *LandingScreen) Render() render.HTML {
+	return ui.Stack(ui.StackConfig{Gap: ui.GapLG},
+		ui.PageHeader(ui.PageHeaderConfig{
+			Eyebrow:  "GoFastr example",
+			Title:    "Remote assist",
+			Subtitle: "An operator shares their camera with support. Support guides them with instructions an in-browser AI agent can also issue.",
+		}),
+		ui.Grid(ui.GridConfig{Min: "18rem"},
+			ui.Card(ui.CardConfig{Heading: "For support", HeadingLevel: 2,
+				Description: "Sign in, create a short-lived session, and get a one-time link for the operator."},
+				ui.LinkButton(ui.LinkButtonConfig{Label: "Support sign in", Href: "/support/login"}),
+			),
+			ui.Card(ui.CardConfig{Heading: "For the operator", HeadingLevel: 2,
+				Description: "Open the one-time link Support sent you. The link trades for a role cookie and opens your side of the session."},
+				ui.StatusPill(ui.StatusPillConfig{Label: "Join links come from support", Dot: true}),
+			),
+			ui.Card(ui.CardConfig{Heading: "What the example shows", HeadingLevel: 2},
+				ui.Stack(ui.StackConfig{Gap: ui.GapSM},
+					html.Paragraph(html.TextConfig{}, render.Text("Browser WebMCP tools scoped to the support console.")),
+					html.Paragraph(html.TextConfig{}, render.Text("WebRTC video that never touches the server; only signaling does.")),
+					html.Paragraph(html.TextConfig{}, render.Text("One typed command behind the manual button and the AI tools.")),
+				),
+			),
+		),
+	)
+}
+
+// SupportLoginScreen mints the support role cookie. A real deployment
+// replaces this with battery/auth; the example keeps the surface so
+// the role boundary stays visible and testable.
+type SupportLoginScreen struct{ component.ContextOnly }
+
+func (s *SupportLoginScreen) ScreenTitle() string { return "Support sign in" }
+
+func (s *SupportLoginScreen) RenderCtx(ctx context.Context) render.HTML {
+	return ui.AuthCard(ui.AuthCardConfig{
+		Title: "Support sign in",
+		Body: ui.Stack(ui.StackConfig{Gap: ui.GapMD},
+			ui.Form(ui.FormConfig{
+				Action:      "/support/login",
+				Method:      "POST",
+				SubmitLabel: "Enter the console",
+				Ctx:         ctx,
+			}, ui.FormField(ui.FormFieldConfig{
+				Label: "Sign-in key", For: "assist-support-key", Required: true,
+				Input: ui.PasswordInput(ui.PasswordInputConfig{
+					Name: "key", ID: "assist-support-key", Required: true,
+					Autocomplete: "current-password", Ctx: ctx,
+				}),
+			})),
+			html.Paragraph(html.TextConfig{},
+				render.Text("Demo sign-in: the key is ASSIST_SUPPORT_KEY, or the value printed in the server log at start. A real app puts its own login here.")),
+		),
+	})
+}
+
+// SupportHomeScreen creates sessions.
+type SupportHomeScreen struct{ component.ContextOnly }
+
+func (s *SupportHomeScreen) ScreenTitle() string { return "Assist sessions" }
+
+func (s *SupportHomeScreen) RenderCtx(ctx context.Context) render.HTML {
+	return ui.Stack(ui.StackConfig{Gap: ui.GapLG},
+		ui.PageHeader(ui.PageHeaderConfig{
+			Title:    "Assist sessions",
+			Subtitle: "Each session lives 10 minutes. The join link works once.",
+		}),
+		ui.Card(ui.CardConfig{Heading: "New session", HeadingLevel: 2},
+			ui.Form(ui.FormConfig{
+				Action:      "/support/sessions",
+				Method:      "POST",
+				SubmitLabel: "Create session",
+				Ctx:         ctx,
+			}),
+		),
+	)
+}
+
+// SupportConsoleScreen is the capability-bearing page: the WebMCP
+// bridge document scope covers /support, the manual forms and the AI
+// tools share one command path, and the operator's camera arrives
+// peer-to-peer in #assist-remote.
+type SupportConsoleScreen struct {
+	component.ContextOnly
+	id string
+}
+
+func (s *SupportConsoleScreen) ScreenTitle() string { return "Support console" }
+
+func (s *SupportConsoleScreen) SetParams(m map[string]string) { s.id = m["id"] }
+
+func (s *SupportConsoleScreen) RenderCtx(ctx context.Context) render.HTML {
+	r := app.RequestFromContext(ctx)
+	snap := assist.snapshotOf(s.id, roleSupport)
+	joinURL := ""
+	if sess := assist.lookup(s.id); sess != nil {
+		joinURL = joinLink(r, sess)
+	}
+
+	return assistRoot(map[string]string{
+		"session": s.id,
+		"role":    string(roleSupport),
+		"ws":      "/support/session/" + s.id + "/ws",
+	},
+		ui.Stack(ui.StackConfig{Gap: ui.GapLG},
+			ui.PageHeader(ui.PageHeaderConfig{
+				Eyebrow: "Session " + shortID(s.id),
+				Title:   "Support console",
+				Actions: ui.Cluster(ui.ClusterConfig{Gap: ui.GapSM},
+					pillPair("assist-pill-op", "operator away", "operator online"),
+					pillPair("assist-pill-media", "no video", "video live"),
+					pillPair("assist-pill-ack", "not acknowledged", "acknowledged"),
+				),
+			}),
+			ui.Grid(ui.GridConfig{Min: "22rem"},
+				ui.Card(ui.CardConfig{Heading: "Operator camera", HeadingLevel: 2,
+					Description: "Peer-to-peer WebRTC. The server relayed the handshake; the video never crosses it."},
+					ui.Stack(ui.StackConfig{Gap: ui.GapMD},
+						videoTag("assist-remote"),
+						html.Paragraph(html.TextConfig{ID: "assist-media-note"},
+							render.Text("Waiting for the operator to share a camera.")),
+					),
+				),
+				ui.Stack(ui.StackConfig{Gap: ui.GapMD},
+					ui.Card(ui.CardConfig{Heading: "Instruction", HeadingLevel: 2,
+						Description: "One instruction at a time. The button and the AI tools issue the same command."},
+						ui.Stack(ui.StackConfig{Gap: ui.GapMD},
+							instructionCard(snap.Instruction, true),
+							ui.Form(ui.FormConfig{
+								Action:      "/support/session/" + s.id + "/instruction",
+								Method:      "POST",
+								SubmitLabel: "Send instruction",
+								ID:          "assist-manual-form",
+								Ctx:         ctx,
+							}, ui.TextField(ui.TextFieldConfig{
+								Name: "instruction", Label: "Instruction",
+								ID: "assist-instruction-input", Required: true,
+								MaxLength:   500,
+								Placeholder: "Press the green restart button",
+							})),
+							ui.Form(ui.FormConfig{
+								Action:      "/support/session/" + s.id + "/clear",
+								Method:      "POST",
+								SubmitLabel: "Clear instruction",
+								ID:          "assist-clear-form",
+								Ctx:         ctx,
+							}),
+						),
+					),
+					ui.Card(ui.CardConfig{Heading: "Invite the operator", HeadingLevel: 2,
+						Description: "One-time link: the first open trades it for the operator cookie."},
+						ui.Stack(ui.StackConfig{Gap: ui.GapSM},
+							ui.TextField(ui.TextFieldConfig{
+								Name: "join", Label: "Join link", ID: "assist-join-link",
+								Value: joinURL, ExtraAttrs: html.Attrs{"readonly": ""},
+							}),
+							ui.CopyButton(ui.CopyButtonConfig{Target: "assist-join-link", Ctx: ctx}),
+						),
+					),
+					ui.Card(ui.CardConfig{Heading: "Browser tools", HeadingLevel: 2,
+						Description: "inspect_session, send_instruction, clear_instruction are registered on this document only."},
+						html.Paragraph(html.TextConfig{ID: "assist-bridge"},
+							render.Text("Checking bridge registration…")),
+					),
+				),
+			),
+		),
+	)
+}
+
+// OperatorScreen is the operator's side: camera sender, instruction
+// receiver, acknowledger. No support tools exist in this document.
+type OperatorScreen struct {
+	component.ContextOnly
+	id string
+}
+
+func (s *OperatorScreen) ScreenTitle() string { return "Assist session" }
+
+func (s *OperatorScreen) SetParams(m map[string]string) { s.id = m["id"] }
+
+func (s *OperatorScreen) RenderCtx(ctx context.Context) render.HTML {
+	snap := assist.snapshotOf(s.id, roleOperator)
+	return assistRoot(map[string]string{
+		"session": s.id,
+		"role":    string(roleOperator),
+		"ws":      "/session/" + s.id + "/ws",
+	},
+		ui.Stack(ui.StackConfig{Gap: ui.GapLG},
+			ui.PageHeader(ui.PageHeaderConfig{
+				Eyebrow:  "Session " + shortID(s.id),
+				Title:    "Your assist session",
+				Subtitle: "Share your camera when you are ready. Support sees what you see and sends instructions here.",
+				Actions:  pillPair("assist-pill-media", "camera off", "camera live"),
+			}),
+			ui.Grid(ui.GridConfig{Min: "22rem"},
+				ui.Card(ui.CardConfig{Heading: "Your camera", HeadingLevel: 2,
+					Description: "Video and no microphone: the stream is send-only to Support, peer-to-peer."},
+					ui.Stack(ui.StackConfig{Gap: ui.GapMD},
+						ui.Cluster(ui.ClusterConfig{Gap: ui.GapSM},
+							ui.Button(ui.ButtonConfig{
+								Label: "Share camera", ID: "assist-share", Type: "button",
+								ExtraAttrs: html.Attrs{"data-assist-live": ""},
+							}),
+						),
+						videoTag("assist-local"),
+					),
+				),
+				ui.Card(ui.CardConfig{Heading: "Instruction from support", HeadingLevel: 2},
+					ui.Stack(ui.StackConfig{Gap: ui.GapMD},
+						instructionCard(snap.Instruction, false),
+						ui.Form(ui.FormConfig{
+							Action:      "/session/" + s.id + "/ack",
+							Method:      "POST",
+							SubmitLabel: "Mark as shown",
+							ID:          "assist-ack-form",
+							Ctx:         ctx,
+						}),
+						pillPair("assist-pill-ack", "not acknowledged", "acknowledged"),
+					),
+				),
+			),
+		),
+	)
+}
+
+// instructionCard renders the current instruction slot. The text
+// element keeps its own id so app.js can replace its content without
+// touching component internals.
+func instructionCard(text string, withInvocation bool) render.HTML {
+	body := []render.HTML{
+		html.Paragraph(html.TextConfig{ID: "assist-instruction-text"},
+			render.Text(instructionText(text))),
+	}
+	if withInvocation {
+		body = append(body,
+			html.Paragraph(html.TextConfig{ID: "assist-invocation", Class: ""},
+				render.Text(invocationText(""))))
+	}
+	return ui.Stack(ui.StackConfig{Gap: ui.GapSM}, body...)
+}
+
+func instructionText(text string) string {
+	if strings.TrimSpace(text) == "" {
+		return "No instruction yet."
+	}
+	return text
+}
+
+func invocationText(inv string) string {
+	if inv == "" {
+		return "Last command: manual or page button."
+	}
+	return "Last command: agent invocation " + shortID(inv) + "."
+}
+
+// SessionGoneScreen is the one recovery screen for every dead path: an
+// expired session, an unknown id, a spent join link, a missing role
+// cookie. Callers never learn which one they hit.
+type SessionGoneScreen struct{}
+
+func (s *SessionGoneScreen) ScreenTitle() string { return "Session ended" }
+
+func (s *SessionGoneScreen) Render() render.HTML {
+	return ui.Stack(ui.StackConfig{Gap: ui.GapLG},
+		ui.PageHeader(ui.PageHeaderConfig{
+			Title:    "This assist session has ended",
+			Subtitle: "Ask Support for a new link, or start another session from the console.",
+		}),
+		ui.Cluster(ui.ClusterConfig{Gap: ui.GapSM},
+			ui.LinkButton(ui.LinkButtonConfig{Label: "Back to the overview", Href: "/"}),
+		),
+	)
+}
+
+// joinLink builds the absolute one-time join URL for the request's
+// scheme and host.
+func joinLink(r *http.Request, s *assistSession) string {
+	if r == nil {
+		return "/join/" + s.joinToken
+	}
+	scheme := "https"
+	if r.TLS == nil && !strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https") {
+		scheme = "http"
+	}
+	return fmt.Sprintf("%s://%s/join/%s", scheme, r.Host, s.joinToken)
+}
+
+func shortID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}

--- a/examples/webmcp-remote-assist/screens.go
+++ b/examples/webmcp-remote-assist/screens.go
@@ -45,12 +45,20 @@ func videoTag(id string) render.HTML {
 	})
 }
 
-// pillPair renders two StatusPills where exactly one is visible;
-// app.js flips the hidden attribute as state changes.
-func pillPair(id string, off, on string) render.HTML {
+// pillPair renders two StatusPills where exactly one is visible: the
+// one matching the state at render time, so a reload shows the truth
+// before hydration; app.js flips the hidden attribute as state changes.
+func pillPair(id string, off, on string, state bool) render.HTML {
+	offAttrs := html.Attrs{"data-assist-live": ""}
+	onAttrs := html.Attrs{"data-assist-live": ""}
+	if state {
+		offAttrs["hidden"] = ""
+	} else {
+		onAttrs["hidden"] = ""
+	}
 	return ui.Cluster(ui.ClusterConfig{Gap: ui.GapSM},
-		ui.StatusPill(ui.StatusPillConfig{ID: id + "-off", Dot: true, Label: off, ExtraAttrs: html.Attrs{"data-assist-live": ""}}),
-		ui.StatusPill(ui.StatusPillConfig{ID: id + "-on", Dot: true, Label: on, ExtraAttrs: html.Attrs{"hidden": "", "data-assist-live": ""}}),
+		ui.StatusPill(ui.StatusPillConfig{ID: id + "-off", Dot: true, Label: off, ExtraAttrs: offAttrs}),
+		ui.StatusPill(ui.StatusPillConfig{ID: id + "-on", Dot: true, Label: on, ExtraAttrs: onAttrs}),
 	)
 }
 
@@ -167,9 +175,9 @@ func (s *SupportConsoleScreen) RenderCtx(ctx context.Context) render.HTML {
 				Eyebrow: "Session " + shortID(s.id),
 				Title:   "Support console",
 				Actions: ui.Cluster(ui.ClusterConfig{Gap: ui.GapSM},
-					pillPair("assist-pill-op", "operator away", "operator online"),
-					pillPair("assist-pill-media", "no video", "video live"),
-					pillPair("assist-pill-ack", "not acknowledged", "acknowledged"),
+					pillPair("assist-pill-op", "operator away", "operator online", snap.OperatorOnline),
+					pillPair("assist-pill-media", "no video", "video live", snap.MediaUp),
+					pillPair("assist-pill-ack", "not acknowledged", "acknowledged", snap.Acked),
 				),
 			}),
 			ui.Grid(ui.GridConfig{Min: "22rem"},
@@ -251,7 +259,7 @@ func (s *OperatorScreen) RenderCtx(ctx context.Context) render.HTML {
 				Eyebrow:  "Session " + shortID(s.id),
 				Title:    "Your assist session",
 				Subtitle: "Share your camera when you are ready. Support sees what you see and sends instructions here.",
-				Actions:  pillPair("assist-pill-media", "camera off", "camera live"),
+				Actions:  pillPair("assist-pill-media", "camera off", "camera live", snap.MediaUp),
 			}),
 			ui.Grid(ui.GridConfig{Min: "22rem"},
 				ui.Card(ui.CardConfig{Heading: "Your camera", HeadingLevel: 2,
@@ -276,7 +284,7 @@ func (s *OperatorScreen) RenderCtx(ctx context.Context) render.HTML {
 							ID:          "assist-ack-form",
 							Ctx:         ctx,
 						}),
-						pillPair("assist-pill-ack", "not acknowledged", "acknowledged"),
+						pillPair("assist-pill-ack", "not acknowledged", "acknowledged", snap.Acked),
 					),
 				),
 			),
@@ -312,6 +320,34 @@ func invocationText(inv string) string {
 		return "Last command: manual or page button."
 	}
 	return "Last command: agent invocation " + shortID(inv) + "."
+}
+
+// JoinScreen is the one-time link's landing page. Rendering it spends
+// nothing: link previewers and mail scanners fetch it and see a button.
+// The button's same-origin POST performs the exchange (handleJoin).
+type JoinScreen struct {
+	component.ContextOnly
+	token string
+}
+
+func (s *JoinScreen) ScreenTitle() string { return "Join assist session" }
+
+func (s *JoinScreen) SetParams(m map[string]string) { s.token = m["token"] }
+
+func (s *JoinScreen) RenderCtx(ctx context.Context) render.HTML {
+	return ui.AuthCard(ui.AuthCardConfig{
+		Title: "Join the assist session",
+		Body: ui.Stack(ui.StackConfig{Gap: ui.GapMD},
+			html.Paragraph(html.TextConfig{},
+				render.Text("Support sent you this link. Joining opens your side of the session, where you can share your camera and read instructions. The link works once.")),
+			ui.Form(ui.FormConfig{
+				Action:      "/join/" + s.token,
+				Method:      "POST",
+				SubmitLabel: "Join the session",
+				Ctx:         ctx,
+			}),
+		),
+	})
 }
 
 // SessionGoneScreen is the one recovery screen for every dead path: an

--- a/examples/webmcp-remote-assist/session.go
+++ b/examples/webmcp-remote-assist/session.go
@@ -301,6 +301,20 @@ func (a *assistApp) dropLocked(s *assistSession) {
 	}()
 }
 
+// joinOpen reports whether the token could still be exchanged, without
+// exchanging it: the confirmation page's GET asks this, so fetching the
+// link spends nothing.
+func (a *assistApp) joinOpen(token string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	sid, found := a.byToken[token]
+	if !found {
+		return false
+	}
+	s := a.sessions[sid]
+	return s != nil && !s.joinUsed && time.Now().Before(s.expires)
+}
+
 // exchangeJoin consumes the one-time join token and mints the
 // operator's role cookie value. The second caller with the same token
 // gets ok=false and learns nothing beyond "gone".
@@ -426,8 +440,12 @@ func crossSite(r *http.Request) bool {
 // applyCommand is the single mutation path. Manual form posts, WebMCP
 // tool calls, and the operator ack all land here after decoding into
 // assistCommand. It validates, mutates under the store lock, bumps the
-// channel-wide sequence, and publishes the event AFTER releasing the
-// lock (Publish is non-blocking and channel-owned).
+// channel-wide sequence, and publishes the event while still holding
+// the lock: Publish is non-blocking by contract (it enqueues or drops),
+// and publishing under the lock is what makes event order equal
+// mutation order. Two callers racing would otherwise be able to
+// enqueue their events in the opposite order of their mutations, and
+// every page would converge on the wrong final state.
 //
 // cmd.Ref is the WebMCP InvocationID for agent-issued commands ("" for
 // the manual button); the ack command echoes the instruction's ref back
@@ -468,11 +486,10 @@ func (a *assistApp) applyCommand(cmd assistCommand) (assistSnapshot, int, error)
 		return assistSnapshot{}, http.StatusBadRequest, errBadRequest{"unknown command kind"}
 	}
 	s.seq++
-	ch := s.channel
+	s.channel.Publish(ev.Kind, ev)
+	snap := a.snapshotLocked(roleSupport, s)
 	a.mu.Unlock()
-
-	ch.Publish(ev.Kind, ev)
-	return a.snapshotFor(roleSupport, s), http.StatusOK, nil
+	return snap, http.StatusOK, nil
 }
 
 // snapshotOf returns a role's view of a session id, nil-safe so a
@@ -517,10 +534,8 @@ func (a *assistApp) presence(s *assistSession, r role, delta int) {
 		s.supConns += delta
 	}
 	s.seq++
-	ev := assistEvent{Kind: "presence", Online: a.onlineLocked(s, r), Role: r}
-	ch := s.channel
+	s.channel.Publish("presence", assistEvent{Kind: "presence", Online: a.onlineLocked(s, r), Role: r})
 	a.mu.Unlock()
-	ch.Publish("presence", ev)
 }
 
 func (a *assistApp) onlineLocked(s *assistSession, r role) bool {
@@ -537,9 +552,8 @@ func (a *assistApp) setMedia(s *assistSession, up bool) {
 	a.mu.Lock()
 	s.mediaUp = up
 	s.seq++
-	ch := s.channel
+	s.channel.Publish("media", assistEvent{Kind: "media", MediaUp: up})
 	a.mu.Unlock()
-	ch.Publish("media", assistEvent{Kind: "media", MediaUp: up})
 }
 
 // relaySignal forwards one signaling frame from `from` to the peer
@@ -552,7 +566,8 @@ func (a *assistApp) setMedia(s *assistSession, up bool) {
 // version must advance with it: a snapshot whose sequence trailed the
 // events a page had already applied would be rejected by the page's
 // reducer, and a reconnect would never rehydrate. Every Publish in
-// this file is paired with one s.seq increment for that reason.
+// this file is paired with one s.seq increment, under the same lock
+// hold, for that reason.
 func (a *assistApp) relaySignal(s *assistSession, from role, msg signalMessage) bool {
 	peer := roleOperator
 	if from == roleOperator {
@@ -573,11 +588,10 @@ func (a *assistApp) relaySignal(s *assistSession, from role, msg signalMessage) 
 	}
 	a.mu.Lock()
 	s.seq++
-	ch := s.channel
-	a.mu.Unlock()
-	ch.Publish("signal", assistEvent{Kind: "signal", Signal: &signalMessage{
+	s.channel.Publish("signal", assistEvent{Kind: "signal", Signal: &signalMessage{
 		From: from, To: peer, Type: msg.Type, Data: msg.Data,
 	}})
+	a.mu.Unlock()
 	return true
 }
 

--- a/examples/webmcp-remote-assist/session.go
+++ b/examples/webmcp-remote-assist/session.go
@@ -1,0 +1,759 @@
+package main
+
+// session.go owns the assist domain: the session store, the one typed
+// command every caller funnels through, and the realtime channel. The
+// Go files in this example split the same way a host app would: screens
+// render, main wires, this file holds the state and the rules.
+//
+// Two boundaries live here and nowhere else:
+//
+//   - Role authorization. Cookies carry roles; every mutating endpoint
+//     and both WebSocket endpoints re-check them. The WebMCP marker
+//     header is never an authorization input (see observeToolEvent).
+//   - State shape on the wire. SnapshotSource filters per role BEFORE
+//     serialization, so a field a role must not see (the WebMCP
+//     invocation id is support-only correlation data) never crosses
+//     the transport.
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/DonaldMurillo/gofastr/core/router"
+	"github.com/DonaldMurillo/gofastr/core/stream"
+	"github.com/DonaldMurillo/gofastr/framework/experimental/webmcp"
+)
+
+// Cookie names and lifetimes. The support cookie is Path=/ because the
+// WebMCP bridge assets live under /__gofastr/, outside the /support
+// page tree; the operator cookie is Path=/session so it never rides on
+// a support URL. Both are HttpOnly: page script can trigger requests
+// that carry them but can never read them.
+const (
+	supportCookieName  = "assist_support"
+	operatorCookieName = "assist_operator"
+	sessionTTL         = 10 * time.Minute
+	cookieTTL          = 12 * time.Hour
+)
+
+// role names the two participants. It is the StateChannel's Role type
+// parameter: snapshots and events are filtered by it.
+type role string
+
+const (
+	roleSupport  role = "support"
+	roleOperator role = "operator"
+)
+
+// Command kinds. One typed command, one apply path.
+const (
+	cmdInstruction = "instruction"
+	cmdClear       = "clear"
+	cmdAck         = "ack"
+)
+
+// assistCommand is the ONE typed mutation shape in the app. The manual
+// form on the support console, the WebMCP send_instruction and
+// clear_instruction tools, and the operator's acknowledgement all
+// decode into this struct and call applyCommand. A rule that holds for
+// one caller therefore holds for every caller; there is no second code
+// path to drift.
+type assistCommand struct {
+	Session     string `json:"session"`
+	Kind        string `json:"kind"` // cmdInstruction | cmdClear | cmdAck
+	Instruction string `json:"instruction,omitempty"`
+
+	// Ref correlates the mutation with its caller: the WebMCP
+	// InvocationID when an in-browser agent issued the command, or ""
+	// for the manual button. The operator's acknowledgement echoes it
+	// back so support can correlate command -> delivery -> ack.
+	Ref string `json:"-"`
+}
+
+// assistSnapshot is a role's view of one session at one sequence. The
+// Invocation field (the WebMCP invocation id of the current
+// instruction) is support-only: SnapshotFor omits it for the operator.
+type assistSnapshot struct {
+	Session        string `json:"session"`
+	Instruction    string `json:"instruction,omitempty"`
+	Acked          bool   `json:"acked"`
+	OperatorOnline bool   `json:"operatorOnline"`
+	SupportOnline  bool   `json:"supportOnline"`
+	MediaUp        bool   `json:"mediaUp"`
+	Invocation     string `json:"invocation,omitempty"` // support view only
+}
+
+// assistEvent is the pre-filter event published to the channel.
+// FilterEvent decides, per role, which payload (if any) each side sees.
+type assistEvent struct {
+	Kind        string         `json:"kind"`
+	Instruction string         `json:"instruction,omitempty"`
+	Acked       bool           `json:"acked,omitempty"`
+	Ref         string         `json:"ref,omitempty"`
+	Online      bool           `json:"online,omitempty"`
+	MediaUp     bool           `json:"mediaUp,omitempty"`
+	Role        role           `json:"role,omitempty"` // presence: whose count changed
+	Signal      *signalMessage `json:"-"`
+}
+
+// signalMessage is one WebRTC signaling frame relayed between peers.
+// The server never interprets the payload: it validates the envelope
+// (type and addressed role) and forwards it. SDP and ICE cross the Go
+// process only as signaling bytes; camera media never does.
+type signalMessage struct {
+	From role            `json:"from"`
+	To   role            `json:"to"`
+	Type string          `json:"type"` // offer | answer | ice
+	Data json.RawMessage `json:"data"`
+}
+
+// assistSession is one assist session and its realtime channel.
+type assistSession struct {
+	id        string
+	joinToken string
+	joinUsed  bool
+	created   time.Time
+	expires   time.Time
+
+	// seq is the channel-wide version of the state below. It is read
+	// and written under assistApp.mu, and SnapshotFor returns it from
+	// the same locked read as the payload (the one-immutable-read
+	// contract stream.SnapshotSource documents).
+	seq         uint64
+	instruction string
+	invocation  string // WebMCP invocation id of the current instruction
+	acked       bool
+	mediaUp     bool
+	opConns     int
+	supConns    int
+
+	channel *stream.StateChannel[role, assistSnapshot, assistEvent]
+
+	// conns tracks the live WebSockets (with role) so the server can
+	// drop a role's transport on demand: the same power a production
+	// revocation needs, and the transport-death the browser test
+	// replays. connIDs records the recent ids (bounded) for
+	// diagnostics, so a browser reconnect reusing its client id
+	// correlates across generations (WSConfig.ConnectionID contract).
+	conns   map[role]*stream.WebSocketConn
+	connIDs []string
+}
+
+// assistApp is the in-memory store. State lives here, not in the
+// interactive layer: any request reconstructs its view from this store
+// plus the request's cookies. A single-process example keeps it in
+// RAM; a multi-replica deployment moves this map to a database and the
+// channel fanout to a shared broker.
+type assistApp struct {
+	mu         sync.Mutex
+	sessions   map[string]*assistSession
+	byToken    map[string]string // join token -> session id
+	operators  map[string]string // operator cookie value -> session id
+	supporters map[string]time.Time
+
+	// supportKey is the demo sign-in credential: ASSIST_SUPPORT_KEY
+	// from the environment, or a random value printed once at boot. A
+	// real deployment replaces the whole sign-in with battery/auth; the
+	// cookie it mints and every check downstream stay the same.
+	supportKey string
+
+	// toolEvents is the bounded observer log (metadata only: phase,
+	// name, status, class). Inputs never enter it — ToolEvent does not
+	// carry them, and the format string below must keep it that way.
+	toolEvents []string
+}
+
+func newAssistApp() *assistApp {
+	key := os.Getenv("ASSIST_SUPPORT_KEY")
+	if key == "" {
+		key = randomID()
+	}
+	return &assistApp{
+		sessions:   map[string]*assistSession{},
+		byToken:    map[string]string{},
+		operators:  map[string]string{},
+		supporters: map[string]time.Time{},
+		supportKey: key,
+	}
+}
+
+// checkSupportKey compares the sign-in credential in constant time.
+func (a *assistApp) checkSupportKey(candidate string) bool {
+	return subtle.ConstantTimeCompare([]byte(candidate), []byte(a.supportKey)) == 1
+}
+
+func randomID() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		log.Fatalf("assist: crypto/rand unavailable: %v", err)
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// observeToolEvent records one WebMCP ToolEvent for diagnostics and
+// tests. ToolEvent deliberately carries no input body, headers, or
+// query string; this log must never add them.
+func (a *assistApp) observeToolEvent(ev webmcp.ToolEvent) {
+	line := strings.Join([]string{
+		string(ev.Phase), ev.Name, ev.Method, ev.Path,
+		strconv.Itoa(ev.StatusCode), ev.ErrClass, ev.Duration.String(), ev.InvocationID,
+	}, " ")
+	a.mu.Lock()
+	if len(a.toolEvents) >= 64 {
+		a.toolEvents = a.toolEvents[1:]
+	}
+	a.toolEvents = append(a.toolEvents, line)
+	a.mu.Unlock()
+	log.Printf("assist webmcp: %s", line)
+}
+
+// createSession starts a short-lived session and its channel. The join
+// token is single-use; the session id is public to both roles once
+// exchanged, the token never is.
+func (a *assistApp) createSession() *assistSession {
+	s := &assistSession{
+		id:        randomID(),
+		joinToken: randomID(),
+		created:   time.Now(),
+		expires:   time.Now().Add(sessionTTL),
+		conns:     map[role]*stream.WebSocketConn{},
+	}
+	s.channel = stream.NewStateChannel[role, assistSnapshot, assistEvent](sessionSource{app: a, id: s.id})
+	go s.channel.Run()
+
+	a.mu.Lock()
+	a.sessions[s.id] = s
+	a.byToken[s.joinToken] = s.id
+	a.mu.Unlock()
+	return s
+}
+
+// toolEventLog snapshots the bounded observer log for tests.
+func (a *assistApp) toolEventLog() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]string(nil), a.toolEvents...)
+}
+
+// dropRoleSocket closes the role's live WebSocket on the session: the
+// server-side transport death a revocation (or a network drop) looks
+// like from the browser. The page's ws module classifies the close,
+// reconnects, and rehydrates from a fresh snapshot.
+func (a *assistApp) dropRoleSocket(id string, r role) bool {
+	s := a.lookup(id)
+	if s == nil {
+		return false
+	}
+	a.mu.Lock()
+	conn := s.conns[r]
+	delete(s.conns, r)
+	a.mu.Unlock()
+	if conn == nil {
+		return false
+	}
+	go conn.Close()
+	return true
+}
+
+// lookup returns the live session, or nil. Expired sessions are
+// dropped here (lazy expiry) and their channel stopped.
+func (a *assistApp) lookup(id string) *assistSession {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	s, ok := a.sessions[id]
+	if !ok {
+		return nil
+	}
+	if time.Now().After(s.expires) {
+		a.dropLocked(s)
+		return nil
+	}
+	return s
+}
+
+// dropLocked removes a session and stops its channel. Caller holds mu.
+func (a *assistApp) dropLocked(s *assistSession) {
+	delete(a.sessions, s.id)
+	delete(a.byToken, s.joinToken)
+	for tok, sid := range a.operators {
+		if sid == s.id {
+			delete(a.operators, tok)
+		}
+	}
+	conns := s.conns
+	s.conns = map[role]*stream.WebSocketConn{}
+	go func() {
+		for _, c := range conns {
+			c.Close()
+		}
+		s.channel.Stop()
+	}()
+}
+
+// exchangeJoin consumes the one-time join token and mints the
+// operator's role cookie value. The second caller with the same token
+// gets ok=false and learns nothing beyond "gone".
+func (a *assistApp) exchangeJoin(token string) (sessionID, cookieValue string, ok bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	sid, found := a.byToken[token]
+	if !found {
+		return "", "", false
+	}
+	s := a.sessions[sid]
+	if s == nil || s.joinUsed || time.Now().After(s.expires) {
+		return "", "", false
+	}
+	s.joinUsed = true
+	cookieValue = randomID()
+	a.operators[cookieValue] = s.id
+	return s.id, cookieValue, true
+}
+
+// authorizeOperator reports whether cookieValue was minted by the join
+// for exactly this session. A cookie from another session authorizes
+// nothing here.
+func (a *assistApp) authorizeOperator(cookieValue, sessionID string) bool {
+	if cookieValue == "" || sessionID == "" {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.operators[cookieValue] == sessionID && a.sessions[sessionID] != nil
+}
+
+// mintSupportCookie registers a fresh support credential and returns
+// its cookie value. In a real deployment this is a login.
+func (a *assistApp) mintSupportCookie() string {
+	v := randomID()
+	a.mu.Lock()
+	a.supporters[v] = time.Now().Add(cookieTTL)
+	a.mu.Unlock()
+	return v
+}
+
+// authorizeSupport reports whether the request carries a live support
+// cookie. This is the ONLY support authorization check; the WebMCP
+// marker header is not consulted and must never be.
+func (a *assistApp) authorizeSupport(r *http.Request) bool {
+	c, err := r.Cookie(supportCookieName)
+	if err != nil || c.Value == "" {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	exp, ok := a.supporters[c.Value]
+	return ok && time.Now().Before(exp)
+}
+
+// requireSupport is the router middleware shape of authorizeSupport
+// for JSON endpoints: 403, plain, no detail a caller can mine.
+func (a *assistApp) requireSupport() router.Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !a.authorizeSupport(r) {
+				http.Error(w, "support role required", http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// requireOperator is the router middleware for the operator's write
+// routes: the cookie must have been minted by the join for exactly the
+// {id} in the route. 403, plain, no detail a caller can mine.
+func (a *assistApp) requireOperator() router.Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !a.authorizeOperator(operatorCookie(r), router.Param(r, "id")) {
+				http.Error(w, "operator role required", http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// sameOrigin refuses cross-site mutating requests. It mirrors the
+// convention battery/auth uses for its login forms (unexported there):
+// Sec-Fetch-Site is the authoritative signal and is checked first;
+// "cross-site" is refused outright, "same-origin" and "none" pass. The
+// Origin host comparison is the fallback for clients without Fetch
+// Metadata. A missing or "null" Origin passes: a legitimate top-level
+// same-origin form navigation sends Origin: null (opaque origin), and
+// curl never sends one. The role cookie remains the authorization
+// decision; this only answers WHERE FROM.
+func sameOrigin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if crossSite(r) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func crossSite(r *http.Request) bool {
+	switch r.Header.Get("Sec-Fetch-Site") {
+	case "cross-site":
+		return true
+	case "same-origin", "none":
+		return false
+	}
+	origin := r.Header.Get("Origin")
+	if origin == "" || origin == "null" {
+		return false
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return true
+	}
+	return !strings.EqualFold(u.Host, r.Host)
+}
+
+// applyCommand is the single mutation path. Manual form posts, WebMCP
+// tool calls, and the operator ack all land here after decoding into
+// assistCommand. It validates, mutates under the store lock, bumps the
+// channel-wide sequence, and publishes the event AFTER releasing the
+// lock (Publish is non-blocking and channel-owned).
+//
+// cmd.Ref is the WebMCP InvocationID for agent-issued commands ("" for
+// the manual button); the ack command echoes the instruction's ref back
+// so support correlates command -> ack without trusting the tool call's
+// HTTP status.
+func (a *assistApp) applyCommand(cmd assistCommand) (assistSnapshot, int, error) {
+	if cmd.Kind == "" || cmd.Session == "" {
+		return assistSnapshot{}, http.StatusBadRequest, errBadRequest{"kind and session are required"}
+	}
+	s := a.lookup(cmd.Session)
+	if s == nil {
+		return assistSnapshot{}, http.StatusGone, errSessionGone{}
+	}
+
+	var ev assistEvent
+	a.mu.Lock()
+	switch cmd.Kind {
+	case cmdInstruction:
+		text := strings.TrimSpace(cmd.Instruction)
+		if text == "" || len(text) > 500 {
+			a.mu.Unlock()
+			return assistSnapshot{}, http.StatusBadRequest, errBadRequest{"instruction must be 1-500 characters"}
+		}
+		s.instruction = text
+		s.invocation = cmd.Ref
+		s.acked = false
+		ev = assistEvent{Kind: cmdInstruction, Instruction: text, Ref: cmd.Ref}
+	case cmdClear:
+		s.instruction = ""
+		s.invocation = cmd.Ref
+		s.acked = false
+		ev = assistEvent{Kind: cmdClear, Ref: cmd.Ref}
+	case cmdAck:
+		s.acked = true
+		ev = assistEvent{Kind: cmdAck, Acked: true, Ref: s.invocation}
+	default:
+		a.mu.Unlock()
+		return assistSnapshot{}, http.StatusBadRequest, errBadRequest{"unknown command kind"}
+	}
+	s.seq++
+	ch := s.channel
+	a.mu.Unlock()
+
+	ch.Publish(ev.Kind, ev)
+	return a.snapshotFor(roleSupport, s), http.StatusOK, nil
+}
+
+// snapshotOf returns a role's view of a session id, nil-safe so a
+// screen can render the empty shape while the guard middleware is
+// already answering the request.
+func (a *assistApp) snapshotOf(id string, r role) assistSnapshot {
+	s := a.lookup(id)
+	if s == nil {
+		return assistSnapshot{Session: id}
+	}
+	return a.snapshotFor(r, s)
+}
+
+// snapshotFor builds the role's view under the store lock.
+func (a *assistApp) snapshotFor(r role, s *assistSession) assistSnapshot {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.snapshotLocked(r, s)
+}
+
+func (a *assistApp) snapshotLocked(r role, s *assistSession) assistSnapshot {
+	snap := assistSnapshot{
+		Session:        s.id,
+		Instruction:    s.instruction,
+		Acked:          s.acked,
+		OperatorOnline: s.opConns > 0,
+		SupportOnline:  s.supConns > 0,
+		MediaUp:        s.mediaUp,
+	}
+	if r == roleSupport {
+		snap.Invocation = s.invocation
+	}
+	return snap
+}
+
+// presence records a role's connection count change and publishes it.
+func (a *assistApp) presence(s *assistSession, r role, delta int) {
+	a.mu.Lock()
+	if r == roleOperator {
+		s.opConns += delta
+	} else {
+		s.supConns += delta
+	}
+	s.seq++
+	ev := assistEvent{Kind: "presence", Online: a.onlineLocked(s, r), Role: r}
+	ch := s.channel
+	a.mu.Unlock()
+	ch.Publish("presence", ev)
+}
+
+func (a *assistApp) onlineLocked(s *assistSession, r role) bool {
+	if r == roleOperator {
+		return s.opConns > 0
+	}
+	return s.supConns > 0
+}
+
+// setMedia records a peer's report that the WebRTC media path is up or
+// down. The server never observes media itself; it trusts a
+// participant's boolean, which is exactly the point of the boundary.
+func (a *assistApp) setMedia(s *assistSession, up bool) {
+	a.mu.Lock()
+	s.mediaUp = up
+	s.seq++
+	ch := s.channel
+	a.mu.Unlock()
+	ch.Publish("media", assistEvent{Kind: "media", MediaUp: up})
+}
+
+// relaySignal forwards one signaling frame from `from` to the peer
+// role. The addressed role must be the peer of the authenticated
+// sender; anything else is dropped (an operator may not address the
+// operator, and support may not talk to itself).
+//
+// A relayed frame is not session state, but it IS a channel event, and
+// the channel assigns every event the next sequence. The session
+// version must advance with it: a snapshot whose sequence trailed the
+// events a page had already applied would be rejected by the page's
+// reducer, and a reconnect would never rehydrate. Every Publish in
+// this file is paired with one s.seq increment for that reason.
+func (a *assistApp) relaySignal(s *assistSession, from role, msg signalMessage) bool {
+	peer := roleOperator
+	if from == roleOperator {
+		peer = roleSupport
+	}
+	if msg.To != peer {
+		return false
+	}
+	switch msg.Type {
+	case "offer", "answer", "ice":
+	default:
+		return false
+	}
+	// SDP for the fake camera is a few KB; the WS ReadLimit (64 KiB)
+	// already bounded the frame. Refuse anything absurd anyway.
+	if len(msg.Data) > 48*1024 {
+		return false
+	}
+	a.mu.Lock()
+	s.seq++
+	ch := s.channel
+	a.mu.Unlock()
+	ch.Publish("signal", assistEvent{Kind: "signal", Signal: &signalMessage{
+		From: from, To: peer, Type: msg.Type, Data: msg.Data,
+	}})
+	return true
+}
+
+// recordConn remembers a connection id for diagnostics (bounded).
+func (a *assistApp) recordConn(s *assistSession, id string) {
+	a.mu.Lock()
+	if len(s.connIDs) >= 16 {
+		s.connIDs = s.connIDs[1:]
+	}
+	s.connIDs = append(s.connIDs, id)
+	a.mu.Unlock()
+}
+
+// errBadRequest / errSessionGone give handlers the status without a
+// stringly-typed API.
+type errBadRequest struct{ msg string }
+
+func (e errBadRequest) Error() string { return e.msg }
+
+type errSessionGone struct{}
+
+func (errSessionGone) Error() string { return "session has ended" }
+
+// sessionSource adapts the store to stream.SnapshotSource. One type,
+// one session: SnapshotFor and FilterEvent both read the same session
+// under the store lock, so payload and sequence always come from one
+// immutable read.
+type sessionSource struct {
+	app *assistApp
+	id  string
+}
+
+func (src sessionSource) SnapshotFor(r role) (assistSnapshot, uint64) {
+	src.app.mu.Lock()
+	defer src.app.mu.Unlock()
+	s, ok := src.app.sessions[src.id]
+	if !ok {
+		return assistSnapshot{Session: src.id}, 0
+	}
+	return src.app.snapshotLocked(r, s), s.seq
+}
+
+// FilterEvent shapes each event per role BEFORE serialization:
+//
+//   - signal: addressed delivery. An offer is FOR support, an answer
+//     is FOR the operator; the sender's role never receives its own
+//     SDP back, and the bytes are never marshaled for anyone else.
+//   - instruction, clear, ack: both roles learn what happened; only
+//     support receives the invocation ref (support-side correlation
+//     data). The ref is stripped from the operator's copy here, and
+//     the operator's snapshot never carried it (snapshotLocked).
+//   - everything else: identical for both roles.
+func (src sessionSource) FilterEvent(r role, ev assistEvent) (any, bool) {
+	switch ev.Kind {
+	case "signal":
+		if ev.Signal == nil || ev.Signal.To != r {
+			return nil, false
+		}
+		return signalMessage{From: ev.Signal.From, To: ev.Signal.To, Type: ev.Signal.Type, Data: ev.Signal.Data}, true
+	case cmdInstruction, cmdClear, cmdAck:
+		if r != roleSupport {
+			ev.Ref = ""
+		}
+		return ev, true
+	default:
+		return ev, true
+	}
+}
+
+// inboundMsg is what a page may send on its socket. Everything else is
+// ignored; the socket is for signaling and media reports only.
+type inboundMsg struct {
+	Kind string          `json:"kind"` // signal | media
+	To   role            `json:"to"`
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data"`
+	Up   bool            `json:"up"`
+}
+
+// handleWS is the per-role WebSocket endpoint: it authorizes the role
+// cookie for THIS endpoint's page tree, upgrades, hydrates via the
+// session's StateChannel, then relays inbound signaling frames.
+//
+// role comes from which endpoint the page connected to, never from the
+// wire: /support/session/{id}/ws requires the support cookie and
+// speaks as support; /session/{id}/ws requires the operator cookie
+// minted by THIS session's join link and speaks as the operator.
+//
+// client is a page-minted id (stored in sessionStorage) passed as a
+// query parameter: reconnects reuse it, so WSConfig.ConnectionID —
+// session-role-client — correlates a browser's reconnect generations
+// in server-side logs while each upgrade stays distinct.
+func (a *assistApp) handleWS(r role) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		sid := router.Param(req, "id")
+		if r == roleSupport {
+			if !a.authorizeSupport(req) {
+				http.Error(w, "support role required", http.StatusForbidden)
+				return
+			}
+		} else if !a.authorizeOperator(operatorCookie(req), sid) {
+			http.Error(w, "operator role required", http.StatusForbidden)
+			return
+		}
+		s := a.lookup(sid)
+		if s == nil {
+			http.Error(w, "session has ended", http.StatusGone)
+			return
+		}
+
+		client := req.URL.Query().Get("client")
+		if len(client) > 64 {
+			client = client[:64]
+		}
+		var conn *stream.WebSocketConn
+		conn, err := stream.Upgrade(w, req, stream.WSConfig{
+			ConnectionID: sid + "-" + string(r) + "-" + client,
+			OnClose: func() {
+				a.presence(s, r, -1)
+				a.mu.Lock()
+				if s.conns[r] == conn {
+					delete(s.conns, r)
+				}
+				a.mu.Unlock()
+			},
+		})
+		if err != nil {
+			return // Upgrade wrote the error
+		}
+		a.recordConn(s, conn.ConnectionID())
+		a.mu.Lock()
+		if s.conns == nil {
+			s.conns = map[role]*stream.WebSocketConn{}
+		}
+		s.conns[r] = conn
+		a.mu.Unlock()
+
+		// Hydrate before counting presence so the snapshot the page
+		// applies is followed by a presence event that says "you are
+		// online"; both orders converge on the same state.
+		s.channel.Connect(r, conn)
+		a.presence(s, r, +1)
+
+		defer conn.Close()
+		for {
+			data, rerr := conn.Read()
+			if rerr != nil {
+				return
+			}
+			var in inboundMsg
+			if json.Unmarshal(data, &in) != nil {
+				continue
+			}
+			switch in.Kind {
+			case "signal":
+				a.relaySignal(s, r, signalMessage{To: in.To, Type: in.Type, Data: in.Data})
+			case "media":
+				a.setMedia(s, in.Up)
+			}
+		}
+	})
+}
+
+// operatorCookie pulls the operator credential without leaking the
+// error shape into handlers.
+func operatorCookie(r *http.Request) string {
+	c, err := r.Cookie(operatorCookieName)
+	if err != nil {
+		return ""
+	}
+	return c.Value
+}
+
+// invocationRef surfaces the WebMCP invocation id for agent-driven
+// commands so applyCommand can correlate the ack. Empty for manual
+// calls: the marker header is absent there and must stay meaningless.
+func invocationRef(ctx context.Context) string {
+	return webmcp.InvocationID(ctx)
+}

--- a/examples/webmcp-remote-assist/static/app.js
+++ b/examples/webmcp-remote-assist/static/app.js
@@ -222,15 +222,19 @@
       }
     };
     pcx.onconnectionstatechange = () => {
-      note('pcState', pcx.connectionState);
-      const live = pcx.connectionState === 'connected';
-      const failed = pcx.connectionState === 'failed';
+      const st = pcx.connectionState;
+      note('pcState', st);
+      const live = st === 'connected';
+      // disconnected may recover on its own; failed and closed do not.
+      // All three clear the server's mediaUp, and connected sets it
+      // again, so the flag never says "live" for a path that is not.
+      const down = st === 'failed' || st === 'disconnected' || st === 'closed';
       if (cfg.role === 'support') {
         const noteEl = byId('assist-media-note');
         if (noteEl && live) noteEl.textContent = 'Receiving the operator\u2019s camera.';
-        if (noteEl && failed) noteEl.textContent = 'The media path failed. Ask the operator to share again.';
+        if (noteEl && down) noteEl.textContent = 'The media path dropped. Ask the operator to share again if it does not come back.';
       }
-      if (live || failed) send({ kind: 'media', up: live });
+      if (live || down) send({ kind: 'media', up: live });
     };
     return pcx;
   }
@@ -302,11 +306,18 @@
   function reportBridge() {
     const el = byId('assist-bridge');
     if (!el) return;
+    let tries = 0;
     const tick = () => {
       const st = window.__gofastrWebMCP;
       if (st && st.attempted > 0) {
         el.textContent = st.registered + ' of ' + st.attempted + ' tools registered'
           + (st.supported ? '' : ' (WebMCP unsupported in this browser)');
+        return;
+      }
+      // Bounded: ten seconds, then report the absence rather than
+      // polling for the life of the document.
+      if (++tries > 40) {
+        el.textContent = 'The bridge did not report a registration attempt.';
         return;
       }
       setTimeout(tick, 250);

--- a/examples/webmcp-remote-assist/static/app.js
+++ b/examples/webmcp-remote-assist/static/app.js
@@ -1,0 +1,324 @@
+// Remote assist browser glue: the one script the session pages load.
+//
+// Responsibilities, and nothing else:
+//   - the WebSocket signaling client (runtime module 'ws':
+//     connectWebSocket + createSequencedReducer), which owns ordering
+//     and reconnect generations;
+//   - the WebRTC call: getUserMedia (video only, never audio), offer /
+//     answer / trickle ICE relayed through the socket, remote video.
+//
+// Commands (send instruction, acknowledge) go through ordinary form
+// POSTs enhanced to fetch, so the page works before this script loads
+// and the server keeps one mutation path. Live state arrives on the
+// socket; nothing here polls.
+//
+// window.__assist is the bounded, metadata-safe debug surface: phases,
+// envelope types, sequences, connection states. No SDP, no camera
+// frames, no credentials, no close reasons.
+(() => {
+  'use strict';
+
+  const root = document.getElementById('assist-root');
+  if (!root) return;
+  const cfg = {
+    session: root.dataset.assistSession || '',
+    role: root.dataset.assistRole || '',
+    wsPath: root.dataset.assistWs || '',
+  };
+  if (!cfg.session || !cfg.role || !cfg.wsPath) return;
+
+  const byId = (id) => document.getElementById(id);
+  const show = (el, on) => { if (el) el.hidden = !on; };
+
+  // Bounded diagnostics + test surface.
+  window.__assist = {
+    role: cfg.role,
+    generations: 0,
+    phase: 'boot',
+    media: 'idle',
+    applied: [],      // envelope type + sequence, in apply order
+    signaling: 'none',
+    pcState: 'new',
+  };
+  const dbg = window.__assist;
+  const note = (k, v) => { dbg[k] = v; };
+
+  // A stable per-tab client id: reconnects reuse it, so the server's
+  // WSConfig.ConnectionID (session-role-client) correlates generations.
+  const clientKey = '__assist_client_' + cfg.session;
+  let clientId = null;
+  try { clientId = sessionStorage.getItem(clientKey); } catch (_) { /* private mode */ }
+  if (!clientId) {
+    clientId = String(Math.random().toString(36).slice(2, 10));
+    try { sessionStorage.setItem(clientKey, clientId); } catch (_) { /* ignore */ }
+  }
+
+  // ── Live region rendering ─────────────────────────────────────
+  // The server rendered every widget; this only flips `hidden` and
+  // sets textContent on elements with stable ids.
+
+  function renderInstruction(text) {
+    const el = byId('assist-instruction-text');
+    if (el) el.textContent = text === '' ? 'No instruction yet.' : text;
+  }
+
+  function renderState(state) {
+    renderInstruction(state.instruction || '');
+    flip('assist-pill-op', !!state.operatorOnline);
+    flip('assist-pill-media', !!state.mediaUp);
+    flip('assist-pill-ack', !!state.acked);
+    const inv = byId('assist-invocation');
+    if (inv) {
+      inv.textContent = state.invocation
+        ? 'Last command: agent invocation ' + state.invocation.slice(0, 8) + '.'
+        : 'Last command: manual or page button.';
+    }
+  }
+
+  // flip shows exactly one of a pillPair's two StatusPills.
+  function flip(idBase, on) {
+    show(byId(idBase + '-on'), on);
+    show(byId(idBase + '-off'), !on);
+  }
+
+  // ── The sequenced protocol ────────────────────────────────────
+
+  const initialState = { instruction: '', invocation: '', acked: false, mediaUp: false, operatorOnline: false, supportOnline: false };
+
+  function apply(state, env) {
+    const next = Object.assign({}, state);
+    switch (env.type) {
+      case 'snapshot': {
+        const p = env.payload || {};
+        next.instruction = p.instruction || '';
+        next.invocation = p.invocation || '';
+        next.acked = !!p.acked;
+        next.mediaUp = !!p.mediaUp;
+        next.operatorOnline = !!p.operatorOnline;
+        next.supportOnline = !!p.supportOnline;
+        break;
+      }
+      case 'instruction':
+        next.instruction = (env.payload && env.payload.instruction) || '';
+        next.invocation = (env.payload && env.payload.ref) || ''; // support only; absent for the operator
+        next.acked = false;
+        break;
+      case 'clear':
+        next.instruction = '';
+        next.invocation = (env.payload && env.payload.ref) || '';
+        next.acked = false;
+        break;
+      case 'ack':
+        next.acked = true;
+        break;
+      case 'presence':
+        if (env.payload && env.payload.role === 'operator') next.operatorOnline = !!env.payload.online;
+        if (env.payload && env.payload.role === 'support') next.supportOnline = !!env.payload.online;
+        break;
+      case 'media':
+        next.mediaUp = !!(env.payload && env.payload.mediaUp);
+        break;
+      default:
+        break; // signal envelopes feed the media layer, not page state
+    }
+    return next;
+  }
+
+  // Created once the 'ws' module is loaded: the factory lives there.
+  let reduce = null;
+
+  let sock = null;
+  let pc = null;
+  let localStream = null;
+
+  function wsURL() {
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return proto + '//' + window.location.host + cfg.wsPath + '?client=' + clientId;
+  }
+
+  function send(obj) {
+    if (!sock) return false;
+    return sock.send(obj);
+  }
+
+  function startSocket() {
+    sock = window.__gofastr.connectWebSocket(wsURL(), {
+      onGenerationStart(info) {
+        note('phase', 'open');
+        dbg.generations = info.generation;
+      },
+      onMessage(info) {
+        const env = info.data;
+        if (!env) return;
+        if (env.type === 'signal') {
+          onSignal(env.payload || {});
+          return;
+        }
+        const res = reduce(env);
+        if (res.applied) {
+          if (dbg.applied.length < 64) dbg.applied.push(env.type + ':' + env.sequence);
+          renderState(res.state);
+        }
+        // A snapshot the reducer refused is one that is not newer than
+        // the state already on the page: hydration is satisfied either
+        // way. (In this app every disconnect bumps the version through
+        // presence, so a reconnect snapshot is always newer; the rule
+        // matters for a protocol whose disconnects are silent.) Bind
+        // the call to the generation the message came from.
+        if (env.type === 'snapshot' && sock.hydrated(env.sequence, info.generation)) {
+          note('phase', 'hydrated');
+          // A live socket proves nothing about media: renegotiate the
+          // peer through the fresh generation (operator re-offers).
+          if (cfg.role === 'operator' && localStream) sendOffer();
+        }
+      },
+      onGenerationEnd(info) {
+        note('phase', 'closed:' + info.reasonClass);
+      },
+    });
+  }
+
+  // ── Commands: enhance the server-rendered forms to fetch ──────
+
+  function enhanceForm(id) {
+    const form = byId(id);
+    if (!form) return;
+    form.addEventListener('submit', (ev) => {
+      ev.preventDefault();
+      const data = new URLSearchParams(new FormData(form));
+      window.fetch(form.action, {
+        method: 'POST',
+        body: data,
+        credentials: 'same-origin',
+      }).then((res) => { if (!res.ok) note('phase', 'command-rejected:' + res.status); })
+        .catch(() => { note('phase', 'command-unreachable'); });
+    });
+  }
+  enhanceForm('assist-manual-form');
+  enhanceForm('assist-clear-form');
+  enhanceForm('assist-ack-form');
+
+  // ── WebRTC: camera out (operator), camera in (support) ────────
+  //
+  // iceServers is empty on purpose: peers on the same network reach
+  // each other through host candidates, and this example runs its
+  // browser test on one machine. README covers STUN/TURN for real
+  // deployments. No audio track is ever requested.
+
+  function newPC() {
+    const pcx = new RTCPeerConnection({ iceServers: [] });
+    pcx.onicecandidate = (ev) => {
+      if (ev.candidate) {
+        send({ kind: 'signal', to: peerRole(), type: 'ice', data: { candidate: ev.candidate.toJSON() } });
+      }
+    };
+    // ontrack fires while setRemoteDescription is still resolving, so
+    // the handler must exist before the offer is applied.
+    pcx.ontrack = (ev) => {
+      const remoteVideo = byId('assist-remote');
+      if (remoteVideo && ev.streams && ev.streams[0]) {
+        remoteVideo.srcObject = ev.streams[0];
+        remoteVideo.hidden = false;
+      }
+    };
+    pcx.onconnectionstatechange = () => {
+      note('pcState', pcx.connectionState);
+      const live = pcx.connectionState === 'connected';
+      const failed = pcx.connectionState === 'failed';
+      if (cfg.role === 'support') {
+        const noteEl = byId('assist-media-note');
+        if (noteEl && live) noteEl.textContent = 'Receiving the operator\u2019s camera.';
+        if (noteEl && failed) noteEl.textContent = 'The media path failed. Ask the operator to share again.';
+      }
+      if (live || failed) send({ kind: 'media', up: live });
+    };
+    return pcx;
+  }
+
+  function peerRole() { return cfg.role === 'operator' ? 'support' : 'operator'; }
+
+  function shareCamera() {
+    const btn = byId('assist-share');
+    if (btn) {
+      btn.addEventListener('click', () => {
+        if (localStream) return;
+        const constraints = { video: { width: 640, height: 480 }, audio: false };
+        navigator.mediaDevices.getUserMedia(constraints).then((stream) => {
+          localStream = stream;
+          const local = byId('assist-local');
+          if (local) { local.srcObject = stream; local.hidden = false; }
+          note('media', 'sharing');
+          flip('assist-pill-media', true);
+          ensurePC();
+          localStream.getTracks().forEach((t) => pc.addTrack(t, localStream));
+          sendOffer();
+        }).catch((err) => { note('media', 'denied:' + (err && err.name)); });
+      });
+    }
+  }
+
+  function ensurePC() {
+    if (!pc) pc = newPC();
+    return pc;
+  }
+
+  function sendOffer() {
+    ensurePC();
+    note('signaling', 'offering');
+    pc.createOffer().then((offer) => pc.setLocalDescription(offer)).then(() => {
+      send({ kind: 'signal', to: peerRole(), type: 'offer', data: { sdp: pc.localDescription } });
+    }).catch(() => { note('signaling', 'offer-failed'); });
+  }
+
+  function onSignal(sig) {
+    if (!sig || !sig.data) return;
+    note('signaling', sig.type);
+    if (sig.type === 'offer') {
+      ensurePC();
+      const remote = new RTCSessionDescription(sig.data.sdp);
+      pc.setRemoteDescription(remote).then(() => pc.createAnswer())
+        .then((answer) => pc.setLocalDescription(answer)).then(() => {
+        send({ kind: 'signal', to: peerRole(), type: 'answer', data: { sdp: pc.localDescription } });
+      }).catch(() => { note('signaling', 'answer-failed'); });
+      return;
+    }
+    if (sig.type === 'answer') {
+      if (!pc) return;
+      pc.setRemoteDescription(new RTCSessionDescription(sig.data.sdp)).catch(() => {
+        note('signaling', 'answer-stale');
+      });
+      return;
+    }
+    if (sig.type === 'ice') {
+      ensurePC();
+      pc.addIceCandidate(new RTCIceCandidate(sig.data.candidate)).catch(() => {
+        note('signaling', 'ice-stale'); // a candidate that outlived its generation
+      });
+    }
+  }
+
+  // Bridge diagnostics on the support console: did the browser even
+  // register the tools? WithBridgeDebug exposes the bounded state.
+  function reportBridge() {
+    const el = byId('assist-bridge');
+    if (!el) return;
+    const tick = () => {
+      const st = window.__gofastrWebMCP;
+      if (st && st.attempted > 0) {
+        el.textContent = st.registered + ' of ' + st.attempted + ' tools registered'
+          + (st.supported ? '' : ' (WebMCP unsupported in this browser)');
+        return;
+      }
+      setTimeout(tick, 250);
+    };
+    tick();
+  }
+
+  shareCamera();
+  reportBridge();
+  window.__gofastr.loadModule('ws').then(() => {
+    reduce = window.__gofastr.createSequencedReducer(initialState, apply);
+    note('phase', 'connecting');
+    startSocket();
+  }).catch(() => { note('phase', 'ws-module-failed'); });
+})();

--- a/framework/docs/content/webmcp.md
+++ b/framework/docs/content/webmcp.md
@@ -514,3 +514,14 @@ evaluating script; the bridge does not depend on it.
   emit `meta[name="csrf-token"]`, every unsafe-method tool behind
   `middleware.CSRF` 403s. Render the meta tag (the token is available
   server-side via `middleware.TokenFromContext`).
+
+## Reference example
+
+`examples/webmcp-remote-assist` composes this whole page end to end:
+role-cookie authorization beside a document-scoped mount, one typed
+command behind both the manual button and the agent tools, the
+observer's invocation ids correlated with an operator acknowledgement,
+and a browser test that drops the transport and proves the sequenced
+channel does not resurrect cleared state. It is the proof that the
+mount policies, the marker contract, and the recovery-screen guard
+pattern from [ui-wiring](ui-wiring.md) compose.

--- a/framework/experimental/webmcp/browser_test.go
+++ b/framework/experimental/webmcp/browser_test.go
@@ -71,7 +71,7 @@ func newWebmcpServer(t *testing.T) *webmcpServer {
 		http.Error(w, "boom", http.StatusInternalServerError)
 	}))
 
-	h := New()
+	h := New(WithInstructions("Probe the scene before mutating it."))
 	h.Group("scene", WithDescription("Scene tools."))
 	for _, tl := range []Tool{
 		{
@@ -234,7 +234,7 @@ func TestBridgeRegistersAndExecutesTools(t *testing.T) {
 		t.Skip("modelContext absent even with --enable-blink-features=WebMCP; browser predates WebMCP (needs Chromium 146+)")
 	}
 
-	waitForTools(t, ctx, "broken,echo_upper,grouped_probe,proto_probe,search")
+	waitForTools(t, ctx, "broken,echo_upper,get_app_instructions,grouped_probe,proto_probe,search")
 
 	// The opt-in debug state is bounded and truthful: every tool
 	// attempted, every tool registered, nothing failed, no invocation
@@ -244,9 +244,18 @@ func TestBridgeRegistersAndExecutesTools(t *testing.T) {
 		`JSON.stringify(window.__gofastrWebMCP)`, &dbg)); err != nil {
 		t.Fatalf("debug state: %v", err)
 	}
-	if want := `{"supported":true,"attempted":5,"registered":5,"failed":[],"lastStatus":""}`; dbg != want {
+	if want := `{"supported":true,"attempted":6,"registered":6,"failed":[],"lastStatus":""}`; dbg != want {
 		t.Fatalf("debug state = %s, want %s", dbg, want)
 	}
+
+	// The generated orientation tool registers like any other (it
+	// skips Register, so its declaration must be browser-complete on
+	// its own) and executes against the instructions route.
+	var instr string
+	if err := evalAwait(ctx, execToolExpr(InstructionsToolName, `{}`), &instr); err != nil {
+		t.Fatalf("execute %s: %v", InstructionsToolName, err)
+	}
+	assertToolResult(t, instr, false, `{"instructions":"Probe the scene before mutating it."}`)
 
 	// POST tool: input arrives as a JSON body, session cookie and the
 	// WebMCP marker header ride along, result text is the endpoint body.
@@ -336,7 +345,7 @@ func TestBridgeReadsCSRFMetaAtDispatchTime(t *testing.T) {
 	if !has {
 		t.Skip("modelContext absent even with --enable-blink-features=WebMCP; browser predates WebMCP (needs Chromium 146+)")
 	}
-	waitForTools(t, ctx, "broken,echo_upper,grouped_probe,proto_probe,search")
+	waitForTools(t, ctx, "broken,echo_upper,get_app_instructions,grouped_probe,proto_probe,search")
 
 	// Stash the token, then remove the meta tag entirely.
 	var token string

--- a/framework/experimental/webmcp/metadata.go
+++ b/framework/experimental/webmcp/metadata.go
@@ -169,11 +169,18 @@ const InstructionsToolName = "get_app_instructions"
 // orientationTool returns the generated declaration for the
 // instructions route. prefix is the mount router's group prefix, so the
 // declared path is where the route actually serves.
+//
+// The declaration joins the manifest without passing through Register,
+// so it must carry the empty-object input schema Register would have
+// defaulted: the browser's registerTool refuses a null inputSchema,
+// and the first host to mount WithInstructions in real Chromium found
+// the orientation tool silently absent from getTools().
 func orientationTool(prefix string) Tool {
 	return Tool{
 		Name:         InstructionsToolName,
 		Title:        "App operating instructions",
 		Description:  "Returns the developer-authored operating instructions for this app's tools: the cross-tool workflow the individual tool descriptions assume. Call this before using the other tools.",
+		InputSchema:  json.RawMessage(defaultInputSchema),
 		Method:       http.MethodGet,
 		Path:         prefix + InstructionsRoute,
 		ReadOnlyHint: true,

--- a/framework/experimental/webmcp/metadata_test.go
+++ b/framework/experimental/webmcp/metadata_test.go
@@ -270,6 +270,12 @@ func TestInstructionsGenerateOrientationTool(t *testing.T) {
 		ot.Method != http.MethodGet || ot.Path != InstructionsRoute {
 		t.Fatalf("orientation tool: %+v", ot)
 	}
+	// The generated declaration skips Register, so it must carry the
+	// input schema Register defaults: the browser refuses a tool whose
+	// inputSchema is null, and the manifest is what the bridge feeds it.
+	if string(ot.InputSchema) != defaultInputSchema {
+		t.Fatalf("orientation tool inputSchema = %s, want %s", ot.InputSchema, defaultInputSchema)
+	}
 
 	// The route serves them, as the tool's endpoint.
 	rec = httptest.NewRecorder()

--- a/framework/ui/status_pill.go
+++ b/framework/ui/status_pill.go
@@ -90,8 +90,10 @@ func statusPillCSS(_ style.Theme) string {
   border-radius: var(--radii-full, 9999px);
 }
 /* Author-origin display beats the UA's [hidden]{display:none}, so a
-   pill a script hides with el.hidden = true would stay visible. */
-[data-fui-comp="ui-status-pill"][hidden] {
+   pill a script hides with el.hidden = true would stay visible.
+   hidden="until-found" is excluded: the UA keeps that state
+   revealable (content-visibility), and display: none would break it. */
+[data-fui-comp="ui-status-pill"][hidden]:not([hidden="until-found"]) {
   display: none;
 }
 [data-fui-comp="ui-status-pill"] .ui-status-pill__dot {

--- a/framework/ui/status_pill.go
+++ b/framework/ui/status_pill.go
@@ -89,6 +89,11 @@ func statusPillCSS(_ style.Theme) string {
   border: 1px solid var(--ui-status-pill-border, var(--color-border, rgba(0,0,0,0.1)));
   border-radius: var(--radii-full, 9999px);
 }
+/* Author-origin display beats the UA's [hidden]{display:none}, so a
+   pill a script hides with el.hidden = true would stay visible. */
+[data-fui-comp="ui-status-pill"][hidden] {
+  display: none;
+}
 [data-fui-comp="ui-status-pill"] .ui-status-pill__dot {
   width: 6px;
   height: 6px;

--- a/framework/ui/status_pill_test.go
+++ b/framework/ui/status_pill_test.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"strings"
 	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/style"
 )
 
 func TestStatusPillRendersLabelAndMarker(t *testing.T) {
@@ -62,5 +64,18 @@ func TestStatusPillExtraAttrsOnRoot(t *testing.T) {
 	root := string(h)[:strings.Index(string(h), ">")+1]
 	if !strings.Contains(root, `data-test="hook"`) {
 		t.Errorf("StatusPill root missing data-test:\n%s", root)
+	}
+}
+
+// A pill hidden by script (el.hidden = true, the pattern a page uses
+// to show one of a pair) must actually disappear: the component's
+// author-origin display rule outranks the UA's [hidden] rule, so the
+// stylesheet has to restate it.
+func TestStatusPillHonorsHidden(t *testing.T) {
+	css := statusPillCSS(style.Theme{})
+	if !strings.Contains(css, `[data-fui-comp="ui-status-pill"][hidden] {
+  display: none;
+}`) {
+		t.Fatalf("status pill CSS has no [hidden] rule:\n%s", css)
 	}
 }

--- a/framework/ui/status_pill_test.go
+++ b/framework/ui/status_pill_test.go
@@ -73,9 +73,11 @@ func TestStatusPillExtraAttrsOnRoot(t *testing.T) {
 // stylesheet has to restate it.
 func TestStatusPillHonorsHidden(t *testing.T) {
 	css := statusPillCSS(style.Theme{})
-	if !strings.Contains(css, `[data-fui-comp="ui-status-pill"][hidden] {
+	// The plain hidden state is display: none; hidden="until-found"
+	// stays out of the rule so the UA's revealable state survives.
+	if !strings.Contains(css, `[data-fui-comp="ui-status-pill"][hidden]:not([hidden="until-found"]) {
   display: none;
 }`) {
-		t.Fatalf("status pill CSS has no [hidden] rule:\n%s", css)
+		t.Fatalf("status pill CSS has no [hidden] rule that spares until-found:\n%s", css)
 	}
 }


### PR DESCRIPTION
Second of the PRs ahead of v0.80.0, based on #382 so the review bot sees only this batch; it retargets to `main` once #382 merges. One example ticket and two framework defects the example exposed, each its own commit.

Closes #376.

## `examples/webmcp-remote-assist` (#376)

One binary, one origin, two roles. A shared sign-in key (`ASSIST_SUPPORT_KEY`, or a random one printed at start) mints an HttpOnly support cookie; a one-time join link trades for an operator cookie scoped to `/session`. The WebMCP bridge ships only on signed-in support documents (`WithDocumentScope`, manifest and script behind the same role check as the endpoints), so leaving the console is a real navigation and the next document carries no tools. The console's manual button and the `send_instruction` / `clear_instruction` tools decode into one typed command; `inspect_session` reads backend state so an agent verifies delivery from the operator's acknowledgement, correlated with the observer's invocation id, which the operator's copy of every event never carries. Each session is a `stream.StateChannel`; every relayed WebRTC signaling frame advances the session version, so a reconnect snapshot is never older than the events a page applied. The camera is video-only and peer-to-peer: the server relays SDP and ICE JSON, and the app's `Permissions-Policy` opens `camera=(self)` while keeping `microphone=()`. Cross-site mutations follow battery/auth's convention (`Sec-Fetch-Site` first, a null `Origin` from a top-level same-origin form post allowed).

The worker's tree built and its HTTP tests passed, but its browser test had never passed. Read line by line and driven through Chrome, eight distinct causes surfaced, each fixed with a pin: the same-origin check refused the `Origin: null` a top-level form post sends; the sign-in minted a role with no credential; signaling frames did not advance the session version, so a reconnect snapshot trailed the page and was refused as stale (the resurrection bug the ticket is about); the reducer was built before the module that defines it loaded; `ontrack` was attached after the offer was applied; the invocation ref reached the operator on instruction and clear events against the README's claim; the default `Permissions-Policy` denied the camera; the error type dropped its message. Every new guard was made to fail by mutation before it counted; the browser flow now includes two socket drops, the second with a mutation landing while the operator is offline, which only the reconnect snapshot can deliver. Every page was screenshotted in light and dark and read.

## webmcp: orientation tool carried `inputSchema: null`

The generated `get_app_instructions` declaration skipped `Register`, so the manifest listed it and Chromium's `registerTool` refused it; the example was the first host to mount `WithInstructions` in a real browser. It now carries the default empty-object schema; the manifest test pins it and the package's Chromium test registers and executes it. Folded into the #373 changelog entry, which has not shipped.

## ui: `StatusPill` ignored `hidden`

The component's display rule outranked the UA's `[hidden]` rule, so both halves of a show-one-of-two pair rendered at once (visible in the first screenshots). The stylesheet restates `display: none` for the hidden state; pinned.

## Verification

`examples/webmcp-remote-assist` (HTTP suite plus the two-tab Chromium flow with a fake camera, three consecutive green runs), `framework/experimental/webmcp` (including the Chromium bridge tests), `framework/ui`, `framework/docs`; `go vet`, `gofmt`, `make analyze`, and the contracts pipeline on the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BLjmqxTmrgQgZg2S2wefZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a WebMCP remote-assistance example with authenticated support and operator sessions, shared commands, live updates, and peer-to-peer camera sharing.
  - Added support for reconnecting sessions and role-appropriate session information.
  - Added the generated `get_app_instructions` tool to browser tool discovery.

- **Bug Fixes**
  - Hidden status pills now remain hidden when using the `hidden` attribute.

- **Documentation**
  - Added setup, usage, security, compatibility, and implementation guidance for the remote-assistance example.
  - Added the example to the available examples and WebMCP reference documentation.

- **Tests**
  - Added comprehensive HTTP and browser coverage for remote assistance, WebMCP behavior, reconnection, authorization, and media sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->