### PR TITLE
Analyzer review round: timing, logged recovers, and seventy-five proven rule gaps closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ### Security
 - **Static rules hardened by an adversarial review round**, and the
-  siblings their widened shapes found, all fixed: `uihost` interpolated
-  a registered style name into the `/__gofastr/comp/<name>.css` path
+  sibling bugs the widened rules then found, all fixed: `uihost`
+  interpolated a registered style name into the `/__gofastr/comp/<name>.css` path
   with no check (a slash rewrote the served path); the MCP call and
   server gates, the cron job gate, the queue type gates, and the notify
   router ran app callbacks on dispatch loops with no recover net (each
@@ -18,9 +18,10 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   ran an app-supplied step while holding its mutex (it runs outside the
   lock now, exactly-once kept by an in-flight flag); three runtime
   registries guarded attribute-borne keys with the `in` operator, which
-  walks the prototype chain; `gofastr new` resolved the scaffold
-  directory lexically only. The five recover guards v0.81.0 added now
-  log the panic instead of swallowing it.
+  walks the prototype chain; `gofastr new` resolves the scaffold
+  directory through symlinks before any write, where it previously
+  compared a lexically cleaned path. The five recover guards v0.81.0
+  added now log the panic instead of swallowing it.
 
 ### Fixed
 - **Analyzers, contract rules, and runtime lints**: five reviewers
@@ -30,8 +31,9 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   message, range variables, and `Referer`/`UserAgent`/`Cookie` sources
   as in scope, stays quiet on outbound request headers, and never lets
   `path.Clean` clear taint; `recovercallback` follows interface dispatch
-  and named deferred guards and stops counting a nested literal's
-  recover; `emitident` no longer flags error messages that start with
+  and named deferred guards and stops counting a nested literal's or a
+  nested defer's recover; `emitident` no longer flags error messages
+  that start with
   `type` or `func`; `asciifold` pops its if stack; `discardederr` fires
   on two-result methods outside `database/sql`; GOFASTR1006 drops the
   `key`/`prefix` name heuristic that flagged API-key prefix checks and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Security
+- **Static rules hardened by an adversarial review round**, and the
+  siblings their widened shapes found, all fixed: `uihost` interpolated
+  a registered style name into the `/__gofastr/comp/<name>.css` path
+  with no check (a slash rewrote the served path); the MCP call and
+  server gates, the cron job gate, the queue type gates, and the notify
+  router ran app callbacks on dispatch loops with no recover net (each
+  now fails closed with the panic logged or returned); the setup wizard
+  ran an app-supplied step while holding its mutex (it runs outside the
+  lock now, exactly-once kept by an in-flight flag); three runtime
+  registries guarded attribute-borne keys with the `in` operator, which
+  walks the prototype chain; `gofastr new` resolved the scaffold
+  directory lexically only. The five recover guards v0.81.0 added now
+  log the panic instead of swallowing it.
+
+### Fixed
+- **Analyzers, contract rules, and runtime lints**: five reviewers
+  executed fixtures against the nineteen rules and proved around
+  seventy-five gaps; every one is pinned red-then-green. Highlights:
+  `controlbytes` now treats package-level `slog`, `fmt.Print*`, the log
+  message, range variables, and `Referer`/`UserAgent`/`Cookie` sources
+  as in scope, stays quiet on outbound request headers, and never lets
+  `path.Clean` clear taint; `recovercallback` follows interface dispatch
+  and named deferred guards and stops counting a nested literal's
+  recover; `emitident` no longer flags error messages that start with
+  `type` or `func`; `asciifold` pops its if stack; `discardederr` fires
+  on two-result methods outside `database/sql`; GOFASTR1006 drops the
+  `key`/`prefix` name heuristic that flagged API-key prefix checks and
+  resolves constants across the package; GOFASTR1406 sees `Sprintf`
+  splices and `http.Header` parameters; GOFASTR1407 tracks one level of
+  same-file helper taint; the runtime lints blank regex literals, never
+  report code inside string literals, see template-literal URLs and
+  compound `innerHTML` assignments, require an anchored wildcard-free
+  regex as a name gate, and resolve lines by binary search. Wrong-typed
+  A2A, process-module, and OpenAPI envelope fields are errors instead
+  of silent skips, and dropped refusals in the admin, resource, and
+  harness surfaces are logged or returned.
+
 ## [0.81.0] - 2026-09-02
 
 ### Security

--- a/battery/admin/admin.go
+++ b/battery/admin/admin.go
@@ -415,10 +415,15 @@ func (b *Battery) handleIndex(w http.ResponseWriter, r *http.Request) {
 		stats, err = b.cfg.Queue.Stats(r.Context())
 		if err != nil {
 			// The overview page degrades to zero counts; the refusal
-			// is logged rather than dropped.
+			// is logged rather than dropped. Stats can return a
+			// partially populated map with the error (DBQueue does on
+			// a mid-scan rows.Err()); those counts are not trustworthy,
+			// so reset to the zero-value display.
 			b.logger().Warn("admin: queue stats", "error", err)
+			stats = queue.JobStats{}
 		}
 	}
+
 	var auditCount int
 	db := b.effectiveDB()
 	if db != nil {
@@ -451,11 +456,17 @@ func (b *Battery) handleQueue(w http.ResponseWriter, r *http.Request) {
 	}
 	stats, err := b.cfg.Queue.Stats(r.Context())
 	if err != nil {
+		// Partially populated stats can ride along with the error (see
+		// handleIndex); the filter chips must show zero counts, not
+		// stale numbers.
 		b.logger().Warn("admin: queue stats", "error", err)
+		stats = queue.JobStats{}
 	}
+
 	// Offer per-row Replay only on the failed view and only when the backend
 	// supports replay (DBQueue does; memory/redis don't yet).
 	showReplay := false
+
 	if status == "failed" {
 		if _, ok := b.cfg.Queue.(queue.Replayable); ok {
 			showReplay = true

--- a/battery/admin/admin.go
+++ b/battery/admin/admin.go
@@ -411,7 +411,13 @@ func adminSuperuserCtx(ctx context.Context) context.Context {
 func (b *Battery) handleIndex(w http.ResponseWriter, r *http.Request) {
 	var stats queue.JobStats
 	if b.cfg.Queue != nil {
-		stats, _ = b.cfg.Queue.Stats(r.Context())
+		var err error
+		stats, err = b.cfg.Queue.Stats(r.Context())
+		if err != nil {
+			// The overview page degrades to zero counts; the refusal
+			// is logged rather than dropped.
+			b.logger().Warn("admin: queue stats", "error", err)
+		}
 	}
 	var auditCount int
 	db := b.effectiveDB()
@@ -443,7 +449,10 @@ func (b *Battery) handleQueue(w http.ResponseWriter, r *http.Request) {
 			adminError("Could not load queue jobs. Check the server logs for details."))
 		return
 	}
-	stats, _ := b.cfg.Queue.Stats(r.Context())
+	stats, err := b.cfg.Queue.Stats(r.Context())
+	if err != nil {
+		b.logger().Warn("admin: queue stats", "error", err)
+	}
 	// Offer per-row Replay only on the failed view and only when the backend
 	// supports replay (DBQueue does; memory/redis don't yet).
 	showReplay := false

--- a/battery/admin/queue_stats_test.go
+++ b/battery/admin/queue_stats_test.go
@@ -1,0 +1,61 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/battery/queue"
+)
+
+// partialStatsQueue is a Browsable whose Stats returns DBQueue's failure
+// shape: a PARTIALLY populated map alongside the error (rows.Err() after
+// some rows scanned). Both stats-rendering screens must drop the
+// partial counts and degrade to the zero-count UI, not present stale
+// numbers the caller has no reason to distrust.
+type partialStatsQueue struct{}
+
+func (partialStatsQueue) ListJobs(_ context.Context, _ string, _ int) ([]queue.Job, error) {
+	return nil, nil
+}
+
+func (partialStatsQueue) Stats(_ context.Context) (queue.JobStats, error) {
+	return queue.JobStats{"pending": 7}, errors.New("rows error mid-scan")
+}
+
+func TestAdmin_StatsErrorClearsPartialCounts(t *testing.T) {
+	b := New(Config{Queue: partialStatsQueue{}})
+
+	// Overview tile: the partial "pending: 7" StatCard must not ship.
+	partialCard := string(statCard("pending", 7))
+	req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	rr := httptest.NewRecorder()
+	b.handleIndex(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("handleIndex status = %d", rr.Code)
+	}
+	if strings.Contains(rr.Body.String(), partialCard) {
+		t.Errorf("overview shipped the partially populated stats (pending=7) alongside the Stats error:\n%s", truncateBody(rr.Body.String()))
+	}
+
+	// Queue page filter chips: "pending (7)" must not ship either.
+	req = httptest.NewRequest(http.MethodGet, "/admin/queue", nil)
+	rr = httptest.NewRecorder()
+	b.handleQueue(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("handleQueue status = %d", rr.Code)
+	}
+	if strings.Contains(rr.Body.String(), "pending (7)") {
+		t.Errorf("queue page shipped the partially populated stats (pending (7)) alongside the Stats error:\n%s", truncateBody(rr.Body.String()))
+	}
+}
+
+func truncateBody(s string) string {
+	if len(s) > 800 {
+		return s[:800] + "…"
+	}
+	return s
+}

--- a/battery/notify/notify.go
+++ b/battery/notify/notify.go
@@ -179,7 +179,10 @@ func (n *Notifier) Send(ctx context.Context, msg Notification) error {
 	onError := n.onError
 	n.mu.RUnlock()
 
-	selected := router(msg.Type, msg.To, chanNames)
+	selected, rerr := routeSafe(router, msg, chanNames)
+	if rerr != nil {
+		return rerr
+	}
 	if len(selected) == 0 {
 		return ErrNoChannels
 	}
@@ -230,6 +233,19 @@ func (n *Notifier) Send(ctx context.Context, msg Notification) error {
 		}
 	}
 	return firstErr
+}
+
+// routeSafe selects channels through the installed router, turning a
+// panicking router into an error instead of an unwound caller: Send
+// fans out through its collect loop on paths with no recover net
+// (recovercallback pins this).
+func routeSafe(router Router, msg Notification, chanNames []string) (selected []string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("notify: router panic: %v", r)
+		}
+	}()
+	return router(msg.Type, msg.To, chanNames), nil
 }
 
 func (n *Notifier) renderFor(ctx context.Context, t Templater, msg Notification, channel string) (Rendered, error) {

--- a/battery/queue/db.go
+++ b/battery/queue/db.go
@@ -426,11 +426,29 @@ func (q *DBQueue) eligibleTypes() []string {
 	}
 	out := types[:0]
 	for _, t := range types {
-		if gate(t) {
+		if gateAllows(q.logger, gate, t, "") {
 			out = append(out, t)
 		}
 	}
 	return out
+}
+
+// gateAllows evaluates the queue gate with the same net safeHandle
+// gives handlers: a panicking gate fails CLOSED — the job type is
+// excluded here, deferred at the worker — instead of tearing down the
+// code path that runs it (recovercallback pins this; eligibleTypes and
+// the worker loop sit on dispatch paths).
+func gateAllows(logger *slog.Logger, gate func(jobType string) bool, jobType, jobID string) (allow bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("queue: gate panic; failing closed",
+				"job_type", jobType,
+				"job_id", jobID,
+				"panic", fmt.Sprintf("%v", r))
+			allow = false
+		}
+	}()
+	return gate(jobType)
 }
 
 // Enqueue inserts a job. Fills in ID/CreatedAt/MaxAttempts/ScheduledAt
@@ -1024,7 +1042,7 @@ func (q *DBQueue) workerLoop(ctx context.Context, lane string) {
 		q.mu.RLock()
 		gate := q.gate
 		q.mu.RUnlock()
-		if gate != nil && !gate(job.Type) {
+		if gate != nil && !gateAllows(q.logger, gate, job.Type, job.ID) {
 			_ = q.release(ctx, job.ID)
 			continue
 		}

--- a/battery/queue/durable_scheduler.go
+++ b/battery/queue/durable_scheduler.go
@@ -54,7 +54,11 @@ type DurableScheduler struct {
 // fires on the scheduler loop, which has no per-request net, and a
 // panicking hook must not take the scheduler (or the process) with it.
 func (s *DurableScheduler) hookBeforeOccurrenceCommit() {
-	defer func() { _ = recover() }()
+	defer func() {
+		if rec := recover(); rec != nil {
+			slog.Default().Error("queue: durable scheduler hook panicked; occurrence commit continues", "panic", rec)
+		}
+	}()
 	s.beforeOccurrenceCommit()
 }
 

--- a/battery/queue/durable_scheduler_hardening_test.go
+++ b/battery/queue/durable_scheduler_hardening_test.go
@@ -1,8 +1,11 @@
 package queue
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 )
@@ -40,6 +43,46 @@ func TestDurableSchedulerWatermarkCASUsesVersionNotTimestamps(t *testing.T) {
 	}
 	if version != 1 {
 		t.Fatalf("watermark version = %d, want 1", version)
+	}
+}
+
+// TestDurableSchedulerHookPanicLogsAndCommits: the partition hook
+// fires on the scheduler loop, which has no per-request net, so a
+// panicking hook must be logged and swallowed while the occurrence
+// commit continues — the recover guard in hookBeforeOccurrenceCommit
+// is what keeps a poison hook from wedging every schedule.
+func TestDurableSchedulerHookPanicLogsAndCommits(t *testing.T) {
+	db := openDurableSchedulerDB(t)
+	q := newDurableTestQueue(t, db)
+	base := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	sched, err := NewDurableScheduler(q, DurableSchedulerConfig{
+		OwnerID: "hook-panic", LeaseDuration: time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sched.Every("digest", time.Minute).Job("send-digest", nil).RegisterAt(base); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	sched.beforeOccurrenceCommit = func() { panic("hook boom") }
+
+	if err := sched.RunOnce(context.Background(), base.Add(time.Minute)); err != nil {
+		t.Fatalf("RunOnce must continue past a panicking hook: %v", err)
+	}
+	if jobs := pendingJobs(t, q); len(jobs) != 1 {
+		t.Fatalf("occurrence commit did not continue: pending jobs = %d, want 1", len(jobs))
+	}
+	if got := occurrenceStatuses(t, q)["enqueued"]; got != 1 {
+		t.Fatalf("enqueued occurrences = %d, want 1", got)
+	}
+	if !strings.Contains(buf.String(), "hook boom") {
+		t.Fatalf("panicking hook not logged; log = %q", buf.String())
 	}
 }
 

--- a/battery/queue/memory.go
+++ b/battery/queue/memory.go
@@ -313,7 +313,7 @@ func (q *MemoryQueue) processJob(job Job) {
 	// Gate: defer jobs whose owning module is disabled. Re-enqueue after
 	// a short delay so the job runs when the module re-enables without
 	// hot-looping the worker.
-	if gate != nil && !gate(job.Type) {
+	if gate != nil && !gateAllows(q.logger, gate, job.Type, job.ID) {
 		q.deferGated(job)
 		return
 	}

--- a/battery/semantic/watcher.go
+++ b/battery/semantic/watcher.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -93,6 +94,7 @@ func NewWatcher(idx Index, opts WatchOptions) *Watcher {
 func (w *Watcher) safeMetadata(absPath string) (m map[string]any) {
 	defer func() {
 		if rec := recover(); rec != nil {
+			slog.Default().Error("semantic: MetadataFunc panicked; indexing without metadata", "path", absPath, "panic", rec)
 			m = nil
 		}
 	}()

--- a/battery/semantic/watcher_test.go
+++ b/battery/semantic/watcher_test.go
@@ -1,9 +1,13 @@
 package semantic
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -50,6 +54,77 @@ func TestWatcherIndexesAndRemoves(t *testing.T) {
 	if len(hits) == 0 {
 		t.Fatalf("updated content not queryable")
 	}
+}
+
+// TestWatcherMetadataFuncPanicIndexesWithNilMetadata: the metadata
+// hook is app-supplied code running on the watcher loop, which has no
+// per-request net — a panicking MetadataFunc must degrade to nil
+// metadata (logged), not kill the scan. The first scan proves the
+// plumbing carries metadata, so the nil result after the panic is the
+// guard's doing, not an unrelated drop.
+func TestWatcherMetadataFuncPanicIndexesWithNilMetadata(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "a.go"), "package a; func Hello() {}")
+
+	idx, _ := Open(Options{Embedder: NewStubEmbedder(64)})
+	w := NewWatcher(idx, WatchOptions{IncludeExts: []string{".go"}, PollInterval: -1})
+	if err := w.ScanOnce(ctx, dir); err != nil {
+		t.Fatalf("ScanOnce: %v", err)
+	}
+	hits, _ := idx.Query(ctx, Query{Text: "Hello", K: 1})
+	if len(hits) == 0 {
+		t.Fatal("control scan did not index the file")
+	}
+	if got := hits[0].Chunk.Metadata["kind"]; got != "code" {
+		t.Fatalf("control scan metadata kind = %v, want code (plumbing proof)", got)
+	}
+
+	var buf syncBuffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	// Re-index the same document with a panicking hook.
+	w.opts.MetadataFunc = func(string) map[string]any { panic("metadata boom") }
+	future := time.Now().Add(2 * time.Second)
+	mustWrite(t, filepath.Join(dir, "a.go"), "package a; func HelloAgain() {}")
+	os.Chtimes(filepath.Join(dir, "a.go"), future, future)
+	if err := w.ScanOnce(ctx, dir); err != nil {
+		t.Fatalf("ScanOnce must survive a panicking MetadataFunc: %v", err)
+	}
+	if got := idx.Stats().Docs; got != 1 {
+		t.Fatalf("after panicking rescan Docs = %d, want 1 (indexing continues)", got)
+	}
+	hits, _ = idx.Query(ctx, Query{Text: "HelloAgain", K: 1})
+	if len(hits) == 0 {
+		t.Fatal("re-indexed content not queryable")
+	}
+	if hits[0].Chunk.Metadata != nil {
+		t.Fatalf("chunk metadata = %v, want nil after the hook panicked", hits[0].Chunk.Metadata)
+	}
+	if !strings.Contains(buf.String(), "metadata boom") {
+		t.Fatalf("panicking MetadataFunc not logged; log = %q", buf.String())
+	}
+}
+
+// syncBuffer is a mutex-guarded bytes.Buffer: the recovered panic is
+// logged from the scan path while the test goroutine reads the buffer.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 func TestWatcherRunCancels(t *testing.T) {

--- a/battery/setup/engine_test.go
+++ b/battery/setup/engine_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // helperBuildRunner creates a Runner with the given steps and a simple
@@ -213,12 +214,16 @@ func TestSecretNeverPrefilled(t *testing.T) {
 }
 
 // TestConcurrentStepExecution_OneRun verifies that two concurrent step
-// submissions don't both execute the step, the mutex + Complete
-// re-check must serialize them.
+// submissions don't both execute the step: the mutex + Complete
+// re-check must serialize them. The sequencing is deterministic —
+// caller A blocks inside Run (so it can neither advance currentStep
+// nor release stepInFlight) until caller B has gone through the guard
+// and returned, which is the only way to prove B hit stepInFlight
+// rather than the currentStep check.
 func TestConcurrentStepExecution_OneRun(t *testing.T) {
 	var runCount atomic.Int64
-	// Complete returns false until the step has run; then true.
-	completed := int32(0)
+	runEntered := make(chan struct{})
+	releaseRun := make(chan struct{})
 
 	cfg := Config{
 		Steps: []Step{
@@ -227,28 +232,92 @@ func TestConcurrentStepExecution_OneRun(t *testing.T) {
 				Fields: []Field{{Name: "x", EnvVar: "CONCURRENT_X"}},
 				Run: func(_ context.Context, _ map[string]string) error {
 					runCount.Add(1)
-					atomic.StoreInt32(&completed, 1)
+					// Hold the claim open: currentStep cannot advance
+					// while Run is blocked, so the later caller can
+					// only be turned away by stepInFlight.
+					runEntered <- struct{}{}
+					<-releaseRun
 					return nil
 				},
 			},
 		},
-		Complete: func(_ context.Context) (bool, error) {
-			return atomic.LoadInt32(&completed) == 1, nil
-		},
+		Complete: func(_ context.Context) (bool, error) { return false, nil },
 	}
 	r := New(cfg)
 
-	// Two concurrent calls to runStepSerialized for the same step.
-	var wg sync.WaitGroup
-	for range 2 {
-		wg.Go(func() {
-			_ = r.runStepSerialized(context.Background(), 0, cfg.Steps[0], map[string]string{"x": "v"})
-		})
+	// Caller A claims the step and blocks inside Run.
+	aDone := make(chan error, 1)
+	go func() {
+		aDone <- r.runStepSerialized(context.Background(), 0, cfg.Steps[0], nil)
+	}()
+	<-runEntered
+
+	// Caller B arrives while A provably holds stepInFlight: it must be
+	// treated as already-advanced without running the step.
+	bDone := make(chan error, 1)
+	go func() {
+		bDone <- r.runStepSerialized(context.Background(), 0, cfg.Steps[0], nil)
+	}()
+	select {
+	case err := <-bDone:
+		if err != nil {
+			t.Fatalf("caller B turned away with error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("caller B never returned from the stepInFlight guard")
 	}
-	wg.Wait()
+
+	// Release A and let it finish + advance.
+	close(releaseRun)
+	if err := <-aDone; err != nil {
+		t.Fatalf("caller A: %v", err)
+	}
 
 	if got := runCount.Load(); got != 1 {
 		t.Fatalf("expected step.Run called exactly once, got %d", got)
+	}
+}
+
+// TestCompletePanicLeavesRunnerUsable pins the contract the review's
+// deadlock fix carries: Config.Complete is app-supplied callback code,
+// so runStepSerialized must never hold r.mu while probing it. A
+// panicking Complete used to unwind past a plain (non-deferred) Unlock
+// and leave r.mu locked forever — every later setup request blocked
+// until the process restarted.
+func TestCompletePanicLeavesRunnerUsable(t *testing.T) {
+	r := New(Config{
+		DisableToken: true,
+		Complete:     func(_ context.Context) (bool, error) { panic("complete boom") },
+		Steps: []Step{
+			{Name: "s", Run: func(_ context.Context, _ map[string]string) error { return nil }},
+		},
+	})
+
+	// The first call panics (net/http recovers this in production).
+	func() {
+		defer func() {
+			if rec := recover(); rec == nil {
+				t.Fatal("expected the panicking Complete to unwind to the caller")
+			}
+		}()
+		_ = r.runStepSerialized(context.Background(), 0, r.cfg.Steps[0], nil)
+	}()
+
+	// The later request must be able to acquire r.mu. TryLock instead
+	// of Lock: on the bug a plain Lock hangs the test binary past its
+	// deadline, TryLock fails fast with a message naming the wedge.
+	if !r.mu.TryLock() {
+		t.Fatal("r.mu still locked after Complete panicked: every later setup request blocks forever")
+	}
+	r.mu.Unlock()
+
+	// And the runner still executes steps once Complete behaves again.
+	r.cfg.Complete = func(_ context.Context) (bool, error) { return false, nil }
+	if err := r.runStepSerialized(context.Background(), 0, r.cfg.Steps[0], nil); err != nil {
+		t.Fatalf("post-panic runStepSerialized: %v", err)
+	}
+	if r.currentStep != 1 {
+		t.Fatalf("currentStep = %d, want 1 after the recovery run", r.currentStep)
 	}
 }
 

--- a/battery/setup/handler.go
+++ b/battery/setup/handler.go
@@ -235,18 +235,31 @@ func (r *Runner) handleSubmit(w http.ResponseWriter, req *http.Request) {
 	http.Redirect(w, req, "/setup", http.StatusSeeOther)
 }
 
-// runStepSerialized runs one step under the mutex and advances
-// currentStep in the same critical section. Checking currentStep ==
-// stepIdx under the lock before running (and advancing before
-// releasing) eliminates the window in which a concurrent POST could
-// re-run an intermediate step.
+// runStepSerialized claims one step under the mutex and runs it
+// OUTSIDE it. Steps are app-supplied callback code (AdminStep creates
+// the admin account over HTTP-round-tripped stores): a blocking or
+// panicking step must not wedge every other setup request against
+// r.mu (callbackunderlock pins this), and a panic must reach the
+// net/http recover net rather than skip a plain Unlock.
+//
+// Exactly-once survives the lock release through stepInFlight: the
+// claim (currentStep check + Complete re-check + flag) and the advance
+// are each atomic under mu, and a concurrent POST for the same step
+// finds the flag set and treats the step as already-advanced. A FAILED
+// step clears the flag and leaves currentStep where it was, so the
+// retry path is unchanged.
 func (r *Runner) runStepSerialized(ctx context.Context, stepIdx int, step Step, values map[string]string) error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	// Re-check: if a concurrent request already advanced past this
 	// step, skip (treat as already-advanced).
 	if r.currentStep != stepIdx {
+		r.mu.Unlock()
+		return nil
+	}
+	// Another request is running this step right now (it released the
+	// mutex to do so): treat as already-advanced.
+	if r.stepInFlight {
+		r.mu.Unlock()
 		return nil
 	}
 
@@ -260,18 +273,42 @@ func (r *Runner) runStepSerialized(ctx context.Context, stepIdx int, step Step, 
 	// is not.
 	done, err := r.cfg.Complete(ctx)
 	if err != nil {
+		r.mu.Unlock()
 		return fmt.Errorf("setup: completion check failed, refusing to run step: %w", err)
 	}
 	if done {
+		r.mu.Unlock()
 		return nil
 	}
 
-	if err := step.Run(ctx, values); err != nil {
+	r.stepInFlight = true
+	r.mu.Unlock()
+
+	// The deferred clear also runs when the step PANICS: the claim is
+	// released while the panic unwinds to the net/http recover net,
+	// exactly as it did before the step left the lock, so the wizard
+	// is never stuck treating the step as in-flight.
+	defer func() {
+		r.mu.Lock()
+		r.stepInFlight = false
+		r.mu.Unlock()
+	}()
+
+	// Run outside the lock: a slow or panicking step holds nothing.
+	err = step.Run(ctx, values)
+	if err != nil {
 		return err
 	}
 
-	// Advance under the same lock, no window between run and advance.
-	r.currentStep = stepIdx + 1
+	// Advance under the lock, no window between run and advance: only
+	// the in-flight runner reaches here (the flag kept every other
+	// request out), and the currentStep guard keeps a test-driven
+	// reset from double-advancing.
+	r.mu.Lock()
+	if r.currentStep == stepIdx {
+		r.currentStep = stepIdx + 1
+	}
+	r.mu.Unlock()
 	return nil
 }
 

--- a/battery/setup/handler.go
+++ b/battery/setup/handler.go
@@ -18,7 +18,7 @@ import (
 //     validates, runs the step, and advances or re-renders on error.
 //   - Atomic exit: when the final step succeeds, swap() is called to
 //     switch to the real app handler. Step execution is serialized and
-//     Complete is re-checked under the mutex so two racing submissions
+//     Complete is re-checked on every claim so two racing submissions
 //     can't both run the steps.
 func (r *Runner) Handler(swap func(), healthz, readyz http.HandlerFunc) http.Handler {
 	r.mu.Lock()
@@ -242,13 +242,33 @@ func (r *Runner) handleSubmit(w http.ResponseWriter, req *http.Request) {
 // r.mu (callbackunderlock pins this), and a panic must reach the
 // net/http recover net rather than skip a plain Unlock.
 //
-// Exactly-once survives the lock release through stepInFlight: the
-// claim (currentStep check + Complete re-check + flag) and the advance
-// are each atomic under mu, and a concurrent POST for the same step
-// finds the flag set and treats the step as already-advanced. A FAILED
-// step clears the flag and leaves currentStep where it was, so the
-// retry path is unchanged.
+// The Complete re-check ALSO runs outside the mutex, for the same
+// reason: Complete is app-supplied callback code too. It used to fire
+// while r.mu was held with no deferred unlock registered yet, so a
+// panicking Complete left the mutex locked and wedged every later
+// setup request; a slow one blocked them all. Exactly-once survives
+// the probe leaving the lock through stepInFlight: the claim
+// (currentStep check + stepInFlight check + flag) and the advance are
+// each atomic under mu, and a concurrent POST for the same step finds
+// the flag set and treats the step as already-advanced. A FAILED step
+// clears the flag and leaves currentStep where it was, so the retry
+// path is unchanged.
 func (r *Runner) runStepSerialized(ctx context.Context, stepIdx int, step Step, values map[string]string) error {
+	// Re-check Complete before taking the mutex.
+	//
+	// A probe ERROR is not "not done", it is "unknown", and this guard is
+	// the only thing standing between a second caller and a re-run of a
+	// step that typically creates the admin account. Refuse rather than
+	// proceed: a failed setup step is recoverable, a silently re-run one
+	// is not.
+	done, err := r.cfg.Complete(ctx)
+	if err != nil {
+		return fmt.Errorf("setup: completion check failed, refusing to run step: %w", err)
+	}
+	if done {
+		return nil
+	}
+
 	r.mu.Lock()
 	// Re-check: if a concurrent request already advanced past this
 	// step, skip (treat as already-advanced).
@@ -259,24 +279,6 @@ func (r *Runner) runStepSerialized(ctx context.Context, stepIdx int, step Step, 
 	// Another request is running this step right now (it released the
 	// mutex to do so): treat as already-advanced.
 	if r.stepInFlight {
-		r.mu.Unlock()
-		return nil
-	}
-
-	// Re-check Complete: if setup already finished (concurrent path),
-	// don't re-run.
-	//
-	// A probe ERROR is not "not done", it is "unknown", and this guard is
-	// the only thing standing between a second caller and a re-run of a
-	// step that typically creates the admin account. Refuse rather than
-	// proceed: a failed setup step is recoverable, a silently re-run one
-	// is not.
-	done, err := r.cfg.Complete(ctx)
-	if err != nil {
-		r.mu.Unlock()
-		return fmt.Errorf("setup: completion check failed, refusing to run step: %w", err)
-	}
-	if done {
 		r.mu.Unlock()
 		return nil
 	}

--- a/battery/setup/setup.go
+++ b/battery/setup/setup.go
@@ -97,6 +97,10 @@ type Runner struct {
 	// wizard state, protected by mu
 	mu          sync.Mutex
 	currentStep int
+	// stepInFlight is set while a step runs OUTSIDE the mutex (see
+	// runStepSerialized): it preserves exactly-once step execution
+	// across the lock release.
+	stepInFlight bool
 
 	// token is the one-time URL token; zeroed after the first
 	// successful exchange so it can't be replayed from access logs.

--- a/benchmarks/apps/full/main.go
+++ b/benchmarks/apps/full/main.go
@@ -125,11 +125,15 @@ func main() {
 	// ----- Search backend wired to /search ----------------------------
 	idx := search.NewMemory()
 	fwApp.Router().GetFunc("/search", func(w http.ResponseWriter, r *http.Request) {
-		results, _ := idx.Search(r.Context(), search.Query{
+		results, err := idx.Search(r.Context(), search.Query{
 			Text:  r.URL.Query().Get("q"),
 			Type:  "posts",
 			Limit: 10,
 		})
+		if err != nil {
+			http.Error(w, "search failed", http.StatusInternalServerError)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{"results": results})
 	})

--- a/cmd/gofastr/generate_cli_openapi.go
+++ b/cmd/gofastr/generate_cli_openapi.go
@@ -241,7 +241,11 @@ func oaResolve(root, node map[string]any) (map[string]any, error) {
 			return nil, fmt.Errorf("$ref %q does not resolve to an object", ref)
 		}
 	}
-	if parts, ok := node["allOf"].([]any); ok {
+	if raw, has := node["allOf"]; has {
+		parts, ok := raw.([]any)
+		if !ok {
+			return nil, fmt.Errorf("allOf: want a list, got %T", raw)
+		}
 		merged := map[string]any{"type": "object"}
 		props := map[string]any{}
 		var required []any
@@ -677,7 +681,11 @@ func oaBuildOp(root, opNode map[string]any, baseParams []any, method, path strin
 		return op, fmt.Errorf("path template %q has placeholder {%s} with no declared path parameter", path, ph)
 	}
 
-	if body, ok := opNode["requestBody"].(map[string]any); ok {
+	if bodyNode, has := opNode["requestBody"]; has {
+		body, ok := bodyNode.(map[string]any)
+		if !ok {
+			return op, fmt.Errorf("operation %s %s: requestBody must be an object, got %T", strings.ToUpper(method), path, bodyNode)
+		}
 		body, err := oaResolve(root, body)
 		if err != nil {
 			return op, err

--- a/cmd/gofastr/harness_http.go
+++ b/cmd/gofastr/harness_http.go
@@ -85,13 +85,16 @@ func startHTTPListener(h *xharness.Harness, sess ids.SessionID, bindAddr string)
 	// chat page. The page embeds it in a meta tag so the inline JS
 	// can use it for fetch + EventSource without round-tripping
 	// through a separate /auth endpoint.
-	token, _ = enc.Encode(auth.Claims{
+	token, err = enc.Encode(auth.Claims{
 		Ver:           auth.VerCurrent,
 		JTI:           ids.NewJTI(),
 		Sessions:      []ids.SessionID{sess},
 		IdentityClass: control.IdentityHuman,
 		ExpiresAt:     time.Now().Add(24 * time.Hour).Unix(),
 	})
+	if err != nil {
+		return "", "", nil, fmt.Errorf("encode harness token: %w", err)
+	}
 
 	mux := http.NewServeMux()
 	mux.Handle("/v1/ws", wsHandler)

--- a/cmd/gofastr/harness_http.go
+++ b/cmd/gofastr/harness_http.go
@@ -51,7 +51,25 @@ func startHTTPListener(h *xharness.Harness, sess ids.SessionID, bindAddr string)
 	// callers can query it via /v1/sessions/<id>.
 	h.Catalog.RegisterEngine(h.Mux.EngineFor(sess))
 
-	// Bind first: the Host/Origin guards below must be pinned to the
+	// Token is generated FIRST, before the listener opens: it depends
+	// on nothing net.Listen produces, and encoding it after Listen
+	// meant an encode failure returned with the socket still open —
+	// repeated startup failures leaked listening sockets. The chat
+	// page embeds it in a meta tag so the inline JS can use it for
+	// fetch + EventSource without round-tripping through a separate
+	// /auth endpoint.
+	token, err = enc.Encode(auth.Claims{
+		Ver:           auth.VerCurrent,
+		JTI:           ids.NewJTI(),
+		Sessions:      []ids.SessionID{sess},
+		IdentityClass: control.IdentityHuman,
+		ExpiresAt:     time.Now().Add(24 * time.Hour).Unix(),
+	})
+	if err != nil {
+		return "", "", nil, fmt.Errorf("encode harness token: %w", err)
+	}
+
+	// Bind: the Host/Origin guards below must be pinned to the
 	// authority we actually got, which for the default "127.0.0.1:0"
 	// is only known after Listen picks the ephemeral port.
 	ln, lerr := net.Listen("tcp", bindAddr)
@@ -79,21 +97,6 @@ func startHTTPListener(h *xharness.Harness, sess ids.SessionID, bindAddr string)
 		Revocations:    revs,
 		AllowedHosts:   hosts,
 		AllowedOrigins: origins,
-	}
-
-	// Token is generated before mux so we can hand it to the SSR
-	// chat page. The page embeds it in a meta tag so the inline JS
-	// can use it for fetch + EventSource without round-tripping
-	// through a separate /auth endpoint.
-	token, err = enc.Encode(auth.Claims{
-		Ver:           auth.VerCurrent,
-		JTI:           ids.NewJTI(),
-		Sessions:      []ids.SessionID{sess},
-		IdentityClass: control.IdentityHuman,
-		ExpiresAt:     time.Now().Add(24 * time.Hour).Unix(),
-	})
-	if err != nil {
-		return "", "", nil, fmt.Errorf("encode harness token: %w", err)
 	}
 
 	mux := http.NewServeMux()

--- a/cmd/gofastr/new.go
+++ b/cmd/gofastr/new.go
@@ -155,7 +155,14 @@ func scaffoldHandler(baseDir, rawName, method, path string, overwrite bool) erro
 		return fmt.Errorf("invalid handler name: %w", err)
 	}
 	name := rawName
-	filename := filepath.Join(baseDir, strings.ToLower(name)+"_handler.go")
+	// Resolve the base dir before joining: a symlinked component would
+	// otherwise redirect the scaffolded file outside it undetected
+	// (lexical containment cannot see symlinks).
+	realDir, err := filepath.EvalSymlinks(baseDir)
+	if err != nil {
+		return fmt.Errorf("resolve base dir: %w", err)
+	}
+	filename := filepath.Join(realDir, strings.ToLower(name)+"_handler.go")
 	if !overwrite {
 		if _, err := os.Stat(filename); err == nil {
 			return fmt.Errorf("handler file already exists: %s", filename)

--- a/core-ui/check/runtimeshapes.go
+++ b/core-ui/check/runtimeshapes.go
@@ -32,18 +32,56 @@ import (
 
 // jsSource is one JavaScript file prepared for linting in two views of
 // the same length (so byte offsets and line numbers agree across all
-// three fields):
+// fields):
 //
 //   - Src   the raw source, for line numbers only;
 //   - Code  comments blanked, string literals preserved verbatim — for
 //     rules that need literal contents (selector strings, URL literals);
 //   - Blank comments AND string literals blanked — for rules that match
-//     code tokens only and must not fire on prose in a comment.
+//     code tokens only and must not fire on prose in a comment, a string
+//     literal, or a template's text (a template's ${…} bodies are code
+//     and survive). Regex literals are blanked here too, so a delimiter
+//     inside a pattern can never shift span matching.
+//
+// Call-shaped tokens are matched on Blank and their argument text is
+// recovered from Code by offset (the views are position-aligned), so
+// code-shaped text inside a string literal is never reported as a call
+// (review 5's documentation-string fixture).
 type jsSource struct {
 	Path  string
 	Src   string
 	Code  string
 	Blank string
+	// lineStarts holds the byte offset of every '\n' in Src, computed
+	// once per file; lineOf binary-searches it instead of rescanning
+	// the prefix per diagnostic. Re-measured on the reviewer's
+	// generated selector-stress files (40,000 findings / 2,080,000
+	// bytes and 80,000 findings / 4,160,000 bytes) after this index and
+	// the safeIdentEvents scope index: 0.94s and 3.23s wall, against
+	// 22.9s and 97.4s for the two backward-scan implementations on the
+	// same machine (the residual super-linearity is safeAt's per-lookup
+	// sweep of same-name events, in line with the reviewer's own
+	// baseline of 1.07s/3.90s).
+	lineStarts []int
+}
+
+// lineOf returns the 1-based line number of byte offset off. The
+// stripped views preserve offsets and newlines.
+func (f jsSource) lineOf(off int) int {
+	if off > len(f.Src) {
+		off = len(f.Src)
+	}
+	return 1 + sort.Search(len(f.lineStarts), func(i int) bool { return f.lineStarts[i] >= off })
+}
+
+func newlineOffsets(s string) []int {
+	var out []int
+	for i := range s {
+		if s[i] == '\n' {
+			out = append(out, i)
+		}
+	}
+	return out
 }
 
 // loadJSSources loads the JavaScript sources under the given roots for
@@ -112,22 +150,14 @@ func loadJSSources(roots ...string) ([]jsSource, error) {
 			return nil, fmt.Errorf("runtime-shape lint: %w", err)
 		}
 		out = append(out, jsSource{
-			Path:  f,
-			Src:   string(raw),
-			Code:  stripJSCommentsKeepStrings(string(raw)),
-			Blank: stripJSCommentsAndStrings(string(raw)),
+			Path:       f,
+			Src:        string(raw),
+			Code:       stripJSCommentsKeepStrings(string(raw)),
+			Blank:      stripJSCommentsAndStrings(string(raw)),
+			lineStarts: newlineOffsets(string(raw)),
 		})
 	}
 	return out, nil
-}
-
-// lineOf returns the 1-based line number of byte offset off, counted on
-// the raw source. The stripped views preserve offsets and newlines.
-func lineOf(src string, off int) int {
-	if off > len(src) {
-		off = len(src)
-	}
-	return 1 + strings.Count(src[:off], "\n")
 }
 
 // stripJSCommentsKeepStrings blanks the contents of JS line and block
@@ -246,19 +276,26 @@ func stripJSCommentsKeepStrings(src string) string {
 
 // matchDelimForward returns the index of the delimiter in s that pairs
 // with the opener at open ('(', '[', or '{'), skipping string and
-// template-literal contents, or -1. Callers use it on comment-stripped
-// views; regex literals are not tokenized, so a regex carrying an
-// unbalanced delimiter shifts the match (none is known in the runtime;
-// the lints that need exact spans do not cross one).
+// template-literal contents, or -1. Each delimiter kind carries its own
+// depth (review 5: one shared depth let a `[}]` inside a regex literal
+// close the enclosing call early), and a closer with no open pair of
+// its kind is skipped rather than trusted — regex literals survive
+// verbatim in the Code view, and this must still match across them.
 func matchDelimForward(s string, open int) int {
-	depth := 0
-	for i := open; i < len(s); i++ {
+	kind := delimKind(s[open])
+	var depth [3]int
+	depth[kind] = 1
+	for i := open + 1; i < len(s); i++ {
 		switch c := s[i]; c {
 		case '(', '[', '{':
-			depth++
+			depth[delimKind(c)]++
 		case ')', ']', '}':
-			depth--
-			if depth == 0 {
+			k := delimKind(c)
+			if depth[k] == 0 {
+				continue // unmatched: debris from a regex literal
+			}
+			depth[k]--
+			if k == kind && depth[k] == 0 {
 				return i
 			}
 		case '\'', '"', '`':
@@ -296,16 +333,23 @@ func matchDelimForward(s string, open int) int {
 }
 
 // matchDelimBack returns the index of the opener pairing with the ')'
-// (or ']' or '}') at i, or -1.
+// (or ']' or '}') at i, or -1. Depths are per delimiter kind, matching
+// matchDelimForward.
 func matchDelimBack(s string, i int) int {
-	depth := 0
-	for j := i; j >= 0; j-- {
+	kind := delimKind(s[i])
+	var depth [3]int
+	depth[kind] = 1
+	for j := i - 1; j >= 0; j-- {
 		switch s[j] {
 		case ')', ']', '}':
-			depth++
+			depth[delimKind(s[j])]++
 		case '(', '[', '{':
-			depth--
-			if depth == 0 {
+			k := delimKind(s[j])
+			if depth[k] == 0 {
+				continue
+			}
+			depth[k]--
+			if k == kind && depth[k] == 0 {
 				return j
 			}
 		}
@@ -313,20 +357,38 @@ func matchDelimBack(s string, i int) int {
 	return -1
 }
 
+// delimKind maps a delimiter byte to its depth slot.
+func delimKind(c byte) int {
+	switch c {
+	case '(', ')':
+		return 0
+	case '[', ']':
+		return 1
+	default:
+		return 2
+	}
+}
+
 // splitTopLevel splits s on sep (a single byte, '+' or ',') at bracket
-// depth zero and outside string/template literals. Returns the trimmed
-// operands in order.
+// depth zero and outside string/template literals. Depths are kept per
+// delimiter kind and an unmatched closer is skipped, so a `[}]` inside
+// a regex literal (verbatim in the Code view) cannot eat the depth the
+// way one shared counter did (review 5). Returns the trimmed operands
+// in order.
 func splitTopLevel(s string, sep byte) []string {
 	var parts []string
-	depth := 0
+	var depth [3]int
 	start := 0
 	i := 0
 	for i < len(s) {
 		switch c := s[i]; c {
 		case '(', '[', '{':
-			depth++
+			depth[delimKind(c)]++
 		case ')', ']', '}':
-			depth--
+			k := delimKind(c)
+			if depth[k] > 0 {
+				depth[k]--
+			}
 		case '\'', '"', '`':
 			q := c
 			i++
@@ -357,7 +419,7 @@ func splitTopLevel(s string, sep byte) []string {
 				i++
 			}
 		case sep:
-			if depth == 0 {
+			if depth[0] == 0 && depth[1] == 0 && depth[2] == 0 {
 				parts = append(parts, strings.TrimSpace(s[start:i]))
 				start = i + 1
 			}
@@ -451,6 +513,10 @@ func isJSIdent(s string) bool {
 //     like window.CSS.escape(…), the defensive spelling for browsers
 //     where the bare global is not bound — or a module-local
 //     cssEscape(…) shim;
+//   - arithmetic on a numeric literal (`index + 1` in an nth-child):
+//     every operand is an identifier, member access, or number and at
+//     least one is a number, so the value cannot carry selector
+//     metacharacters (review 5);
 //   - identifiers whose LAST assignment before the use, within the
 //     enclosing function, is from one string literal (dropdown.js's
 //     IS_OPEN, reveal.js's REVEAL_ATTR) or an escape call
@@ -458,11 +524,16 @@ func isJSIdent(s string) bool {
 //     loop variables iterating an array of string literals (boot.js's
 //     eventType): those provably hold a literal at the lookup point.
 //     A later reassignment from anything else (an attribute read, a
-//     concatenation, a compound append) revokes the status, and a
-//     same-named identifier in a different function never shares it —
-//     the safe set is per function scope, ordered by assignment
-//     position;
+//     concatenation, a compound append — review 5's
+//     `id = CSS.escape('fixed'); id = el.dataset.target`) revokes the
+//     status, and a same-named identifier in a different function
+//     never shares it — the safe set is per function scope, ordered by
+//     assignment position;
 //   - getElementById (never scanned).
+//
+// Call tokens are matched on the Blank view and the argument text is
+// recovered from Code by offset, so selector-shaped text inside a
+// string or template literal is prose and never reported (review 5).
 func LintSelectorInterpolation(roots ...string) (*Result, error) {
 	res := &Result{}
 	files, err := loadJSSources(roots...)
@@ -471,12 +542,12 @@ func LintSelectorInterpolation(roots ...string) (*Result, error) {
 	}
 	for _, f := range files {
 		events := safeIdentEvents(f.Code)
-		for _, loc := range reSelectorCall.FindAllStringIndex(f.Code, -1) {
-			if loc[0] > 0 && isJSIdentChar(f.Code[loc[0]-1]) {
+		for _, loc := range reSelectorCall.FindAllStringIndex(f.Blank, -1) {
+			if loc[0] > 0 && isJSIdentChar(f.Blank[loc[0]-1]) {
 				continue // part of a longer identifier (prefetch(, myMatches()
 			}
 			open := loc[1] - 1
-			close := matchDelimForward(f.Code, open)
+			close := matchDelimForward(f.Blank, open)
 			if close < 0 {
 				continue
 			}
@@ -485,7 +556,7 @@ func LintSelectorInterpolation(roots ...string) (*Result, error) {
 			if !ok {
 				continue
 			}
-			res.add(f.Path, lineOf(f.Src, loc[0]),
+			res.add(f.Path, f.lineOf(loc[0]),
 				fmt.Sprintf("[selector-interpolation] selector interpolates %q unescaped — a value carrying '\"]' re-targets the lookup or throws and silently drops the module's wiring; wrap it in CSS.escape() (a module-local cssEscape() shim counts)", bad))
 		}
 	}
@@ -526,11 +597,16 @@ var (
 // each tagged with its enclosing function scope. The safe set is per
 // function (plus the file's top level as one scope), so an identifier
 // escaped in one function never launders a same-named attribute read in
-// another.
+// another. Function scopes are indexed ONCE per file and resolved by
+// binary search plus a parent walk: calling enclosingFunction per event
+// walked the source backward to the file start for top-level code,
+// which made a many-assignment file quadratic (measured 22.9s user on
+// the reviewer's 40k-line generated file before this index).
 func safeIdentEvents(code string) []safeEvent {
+	scopes, parents := functionScopes(code)
 	var events []safeEvent
 	record := func(name string, pos int, safe bool) {
-		s, e := enclosingFunction(code, pos)
+		s, e := scopeOf(code, scopes, parents, pos)
 		events = append(events, safeEvent{name: name, scopeStart: s, scopeEnd: e, pos: pos, safe: safe})
 	}
 	for _, m := range reSafeAssign.FindAllStringSubmatchIndex(code, -1) {
@@ -553,6 +629,76 @@ func safeIdentEvents(code string) []safeEvent {
 		record(code[m[2]:m[3]], m[0], true)
 	}
 	return events
+}
+
+// functionScopes returns the [start, end) span of every function body
+// in code, sorted by start, and, in parallel, each scope's parent (the
+// innermost function scope containing it; -1 at the top level). One
+// left-to-right pass; non-function braces do not open scopes, exactly
+// as isFunctionOpener defines them.
+func functionScopes(code string) ([][2]int, []int) {
+	var spans [][2]int
+	var parents []int
+	var stack []int // indices of currently open function scopes
+	for i := 0; i < len(code); i++ {
+		for len(stack) > 0 && spans[stack[len(stack)-1]][1] <= i {
+			stack = stack[:len(stack)-1]
+		}
+		switch code[i] {
+		case '\'', '"', '`':
+			q := code[i]
+			i++
+			for i < len(code) {
+				if code[i] == '\\' {
+					i += 2
+					continue
+				}
+				if code[i] == q {
+					break
+				}
+				i++
+			}
+		case '{':
+			if !isFunctionOpener(code, i) {
+				continue
+			}
+			end := matchDelimForward(code, i)
+			if end < 0 {
+				end = len(code) - 1
+			}
+			parent := -1
+			if len(stack) > 0 {
+				parent = stack[len(stack)-1]
+			}
+			stack = append(stack, len(spans))
+			spans = append(spans, [2]int{i, end + 1})
+			parents = append(parents, parent)
+		}
+	}
+	return spans, parents
+}
+
+// scopeOf returns the span of the innermost function scope containing
+// pos (binary search for the rightmost scope starting at or before pos,
+// then a parent walk past scopes that closed before pos — the walk is
+// bounded by nesting depth), or the whole file at the top level. Same
+// answer as enclosingFunction, without the backward source walk.
+func scopeOf(code string, scopes [][2]int, parents []int, pos int) (int, int) {
+	lo, hi := 0, len(scopes)
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if scopes[mid][0] <= pos {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	for i := lo - 1; i >= 0; i = parents[i] {
+		if scopes[i][1] > pos {
+			return scopes[i][0], scopes[i][1]
+		}
+	}
+	return 0, len(code)
 }
 
 // rhsSafeForm reports whether an assignment RHS provably cannot carry a
@@ -642,7 +788,51 @@ func selectorOperandSafe(op string, safe func(string) bool) bool {
 	if isJSStringLiteral(op) || isJSNumericLiteral(op) {
 		return true
 	}
+	if isNumericArithExpr(op) {
+		return true // `index + 1` in an nth-child: digits only, no metacharacters
+	}
 	return isJSIdent(op) && safe(op)
+}
+
+// isNumericArithExpr reports whether s is arithmetic over a numeric
+// literal (`index + 1`, `i * 2`): every +-*/%-separated token is a
+// plain identifier or a number, and at least one operand is a number.
+// Such a value is a number at runtime and cannot carry a selector
+// metacharacter (review 5's li:nth-child(${index + 1})). Dots,
+// parentheses, quotes, and calls disqualify the token: a member access
+// or call result is not provably numeric.
+func isNumericArithExpr(s string) bool {
+	if !strings.ContainsAny(s, "+-*/%") {
+		return false
+	}
+	hasNumber := false
+	for _, tok := range strings.FieldsFunc(s, func(r rune) bool {
+		return strings.ContainsRune("+-*/% \t", r)
+	}) {
+		switch {
+		case isNumericDotToken(tok):
+			hasNumber = true
+		case isJSIdent(tok):
+			// an identifier: numeric only in combination with the literal
+		default:
+			return false
+		}
+	}
+	return hasNumber
+}
+
+// isNumericDotToken reports whether tok is a numeric literal (digits
+// and at most the decimal point).
+func isNumericDotToken(tok string) bool {
+	if tok == "" {
+		return false
+	}
+	for i := range tok {
+		if (tok[i] < '0' || tok[i] > '9') && tok[i] != '.' {
+			return false
+		}
+	}
+	return true
 }
 
 // ── lint 2: {} registry read as plain bracket access ───────────────────
@@ -674,6 +864,12 @@ func selectorOperandSafe(op string, safe func(string) bool) bool {
 //     brace-matched loop span (however long the body): enumeration
 //     keys of an in-code registry (boot.js's module-scanner loop), not
 //     attribute input;
+//   - member-chain indices other than attribute reads: cfg.name and
+//     marker.name are catalog/marker-table-borne config values, out of
+//     scope exactly as the probe's surface list scopes them. A
+//     `.dataset.` member chain (el.dataset.name, el.dataset['name'])
+//     or a getAttribute( call IS attribute-borne and is checked
+//     (review 5);
 //   - guarded reads. The guard is the own-property idiom
 //     (Object.prototype.hasOwnProperty.call(REG, … / Object.hasOwn(REG,
 //     …, optionally qualified NS.REG), including the module-local
@@ -681,12 +877,21 @@ func selectorOperandSafe(op string, safe func(string) bool) bool {
 //     it counts wherever it actually guards the read: on the read's
 //     own line or the previous non-blank line (the fixed spellings wrap
 //     onto two lines), in the condition of the if or ternary lexically
-//     enclosing the read, or through a boolean assigned exactly once in
-//     the enclosing function from that guard idiom and branched on
-//     (the compute-once spelling that avoids calling hasOwnProperty
-//     twice). A guard on a DIFFERENT registry does not count;
+//     enclosing the read (however many lines the formatter spread it
+//     over — review 5's multiline spelling), or through a boolean
+//     assigned exactly once in the enclosing function from that guard
+//     idiom and branched on (the compute-once spelling that avoids
+//     calling hasOwnProperty twice). A guard on a DIFFERENT registry
+//     does not count, and neither does `name in REG`: `in` walks the
+//     prototype chain, so with name == "constructor" it passes and the
+//     read still returns the inherited member — the operator is the
+//     bug, not a guard, and it is not recognized (review 5);
 //   - registries created with Object.create(null) (never collected:
 //     only {} initializers are).
+//
+// Registry declarations are recognized anywhere on a line, not only at
+// line start (review 5): a one-line function or minified source
+// declares `const REGISTRY={}` mid-line like any other spelling.
 //
 // The pass is linear in corpus bytes: each file is prescanned once for
 // candidate bracket reads (one regex, one pass), indexed by identifier,
@@ -732,13 +937,20 @@ func LintRegistryOwnProps(roots ...string) (*Result, error) {
 					continue
 				}
 				idx := strings.TrimSpace(f.Blank[open+1 : close])
-				// Identifier indices only: the attribute-borne name
-				// variables of the audited sites. Member-chain indices
+				// Identifier indices are the attribute-borne name
+				// variables of the audited sites. A non-identifier
+				// index is checked only when it is itself
+				// attribute-borne (el.dataset.name,
+				// REG[el.getAttribute('data-x')]); other member chains
 				// (cfg.name, marker.name) are catalog/marker-table-borne
 				// config values, out of scope exactly as the probe's
-				// surface list scopes them; numeric and template indices
-				// carry no dynamic name.
-				if !isJSIdent(idx) || isJSNumericLiteral(idx) {
+				// surface list scopes them, and numeric and template
+				// indices carry no dynamic name.
+				if !isJSIdent(idx) {
+					if isJSNumericLiteral(idx) || !attrBorneIndex(idx) {
+						continue
+					}
+				} else if isJSNumericLiteral(idx) {
 					continue
 				}
 				if isCompositeIndex(idx, composite) {
@@ -753,10 +965,10 @@ func LintRegistryOwnProps(roots ...string) (*Result, error) {
 				if registryAccessIsDelete(f.Blank, start) {
 					continue
 				}
-				if registryGuardNearby(f.Blank, f.Src, name, start, guards) {
+				if registryGuardNearby(f, name, start, guards) {
 					continue
 				}
-				res.add(f.Path, lineOf(f.Src, start),
+				res.add(f.Path, f.lineOf(start),
 					fmt.Sprintf("[registry-own-prop] %s[...] reads a {} registry through the prototype chain — an attribute-borne name like \"constructor\" resolves to an Object.prototype member and passes the truthiness gate; read it as an own property (Object.prototype.hasOwnProperty.call(%s, name), the idiom computed.js uses)", name, name))
 			}
 		}
@@ -781,13 +993,30 @@ func bracketReads(blank string) map[string][]int {
 }
 
 // Registry-declaration shapes, matched on the blank view so a '{}' in
-// a string literal cannot declare anything.
+// a string literal cannot declare anything. Each shape is recognized
+// anywhere on a line, not only at line start (review 5): a one-line
+// function or minified source declares its registry mid-line like any
+// other spelling.
 var (
-	reRegistryTopDecl  = regexp.MustCompile(`(?m)^\s*(?:const|let|var)\s+(\w+)\s*=\s*(?:\w+(?:\.\w+)*\s*\|\|\s*)?\{\}\s*[;,)]`)
-	reRegistryNSDecl   = regexp.MustCompile(`(?m)^\s*(?:\w+\s*\.\s*)*(\w+)\s*\.\s*(\w+)\s*=\s*(?:\w+(?:\.\w+)*\s*\|\|\s*)?\{\}\s*[;,]`)
+	reRegistryTopDecl  = regexp.MustCompile(`\b(?:const|let|var)\s+(\w+)\s*=\s*(?:\w+(?:\.\w+)*\s*\|\|\s*)?\{\}\s*[;,)]`)
+	reRegistryNSDecl   = regexp.MustCompile(`(?:\w+\s*\.\s*)*(\w+)\s*\.\s*(\w+)\s*=\s*(?:\w+(?:\.\w+)*\s*\|\|\s*)?\{\}\s*[;,]`)
 	reRegistryOrAssign = regexp.MustCompile(`\(\s*(?:\w+\s*\.\s*)*(\w+)\s*\.\s*(\w+)\s*\|\|=\s*\{\}\s*\)`)
-	reRegistryPropDecl = regexp.MustCompile(`(?m)^\s*(\w+)\s*:\s*\{\}\s*,?\s*$`)
+	reRegistryPropDecl = regexp.MustCompile(`\b(\w+)\s*:\s*\{\}\s*[,}]`)
 )
+
+// reAttrIndex matches an attribute-borne index expression: a .dataset
+// member chain (dot or bracket spelling — the bracket's string literal
+// is blank in this view, so only the shape is matched) or a
+// getAttribute( call.
+var reAttrIndex = regexp.MustCompile(`\.\s*dataset\s*(?:\.|\[)|getAttribute\s*\(`)
+
+// attrBorneIndex reports whether a non-identifier bracket index is
+// itself attribute-borne (review 5's REGISTRY[el.dataset.name]): such
+// an index is checked exactly like an identifier index; every other
+// member chain (cfg.name) stays the declared silence.
+func attrBorneIndex(idx string) bool {
+	return reAttrIndex.MatchString(idx)
+}
 
 // collectRegistryNames gathers every identifier declared as a plain {}
 // across the corpus. Registries are cross-file in this runtime (kernel
@@ -1010,9 +1239,12 @@ func ownHelpers(blank string) []string {
 // patterns, compiled once per lint run, whose captured receiver is then
 // compared against the registry name — no per-name regex compilation,
 // so a corpus of R registry names per file costs zero extra compiles.
+// The `in` operator is deliberately absent (review 5): it walks the
+// prototype chain, so `name in REG` passes for name == "constructor"
+// and the read still returns the inherited member — the operator is
+// the bug this lint exists for, not a guard against it.
 type guardMatcher struct {
 	call   *regexp.Regexp // hasOwnProperty.call(RECV, / Object.hasOwn(RECV,
-	in     *regexp.Regexp // k in RECV
 	init   *regexp.Regexp // BOOL = <call idiom>(RECV,
 	helper []*regexp.Regexp
 }
@@ -1023,7 +1255,6 @@ const receiverPattern = `(?:\w+\s*\.\s*)*\w+`
 func newGuardMatcher(helpers []string) *guardMatcher {
 	g := &guardMatcher{
 		call: regexp.MustCompile(`(?:hasOwnProperty\s*\.\s*call|Object\s*\.\s*hasOwn)\s*\(\s*(` + receiverPattern + `)\s*,`),
-		in:   regexp.MustCompile(`\bin\s+(` + receiverPattern + `)\b`),
 	}
 	callee := `(?:hasOwnProperty\s*\.\s*call|Object\s*\.\s*hasOwn`
 	for _, h := range helpers {
@@ -1050,8 +1281,7 @@ func receiverIs(recv, name string) bool {
 }
 
 // guarded reports whether text carries the own-property guard for the
-// registry name: the call idiom, a module-local own() helper, or the
-// `k in REG` membership check.
+// registry name: the call idiom or a module-local own() helper.
 func (g *guardMatcher) guarded(text, name string) bool {
 	for _, m := range g.call.FindAllStringSubmatch(text, -1) {
 		if receiverIs(m[1], name) {
@@ -1063,11 +1293,6 @@ func (g *guardMatcher) guarded(text, name string) bool {
 			if receiverIs(m[1], name) {
 				return true
 			}
-		}
-	}
-	for _, m := range g.in.FindAllStringSubmatch(text, -1) {
-		if receiverIs(m[1], name) {
-			return true
 		}
 	}
 	return false
@@ -1084,19 +1309,20 @@ var reIfLine = regexp.MustCompile(`\bif\s*\(`)
 //     fixed spellings wrap onto two lines) — including that line's if
 //     condition referencing a guard boolean;
 //   - in the condition of the if or ternary that lexically encloses
-//     the read;
+//     the read (however many lines the formatter spread that condition
+//     over — review 5's multiline spelling);
 //   - through a boolean assigned exactly once in the enclosing
 //     function from the guard idiom (const known =
 //     hasOwnProperty.call(REG, x)) and referenced in one of those
 //     conditions: the compute-once spelling. A boolean initialized
 //     from a guard on a DIFFERENT registry is not a guard for this
 //     one, and a boolean from another function never applies.
-func registryGuardNearby(blank, src, name string, pos int, g *guardMatcher) bool {
-	if cond := enclosingCondition(blank, pos); g.guarded(cond, name) || g.guardBooleanIn(blank, pos, cond, name) {
+func registryGuardNearby(f jsSource, name string, pos int, g *guardMatcher) bool {
+	if cond := enclosingCondition(f.Blank, pos); g.guarded(cond, name) || g.guardBooleanIn(f.Blank, pos, cond, name) {
 		return true
 	}
-	line := lineOf(src, pos)
-	lines := strings.Split(blank, "\n")
+	line := f.lineOf(pos)
+	lines := strings.Split(f.Blank, "\n")
 	check := func(n int) bool {
 		if n < 1 || n > len(lines) {
 			return false
@@ -1114,7 +1340,7 @@ func registryGuardNearby(blank, src, name string, pos int, g *guardMatcher) bool
 			// The previous non-blank line's if condition referencing a
 			// compute-once guard boolean (`if (!known) return null;`
 			// above the read).
-			return reIfLine.MatchString(lines[n-1]) && g.guardBooleanIn(blank, pos, lines[n-1], name)
+			return reIfLine.MatchString(lines[n-1]) && g.guardBooleanIn(f.Blank, pos, lines[n-1], name)
 		}
 	}
 	return false
@@ -1257,17 +1483,28 @@ func skipSpaceBack(s string, i int) int {
 // response body and mounts it as markup with no .ok/.status check
 // anywhere in the chain.
 //
-// Bug class: within one promise chain (the fetch( call plus its .then(
-// continuations up to the statement boundary), a .text()/.json()
-// result reaches innerHTML/outerHTML/insertAdjacentHTML or a
-// mount/swap-named helper while no .ok (or .status) gate appears. An
-// error body routinely reflects the request URL and attacker-influenced
-// path segments; mounting it replaces live page markup with reflected
+// Bug class: within one promise chain (the fetch( call plus its
+// .then( / ?.then( / .catch( / ?.catch( / .finally( continuations up
+// to the statement boundary — optional chaining is a chain step like
+// any other, review 5), a .text()/.json() result reaches a DOM-markup
+// mount while no .ok (or .status) gate appears. An error body
+// routinely reflects the request URL and attacker-influenced path
+// segments; mounting it replaces live page markup with reflected
 // output. Probe: TestResponseHTMLMountedOnlyAfterOK, whose control
 // group (rpc.js, intercept.js, infinitescroll.js, poll.js) documents
 // the convention "an HTTP error must reach .catch, never the mount".
 // The audited fix (e936f791) gated sortablelist's conflict-recovery
 // refresh with `if (!r.ok) throw`.
+//
+// A mount is: an innerHTML/outerHTML assignment — simple or compound
+// (`=`, `+=`, every compound operator; review 5's innerHTML +=), an
+// insertAdjacentHTML( call, a helper named exactly `mount`, a helper
+// whose name starts with `mount` followed by an upper-case letter
+// (mountWidget), or one of the runtime's own swap helpers, grepped
+// from core-ui/runtime/src and frag: swapPane (panehost.js),
+// swapAtSlot, swapShell (nav.js). An explicit list, because
+// "any identifier containing mount or swap" reported string transforms
+// like swapCase( (review 5) — a name is not a markup sink.
 //
 // Silent on:
 //   - chains gated on the response: a whole-token .ok or .status read
@@ -1312,7 +1549,7 @@ func LintResponseMountedAfterOK(roots ...string) (*Result, error) {
 			if !reHTMLMount.MatchString(scan) {
 				continue
 			}
-			res.add(f.Path, lineOf(f.Src, loc[0]),
+			res.add(f.Path, f.lineOf(loc[0]),
 				"[response-mounted-unchecked] fetch chain reads the body (.text()/.json()) and mounts it via innerHTML/mount with no .ok/.status check in the chain — an error body reflects the request and replaces live markup; gate it like rpc.js/poll.js (if (!r.ok) throw …)")
 		}
 	}
@@ -1322,8 +1559,20 @@ func LintResponseMountedAfterOK(roots ...string) (*Result, error) {
 var (
 	reFetchCall = regexp.MustCompile(`\bfetch\s*\(`)
 	reBodyRead  = regexp.MustCompile(`\.(?:text|json)\s*\(\s*\)`)
-	reHTMLMount = regexp.MustCompile(`(?:innerHTML|outerHTML)\s*=[^=]|insertAdjacentHTML\s*\(` +
-		`|\b\w*(?:mount|swap)\w*\s*\(`)
+	// reHTMLMount matches a DOM-markup mount: any assignment operator
+	// (simple or compound) to innerHTML/outerHTML, insertAdjacentHTML(,
+	// a helper named exactly `mount`, a helper whose name starts with
+	// `mount` + an upper-case letter, or one of the runtime's own swap
+	// helpers (swapPane in panehost.js; swapAtSlot, swapShell in
+	// nav.js). An explicit list — `swapCase(` and friends are string
+	// transforms, not markup sinks (review 5).
+	reHTMLMount = regexp.MustCompile(`(?:innerHTML|outerHTML)\s*(?:\?\?=|\*\*=|>>>=|<<=|>>=|&&=|\|\|=|\+=|-=|\*=|/=|%=|&=|\|=|\^=|=[^=])` +
+		`|insertAdjacentHTML\s*\(` +
+		`|\bmount\s*\(` +
+		`|\bmount[A-Z]\w*\s*\(` +
+		`|\bswapPane\s*\(` +
+		`|\bswapAtSlot\s*\(` +
+		`|\bswapShell\s*\(`)
 )
 
 var reThenIdent = regexp.MustCompile(`\.\s*then\s*\(\s*(\w+)\s*\)`)
@@ -1448,10 +1697,16 @@ func insideIfCondition(s string, pos int) bool {
 
 // chainEnd extends a fetch call's closing paren through its .then(…)
 // (and ?.then(…), .catch(…), .finally(…)) continuations and returns the
-// index of the last closing paren of the chain.
+// index of the last closing paren of the chain. A continuation may
+// start with either '.' or '?.' — review 5's fetch(…)?.then(…)
+// spelled the first link with the optional-chaining token, and the
+// chain must not end before it.
 func chainEnd(blank string, close int) int {
 	for {
 		i := skipSpace(blank, close+1)
+		if i+1 < len(blank) && blank[i] == '?' && blank[i+1] == '.' {
+			i++ // past the '?'; the '.' handling below takes it from here
+		}
 		if i >= len(blank) || blank[i] != '.' {
 			return close
 		}
@@ -1535,9 +1790,10 @@ func templateOperands(tpl string) []string {
 // name-shape gate.
 //
 // Bug class: a fetch( URL, an XMLHttpRequest .open( URL, or an
-// assignment to src/href, built by concatenating a literal that ends
-// in "/" with el.getAttribute('data-*'), el.dataset.*, or a variable
-// assigned from one of those, while no gate of that value appears in
+// assignment to src/href, built by concatenating or interpolating a
+// literal that ends in "/" with el.getAttribute('data-*'),
+// el.dataset.name, el.dataset['name'], or a variable assigned from one
+// of those, while no gate of that value precedes the construction in
 // the enclosing function. The browser normalizes "../" segments and
 // re-targets the request onto any same-origin route, past the handler
 // that owns the prefix — with the page's CSRF token attached on POSTs.
@@ -1546,13 +1802,27 @@ func templateOperands(tpl string) []string {
 // audited fix (e936f791) gated _kilnPost with
 // /^[A-Za-z0-9_-]+$/.test(tool).
 //
+// Call tokens are matched on the Blank view and the URL expression
+// text is recovered from Code by offset, so fetch-shaped text inside a
+// string or template literal is prose and never reported (review 5).
+//
 // Silent on:
-//   - gates in the enclosing function: an anchored regex test
+//   - gates that PRECEDE the URL construction in source order within
+//     the enclosing function (review 5: a validating regex after the
+//     fetch does not un-send the request): an anchored regex test
 //     (/^[A-Za-z0-9_-]+$/.test(v)), a SAFE_NAME-style constant
 //     assigned a regex literal then .test(v), or an allowlist
 //     membership (X[v] inside an if condition, X.has(v)) — a
 //     server-emitted manifest or Set stops re-targeting exactly like a
-//     name-shape class;
+//     name-shape class. A regex gate counts only when the literal is
+//     anchored (^…$) and its body carries no ".", "\s", "\S", "\W", or
+//     negated class "[^" (review 5: /./ accepts "../admin", and a dot
+//     anywhere admits path separators);
+//   - numeric coercion of the value (Number(v), parseInt(v),
+//     parseFloat(v)): the result is a number or NaN and can never
+//     spell a traversal segment (review 5);
+//   - a literal beginning with "#": it builds a fragment, not a
+//     request path, and no same-origin route is re-targeted (review 5);
 //   - values used only as query parameters (the adjacent literal does
 //     not end in "/") or wrapped in encodeURIComponent(…);
 //   - whole-URL uses (fetch(attr)) with no path-literal concatenation.
@@ -1565,11 +1835,14 @@ func LintAttributePathSegments(roots ...string) (*Result, error) {
 	for _, f := range files {
 		attrVars := attributeBorneIdents(f.Code)
 		regexConsts := regexConstNames(f.Code)
-		for _, site := range pathBuildSites(f.Code) {
+		for _, site := range pathBuildSites(f.Blank, f.Code) {
 			for _, pair := range concatPathPairs(site.expr) {
 				lit, val := pair[0], pair[1]
 				if !pathLiteralEndsInSlash(lit) {
 					continue
+				}
+				if fragmentLiteral(lit) {
+					continue // '#…' sets a fragment; no request path is built
 				}
 				v := attributeBorneValue(val, attrVars)
 				if v == "" {
@@ -1578,7 +1851,7 @@ func LintAttributePathSegments(roots ...string) (*Result, error) {
 				if attrPathGated(f.Code, v, regexConsts, site.start) {
 					continue
 				}
-				res.add(f.Path, lineOf(f.Src, site.start),
+				res.add(f.Path, f.lineOf(site.start),
 					fmt.Sprintf("[attr-path-segment] %s is attribute-borne and joined into a request URL path after %q with no name-shape gate — \"../\" re-targets the request onto any same-origin route; gate it like loadModule (/^[A-Za-z0-9_-]+$/.test(%s)) or an allowlist check", v, lit, v))
 			}
 		}
@@ -1595,42 +1868,54 @@ type pathSite struct {
 
 var (
 	reFetchOpen     = regexp.MustCompile(`\bfetch\s*\(`)
-	reXHROpen       = regexp.MustCompile(`\bopen\s*\(\s*['"][A-Z]+['"]\s*,`)
+	reOpenCall      = regexp.MustCompile(`\bopen\s*\(`)
+	reHTTPMethod    = regexp.MustCompile(`^['"][A-Z]+['"]$`)
 	reSrcHrefAssign = regexp.MustCompile(`\.(?:src|href)\s*=[^=\n]`)
 )
 
 // pathBuildSites finds the URL expressions of fetch calls, XHR .open(
-// calls, and src/href assignments.
-func pathBuildSites(code string) []pathSite {
+// calls, and src/href assignments. Call tokens are matched on the
+// blank view (strings and comments cannot spell a call); delimiter
+// spans are computed there too, and the argument text is recovered
+// from the code view by offset so literals stay visible. The XHR
+// method literal is verified in the code text — the blank view cannot
+// see 'GET'.
+func pathBuildSites(blank, code string) []pathSite {
 	var sites []pathSite
-	for _, loc := range reFetchOpen.FindAllStringIndex(code, -1) {
-		if loc[0] > 0 && isJSIdentChar(code[loc[0]-1]) {
+	for _, loc := range reFetchOpen.FindAllStringIndex(blank, -1) {
+		if loc[0] > 0 && isJSIdentChar(blank[loc[0]-1]) {
 			continue // prefetch(, myFetch(
 		}
 		open := loc[1] - 1
-		close := matchDelimForward(code, open)
+		close := matchDelimForward(blank, open)
 		if close < 0 {
 			continue
 		}
-		if first := firstArgument(code, open, close); first != "" {
+		if first := firstArgument(code, blank, open, close); first != "" {
 			sites = append(sites, pathSite{start: open + 1, expr: first})
 		}
 	}
-	for _, loc := range reXHROpen.FindAllStringIndex(code, -1) {
-		open := strings.LastIndexByte(code[loc[0]:loc[1]], '(') + loc[0]
-		close := matchDelimForward(code, open)
+	for _, loc := range reOpenCall.FindAllStringIndex(blank, -1) {
+		if loc[0] > 0 && isJSIdentChar(blank[loc[0]-1]) {
+			continue // reopen(, myOpen(
+		}
+		open := loc[1] - 1
+		close := matchDelimForward(blank, open)
 		if close < 0 {
 			continue
 		}
-		comma := topLevelComma(code, open+1, close)
+		comma := topLevelComma(blank, open+1, close)
 		if comma < 0 {
 			continue
 		}
-		if second := firstArgument(code, comma, close); second != "" {
+		if !reHTTPMethod.MatchString(strings.TrimSpace(code[open+1 : comma])) {
+			continue // not an XHR open('GET', url)
+		}
+		if second := firstArgument(code, blank, comma, close); second != "" {
 			sites = append(sites, pathSite{start: comma + 1, expr: second})
 		}
 	}
-	for _, loc := range reSrcHrefAssign.FindAllStringIndex(code, -1) {
+	for _, loc := range reSrcHrefAssign.FindAllStringIndex(blank, -1) {
 		rhsStart := loc[1] - 1 // include the char [^=] consumed (the value's first byte)
 		if end := statementEnd(code, rhsStart); end > rhsStart {
 			sites = append(sites, pathSite{start: rhsStart, expr: strings.TrimSpace(code[rhsStart:end])})
@@ -1640,10 +1925,12 @@ func pathBuildSites(code string) []pathSite {
 }
 
 // firstArgument returns the text of the first call argument between
-// open (a '(' or ',') and close (its matching closer), or "" when the
-// argument region is empty.
-func firstArgument(code string, open, close int) string {
-	comma := topLevelComma(code, open+1, close)
+// open (a '(' or ',') and close (its matching closer): the argument
+// boundary is found on the blank view (a comma inside a string literal
+// is not a separator), the text is read from the code view. Returns ""
+// when the argument region is empty.
+func firstArgument(code, blank string, open, close int) string {
+	comma := topLevelComma(blank, open+1, close)
 	end := close
 	if comma >= 0 {
 		end = comma
@@ -1719,6 +2006,8 @@ func statementEnd(code string, from int) int {
 	return len(code)
 }
 
+// pathLiteralEndsInSlash reports whether lit is a string literal whose
+// value ends in "/" — the path-prefix position.
 func pathLiteralEndsInSlash(lit string) bool {
 	if !isJSStringLiteral(lit) {
 		return false
@@ -1726,14 +2015,27 @@ func pathLiteralEndsInSlash(lit string) bool {
 	return strings.HasSuffix(lit[1:len(lit)-1], "/")
 }
 
+// fragmentLiteral reports whether lit is a string literal beginning
+// with "#": everything after it is a fragment, and no request path is
+// built (review 5's '#/settings/' href).
+func fragmentLiteral(lit string) bool {
+	return isJSStringLiteral(lit) && strings.HasPrefix(lit[1:len(lit)-1], "#")
+}
+
 // reAttrRead matches the attribute-borne sources: getAttribute('data-…')
-// and .dataset.member.
-var reAttrRead = regexp.MustCompile(`getAttribute\s*\(\s*['"]data-[A-Za-z0-9_-]+['"]\s*\)|\.\s*dataset\s*\.\s*\w+`)
+// and .dataset.member, in both the dot and the bracket spelling
+// (el.dataset['tool'] — review 5).
+var reAttrRead = regexp.MustCompile(`getAttribute\s*\(\s*['"]data-[A-Za-z0-9_-]+['"]\s*\)` +
+	`|\.\s*dataset\s*\.\s*\w+` +
+	`|\.\s*dataset\s*\[\s*['"][A-Za-z0-9_-]+['"]\s*\]`)
 
 // reAttrVarAssign matches an identifier assigned from an attribute read
 // on the same line (const tool = el.getAttribute('data-kiln-tool') || ”).
 // The (>?) capture rejects arrow parameters (k => el.getAttribute(…)).
-var reAttrVarAssign = regexp.MustCompile(`(\w+)\s*=(>?)\s*([^;\n=]*)(?:getAttribute\s*\(\s*['"]data-[A-Za-z0-9_-]+['"]\s*\)|\.\s*dataset\s*\.\s*\w+)`)
+var reAttrVarAssign = regexp.MustCompile(`(\w+)\s*=(>?)\s*([^;\n=]*)(?:` +
+	`getAttribute\s*\(\s*['"]data-[A-Za-z0-9_-]+['"]\s*\)` +
+	`|\.\s*dataset\s*\.\s*\w+` +
+	`|\.\s*dataset\s*\[\s*['"][A-Za-z0-9_-]+['"]\s*\])`)
 
 // attributeBorneIdents returns identifiers assigned (same line) from a
 // data-* attribute read.
@@ -1748,14 +2050,24 @@ func attributeBorneIdents(code string) map[string]bool {
 	return set
 }
 
+// reNumericCoerce matches the numeric coercions: Number(v),
+// parseInt(v), parseFloat(v).
+var reNumericCoerce = regexp.MustCompile(`^(?:Number|parseInt|parseFloat)\s*\(`)
+
 // attributeBorneValue returns the value text when val is an
 // attribute-borne identifier or contains an attribute read directly;
-// "" when the value is neither (or is encodeURIComponent-wrapped).
+// "" when the value is neither — or is sanitized: wrapped in
+// encodeURIComponent(…), or numerically coerced (Number/parseInt/
+// parseFloat of the read yields a number or NaN, never a traversal
+// segment — review 5).
 func attributeBorneValue(val string, attrVars map[string]bool) string {
 	if strings.Contains(val, "encodeURIComponent(") {
 		return ""
 	}
 	v := strings.TrimSpace(val)
+	if reNumericCoerce.MatchString(v) {
+		return ""
+	}
 	if reAttrRead.MatchString(v) {
 		return v
 	}
@@ -1766,35 +2078,41 @@ func attributeBorneValue(val string, attrVars map[string]bool) string {
 }
 
 // reRegexConst matches const/let/var declarations initialized from a
-// regex literal (SAFE_NAME-style gate constants).
-var reRegexConst = regexp.MustCompile(`(?:const|let|var)\s+(\w+)\s*=\s*/`)
+// regex literal (SAFE_NAME-style gate constants) and captures the
+// literal, so the gate can be validated like an inline one.
+var reRegexConst = regexp.MustCompile(`(?:const|let|var)\s+(\w+)\s*=\s*(/[^\n]+?/[a-z]*)`)
 
-func regexConstNames(code string) map[string]bool {
-	set := map[string]bool{}
+func regexConstNames(code string) map[string]string {
+	set := map[string]string{}
 	for _, m := range reRegexConst.FindAllStringSubmatch(code, -1) {
-		set[m[1]] = true
+		set[m[1]] = m[2]
 	}
 	return set
 }
 
 // attrPathGated reports whether a name-shape or allowlist gate on
-// value v appears in the enclosing function of the site at pos. For an
-// inline attribute read (not a bare variable) any regex .test( in the
-// function counts: there is no variable to match.
-func attrPathGated(code, v string, regexConsts map[string]bool, pos int) bool {
-	start, end := enclosingFunction(code, pos)
-	body := code[start:end]
+// value v appears in the enclosing function of the site at pos BEFORE
+// pos in source order — the URL is built at pos, and a gate that runs
+// later cannot un-send the request (review 5). For an inline attribute
+// read (not a bare variable) any regex .test( counts: there is no
+// variable to match.
+func attrPathGated(code, v string, regexConsts map[string]string, pos int) bool {
+	start, _ := enclosingFunction(code, pos)
+	body := code[start:pos]
 	ident := `\w+`
 	if isJSIdent(v) {
 		ident = regexp.QuoteMeta(v)
 	}
-	// Regex-literal gate: /^[A-Za-z0-9_-]+$/.test(v)
-	if regexp.MustCompile(`/[^\n/]+/[a-z]*\s*\.\s*test\s*\(\s*` + ident + `\b`).MatchString(body) {
-		return true
+	// Regex-literal gate: /^[A-Za-z0-9_-]+$/.test(v) — anchored and
+	// metacharacter-free only; /./ accepts "../admin".
+	for _, m := range regexp.MustCompile(`(/[^/\n]+/[a-z]*)\s*\.\s*test\s*\(\s*`+ident+`\b`).FindAllStringSubmatch(body, -1) {
+		if regexGateAnchored(m[1]) {
+			return true
+		}
 	}
 	// SAFE_NAME-style constant holding a regex literal.
 	for _, m := range regexp.MustCompile(`(\w+)\s*\.\s*test\s*\(\s*`+ident+`\b`).FindAllStringSubmatch(body, -1) {
-		if regexConsts[m[1]] {
+		if lit, ok := regexConsts[m[1]]; ok && regexGateAnchored(lit) {
 			return true
 		}
 	}
@@ -1803,6 +2121,31 @@ func attrPathGated(code, v string, regexConsts map[string]bool, pos int) bool {
 		return true
 	}
 	return regexp.MustCompile(`\w+\.has\s*\(\s*` + ident + `\b`).MatchString(body)
+}
+
+// regexGateAnchored reports whether a regex literal (with its slashes,
+// optionally flagged) accepts a bounded name shape only: anchored at
+// both ends (^…$) and carrying no ".", "\s", "\S", "\W", or negated
+// class "[^" — each of those admits path separators or arbitrary
+// characters (review 5: /./ accepts "../admin").
+func regexGateAnchored(lit string) bool {
+	if len(lit) < 3 || lit[0] != '/' {
+		return false
+	}
+	end := strings.LastIndexByte(lit, '/')
+	if end <= 0 {
+		return false
+	}
+	body := lit[1:end]
+	if !strings.HasPrefix(body, "^") || !strings.HasSuffix(body, "$") {
+		return false
+	}
+	for _, forbidden := range []string{".", `\s`, `\S`, `\W`, "[^"} {
+		if strings.Contains(body, forbidden) {
+			return false
+		}
+	}
+	return true
 }
 
 // enclosingFunction returns the [start, end) span of the innermost

--- a/core-ui/check/runtimeshapes.go
+++ b/core-ui/check/runtimeshapes.go
@@ -447,14 +447,21 @@ func isJSIdent(s string) bool {
 //   - literal-only selectors (no non-literal operand, no ${…});
 //   - a bare variable argument (querySelector(sel)) — provenance is
 //     not traceable line-locally, and the repo has no such site;
-//   - values wrapped in CSS.escape(…) or a module-local cssEscape(…)
-//     shim, and identifiers assigned from either (rangeslider.js's
-//     `const sel = CSS.escape(id)` pattern);
-//   - identifiers provably holding string literals: a const/let/var
-//     initialized from one string literal (dropdown.js's IS_OPEN,
-//     reveal.js's REVEAL_ATTR), and for-of loop variables iterating an
-//     array of string literals (boot.js's eventType) — a literal cannot
-//     carry `"]` from input;
+//   - values wrapped in CSS.escape(…) — including dotted references
+//     like window.CSS.escape(…), the defensive spelling for browsers
+//     where the bare global is not bound — or a module-local
+//     cssEscape(…) shim;
+//   - identifiers whose LAST assignment before the use, within the
+//     enclosing function, is from one string literal (dropdown.js's
+//     IS_OPEN, reveal.js's REVEAL_ATTR) or an escape call
+//     (rangeslider.js's `const sel = CSS.escape(id)`), and for-of
+//     loop variables iterating an array of string literals (boot.js's
+//     eventType): those provably hold a literal at the lookup point.
+//     A later reassignment from anything else (an attribute read, a
+//     concatenation, a compound append) revokes the status, and a
+//     same-named identifier in a different function never shares it —
+//     the safe set is per function scope, ordered by assignment
+//     position;
 //   - getElementById (never scanned).
 func LintSelectorInterpolation(roots ...string) (*Result, error) {
 	res := &Result{}
@@ -463,7 +470,7 @@ func LintSelectorInterpolation(roots ...string) (*Result, error) {
 		return nil, err
 	}
 	for _, f := range files {
-		safe := selectorSafeIdents(f.Code)
+		events := safeIdentEvents(f.Code)
 		for _, loc := range reSelectorCall.FindAllStringIndex(f.Code, -1) {
 			if loc[0] > 0 && isJSIdentChar(f.Code[loc[0]-1]) {
 				continue // part of a longer identifier (prefetch(, myMatches()
@@ -473,6 +480,7 @@ func LintSelectorInterpolation(roots ...string) (*Result, error) {
 			if close < 0 {
 				continue
 			}
+			safe := func(name string) bool { return safeAt(events, name, loc[0]) }
 			bad, ok := selectorUnsafeOperand(f.Code[open+1:close], safe)
 			if !ok {
 				continue
@@ -486,32 +494,106 @@ func LintSelectorInterpolation(roots ...string) (*Result, error) {
 
 var reSelectorCall = regexp.MustCompile(`(?:querySelectorAll|querySelector|closest|matches)\s*\(`)
 
-// selectorSafeIdents returns identifiers that provably cannot carry a
-// selector metacharacter: escape results, string-literal constants, and
-// for-of variables over arrays of string literals.
-var safeIdentRes = []*regexp.Regexp{
-	// const/let/var X = CSS.escape(…) / cssEscape(…)
-	regexp.MustCompile(`(?:const|let|var)\s+(\w+)\s*=\s*(?:CSS\.escape|cssEscape)\s*\(`),
-	// const/let/var X = 'literal' / "literal"
-	regexp.MustCompile(`(?:const|let|var)\s+(\w+)\s*=\s*(?:'[^']*'|"[^"]*")\s*[;,\n]`),
-	// for (const X of ['a', 'b']) — every element a string literal
-	regexp.MustCompile(`for\s*\(\s*(?:const|let|var)\s+(\w+)\s+of\s*\[((?:\s*(?:'[^']*'|"[^"]*")\s*,?)*)\]\s*\)`),
+// safeEvent is one assignment to an identifier, with the enclosing
+// function scope it happened in: an init from a string literal or an
+// escape call forms the safe set at that point; any later assignment
+// from something else (an attribute read, a concatenation, a compound
+// append) revokes it.
+type safeEvent struct {
+	name                 string
+	scopeStart, scopeEnd int
+	pos                  int
+	safe                 bool
 }
 
-func selectorSafeIdents(code string) map[string]bool {
-	safe := map[string]bool{}
-	for _, re := range safeIdentRes {
-		for _, m := range re.FindAllStringSubmatch(code, -1) {
-			safe[m[1]] = true
+var (
+	// reSafeAssign matches identifier assignments with their RHS up to
+	// the statement end. The (>?) capture rejects arrow parameters
+	// (k => …); an RHS beginning '=' is a misread == / === and is
+	// dropped in code.
+	reSafeAssign = regexp.MustCompile(`\b(\w+)\s*=(>?)\s*([^;\n]*)`)
+	// reSafeCompound marks compound appends (sel += v): a reassignment
+	// from a non-literal.
+	reSafeCompound = regexp.MustCompile(`\b(\w+)\s*(?:\+|-|\*|/|%|&&|\|\||\?\?|\*\*)=`)
+	// for (const X of ['a', 'b']) — every element a string literal.
+	reSafeForOf = regexp.MustCompile(`for\s*\(\s*(?:const|let|var)\s+(\w+)\s+of\s*\[((?:\s*(?:'[^']*'|"[^"]*")\s*,?)*)\]\s*\)`)
+	// reEscapeCall matches an escape call at the start of an operand:
+	// CSS.escape(, window.CSS.escape(, this.CSS.escape(, cssEscape(.
+	reEscapeCall = regexp.MustCompile(`^(?:(?:\w+\.)*CSS\.escape|cssEscape)\s*\(`)
+)
+
+// safeIdentEvents collects the ordered assignment events of the file,
+// each tagged with its enclosing function scope. The safe set is per
+// function (plus the file's top level as one scope), so an identifier
+// escaped in one function never launders a same-named attribute read in
+// another.
+func safeIdentEvents(code string) []safeEvent {
+	var events []safeEvent
+	record := func(name string, pos int, safe bool) {
+		s, e := enclosingFunction(code, pos)
+		events = append(events, safeEvent{name: name, scopeStart: s, scopeEnd: e, pos: pos, safe: safe})
+	}
+	for _, m := range reSafeAssign.FindAllStringSubmatchIndex(code, -1) {
+		name := code[m[2]:m[3]]
+		if jsKeywords[name] || m[4] != m[5] { // arrow parameter, not an assignment
+			continue
+		}
+		rhs := strings.TrimSpace(code[m[6]:m[7]])
+		if strings.HasPrefix(rhs, "=") { // == / === read through the '='
+			continue
+		}
+		record(name, m[2], rhsSafeForm(rhs))
+	}
+	for _, m := range reSafeCompound.FindAllStringSubmatchIndex(code, -1) {
+		if name := code[m[2]:m[3]]; !jsKeywords[name] {
+			record(name, m[0], false)
 		}
 	}
-	return safe
+	for _, m := range reSafeForOf.FindAllStringSubmatchIndex(code, -1) {
+		record(code[m[2]:m[3]], m[0], true)
+	}
+	return events
+}
+
+// rhsSafeForm reports whether an assignment RHS provably cannot carry a
+// selector metacharacter: exactly one string literal, or an escape call.
+func rhsSafeForm(rhs string) bool {
+	if rhs == "" {
+		return false
+	}
+	if isJSStringLiteral(rhs) {
+		return true
+	}
+	return reEscapeCall.MatchString(rhs)
+}
+
+// safeAt reports whether identifier name provably holds a literal or an
+// escape result at pos: among the events for name before pos whose
+// scope CONTAINS pos, the one from the innermost scope wins, and within
+// it the latest position wins. A module-level constant therefore covers
+// every function in the file, a same-named local in a sibling function
+// covers nothing outside itself, and a reassignment inside the scope
+// revokes the status from that point on. No event at all (a parameter,
+// an import) is not provable and stays unsafe.
+func safeAt(events []safeEvent, name string, pos int) bool {
+	bestScope, bestPos := -1, -1
+	res := false
+	for _, e := range events {
+		if e.name != name || e.pos >= pos || e.scopeStart > pos || e.scopeEnd <= pos {
+			continue
+		}
+		if e.scopeStart > bestScope || (e.scopeStart == bestScope && e.pos > bestPos) {
+			bestScope, bestPos = e.scopeStart, e.pos
+			res = e.safe
+		}
+	}
+	return res
 }
 
 // selectorUnsafeOperand inspects one selector argument and reports an
 // unescaped interpolated value, if the argument is a composite selector
 // expression (concatenation or template interpolation) carrying one.
-func selectorUnsafeOperand(arg string, safe map[string]bool) (string, bool) {
+func selectorUnsafeOperand(arg string, safe func(string) bool) (string, bool) {
 	ops := splitTopLevel(arg, '+')
 	hasTemplate := false
 	for _, op := range ops {
@@ -549,18 +631,18 @@ func selectorUnsafeOperand(arg string, safe map[string]bool) (string, bool) {
 
 // selectorOperandSafe reports whether one concatenation operand or
 // interpolation body cannot carry a selector metacharacter.
-func selectorOperandSafe(op string, safe map[string]bool) bool {
+func selectorOperandSafe(op string, safe func(string) bool) bool {
 	op = strings.TrimSpace(op)
 	if op == "" {
 		return true
 	}
-	if strings.HasPrefix(op, "CSS.escape(") || strings.HasPrefix(op, "cssEscape(") {
-		return true
+	if reEscapeCall.MatchString(op) {
+		return true // CSS.escape(…), window.CSS.escape(…), cssEscape(…)
 	}
 	if isJSStringLiteral(op) || isJSNumericLiteral(op) {
 		return true
 	}
-	return safe[op]
+	return isJSIdent(op) && safe(op)
 }
 
 // ── lint 2: {} registry read as plain bracket access ───────────────────
@@ -588,16 +670,35 @@ func selectorOperandSafe(op string, safe map[string]bool) bool {
 //     or an index identifier whose assignments in the file all
 //     concatenate (widgets.js's chrome-cache key name+'\0'+ctx) — a
 //     composite string can never equal a bare prototype property name;
-//   - indices bound by an enclosing for…in: enumeration keys of an
-//     in-code registry (boot.js's module-scanner loop), not attribute
-//     input;
-//   - reads whose own line or the previous non-blank line carries the
-//     guard idiom (Object.prototype.hasOwnProperty.call(REG, … /
-//     Object.hasOwn(REG, …), optionally qualified NS.REG), including
-//     the module-local `own()` helper the runtime declares as exactly
-//     that idiom (kernel.js's shared own(REG, name) spelling);
+//   - indices bound by an enclosing for…in, matched by exact
+//     brace-matched loop span (however long the body): enumeration
+//     keys of an in-code registry (boot.js's module-scanner loop), not
+//     attribute input;
+//   - guarded reads. The guard is the own-property idiom
+//     (Object.prototype.hasOwnProperty.call(REG, … / Object.hasOwn(REG,
+//     …, optionally qualified NS.REG), including the module-local
+//     `own()` helper the runtime declares as exactly that idiom), and
+//     it counts wherever it actually guards the read: on the read's
+//     own line or the previous non-blank line (the fixed spellings wrap
+//     onto two lines), in the condition of the if or ternary lexically
+//     enclosing the read, or through a boolean assigned exactly once in
+//     the enclosing function from that guard idiom and branched on
+//     (the compute-once spelling that avoids calling hasOwnProperty
+//     twice). A guard on a DIFFERENT registry does not count;
 //   - registries created with Object.create(null) (never collected:
 //     only {} initializers are).
+//
+// The pass is linear in corpus bytes: each file is prescanned once for
+// candidate bracket reads (one regex, one pass), indexed by identifier,
+// and only names that are both declared {} somewhere and bracket-read
+// in this file pay the per-read filters; the guard idioms are matched
+// with static run-once patterns whose captured receiver is compared to
+// the registry name, so no per-name regex is compiled at all. Measured
+// on a generated 150-file, ~4.7MB corpus with 8 unique registries per
+// file (1200 names): 1m30.28s before the prescan — every name swept
+// every file — against ~0.75s of CPU after (wall time varies with
+// machine load; the live core-ui/runtime tree stays well under a
+// second).
 func LintRegistryOwnProps(roots ...string) (*Result, error) {
 	res := &Result{}
 	files, err := loadJSSources(roots...)
@@ -611,16 +712,21 @@ func LintRegistryOwnProps(roots ...string) (*Result, error) {
 	for _, f := range files {
 		helpers = append(helpers, ownHelpers(f.Blank)...)
 	}
-	readRes := map[string]*regexp.Regexp{}
+	names := map[string]bool{}
 	for _, name := range collectRegistryNames(files) {
-		readRes[name] = registryReadRe(name)
+		names[name] = true
 	}
+	guards := newGuardMatcher(helpers)
 	for _, f := range files {
 		composite := compositeIndexIdents(f.Blank)
-		for _, name := range sortedKeys(readRes) {
-			re := readRes[name]
-			for _, loc := range re.FindAllStringIndex(f.Blank, -1) {
-				open := loc[1] - 1 // the '[' the match ends on
+		spans := forInSpans(f.Blank)
+		reads := bracketReads(f.Blank)
+		for _, name := range sortedKeys(reads) {
+			if !names[name] {
+				continue
+			}
+			for _, start := range reads[name] {
+				open := strings.IndexByte(f.Blank[start:], '[') + start // the '[' the read opens
 				close := matchDelimForward(f.Blank, open)
 				if close < 0 {
 					continue
@@ -638,24 +744,40 @@ func LintRegistryOwnProps(roots ...string) (*Result, error) {
 				if isCompositeIndex(idx, composite) {
 					continue
 				}
-				if isForInIndex(f.Blank, loc[0], idx) {
+				if isForInIndex(spans, start, idx) {
 					continue
 				}
 				if registryAccessIsWrite(f.Blank, close) {
 					continue
 				}
-				if registryAccessIsDelete(f.Blank, loc[0]) {
+				if registryAccessIsDelete(f.Blank, start) {
 					continue
 				}
-				if registryGuardNearby(f.Blank, f.Src, name, loc[0], helpers) {
+				if registryGuardNearby(f.Blank, f.Src, name, start, guards) {
 					continue
 				}
-				res.add(f.Path, lineOf(f.Src, loc[0]),
+				res.add(f.Path, lineOf(f.Src, start),
 					fmt.Sprintf("[registry-own-prop] %s[...] reads a {} registry through the prototype chain — an attribute-borne name like \"constructor\" resolves to an Object.prototype member and passes the truthiness gate; read it as an own property (Object.prototype.hasOwnProperty.call(%s, name), the idiom computed.js uses)", name, name))
 			}
 		}
 	}
 	return res, nil
+}
+
+// reBracketRead matches every bracket access and captures the
+// identifier it is made on: REG[, NS.REG[… (the captured name is REG —
+// '.' is not a word character), and REG?.[….
+var reBracketRead = regexp.MustCompile(`\b(\w+)\s*(?:\?\.)?\s*\[`)
+
+// bracketReads indexes the bracket reads of one file by identifier, in
+// order. One pass replaces one regex sweep per registry name: a corpus
+// of F files × R names pays F passes, not F×R.
+func bracketReads(blank string) map[string][]int {
+	reads := map[string][]int{}
+	for _, m := range reBracketRead.FindAllStringSubmatchIndex(blank, -1) {
+		reads[blank[m[2]:m[3]]] = append(reads[blank[m[2]:m[3]]], m[0])
+	}
+	return reads
 }
 
 // Registry-declaration shapes, matched on the blank view so a '{}' in
@@ -688,12 +810,6 @@ func collectRegistryNames(files []jsSource) []string {
 		}
 	}
 	return sortedSet(set)
-}
-
-// registryReadRe matches REG[ and REG?.[ reads (both resolve through
-// the prototype chain). A preceding '.' is allowed: NS.REG[…].
-func registryReadRe(name string) *regexp.Regexp {
-	return regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\s*(?:\?\.)?\s*\[`)
 }
 
 func sortedSet(set map[string]bool) []string {
@@ -760,22 +876,54 @@ func isCompositeIndex(idx string, composite map[string]bool) bool {
 	return composite[idx]
 }
 
+// forInSpan is one for…in loop: the bound identifier and the exact
+// byte span of its body.
+type forInSpan struct {
+	idx        string
+	start, end int
+}
+
+var reForInHeader = regexp.MustCompile(`for\s*\(\s*(?:const|let|var)?\s*(\w+)\s+in\s`)
+
+// forInSpans collects the for…in loops of one file: enumeration keys
+// of an in-code registry, not attribute input. The span is exact —
+// the brace-matched body, or the single statement up to its ';' when
+// the loop has no braces — so a long loop body cannot outgrow the
+// binding the way a fixed byte window could.
+func forInSpans(blank string) []forInSpan {
+	var out []forInSpan
+	for _, m := range reForInHeader.FindAllStringSubmatchIndex(blank, -1) {
+		open := strings.IndexByte(blank[m[0]:m[1]], '(') + m[0]
+		close := matchDelimForward(blank, open)
+		if close < 0 {
+			continue
+		}
+		i := skipSpace(blank, close+1)
+		if i >= len(blank) {
+			continue
+		}
+		if blank[i] == '{' {
+			end := matchDelimForward(blank, i)
+			if end < 0 {
+				continue
+			}
+			out = append(out, forInSpan{idx: blank[m[2]:m[3]], start: i, end: end})
+			continue
+		}
+		out = append(out, forInSpan{idx: blank[m[2]:m[3]], start: i, end: statementEnd(blank, i)})
+	}
+	return out
+}
+
 // isForInIndex reports whether the identifier idx is the loop variable
-// of a for…in header shortly before the read at pos: enumeration keys
-// of an in-code registry, not attribute input. Lexical approximation —
-// the header must appear within the preceding 400 bytes; a same-named
-// for…in that much earlier is contrived in this corpus.
-func isForInIndex(blank string, pos int, idx string) bool {
-	if !isJSIdent(idx) {
-		return false
+// of a for…in loop whose exact span contains the read at pos.
+func isForInIndex(spans []forInSpan, pos int, idx string) bool {
+	for _, s := range spans {
+		if s.idx == idx && pos >= s.start && pos <= s.end {
+			return true
+		}
 	}
-	start := pos - 400
-	if start < 0 {
-		start = 0
-	}
-	window := blank[start:pos]
-	re := regexp.MustCompile(`for\s*\(\s*(?:const|let|var)\s+` + regexp.QuoteMeta(idx) + `\s+in\s`)
-	return re.MatchString(window)
+	return false
 }
 
 // registryAccessIsWrite reports whether the bracket access closing at
@@ -858,23 +1006,94 @@ func ownHelpers(blank string) []string {
 	return names
 }
 
-// registryGuardNearby reports whether the read's own line or the
-// previous non-blank line carries the own-property guard for name
-// (Object.prototype.hasOwnProperty.call(REG, … / Object.hasOwn(REG, … /
-// a module-local own() helper defined as that idiom, each optionally
-// qualified NS.REG — the fixed spellings wrap onto two lines, hence the
-// previous-line lookup) or a `k in REG` membership check.
-func registryGuardNearby(blank, src, name string, pos int, helpers []string) bool {
-	pats := []string{
-		`(?:hasOwnProperty\s*\.\s*call|Object\s*\.\s*hasOwn)\s*\(\s*(?:\w+\s*\.\s*)*` + regexp.QuoteMeta(name) + `\s*,`,
-		`\bin\s+(?:\w+\s*\.\s*)*` + regexp.QuoteMeta(name) + `\b`,
+// guardMatcher matches the own-property guard idioms with STATIC
+// patterns, compiled once per lint run, whose captured receiver is then
+// compared against the registry name — no per-name regex compilation,
+// so a corpus of R registry names per file costs zero extra compiles.
+type guardMatcher struct {
+	call   *regexp.Regexp // hasOwnProperty.call(RECV, / Object.hasOwn(RECV,
+	in     *regexp.Regexp // k in RECV
+	init   *regexp.Regexp // BOOL = <call idiom>(RECV,
+	helper []*regexp.Regexp
+}
+
+// receiverPattern matches a receiver: dotted parts, optional spaces.
+const receiverPattern = `(?:\w+\s*\.\s*)*\w+`
+
+func newGuardMatcher(helpers []string) *guardMatcher {
+	g := &guardMatcher{
+		call: regexp.MustCompile(`(?:hasOwnProperty\s*\.\s*call|Object\s*\.\s*hasOwn)\s*\(\s*(` + receiverPattern + `)\s*,`),
+		in:   regexp.MustCompile(`\bin\s+(` + receiverPattern + `)\b`),
 	}
+	callee := `(?:hasOwnProperty\s*\.\s*call|Object\s*\.\s*hasOwn`
 	for _, h := range helpers {
-		pats = append(pats, h+`\s*\(\s*(?:\w+\s*\.\s*)*`+regexp.QuoteMeta(name)+`\s*,`)
+		callee += `|` + h
+		g.helper = append(g.helper, regexp.MustCompile(h+`\s*\(\s*(`+receiverPattern+`)\s*,`))
 	}
-	guards := make([]*regexp.Regexp, len(pats))
-	for i, p := range pats {
-		guards[i] = regexp.MustCompile(p)
+	g.init = regexp.MustCompile(`(\w+)\s*=\s*(?:\w+\s*\.\s*)*` + callee + `)\s*\(\s*(` + receiverPattern + `)\s*,`)
+	return g
+}
+
+// receiverIs reports whether a captured receiver text is name,
+// optionally NS-qualified (NS.name): same semantics as the old per-name
+// patterns, which required dotted parts before the name.
+func receiverIs(recv, name string) bool {
+	var b strings.Builder
+	for _, r := range recv {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	s := b.String()
+	return s == name || strings.HasSuffix(s, "."+name)
+}
+
+// guarded reports whether text carries the own-property guard for the
+// registry name: the call idiom, a module-local own() helper, or the
+// `k in REG` membership check.
+func (g *guardMatcher) guarded(text, name string) bool {
+	for _, m := range g.call.FindAllStringSubmatch(text, -1) {
+		if receiverIs(m[1], name) {
+			return true
+		}
+	}
+	for _, re := range g.helper {
+		for _, m := range re.FindAllStringSubmatch(text, -1) {
+			if receiverIs(m[1], name) {
+				return true
+			}
+		}
+	}
+	for _, m := range g.in.FindAllStringSubmatch(text, -1) {
+		if receiverIs(m[1], name) {
+			return true
+		}
+	}
+	return false
+}
+
+// reIfLine requires an if-condition on a line before a guard boolean
+// found there is credited: the boolean must be branched on, not merely
+// mentioned.
+var reIfLine = regexp.MustCompile(`\bif\s*\(`)
+
+// registryGuardNearby reports whether the read at pos is guarded. The
+// guard counts wherever it actually guards:
+//   - on the read's own line, or on the previous non-blank line (the
+//     fixed spellings wrap onto two lines) — including that line's if
+//     condition referencing a guard boolean;
+//   - in the condition of the if or ternary that lexically encloses
+//     the read;
+//   - through a boolean assigned exactly once in the enclosing
+//     function from the guard idiom (const known =
+//     hasOwnProperty.call(REG, x)) and referenced in one of those
+//     conditions: the compute-once spelling. A boolean initialized
+//     from a guard on a DIFFERENT registry is not a guard for this
+//     one, and a boolean from another function never applies.
+func registryGuardNearby(blank, src, name string, pos int, g *guardMatcher) bool {
+	if cond := enclosingCondition(blank, pos); g.guarded(cond, name) || g.guardBooleanIn(blank, pos, cond, name) {
+		return true
 	}
 	line := lineOf(src, pos)
 	lines := strings.Split(blank, "\n")
@@ -882,22 +1101,154 @@ func registryGuardNearby(blank, src, name string, pos int, helpers []string) boo
 		if n < 1 || n > len(lines) {
 			return false
 		}
-		for _, g := range guards {
-			if g.MatchString(lines[n-1]) {
-				return true
-			}
-		}
-		return false
+		return g.guarded(lines[n-1], name)
 	}
 	if check(line) {
 		return true
 	}
 	for n := line - 1; n >= 1; n-- {
 		if strings.TrimSpace(lines[n-1]) != "" {
-			return check(n)
+			if check(n) {
+				return true
+			}
+			// The previous non-blank line's if condition referencing a
+			// compute-once guard boolean (`if (!known) return null;`
+			// above the read).
+			return reIfLine.MatchString(lines[n-1]) && g.guardBooleanIn(blank, pos, lines[n-1], name)
 		}
 	}
 	return false
+}
+
+// guardBooleanIn reports whether cond (a condition text or a line)
+// references a boolean that was assigned exactly once, inside the
+// function enclosing pos, from the guard idiom on THIS registry name.
+func (g *guardMatcher) guardBooleanIn(blank string, pos int, cond, name string) bool {
+	if cond == "" {
+		return false
+	}
+	fs, fe := enclosingFunction(blank, pos)
+	region := blank[fs:fe]
+	counts := map[string]int{}
+	for _, m := range reIdentAssign.FindAllStringSubmatch(region, -1) {
+		if !jsKeywords[m[1]] {
+			counts[m[1]]++
+		}
+	}
+	for _, m := range g.init.FindAllStringSubmatch(region, -1) {
+		if jsKeywords[m[1]] || counts[m[1]] != 1 || !receiverIs(m[2], name) {
+			continue
+		}
+		if containsWord(cond, m[1]) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsWord reports whether s contains w as a whole identifier word.
+func containsWord(s, w string) bool {
+	for i := 0; i+len(w) <= len(s); i++ {
+		if s[i:i+len(w)] != w {
+			continue
+		}
+		if i > 0 && isJSIdentChar(s[i-1]) {
+			continue
+		}
+		if i+len(w) < len(s) && isJSIdentChar(s[i+len(w)]) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// enclosingCondition returns the condition text of the if or ternary
+// that lexically contains pos, or "". From pos it walks left to the
+// innermost opener at bracket depth zero: a '(' headed by `if`/`while`
+// contributes its parenthesized condition; a '{' whose header is
+// `if (...)` contributes that header's condition; a ternary '?' (not
+// `?.` or `??`) contributes everything back to the previous statement
+// or sequence boundary at depth zero.
+func enclosingCondition(blank string, pos int) string {
+	depth := 0
+	for i := pos - 1; i >= 0; i-- {
+		switch blank[i] {
+		case ')', ']', '}':
+			depth++
+		case '(', '[', '{':
+			if depth > 0 {
+				depth--
+				continue
+			}
+			if blank[i] == '(' {
+				if w := wordBefore(blank, i); w == "if" || w == "while" {
+					if close := matchDelimForward(blank, i); close > i {
+						return blank[i+1 : close]
+					}
+				}
+				return ""
+			}
+			// A block: an `if (...) {` header guards the whole body.
+			j := skipSpaceBack(blank, i-1)
+			if j >= 0 && blank[j] == ')' {
+				if k := matchDelimBack(blank, j); k > 0 && wordBefore(blank, k) == "if" {
+					return blank[k+1 : j]
+				}
+			}
+			return ""
+		case '?':
+			if depth != 0 || (i+1 < len(blank) && (blank[i+1] == '.' || blank[i+1] == '?')) ||
+				(i > 0 && blank[i-1] == '?') {
+				continue
+			}
+			return ternaryCondition(blank, i)
+		}
+	}
+	return ""
+}
+
+// ternaryCondition returns the condition text ending at the ternary '?'
+// at i: everything back to the previous statement or sequence boundary
+// at bracket depth zero.
+func ternaryCondition(blank string, i int) string {
+	depth := 0
+	for j := i - 1; j >= 0; j-- {
+		switch blank[j] {
+		case ')', ']', '}':
+			depth++
+		case '(', '[', '{':
+			if depth == 0 {
+				return blank[j+1 : i]
+			}
+			depth--
+		case ',', ';', ':', '?':
+			if depth == 0 {
+				return blank[j+1 : i]
+			}
+		}
+	}
+	return blank[:i]
+}
+
+// wordBefore returns the identifier ending just before i (spaces
+// skipped), or "" — the keyword heading an opener.
+func wordBefore(s string, i int) string {
+	i = skipSpaceBack(s, i-1)
+	end := i + 1
+	for i >= 0 && isJSIdentChar(s[i]) {
+		i--
+	}
+	return s[i+1 : end]
+}
+
+// skipSpaceBack returns the index of the last non-space byte at or
+// before i, or -1.
+func skipSpaceBack(s string, i int) int {
+	for i >= 0 && (s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r') {
+		i--
+	}
+	return i
 }
 
 // ── lint 3: response text mounted without r.ok ──────────────────────────
@@ -919,13 +1270,18 @@ func registryGuardNearby(blank, src, name string, pos int, helpers []string) boo
 // refresh with `if (!r.ok) throw`.
 //
 // Silent on:
-//   - chains that check .ok/.status anywhere between the fetch and the
-//     end of the chain (the convention's own spelling);
+//   - chains gated on the response: a whole-token .ok or .status read
+//     (word boundary — displaying r.statusText or r.okButton is not a
+//     check) used as a condition — negated, compared, inside an
+//     if/while condition, or feeding a ternary / && / ||;
 //   - await/multi-statement flows (const r = await fetch(…); …) — the
 //     chain ends at the statement boundary and the mount lives in
 //     later statements; those sites are pinned individually by the
 //     probe's surface list instead;
-//   - chains that never read the body or never mount.
+//   - chains that never read the body or never mount. A continuation
+//     passed by bare reference (.then(bind)) contributes the named
+//     function's same-file body to the mount and gate scans; a name
+//     not declared in the file stays silent as today.
 func LintResponseMountedAfterOK(roots ...string) (*Result, error) {
 	res := &Result{}
 	files, err := loadJSSources(roots...)
@@ -946,10 +1302,14 @@ func LintResponseMountedAfterOK(roots ...string) (*Result, error) {
 			if !reBodyRead.MatchString(span) {
 				continue
 			}
-			if strings.Contains(span, ".ok") || strings.Contains(span, ".status") {
+			// A bare-reference continuation puts the mount in the
+			// named function's body, one declaration away: include it
+			// in the mount and gate scans.
+			scan := span + namedThenBodies(f.Blank, span)
+			if responseGateIn(scan) {
 				continue
 			}
-			if !reHTMLMount.MatchString(span) {
+			if !reHTMLMount.MatchString(scan) {
 				continue
 			}
 			res.add(f.Path, lineOf(f.Src, loc[0]),
@@ -965,6 +1325,126 @@ var (
 	reHTMLMount = regexp.MustCompile(`(?:innerHTML|outerHTML)\s*=[^=]|insertAdjacentHTML\s*\(` +
 		`|\b\w*(?:mount|swap)\w*\s*\(`)
 )
+
+var reThenIdent = regexp.MustCompile(`\.\s*then\s*\(\s*(\w+)\s*\)`)
+
+// namedThenBodies appends the bodies of same-file functions passed to
+// .then( by bare reference inside the chain span: the fetched text is
+// handed to them by name, so their bodies are part of the chain's
+// mount and gate surface. Function declarations and const-arrow forms
+// both resolve; an unresolved name (imported, or not a function)
+// contributes nothing.
+func namedThenBodies(blank, span string) string {
+	var b strings.Builder
+	for _, m := range reThenIdent.FindAllStringSubmatch(span, -1) {
+		name := regexp.QuoteMeta(m[1])
+		decl := regexp.MustCompile(`(?:function\s+` + name + `\s*\([^)]*\)\s*\{` +
+			`|(?:const|let|var)\s+` + name + `\s*=\s*(?:async\s+)?(?:function\s*\([^)]*\)\s*\{|\([^)]*\)\s*=>\s*\{))`)
+		loc := decl.FindStringIndex(blank)
+		if loc == nil {
+			continue
+		}
+		open := loc[1] - 1 // the '{' the declaration form ends on
+		end := matchDelimForward(blank, open)
+		if end < 0 {
+			continue
+		}
+		b.WriteString(blank[open : end+1])
+	}
+	return b.String()
+}
+
+// reResponseToken matches a .ok / .status member read as a whole token:
+// .statusText and .okButton do not match (\b after the property).
+var reResponseToken = regexp.MustCompile(`\.\s*(?:ok|status)\b`)
+
+// responseGateIn reports whether the chain text actually gates on the
+// response: a whole-token .ok/.status read used as a condition —
+// negated (!r.ok), compared on either side (r.status !== 200,
+// 200 === r.status), inside an if/while condition (if (resp.ok)), or
+// feeding a ternary / && / ||. Displaying the value (r.statusText,
+// r.okButton) or passing it to a function is not a gate.
+func responseGateIn(span string) bool {
+	for _, m := range reResponseToken.FindAllStringIndex(span, -1) {
+		if i := skipSpace(span, m[1]); i < len(span) && gateOpRight(span, i) {
+			return true
+		}
+		j := memberExprStart(span, m[0])
+		if k := skipSpaceBack(span, j-1); k >= 0 && gateOpLeft(span, k) {
+			return true
+		}
+		if insideIfCondition(span, m[0]) {
+			return true
+		}
+	}
+	return false
+}
+
+// gateOpRight reports whether a comparison, ternary, or logical
+// operator starts at i.
+func gateOpRight(s string, i int) bool {
+	for _, op := range []string{"===", "!==", "==", "!=", "<=", ">=", "&&", "||", "?", "<", ">"} {
+		if !strings.HasPrefix(s[i:], op) {
+			continue
+		}
+		// The '>' of an arrow (=>) is not a comparison.
+		if op == ">" && i > 0 && s[i-1] == '=' {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+// gateOpLeft reports whether the operator ending at k (immediately
+// left of the member expression) is a negation or a comparison.
+func gateOpLeft(s string, k int) bool {
+	switch s[k] {
+	case '!':
+		return true
+	case '=':
+		return k >= 1 && strings.IndexByte("=!<>", s[k-1]) >= 0
+	case '&', '|':
+		return k >= 1 && (s[k-1] == s[k])
+	case '<', '>':
+		return !(s[k] == '>' && k >= 1 && s[k-1] == '=') // not the '>' of =>
+	default:
+		return false
+	}
+}
+
+// memberExprStart returns the index where the member expression
+// containing the '.' at dot begins.
+func memberExprStart(s string, dot int) int {
+	j := dot - 1
+	for j >= 0 && (isJSIdentChar(s[j]) || s[j] == '.') {
+		j--
+	}
+	return j + 1
+}
+
+// insideIfCondition reports whether pos sits inside the parenthesized
+// condition of an if/while.
+func insideIfCondition(s string, pos int) bool {
+	depth := 0
+	for i := pos - 1; i >= 0; i-- {
+		switch s[i] {
+		case ')', ']', '}':
+			depth++
+		case '(', '[', '{':
+			if depth > 0 {
+				depth--
+				continue
+			}
+			if s[i] != '(' {
+				return false // left the condition region via a block
+			}
+			w := wordBefore(s, i)
+			return w == "if" || w == "while"
+		}
+	}
+	return false
+}
 
 // chainEnd extends a fetch call's closing paren through its .then(…)
 // (and ?.then(…), .catch(…), .finally(…)) continuations and returns the
@@ -995,6 +1475,57 @@ func chainEnd(blank string, close int) int {
 		}
 		close = next
 	}
+}
+
+// concatPathPairs returns the adjacent (literal, value) operand pairs
+// of a top-level '+' concatenation. A template-literal operand is
+// decomposed first into its alternating literal-chunk /
+// interpolation-body operands, so `/api/${v}` is judged exactly like '/api/' + v.
+func concatPathPairs(expr string) [][2]string {
+	ops := splitTopLevel(expr, '+')
+	expanded := make([]string, 0, len(ops))
+	for _, op := range ops {
+		if t := strings.TrimSpace(op); strings.HasPrefix(t, "`") {
+			expanded = append(expanded, templateOperands(t)...)
+			continue
+		}
+		expanded = append(expanded, op)
+	}
+	pairs := make([][2]string, 0, len(expanded))
+	for i := 0; i+1 < len(expanded); i++ {
+		pairs = append(pairs, [2]string{expanded[i], expanded[i+1]})
+	}
+	return pairs
+}
+
+// templateOperands splits one template literal into its alternating
+// literal chunks (quoted, so they read as string literals downstream)
+// and interpolation bodies.
+func templateOperands(tpl string) []string {
+	end := templateEnd(tpl, 0)
+	if end >= len(tpl) {
+		end = len(tpl) - 1
+	}
+	inner := tpl[1:end] // between the backticks
+	var ops []string
+	var chunk strings.Builder
+	for j := 0; j < len(inner); j++ {
+		if inner[j] != '$' || j+1 >= len(inner) || inner[j+1] != '{' {
+			chunk.WriteByte(inner[j])
+			continue
+		}
+		body, close := templateExprEnd(inner, j+2)
+		if chunk.Len() > 0 {
+			ops = append(ops, "'"+chunk.String()+"'")
+			chunk.Reset()
+		}
+		ops = append(ops, strings.TrimSpace(body))
+		j = close
+	}
+	if chunk.Len() > 0 {
+		ops = append(ops, "'"+chunk.String()+"'")
+	}
+	return ops
 }
 
 // ── lint 4: attribute-borne URL path segment ───────────────────────────
@@ -1186,17 +1717,6 @@ func statementEnd(code string, from int) int {
 		}
 	}
 	return len(code)
-}
-
-// concatPathPairs returns the adjacent (literal, value) operand pairs
-// of a top-level '+' concatenation.
-func concatPathPairs(expr string) [][2]string {
-	ops := splitTopLevel(expr, '+')
-	pairs := make([][2]string, 0, len(ops))
-	for i := 0; i+1 < len(ops); i++ {
-		pairs = append(pairs, [2]string{ops[i], ops[i+1]})
-	}
-	return pairs
 }
 
 func pathLiteralEndsInSlash(lit string) bool {

--- a/core-ui/check/runtimeshapes.go
+++ b/core-ui/check/runtimeshapes.go
@@ -926,6 +926,7 @@ func LintRegistryOwnProps(roots ...string) (*Result, error) {
 		composite := compositeIndexIdents(f.Blank)
 		spans := forInSpans(f.Blank)
 		reads := bracketReads(f.Blank)
+		lines := strings.Split(f.Blank, "\n")
 		for _, name := range sortedKeys(reads) {
 			if !names[name] {
 				continue
@@ -965,7 +966,7 @@ func LintRegistryOwnProps(roots ...string) (*Result, error) {
 				if registryAccessIsDelete(f.Blank, start) {
 					continue
 				}
-				if registryGuardNearby(f, name, start, guards) {
+				if registryGuardNearby(f, lines, name, start, guards) {
 					continue
 				}
 				res.add(f.Path, f.lineOf(start),
@@ -1317,12 +1318,15 @@ var reIfLine = regexp.MustCompile(`\bif\s*\(`)
 //     conditions: the compute-once spelling. A boolean initialized
 //     from a guard on a DIFFERENT registry is not a guard for this
 //     one, and a boolean from another function never applies.
-func registryGuardNearby(f jsSource, name string, pos int, g *guardMatcher) bool {
+//
+// lines is the file's line index, computed once per file by the caller:
+// this runs per candidate read, and splitting the whole Blank view
+// here cost O(bytes·reads).
+func registryGuardNearby(f jsSource, lines []string, name string, pos int, g *guardMatcher) bool {
 	if cond := enclosingCondition(f.Blank, pos); g.guarded(cond, name) || g.guardBooleanIn(f.Blank, pos, cond, name) {
 		return true
 	}
 	line := f.lineOf(pos)
-	lines := strings.Split(f.Blank, "\n")
 	check := func(n int) bool {
 		if n < 1 || n > len(lines) {
 			return false

--- a/core-ui/check/runtimeshapes_test.go
+++ b/core-ui/check/runtimeshapes_test.go
@@ -525,3 +525,319 @@ func TestLintAttributePathSegments_RepoIsClean(t *testing.T) {
 		t.Errorf("runtime JS joins attribute-borne values into URL paths ungated:\n%s", res.Error())
 	}
 }
+
+// ── review findings (7-14): named .then handlers, statusText gates,
+// template URLs, hoisted guards, long for-in bodies, window.CSS.escape,
+// revocable safe identifiers ────────────────────────────────────────────
+
+const namedThenFixture = `// .then continuations passed by bare reference (review finding 7):
+// the fetched text is handed to a named function one declaration away,
+// so nothing inside the chain span itself carries the mount token.
+function mountPanel(el, html) {
+  el.innerHTML = html;
+}
+function refresh(el, src) {
+  fetch(src).then(r => r.text()).then(function (t) { mountPanel(el, t); }).catch(() => {});
+}
+// The handler itself passed by bare reference (function declaration).
+function refresh2(el, src) {
+  fetch(src).then(r => r.text()).then(bind);
+  function bind(t) { mountPanel(el, t); }
+}
+// Bare reference to a const-arrow declaration.
+function refresh3(el, src) {
+  fetch(src).then(r => r.text()).then(panel);
+  const panel = (t) => { el.insertAdjacentHTML('beforeend', t); };
+}
+// Control: the inline spelling the lint already catches.
+function refreshInline(el, src) {
+  fetch(src).then(r => r.text()).then(t => { el.innerHTML = t; });
+}
+// Silent: a named continuation that never mounts.
+function logIt(t) { console.log(t); }
+function refreshLog(el, src) {
+  fetch(src).then(r => r.text()).then(logIt);
+}
+// Silent: a named continuation that gates before mounting.
+function mountChecked(el, t) {
+  if (!t.ok) return;
+  el.innerHTML = t.body;
+}
+function refreshChecked(el, src) {
+  fetch(src).then(r => r.json()).then(mountChecked);
+}
+`
+
+func TestLintResponseMountedAfterOK_NamedThenHandler(t *testing.T) {
+	dir := writeRuntimeFixture(t, "named.js", namedThenFixture)
+	res, err := LintResponseMountedAfterOK(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 4 {
+		t.Fatalf("expected 4 findings (refresh, refresh2, refresh3, refreshInline), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+	for _, v := range res.Violations {
+		if !strings.HasPrefix(v.Message, "[response-mounted-unchecked]") {
+			t.Errorf("unexpected message: %s", v.Message)
+		}
+	}
+}
+
+const statusTextFixture = `// .statusText displayed is not a .status check (review finding 14):
+// the gate is a whole-token .ok/.status read in a condition context,
+// not the substring ".status" anywhere in the chain.
+function load(el, src, note) {
+  fetch(src).then(function (r) {
+    note.textContent = 'HTTP ' + r.statusText;
+    return r.text();
+  }).then(function (t) { el.innerHTML = t; });
+}
+// Control: no status mention at all — fires.
+function loadCtl(el, src, note) {
+  fetch(src).then(function (r) {
+    note.textContent = 'loading';
+    return r.text();
+  }).then(function (t) { el.innerHTML = t; });
+}
+// .okButton is not .ok either — token boundary required.
+function loadOkButton(el, src, note) {
+  fetch(src).then(function (r) {
+    note.textContent = r.okButton;
+    return r.text();
+  }).then(function (t) { el.innerHTML = t; });
+}
+// Gates that count, all silent: negated .ok, compared .status, .ok in
+// an if condition, ternary on .ok.
+function loadNeg(el, src) {
+  fetch(src).then(r => { if (!r.ok) throw new Error('x'); return r.text(); }).then(t => { el.innerHTML = t; });
+}
+function loadCmp(el, src) {
+  fetch(src).then(r => { if (r.status !== 200) throw new Error('x'); return r.text(); }).then(t => { el.innerHTML = t; });
+}
+function loadTruthy(el, src) {
+  fetch(src).then(r => { if (r.ok) return r.text(); throw new Error('x'); }).then(t => { el.innerHTML = t; });
+}
+function loadTern(el, src) {
+  fetch(src).then(r => r.ok ? r.text() : Promise.reject(new Error('x'))).then(t => { el.innerHTML = t; });
+}
+`
+
+func TestLintResponseMountedAfterOK_StatusTextIsNotAGate(t *testing.T) {
+	dir := writeRuntimeFixture(t, "statustext.js", statusTextFixture)
+	res, err := LintResponseMountedAfterOK(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 3 {
+		t.Fatalf("expected exactly 3 findings (load, loadCtl, loadOkButton), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+	for _, v := range res.Violations {
+		if !strings.HasPrefix(v.Message, "[response-mounted-unchecked]") {
+			t.Errorf("unexpected message: %s", v.Message)
+		}
+	}
+}
+
+// attrTplFixtureRaw uses ~ for JS backticks; untailed below.
+const attrTplFixtureRaw = `// Template-literal URL building (review finding 8): the same
+// attribute-borne value joined into the path after a literal chunk
+// ending in "/".
+const postTpl = (el, body) => {
+  return fetch(~/kiln/tool/${el.getAttribute('data-kiln-tool')}~, {
+    method: 'POST',
+    body,
+  }).catch(() => {});
+};
+// Template via a variable holding the attribute read.
+function loadNote(btn) {
+  const note = btn.getAttribute('data-note-id');
+  fetch(~ /api/notes/${note}~);
+}
+// Template plus a '+' operand on the same expression.
+function mixed(el) {
+  const id = el.dataset.rowId;
+  fetch(~ /rows/${id}~ + '?full=1');
+}
+// Silent: the adjacent literal chunk does not end in "/" (query form).
+function queryish(el) {
+  fetch(~ /find?q=${el.getAttribute('data-q')}~);
+}
+// Control: the '+' spelling the lint already catches.
+const postCat = (el, body) => {
+  return fetch('/kiln/tool/' + el.getAttribute('data-kiln-tool'), {
+    method: 'POST',
+    body,
+  }).catch(() => {});
+};
+`
+
+var attrTplFixture = strings.ReplaceAll(attrTplFixtureRaw, "~", "\x60")
+
+func TestLintAttributePathSegments_TemplateLiterals(t *testing.T) {
+	dir := writeRuntimeFixture(t, "tpl.js", attrTplFixture)
+	res, err := LintAttributePathSegments(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 4 {
+		t.Fatalf("expected exactly 4 findings (postTpl, loadNote, mixed, postCat), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+	for _, v := range res.Violations {
+		if !strings.HasPrefix(v.Message, "[attr-path-segment]") {
+			t.Errorf("unexpected message: %s", v.Message)
+		}
+	}
+}
+
+const registryHoistedFixture = `// Guard hoisted into a compute-once boolean (review finding 9): a
+// boolean assigned exactly once from the guard idiom, referenced in the
+// condition of the if/ternary that guards the read, counts.
+const catalog = {};
+const other = {};
+function find(name) {
+  const known = Object.prototype.hasOwnProperty.call(catalog, name);
+  if (!known) return null;
+  return catalog[name];
+}
+function findTern(name) {
+  const has = Object.prototype.hasOwnProperty.call(catalog, name);
+  return has ? catalog[name] : null;
+}
+function findInline(name) {
+  if (Object.prototype.hasOwnProperty.call(catalog, name)) {
+    return catalog[name];
+  }
+  return null;
+}
+// The repo's own fixed spelling: guard on the previous line.
+function findFixed(name) {
+  const entry = Object.prototype.hasOwnProperty.call(catalog, name)
+    ? catalog[name]
+    : undefined;
+  return entry;
+}
+// A boolean initialized from a guard on a DIFFERENT registry does not
+// guard this one, and per-function scoping keeps one function's boolean
+// from laundering another's read.
+function findMixed(name) {
+  const known = Object.prototype.hasOwnProperty.call(other, name);
+  if (!known) return null;
+  return catalog[name];
+}
+// Still fires: no guard at all.
+function findAny(name) {
+  return catalog[name];
+}
+`
+
+func TestLintRegistryOwnProps_HoistedGuardBoolean(t *testing.T) {
+	dir := writeRuntimeFixture(t, "hoisted.js", registryHoistedFixture)
+	res, err := LintRegistryOwnProps(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 2 {
+		t.Fatalf("expected exactly 2 findings (findMixed, findAny), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+	for _, v := range res.Violations {
+		if !strings.HasPrefix(v.Message, "[registry-own-prop] catalog[") {
+			t.Errorf("finding on a fixed/silent spelling: %s:%d: %s", v.File, v.Line, v.Message)
+		}
+	}
+}
+
+const longForInFixture = `// A for-in loop whose body far exceeds any fixed byte window (review
+// finding 10): the loop span is brace-matched, so the enumeration-key
+// read stays bound however long the body grows.
+const reg = {};
+for (const k in reg) {
+  console.log('padding step 0 with a reasonably long line of ordinary code');
+  console.log('padding step 1 with a reasonably long line of ordinary code');
+  console.log('padding step 2 with a reasonably long line of ordinary code');
+  console.log('padding step 3 with a reasonably long line of ordinary code');
+  console.log('padding step 4 with a reasonably long line of ordinary code');
+  console.log('padding step 5 with a reasonably long line of ordinary code');
+  console.log('padding step 6 with a reasonably long line of ordinary code');
+  console.log('padding step 7 with a reasonably long line of ordinary code');
+  console.log('padding step 8 with a reasonably long line of ordinary code');
+  console.log('padding step 9 with a reasonably long line of ordinary code');
+  console.log('padding step 10 with a reasonably long line of ordinary code');
+  console.log('padding step 11 with a reasonably long line of ordinary code');
+  console.log('padding step 12 with a reasonably long line of ordinary code');
+  console.log('padding step 13 with a reasonably long line of ordinary code');
+  total += reg[k];
+}
+// The same identifier OUTSIDE the loop: the binding ends at the brace.
+after += reg[k];
+`
+
+func TestLintRegistryOwnProps_LongForInBody(t *testing.T) {
+	dir := writeRuntimeFixture(t, "longforin.js", longForInFixture)
+	res, err := LintRegistryOwnProps(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 1 {
+		t.Fatalf("expected exactly 1 finding (the read after the loop), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+	if !strings.HasPrefix(res.Violations[0].Message, "[registry-own-prop] reg[") {
+		t.Errorf("unexpected message: %s", res.Violations[0].Message)
+	}
+}
+
+const selReassignFixture = `// window.CSS.escape (review finding 11): the defensive global
+// reference is the same escape.
+function viaWindow(id) {
+  return document.querySelector('#' + window.CSS.escape(id));
+}
+// Reassigned literal (review finding 13): kind is initialized from a
+// literal but REASSIGNED from an attribute before use — not provably a
+// literal at the lookup.
+let kind = 'input';
+kind = el.dataset.kind;
+document.querySelector('[data-kind="' + kind + '"]');
+// Same name, different functions: the escape in viaEsc must not launder
+// the attribute-borne sel in viaAttr.
+function viaEsc(id) {
+  const sel = CSS.escape(id);
+  return document.querySelector('[data-x="' + sel + '"]');
+}
+function viaAttr(el) {
+  const sel = el.dataset.sel;
+  return document.querySelector('[data-x="' + sel + '"]');
+}
+// Silent postures that must survive: literal constant, literal read
+// with no reassignment, for-of over an array of literals.
+const IS_OPEN2 = 'data-fui-open';
+document.querySelectorAll('[' + IS_OPEN2 + ']');
+function viaLit() {
+  const tag = 'section';
+  return document.querySelector(tag + '[data-live]');
+}
+for (const ev of ['input', 'change']) {
+  document.querySelector('[data-action-type="' + ev + '"]');
+}
+`
+
+func TestLintSelectorInterpolation_WindowEscapeAndReassignedSafeIdents(t *testing.T) {
+	dir := writeRuntimeFixture(t, "reassign.js", selReassignFixture)
+	res, err := LintSelectorInterpolation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 2 {
+		t.Fatalf("expected exactly 2 findings (the reassigned kind, viaAttr's sel), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+	for _, v := range res.Violations {
+		if !strings.Contains(v.Message, `"kind"`) && !strings.Contains(v.Message, `"sel"`) {
+			t.Errorf("finding on a fixed/silent spelling: %s:%d: %s", v.File, v.Line, v.Message)
+		}
+	}
+}

--- a/core-ui/check/runtimeshapes_test.go
+++ b/core-ui/check/runtimeshapes_test.go
@@ -357,10 +357,10 @@ function conflictRefresh(dest, crpc, restoreFn) {
     .catch(function () { restoreFn(); });
 }
 
-// Synthetic positives (never in this repo): a swap helper and an
-// insertAdjacentHTML mount.
+// Synthetic positives (never in this repo): one of the runtime's own
+// swap helpers and an insertAdjacentHTML mount.
 function loadPanel(slot, path) {
-  fetch(path).then(r => r.json()).then(d => { swap(slot, d.panel); });
+  fetch(path).then(r => r.json()).then(d => { swapPane(slot, d.panel); });
 }
 function loadBadge(el, src) {
   fetch(src).then(r => r.text()).then(t => el.insertAdjacentHTML('beforeend', t));
@@ -838,6 +838,226 @@ func TestLintSelectorInterpolation_WindowEscapeAndReassignedSafeIdents(t *testin
 	for _, v := range res.Violations {
 		if !strings.Contains(v.Message, `"kind"`) && !strings.Contains(v.Message, `"sel"`) {
 			t.Errorf("finding on a fixed/silent spelling: %s:%d: %s", v.File, v.Line, v.Message)
+		}
+	}
+}
+
+// ── review 5 findings: revoked escape results, regex delimiters,
+// numeric interpolation, string-literal code, inline registry decls,
+// attribute indices, the in operator, compound mounts, optional
+// chaining, unanchored and late gates, numeric coercion, fragments ──
+
+// selRevTwoFixtureRaw uses ~ for JS backticks; untailed below.
+const selRevTwoFixtureRaw = `// An escape result revoked by a later attribute reassignment
+// (review 5): the safe set follows assignments, not spellings.
+function findTarget(el) {
+  let id = CSS.escape('fixed');
+  id = el.dataset.target;
+  return document.querySelector('[data-target="' + id + '"]');
+}
+// A regex literal carrying an unbalanced delimiter inside a selector
+// call must not truncate the call span (review 5): the closing paren
+// of selectorPrefix(/[}]/) is not the closing paren of querySelector.
+function viaPrefix(el) {
+  return document.querySelector(selectorPrefix(/[}]/) + el.dataset.target);
+}
+function selectorPrefix(pattern) { return '#'; }
+// Arithmetic on a numeric literal cannot carry selector
+// metacharacters (review 5): nth-child(index + 1) is quiet.
+function rows(list) {
+  const found = [];
+  for (let index = 0; index < 3; index++) {
+    found.push(list.querySelector(~li:nth-child(${index + 1})~));
+  }
+  return found;
+}
+`
+
+var selRevTwoFixture = strings.ReplaceAll(selRevTwoFixtureRaw, "~", "\x60")
+
+func TestLintSelectorInterpolation_Review5SpansAndArithmetic(t *testing.T) {
+	dir := writeRuntimeFixture(t, "review5sel.js", selRevTwoFixture)
+	res, err := LintSelectorInterpolation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 2 {
+		t.Fatalf("expected exactly 2 findings (the revoked id, the regex-delim span), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+	if !strings.Contains(res.Violations[0].Message, `"id"`) &&
+		!strings.Contains(res.Violations[1].Message, `"id"`) {
+		t.Errorf("expected one finding on the revoked id: %s", res.Error())
+	}
+	if !strings.Contains(res.Error(), "selectorPrefix") {
+		t.Errorf("expected a finding in the span past the regex delimiter: %s", res.Error())
+	}
+}
+
+// Code-shaped text inside string literals is prose, not a call (review
+// 5): both examples must stay quiet under the selector and attribute
+// lints.
+const stringCodeFixture = `const selectorExample = ~document.querySelector('[data-target="' + el.dataset.target + '"]')~;
+const fetchExample = ~fetch('/kiln/tool/' + el.dataset.tool)~;
+console.log(selectorExample, fetchExample);
+`
+
+var stringCodeFixtureJS = strings.ReplaceAll(stringCodeFixture, "~", "\x60")
+
+func TestLintSelectorAndAttribute_StringLiteralCodeIsQuiet(t *testing.T) {
+	dir := writeRuntimeFixture(t, "stringcode.js", stringCodeFixtureJS)
+	sel, err := LintSelectorInterpolation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sel.HasErrors() {
+		t.Errorf("selector lint fired on string-literal prose:\n%s", sel.Error())
+	}
+	attr, err := LintAttributePathSegments(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attr.HasErrors() {
+		t.Errorf("attribute lint fired on string-literal prose:\n%s", attr.Error())
+	}
+}
+
+const registryReview5Fixture = `// Review 5: declarations mid-line (a one-line function or minified
+// source declares its {} registry like any other), attribute-borne
+// member indices, and the in operator.
+function lookupInline(name){const REGISTRY={};return REGISTRY[name]}
+const REGISTRY2 = {};
+function lookupMember(el) {
+  return REGISTRY2[el.dataset.name];
+}
+// The in operator walks the prototype chain — it is the bug this lint
+// exists for, not a guard against it, so this read reports.
+function lookupIn(name) {
+  if (name in REGISTRY2) return REGISTRY2[name];
+}
+// A correctly dominating own-property guard spread over several lines
+// by the formatter stays quiet.
+function lookupMultiline(name) {
+  if (
+    Object.prototype.hasOwnProperty.call(
+      REGISTRY2,
+      name,
+    )
+  ) {
+    return REGISTRY2[name];
+  }
+}
+`
+
+func TestLintRegistryOwnProps_Review5DeclsIndicesAndIn(t *testing.T) {
+	dir := writeRuntimeFixture(t, "review5reg.js", registryReview5Fixture)
+	res, err := LintRegistryOwnProps(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 3 {
+		t.Fatalf("expected exactly 3 findings (inline decl, member index, in-guarded read), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+	for _, v := range res.Violations {
+		if !strings.HasPrefix(v.Message, "[registry-own-prop] REGISTRY") {
+			t.Errorf("finding on a fixed/silent spelling: %s:%d: %s", v.File, v.Line, v.Message)
+		}
+	}
+}
+
+const responseReview5Fixture = `// Review 5: every compound assignment to innerHTML/outerHTML is a
+// mount, ?.then is a chain step, and the mount-helper list is
+// explicit — swapCase is a string transform, not a mount.
+function plusMount(target, src) {
+  return fetch(src).then(r => r.text()).then(html => { target.innerHTML += html; });
+}
+function optionalChain(target, src) {
+  return fetch(src)
+    ?.then(r => r.text())
+    ?.then(html => { target.innerHTML = html; });
+}
+function loadWord(src) {
+  return fetch(src).then(r => r.text()).then(text => swapCase(text));
+}
+function swapCase(text) {
+  return [...text].map(char => char === char.toUpperCase() ? char.toLowerCase() : char.toUpperCase()).join('');
+}
+// The runtime's own swap helpers (swapPane/swapAtSlot/swapShell) are
+// mounts.
+function loadSlot(slot, src) {
+  return fetch(src).then(r => r.json()).then(d => { swapPane(slot, d.panel); });
+}
+`
+
+func TestLintResponseMountedAfterOK_Review5MountsAndChains(t *testing.T) {
+	dir := writeRuntimeFixture(t, "review5resp.js", responseReview5Fixture)
+	res, err := LintResponseMountedAfterOK(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 3 {
+		t.Fatalf("expected exactly 3 findings (+=, ?.then, swapPane), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+	for _, v := range res.Violations {
+		if !strings.HasPrefix(v.Message, "[response-mounted-unchecked]") {
+			t.Errorf("unexpected message: %s", v.Message)
+		}
+	}
+}
+
+// attrReview5FixtureRaw uses ~ for JS backticks; untailed below.
+const attrReview5FixtureRaw = `// Review 5: bracket dataset reads, unanchored gates, gates after the
+// construction, numeric coercion, and fragment hrefs.
+function loadTool(el) {
+  return fetch(~/kiln/tool/${el.dataset.tool}~);
+}
+function loadToolBracket(el) {
+  return fetch('/kiln/tool/' + el.dataset['tool']);
+}
+// /./ accepts ../admin — an unanchored gate is no gate.
+function loadDot(el) {
+  const tool = el.dataset.tool;
+  if (/./.test(tool)) {
+    return fetch('/kiln/tool/' + tool);
+  }
+}
+// The validating regex runs AFTER the request was built: too late.
+function loadLate(el) {
+  const tool = el.dataset.tool;
+  const request = fetch('/kiln/tool/' + tool);
+  if (!/^[A-Za-z0-9_-]+$/.test(tool)) return;
+  return request;
+}
+// Number() output is a number or NaN: never a traversal segment.
+function loadItem(el) {
+  return fetch('/items/' + Number(el.dataset.itemId));
+}
+// A '#'-prefixed literal sets a fragment: no request path is built.
+function setRoute(link, el) {
+  link.href = '#/settings/' + el.dataset.tab;
+}
+`
+
+var attrReview5Fixture = strings.ReplaceAll(attrReview5FixtureRaw, "~", "\x60")
+
+func TestLintAttributePathSegments_Review5GatesAndSanitizers(t *testing.T) {
+	dir := writeRuntimeFixture(t, "review5attr.js", attrReview5Fixture)
+	res, err := LintAttributePathSegments(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 4 {
+		t.Fatalf("expected exactly 4 findings (template, bracket, unanchored gate, late gate), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+	for _, v := range res.Violations {
+		if !strings.HasPrefix(v.Message, "[attr-path-segment]") {
+			t.Errorf("unexpected message: %s", v.Message)
+		}
+		if strings.Contains(v.Message, "Number(") || strings.Contains(v.Message, "'#/settings/'") {
+			t.Errorf("finding on a sanitized or fragment-only use: %s", v.Message)
 		}
 	}
 }

--- a/core-ui/runtime/src/panehost.js
+++ b/core-ui/runtime/src/panehost.js
@@ -189,7 +189,11 @@
     if (i >= 0) s.stack.splice(i, 1);
     if (!syncing) stripPane(host, pane);
     host.dispatchEvent(new CustomEvent('pane-host:close', { bubbles: true, detail: { pane } }));
-    const trig = s.triggers[pane];
+    // Own-property read: pane ids are attribute-borne, and "constructor"
+    // would otherwise resolve through the prototype chain.
+    const trig = Object.prototype.hasOwnProperty.call(s.triggers, pane)
+      ? s.triggers[pane]
+      : null;
     if (trig && typeof trig.focus === 'function') {
       try { trig.focus({ preventScroll: true }); } catch (_) { trig.focus(); }
     }

--- a/core-ui/runtime/src/widgetlinks.js
+++ b/core-ui/runtime/src/widgetlinks.js
@@ -7,7 +7,9 @@
     const url = new URL(location.href);
     url.searchParams.set(cfg.deepLinkKey, cfg.deepLinkValue);
     for (const key of cfg.deepLinkParams || []) {
-      if (key in params) url.searchParams.set(key, params[key]);
+      // Own-property check: `in` walks the prototype chain, and a
+      // param literally named "constructor" would pass it.
+      if (Object.prototype.hasOwnProperty.call(params, key)) url.searchParams.set(key, params[key]);
     }
     if (url.href !== location.href) G._pushURL(url.pathname + url.search + url.hash);
   };

--- a/core-ui/runtime/src/widgets.js
+++ b/core-ui/runtime/src/widgets.js
@@ -58,7 +58,9 @@
     if (declared.length) {
       const url = new URL(window.location.href);
       for (const k of declared) {
-        const fromCaller = (k in params);
+        // Own-property check: `in` walks the prototype chain, and a
+        // param literally named "constructor" would pass it.
+        const fromCaller = Object.prototype.hasOwnProperty.call(params, k);
         const v = fromCaller ? params[k] : url.searchParams.get(k);
         // Values read off the query string are attacker-supplied.
         // Flagging them here is what lets setSignal's html render mode

--- a/core/mcp/listgate_security_test.go
+++ b/core/mcp/listgate_security_test.go
@@ -438,6 +438,70 @@ func TestListingGateNeverBlocksRegistry(t *testing.T) {
 	})
 }
 
+// Property: the REGISTRY-WIDE call gate is app-supplied callback code
+// too, and must run OUTSIDE the registry lock. listTools and
+// listToolsUnfiltered evaluated runCallGate while still holding
+// s.mu.RLock, so a gate that (directly, or via a module toggle that
+// ends in RegisterTool) re-entered the registry deadlocked it: the
+// gate cannot return while the write lock waits, and the read lock
+// cannot release until the gate returns. Same contract the per-caller
+// gate test above pins, on the surfaces it did not cover.
+func TestCallGateNeverBlocksRegistry(t *testing.T) {
+	surfaces := []struct {
+		name string
+		list func(s *Server)
+	}{
+		{
+			name: "listTools",
+			list: func(s *Server) { _, _ = s.ListToolsFor(context.Background()) },
+		},
+		{
+			name: "listToolsUnfiltered",
+			list: func(s *Server) { _ = s.ListTools() },
+		},
+	}
+	for _, sf := range surfaces {
+		t.Run(sf.name, func(t *testing.T) {
+			s := NewServer()
+			mustRegisterOpen(t, s, "open")
+			entered := make(chan struct{}, 1)
+			release := make(chan struct{})
+			s.SetCallGate(func(string) error {
+				entered <- struct{}{}
+				<-release
+				return nil
+			})
+
+			listDone := make(chan struct{}, 1)
+			go func() {
+				sf.list(s)
+				listDone <- struct{}{}
+			}()
+			<-entered // the listing is now inside its call gate
+
+			regDone := make(chan error, 1)
+			go func() {
+				regDone <- s.RegisterTool("writer", "d", nil, func(context.Context, map[string]any) (any, error) { return nil, nil })
+			}()
+			select {
+			case err := <-regDone:
+				if err != nil {
+					t.Fatalf("unrelated registration failed: %v", err)
+				}
+				close(release)
+				<-listDone
+			case <-time.After(750 * time.Millisecond):
+				t.Errorf("SECURITY: [DoS] registration stalled behind a blocked %s call gate: the registry-wide gate must not run under the registry lock", sf.name)
+				close(release)
+				<-listDone
+				if err := <-regDone; err != nil {
+					t.Fatalf("late registration failed: %v", err)
+				}
+			}
+		})
+	}
+}
+
 // Property: a panicking gate fails closed as a well-formed refusal at
 // every gate evaluation surface — the package's own stated contract
 // (checkPromptGate: "a panicking gate must become a well-formed error,

--- a/core/mcp/server.go
+++ b/core/mcp/server.go
@@ -357,27 +357,28 @@ func (s *Server) ListToolsFor(ctx context.Context) ([]Tool, error) {
 // are cut from this listing across separate requests, so map iteration
 // order would reshuffle items between pages and duplicate or drop them.
 func (s *Server) listTools(ctx context.Context) []Tool {
-	// Snapshot the registry under the read lock, then evaluate the
-	// per-caller gates OUTSIDE it. Gates are app-supplied callback code
-	// (an auth check free to do I/O), and notifications.go states this
-	// package's own rule: per-caller gates "must never contend with (or
-	// nest inside) the registry lock". One slow gate used to block every
-	// registration — and Go's RWMutex is writer-preferring, so a queued
-	// RegisterTool blocked every other reader too; a gate that panicked
-	// unwound past the plain (non-deferred) RUnlock and wedged the
-	// registry permanently.
+	// Snapshot the registry AND the gate under the read lock, then
+	// evaluate every gate OUTSIDE it. Gates are app-supplied callback
+	// code (an auth check free to do I/O), and notifications.go states
+	// this package's own rule: per-caller gates "must never contend
+	// with (or nest inside) the registry lock". One slow gate used to
+	// block every registration — and Go's RWMutex is writer-preferring,
+	// so a queued RegisterTool blocked every other reader too; a gate
+	// that re-entered the registry (module toggles re-register tools)
+	// deadlocked it outright.
 	s.mu.RLock()
 	gate := s.callGate
 	snapshot := make([]Tool, 0, len(s.tools))
 	for _, t := range s.tools {
-		if gate != nil && runCallGate(gate, t.Name) != nil {
-			continue // gated tool excluded from listing
-		}
 		snapshot = append(snapshot, t)
 	}
 	s.mu.RUnlock()
+
 	tools := make([]Tool, 0, len(snapshot))
 	for _, t := range snapshot {
+		if gate != nil && runCallGate(gate, t.Name) != nil {
+			continue // gated tool excluded from listing
+		}
 		// A tool the caller cannot invoke is not listed to them: the
 		// inputSchema is the disclosure, not the call.
 		if gateRefused(t.Gate, ctx) {
@@ -441,14 +442,19 @@ func runCallGate(gate func(toolName string) error, name string) (err error) {
 }
 
 // listToolsUnfiltered applies only the name-based call gate (disabled
-// modules), not per-caller gates. See ListTools.
+// modules), not per-caller gates. See ListTools. The gate evaluation
+// follows the same outside-the-lock rule as listTools.
 func (s *Server) listToolsUnfiltered() []Tool {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	gate := s.callGate
-	tools := make([]Tool, 0, len(s.tools))
+	snapshot := make([]Tool, 0, len(s.tools))
 	for _, t := range s.tools {
+		snapshot = append(snapshot, t)
+	}
+	s.mu.RUnlock()
+
+	tools := make([]Tool, 0, len(snapshot))
+	for _, t := range snapshot {
 		if gate != nil && runCallGate(gate, t.Name) != nil {
 			continue
 		}

--- a/core/mcp/server.go
+++ b/core/mcp/server.go
@@ -370,7 +370,7 @@ func (s *Server) listTools(ctx context.Context) []Tool {
 	gate := s.callGate
 	snapshot := make([]Tool, 0, len(s.tools))
 	for _, t := range s.tools {
-		if gate != nil && gate(t.Name) != nil {
+		if gate != nil && runCallGate(gate, t.Name) != nil {
 			continue // gated tool excluded from listing
 		}
 		snapshot = append(snapshot, t)
@@ -427,6 +427,19 @@ func (s *Server) checkToolGate(ctx context.Context, t Tool) (err error) {
 	return nil
 }
 
+// runCallGate evaluates the registry-wide call gate with the same net
+// checkToolGate gives the per-tool gate: a panicking gate refuses the
+// call instead of unwinding the transport loop it runs on
+// (recovercallback pins this).
+func runCallGate(gate func(toolName string) error, name string) (err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			err = errors.New("internal tool error")
+		}
+	}()
+	return gate(name)
+}
+
 // listToolsUnfiltered applies only the name-based call gate (disabled
 // modules), not per-caller gates. See ListTools.
 func (s *Server) listToolsUnfiltered() []Tool {
@@ -436,7 +449,7 @@ func (s *Server) listToolsUnfiltered() []Tool {
 	gate := s.callGate
 	tools := make([]Tool, 0, len(s.tools))
 	for _, t := range s.tools {
-		if gate != nil && gate(t.Name) != nil {
+		if gate != nil && runCallGate(gate, t.Name) != nil {
 			continue
 		}
 		tools = append(tools, t)
@@ -461,14 +474,22 @@ func (s *Server) SetGate(gate func(ctx context.Context) error) {
 	s.mu.Unlock()
 }
 
-// checkServerGate evaluates the server-wide gate, if any.
-func (s *Server) checkServerGate(ctx context.Context) error {
+// checkServerGate evaluates the server-wide gate, if any, with the
+// same fail-closed net checkToolGate gives the per-tool gate: a
+// panicking gate answers as an error, not an unwound transport
+// (recovercallback pins this).
+func (s *Server) checkServerGate(ctx context.Context) (err error) {
 	s.mu.RLock()
 	gate := s.serverGate
 	s.mu.RUnlock()
 	if gate == nil {
 		return nil
 	}
+	defer func() {
+		if rec := recover(); rec != nil {
+			err = errors.New("internal tool error")
+		}
+	}()
 	return gate(ctx)
 }
 
@@ -504,7 +525,7 @@ func (s *Server) callTool(ctx context.Context, name string, params map[string]an
 	gate := s.callGate
 	s.mu.RUnlock()
 	if gate != nil {
-		if err := gate(name); err != nil {
+		if err := runCallGate(gate, name); err != nil {
 			return nil, &RPCError{
 				Code:    ErrInternalError,
 				Message: "tool unavailable",

--- a/core/stream/websocket.go
+++ b/core/stream/websocket.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -453,7 +454,11 @@ func (c *WebSocketConn) Close() error {
 			// goroutine, which has no net: a panicking hook must not
 			// take the process down with the connection.
 			go func(fn func()) {
-				defer func() { _ = recover() }()
+				defer func() {
+					if rec := recover(); rec != nil {
+						slog.Default().Error("stream: websocket close hook panicked", "panic", rec)
+					}
+				}()
 				fn()
 			}(fn)
 		}

--- a/core/stream/websocket_test.go
+++ b/core/stream/websocket_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"log/slog"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -84,6 +86,67 @@ func TestWebSocketConnClose(t *testing.T) {
 			runtime.Gosched()
 		}
 	}
+}
+
+// TestWebSocketConnClosePanickingHook: OnClose hooks are app-supplied
+// callbacks on their own goroutine, which has no recover net — a
+// panicking hook must be logged and swallowed while Close stays
+// successful (and the closed channel still signals).
+func TestWebSocketConnClosePanickingHook(t *testing.T) {
+	conn := &WebSocketConn{
+		conn:       &nopConn{r: bytes.NewReader(nil), w: &bytes.Buffer{}},
+		sendBuffer: make(chan []byte, 8),
+		closed:     make(chan struct{}),
+		onClose:    []func(){func() { panic("close hook boom") }},
+	}
+	go conn.writePump()
+
+	var buf lockedBuffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close must succeed despite a panicking close hook: %v", err)
+	}
+	select {
+	case <-conn.Closed():
+	case <-time.After(time.Second):
+		t.Fatal("closed channel not signaled")
+	}
+
+	// The hook runs (and its recovery logs) on the hook goroutine.
+	deadline := time.After(2 * time.Second)
+	for {
+		if s := buf.String(); strings.Contains(s, "close hook boom") {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("panicking close hook not logged; log = %q", buf.String())
+		default:
+			runtime.Gosched()
+		}
+	}
+}
+
+// lockedBuffer is a mutex-guarded bytes.Buffer: the hook goroutine
+// writes the recovered-panic log while the test goroutine polls it.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 func TestWebSocketConnWriteAfterClose(t *testing.T) {

--- a/examples/blog/main.go
+++ b/examples/blog/main.go
@@ -156,7 +156,10 @@ func searchPosts(index search.Backend) http.HandlerFunc {
 
 // postsByStatus returns a handler that lists posts filtered by status.
 func postsByStatus(app *framework.App, status string) http.HandlerFunc {
-	entity, _ := app.Registry.Get("posts")
+	entity, err := app.Registry.Get("posts")
+	if err != nil {
+		log.Fatalf("blog: posts entity: %v", err)
+	}
 	handler := framework.NewCrudHandler(entity, app.DB)
 	listHandler := handler.List()
 

--- a/framework/a2a.go
+++ b/framework/a2a.go
@@ -363,9 +363,11 @@ func (a *App) entitySkillHandler(set entitySkillSet) a2a.Handler {
 }
 
 // entityInvocation reads the data-part contract from the message: the
-// first data part whose object carries a string "operation", with an
-// optional "arguments" object (missing → empty arguments; a present
-// non-object is a client error). A nil error return means ok.
+// first data part whose object carries a string "operation" (a part
+// whose object lacks the key is skipped, a present non-string is a
+// client error), with an optional "arguments" object (missing → empty
+// arguments; a present non-object is a client error). A nil error
+// return means ok.
 func entityInvocation(msg *a2a.Message) (operation string, args map[string]any, ierr error) {
 	if msg != nil {
 		for i := range msg.Parts {
@@ -377,9 +379,17 @@ func entityInvocation(msg *a2a.Message) (operation string, args map[string]any, 
 			if !ok {
 				continue
 			}
-			op, isStr := obj["operation"].(string)
+			raw, present := obj["operation"]
+			if !present {
+				// Absent key: this part carries no invocation, keep
+				// scanning (a failed type assertion on a missing key
+				// is not absence — that error shape used to reject a
+				// valid operation in a LATER part).
+				continue
+			}
+			op, isStr := raw.(string)
 			if !isStr {
-				return "", nil, fmt.Errorf(`data part "operation" must be a string, got %T`, obj["operation"])
+				return "", nil, fmt.Errorf(`data part "operation" must be a string, got %T`, raw)
 			}
 			if op == "" {
 				continue

--- a/framework/a2a.go
+++ b/framework/a2a.go
@@ -378,7 +378,10 @@ func entityInvocation(msg *a2a.Message) (operation string, args map[string]any, 
 				continue
 			}
 			op, isStr := obj["operation"].(string)
-			if !isStr || op == "" {
+			if !isStr {
+				return "", nil, fmt.Errorf(`data part "operation" must be a string, got %T`, obj["operation"])
+			}
+			if op == "" {
 				continue
 			}
 			args = map[string]any{}

--- a/framework/a2a_cover_test.go
+++ b/framework/a2a_cover_test.go
@@ -117,6 +117,44 @@ func TestEntityInvocationRefusals(t *testing.T) {
 	}
 }
 
+// TestEntityInvocationMissingOperationFallsThrough pins the data-part
+// loop's presence-before-type contract: a part whose object simply
+// LACKS "operation" (e.g. a routing hint) is skipped, not rejected, so
+// a valid operation in a LATER part still parses. The laxcoerce bug
+// shape: a failed type assertion on a missing key is not absence of
+// the key.
+func TestEntityInvocationMissingOperationFallsThrough(t *testing.T) {
+	hint := any(map[string]any{"skill": "entity.notes"})
+	valid := any(map[string]any{"operation": "list"})
+	op, args, err := entityInvocation(&a2a.Message{Parts: []a2a.Part{
+		{Data: &hint},
+		{Data: &valid},
+	}})
+	if err != nil {
+		t.Fatalf("missing key before a later valid part must fall through, got err = %v", err)
+	}
+	if op != "list" || args == nil || len(args) != 0 {
+		t.Fatalf("op=%q args=%v, want list with empty args", op, args)
+	}
+}
+
+// TestEntityInvocationPresentNonStringRejected: a PRESENT non-string
+// "operation" is a client error, not a skip — the empty-string skip
+// and the missing-key skip must not swallow it.
+func TestEntityInvocationPresentNonStringRejected(t *testing.T) {
+	num := any(3.0)
+	badOp := any(map[string]any{"operation": num})
+	if _, _, err := entityInvocation(&a2a.Message{Parts: []a2a.Part{{Data: &badOp}}}); err == nil ||
+		!strings.Contains(err.Error(), `data part "operation" must be a string`) {
+		t.Fatalf("present non-string operation: err = %v, want the must-be-a-string client error", err)
+	}
+	// A nil-valued operation is present-but-not-a-string too.
+	nilOp := any(map[string]any{"operation": nil})
+	if _, _, err := entityInvocation(&a2a.Message{Parts: []a2a.Part{{Data: &nilOp}}}); err == nil {
+		t.Fatal("nil-valued operation must be rejected, not skipped")
+	}
+}
+
 // A tool refusal (update without an id) fails the task and carries the
 // refusal text; it is not a rejection, which is reserved for a request
 // the skill cannot even read.

--- a/framework/contracts/analyzers/forwardedproto_test.go
+++ b/framework/contracts/analyzers/forwardedproto_test.go
@@ -113,6 +113,93 @@ func origin(r *http.Request) *url.URL {
 	}
 }
 
+// fmt.Sprintf("%s://%s", u, r.Host) splices the forged header verbatim —
+// the concatenation spelling's most common cousin, invisible to the rule
+// because "fmt.Sprintf" contains no "url". A scheme-bearing format
+// literal is a reflection sink.
+func TestForwardedProtoSprintfSpliceIsReported(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"origin.go": `package origin
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// sprintfOrigin: the pre-fix resolveBaseURL bug with the concatenation
+// spelled as fmt.Sprintf — the holder is named u, exactly like the bug.
+func sprintfOrigin(r *http.Request) string {
+	u := r.Header.Get("X-Forwarded-Proto")
+	return fmt.Sprintf("%s://%s", u, r.Host)
+}
+
+// concatOrigin: identical bug, concatenation spelling (control).
+func concatOrigin(r *http.Request) string {
+	u := r.Header.Get("X-Forwarded-Proto")
+	return u + "://" + r.Host
+}
+`,
+	})
+	assertHas(t, ds, contracts.RuleForwardedProtoEnum)
+	if got := rules(ds)[contracts.RuleForwardedProtoEnum]; got != 2 {
+		t.Errorf("expected both the Sprintf and the concatenation spelling to fire, got %d findings", got)
+	}
+}
+
+// The header map passed to a helper as h http.Header: Get on an
+// identifier receiver is the same read of the same header. The argument
+// literal is the gate (any other Get is out of scope) and the reflection
+// sink keeps the precision, so a read that never reflects stays quiet.
+func TestForwardedProtoHeaderParameterIsReported(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"header.go": `package header
+
+import "net/http"
+
+func originFromHeader(h http.Header, host string) string {
+	return h.Get("X-Forwarded-Proto") + "://" + host
+}
+
+// A read that is never reflected (a boolean) stays quiet even under the
+// widened receiver — and this one also carries the enum.
+func isSecure(h http.Header) bool {
+	return h.Get("X-Forwarded-Proto") == "https"
+}
+`,
+	})
+	assertHas(t, ds, contracts.RuleForwardedProtoEnum)
+	if got := rules(ds)[contracts.RuleForwardedProtoEnum]; got != 1 {
+		t.Errorf("expected only the reflected identifier-receiver read to fire, got %d findings", got)
+	}
+}
+
+// An enum comparison on a DIFFERENT value — an outbound URL's scheme —
+// must not silence the reflected header. Only comparisons whose other
+// side touches the get or one of its holders count.
+func TestForwardedProtoEnumOnUnrelatedValueDoesNotSilence(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"resolve.go": `package resolve
+
+import (
+	"net/http"
+	"net/url"
+)
+
+// resolve mixes an outbound URL's scheme check with the forwarded
+// header: the enum on target.Scheme belongs to a different value, and
+// the reflected u is never compared against anything.
+func resolve(r *http.Request, target *url.URL) string {
+	u := r.Header.Get("X-Forwarded-Proto")
+	if target.Scheme == "https" {
+		return u + "://" + r.Host + target.Path
+	}
+	return u + "://" + r.Host
+}
+`,
+	})
+	assertHas(t, ds, contracts.RuleForwardedProtoEnum)
+}
+
 // The documented silences: an EqualFold comparison (battery/setup's
 // spelling), a switch enum (framework/pluginhost/assets.go's spelling),
 // and writing the header outbound (battery/relay's Set), which is not a

--- a/framework/contracts/analyzers/prefixboundary_test.go
+++ b/framework/contracts/analyzers/prefixboundary_test.go
@@ -113,11 +113,18 @@ func (s scope) covers(u *url.URL) bool {
 }
 
 // The narrowed literal posture (narrowed after the first whole-repo run):
-// a literal only fires when its value names part of a slash-hierarchy
-// without the boundary ("/_gofastr/doc", the v0.80 uihost shape).
-// Namespace literals ("screen_", "color-", "v") and constants whose value
-// is bounded ("/__gofastr/runtime/") or non-hierarchical are silent; a
-// dynamic prefix with an invisible value still fires.
+// a literal or resolvable constant fires when its value names part of a
+// slash-hierarchy without the boundary ("/_gofastr/doc", the v0.80 uihost
+// shape) — and, narrowed a second time after the adversarial review, when
+// its value contains no "/" at all but the haystack is STRONGLY path-named
+// (an identifier matching path/route/url/uri/dir, or exactly rel):
+// HasPrefix(importPath, "cmd") is the original stability bug with the
+// manifest entry spelled as a literal, and "cmd" must not classify
+// cmdline/tools. Namespace literals ("screen_", "v", "btk_") stay silent
+// on haystacks that are pathish only through key or prefix naming — YAML
+// keys, token names, and versions are value spaces where every longer
+// sibling IS the intent. Bounded constants ("/__gofastr/runtime/") stay
+// silent, and a dynamic prefix with an invisible value still fires.
 func TestPrefixBoundaryNarrowedLiteralsAndConstants(t *testing.T) {
 	ds := fixture(t, map[string]string{
 		"narrow.go": `package main
@@ -126,12 +133,25 @@ import "strings"
 
 const runtimePrefix = "/__gofastr/runtime/"
 const tokenNamespace = "btk_"
+const firstSegment = "cmd"
 
-func scoped(path string, mount string) bool {
-	return strings.HasPrefix(path, "/_gofastr/doc") ||
-		strings.HasPrefix(path, runtimePrefix) ||
-		strings.HasPrefix(path, tokenNamespace) ||
-		strings.HasPrefix(path, "screen_")
+func namespaced(key string, prefix string) bool {
+	return strings.HasPrefix(key, tokenNamespace) ||
+		strings.HasPrefix(key, "screen_") ||
+		strings.HasPrefix(prefix, "v")
+}
+
+func literalShape(importPath string) bool {
+	return strings.HasPrefix(importPath, "cmd") ||
+		strings.HasPrefix(importPath, firstSegment)
+}
+
+func literalRel(rel string) bool {
+	return strings.HasPrefix(rel, "cmd")
+}
+
+func scoped(path string) bool {
+	return strings.HasPrefix(path, "/_gofastr/doc")
 }
 
 func dyn(path string, mount string) bool {
@@ -140,9 +160,77 @@ func dyn(path string, mount string) bool {
 `,
 	})
 	assertHas(t, ds, contracts.RulePrefixSegmentBoundary)
-	if got := rules(ds)[contracts.RulePrefixSegmentBoundary]; got != 2 {
-		t.Errorf("expected the doc-scope literal and the dynamic mount to fire (got %d): namespace literals and bounded constants must stay silent", got)
+	if got := rules(ds)[contracts.RulePrefixSegmentBoundary]; got != 5 {
+		t.Errorf("expected the slash-bearing literal, the two no-slash first-segment spellings, and the dynamic mount to fire (got %d): namespace literals on key/prefix-named haystacks and bounded constants must stay silent", got)
 	}
+}
+
+// A bounded package-level constant may live in any file of the package
+// (consts.go / scope.go is standard Go layout): same-package resolution,
+// not same-file, is the idiom. The suggested fix docPrefix+"/" would
+// match a double slash, so the silence is also the only correct advice.
+func TestPrefixBoundaryResolvesSamePackageConstantsFromOtherFiles(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"consts.go": `package main
+
+// docPrefix is the bounded document-script scope prefix (the uihost
+// shape, fixed spelling): it carries its own trailing boundary.
+const docPrefix = "/__gofastr/doc/"
+`,
+		"scope.go": `package main
+
+import "strings"
+
+// inScope: exactly the documented safe shape — the prefix resolves to
+// a constant that ends in "/". The constant lives in consts.go, same
+// package, sibling file.
+func inScope(docPath string) bool {
+	return strings.HasPrefix(docPath, docPrefix)
+}
+`,
+	})
+	assertNot(t, ds, contracts.RulePrefixSegmentBoundary,
+		"a same-package constant from a sibling file carries its own boundary — only cross-package values are dynamic")
+}
+
+// Postures pinned by the whole-repo run: the generator's screen_ file
+// namespace (the haystack reads a filename through filepath.ToSlash —
+// the callee names the transform, not the value) and isolation's
+// "file:" DSN scheme literal (the colon terminates the scheme token) are
+// legitimate idioms the strongly-path-named widening must not reach.
+func TestPrefixBoundarySparesRepoIdioms(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"gen/gen.go": `package gen
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func hasNewScreens(written []struct{ name string }) bool {
+	for _, f := range written {
+		if strings.HasPrefix(filepath.ToSlash(f.name), "screen_") {
+			return true
+		}
+	}
+	return false
+}
+`,
+		"iso/iso.go": `package iso
+
+import "strings"
+
+func sqliteDSN(dsn string) string {
+	path := dsn
+	if strings.HasPrefix(path, "file:") {
+		path = strings.TrimPrefix(path, "file:")
+	}
+	return path
+}
+`,
+	})
+	assertNot(t, ds, contracts.RulePrefixSegmentBoundary,
+		"a transformed filename's package qualifier and a ':'-terminated scheme literal are not first-segment matches")
 }
 
 // The documented silences: a literal that carries its own boundary, the

--- a/framework/contracts/analyzers/prefixboundary_test.go
+++ b/framework/contracts/analyzers/prefixboundary_test.go
@@ -280,3 +280,132 @@ func TestClassify(t *testing.T) {
 	assertNot(t, ds, contracts.RulePrefixSegmentBoundary,
 		"_test.go is a documented silence")
 }
+
+// Review 5, flow-insensitive literals: a local counts as a resolvable
+// literal only when it is not a parameter and EVERY assignment to it in
+// the function is a string literal. The stale spelling — a parameter
+// conditionally defaulted to "/api/" — lets the executed "/api" claim
+// /apiary, and the mixed spelling (one literal, one dynamic assignment)
+// is just as unprovable: both are dynamic and report.
+func TestPrefixBoundaryEveryAssignmentMustBeALiteral(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"stale.go": `package main
+
+import "strings"
+
+func under(path, prefix string) bool {
+	if prefix == "" {
+		prefix = "/api/"
+	}
+	return strings.HasPrefix(path, prefix)
+}
+
+func reassigned(path string, base string) bool {
+	local := "/api/"
+	if base != "" {
+		local = base
+	}
+	return strings.HasPrefix(path, local)
+}
+`,
+	})
+	assertHas(t, ds, contracts.RulePrefixSegmentBoundary)
+	if got := rules(ds)[contracts.RulePrefixSegmentBoundary]; got != 2 {
+		t.Errorf("expected the parameter-conditioned and mixed-assignment locals to be dynamic (got %d findings)", got)
+	}
+}
+
+// Review 5, the key/prefix heuristic: key and prefix are dropped from
+// the pathish-name regex entirely. API keys and token types are value
+// spaces where matching every longer sibling is the intent; adding "/"
+// there would break the check.
+func TestPrefixBoundaryAPIKeyPrefixChecksAreNotPaths(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"keyed.go": `package main
+
+import "strings"
+
+func hasExpectedKeyPrefix(apiKey, expectedKeyPrefix string) bool {
+	return strings.HasPrefix(apiKey, expectedKeyPrefix)
+}
+
+func tokenType(token, tokenPrefix string) bool {
+	return strings.HasPrefix(token, tokenPrefix)
+}
+`,
+	})
+	assertNot(t, ds, contracts.RulePrefixSegmentBoundary,
+		"key- and prefix-named haystacks are value spaces, not slash trees — the rule keys on path-named haystacks only")
+}
+
+// Review 5, concatenation: a binary + chain is silent only when its
+// RIGHTMOST operand is a string literal (or resolves to one) ending in
+// "/", or the platform separator spelled string(os.PathSeparator) /
+// string(filepath.Separator) — directly or through a local whose every
+// assignment is exactly that (the whole-repo containment idiom
+// absBase+string(os.PathSeparator), which a hardcoded "/" would break
+// on Windows). root+"/" keeps its silence; root+leaf and a sep PARAM
+// carry no proven boundary and report.
+func TestPrefixBoundaryConcatenationNeedsRightmostBoundary(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"concat.go": `package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const slash = "/"
+
+func unboundedConcat(path, root, leaf string) bool {
+	return strings.HasPrefix(path, root+leaf)
+}
+
+func sepConcat(path, root, sep string) bool {
+	return strings.HasPrefix(path, root+sep)
+}
+
+func boundedConcat(rel string, root string) bool {
+	return strings.HasPrefix(rel, root+"/")
+}
+
+func constConcat(rel string, root string) bool {
+	return strings.HasPrefix(rel, root+slash)
+}
+
+func osSepConcat(path, base string) bool {
+	return strings.HasPrefix(path, base+string(os.PathSeparator))
+}
+
+func sepLocalConcat(rel, root string) bool {
+	sep := string(filepath.Separator)
+	return strings.HasPrefix(rel, root+sep)
+}
+`,
+	})
+	assertHas(t, ds, contracts.RulePrefixSegmentBoundary)
+	if got := rules(ds)[contracts.RulePrefixSegmentBoundary]; got != 2 {
+		t.Errorf("expected root+leaf and the sep parameter to fire; the /-terminated chains and both separator spellings must stay quiet (got %d findings)", got)
+	}
+}
+
+// Review 5, fixture C: a path held in neutrally named variables is out
+// of reach for a parse-only pass. The rule keys on path-named haystacks
+// (path/route/url/uri/dir, exactly rel, or a .URL selection); s and p
+// carry no path semantics it can see, so this is a declared silence,
+// not a gap it can close.
+func TestPrefixBoundaryNeutrallyNamedVariablesAreOutOfReach(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"neutral.go": `package main
+
+import "strings"
+
+func under(s, p string) bool {
+	return strings.HasPrefix(s, p)
+}
+`,
+	})
+	assertNot(t, ds, contracts.RulePrefixSegmentBoundary,
+		"a path held in a neutrally named variable is out of reach for a parse-only pass")
+}

--- a/framework/contracts/analyzers/prefixboundary_test.go
+++ b/framework/contracts/analyzers/prefixboundary_test.go
@@ -345,7 +345,11 @@ func tokenType(token, tokenPrefix string) bool {
 // assignment is exactly that (the whole-repo containment idiom
 // absBase+string(os.PathSeparator), which a hardcoded "/" would break
 // on Windows). root+"/" keeps its silence; root+leaf and a sep PARAM
-// carry no proven boundary and report.
+// carry no proven boundary and report. A sep local conditionally
+// defaulted from a caller value is the stale-default shape the literal
+// path already rejects: one non-separator assignment disqualifies the
+// name for good, so the re-assignment to string(filepath.Separator)
+// cannot launder it back.
 func TestPrefixBoundaryConcatenationNeedsRightmostBoundary(t *testing.T) {
 	ds := fixture(t, map[string]string{
 		"concat.go": `package main
@@ -382,11 +386,19 @@ func sepLocalConcat(rel, root string) bool {
 	sep := string(filepath.Separator)
 	return strings.HasPrefix(rel, root+sep)
 }
+
+func conditionalSepConcat(rel, root, cfgSep string) bool {
+	sep := cfgSep
+	if sep == "" {
+		sep = string(filepath.Separator)
+	}
+	return strings.HasPrefix(rel, root+sep)
+}
 `,
 	})
 	assertHas(t, ds, contracts.RulePrefixSegmentBoundary)
-	if got := rules(ds)[contracts.RulePrefixSegmentBoundary]; got != 2 {
-		t.Errorf("expected root+leaf and the sep parameter to fire; the /-terminated chains and both separator spellings must stay quiet (got %d findings)", got)
+	if got := rules(ds)[contracts.RulePrefixSegmentBoundary]; got != 3 {
+		t.Errorf("expected root+leaf, the sep parameter, and the conditionally-defaulted sep to fire; the /-terminated chains and both separator spellings must stay quiet (got %d findings)", got)
 	}
 }
 
@@ -408,4 +420,43 @@ func under(s, p string) bool {
 	})
 	assertNot(t, ds, contracts.RulePrefixSegmentBoundary,
 		"a path held in a neutrally named variable is out of reach for a parse-only pass")
+}
+
+// Same-package resolution is same-DIRECTORY resolution: the pass
+// walks every directory under the root, and two directories can both
+// declare `package main` (or any shared name) while being separate
+// packages. Keying package constants by package NAME let one
+// directory's constant overwrite or resolve for the other's
+// identifiers — beta's bounded "/v1/" could silence alpha's
+// unbounded "/api/users", or the reverse by file order.
+func TestPrefixBoundaryPackageConstantsDoNotCrossDirectories(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"alpha/alpha.go": `package main
+
+import "strings"
+
+const base = "/api/users"
+
+func underAlpha(routePath string) bool {
+	return strings.HasPrefix(routePath, base)
+}
+`,
+		"beta/beta.go": `package main
+
+import "strings"
+
+const base = "/v1/"
+
+func underBeta(assetPath string) bool {
+	return strings.HasPrefix(assetPath, base)
+}
+`,
+	})
+	d := assertHas(t, ds, contracts.RulePrefixSegmentBoundary)
+	if !strings.Contains(d.Message, `HasPrefix(routePath, base)`) {
+		t.Errorf("expected the unbounded alpha constant to fire, got %q", d.Message)
+	}
+	if got := rules(ds)[contracts.RulePrefixSegmentBoundary]; got != 1 {
+		t.Errorf("beta's %q is bounded by its own trailing slash; the same package NAME in another directory is a different package and must not cross-resolve (got %d findings)", "/v1/", got)
+	}
 }

--- a/framework/contracts/analyzers/rawjsonbody_test.go
+++ b/framework/contracts/analyzers/rawjsonbody_test.go
@@ -120,6 +120,120 @@ func update(req *http.Request) error {
 	}
 }
 
+// The body ferried through a helper: io.ReadAll wrapped in a one-line
+// local function is the same stdlib decode of raw request bytes — the
+// pass parses this file, so the helper's return is visible. One bounded
+// level of same-file tracking; a helper in another file stays invisible
+// (documented silence), because the pass never loads another file's
+// bodies.
+func TestRawJSONBodyDecodeThroughSameFileHelperIsReported(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"update.go": `package cart
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// readBody is a one-line local helper, same file, fully visible.
+func readBody(r *http.Request) ([]byte, error) {
+	return io.ReadAll(r.Body)
+}
+
+// updateViaHelper: the battery/auth bug with io.ReadAll wrapped in the
+// local helper above. json.Unmarshal still decodes raw request bytes
+// with stdlib semantics.
+func updateViaHelper(w http.ResponseWriter, r *http.Request) {
+	raw, err := readBody(r)
+	if err != nil {
+		return
+	}
+	var cart struct {
+		SKU string ` + "`json:\"sku\"`" + `
+	}
+	json.Unmarshal(raw, &cart)
+}
+`,
+		"caller.go": `package cart
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// updateViaCrossFile: identical shape, but the helper lives in another
+// file of the same package — invisible to a per-file pass, and the
+// documented silence.
+func updateViaCrossFile(w http.ResponseWriter, r *http.Request) {
+	raw, err := readBodyCrossFile(r)
+	if err != nil {
+		return
+	}
+	var note struct {
+		ID int ` + "`json:\"id\"`" + `
+	}
+	json.Unmarshal(raw, &note)
+}
+`,
+		"helper.go": `package cart
+
+import (
+	"io"
+	"net/http"
+)
+
+func readBodyCrossFile(r *http.Request) ([]byte, error) {
+	return io.ReadAll(r.Body)
+}
+`,
+	})
+	assertHas(t, ds, contracts.RuleRawJSONBodyDecode)
+	if got := rules(ds)[contracts.RuleRawJSONBodyDecode]; got != 1 {
+		t.Errorf("expected exactly the same-file ferry to fire (got %d findings): the cross-file ferry is the documented silence", got)
+	}
+}
+
+// Posture pinned by the whole-repo run: the module proxy buffers the
+// request body into params via a same-file helper, but the bytes it
+// decodes afterwards are the child module's RESPONSE (peer.CallWithID),
+// not the request body — taint does not flow through an arbitrary call
+// that merely receives tainted arguments, only through reader wrappers
+// (ReadAll/MaxBytesReader/LimitReader) and the same-file helper ferry.
+func TestRawJSONBodyDecodeDoesNotTaintThroughArbitraryCalls(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"proxy.go": `package proxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+func buildParams(r *http.Request) ([]byte, error) {
+	return io.ReadAll(io.LimitReader(r.Body, 1<<20))
+}
+
+func serve(w http.ResponseWriter, r *http.Request) {
+	params, err := buildParams(r)
+	if err != nil {
+		return
+	}
+	raw, err := peer.Call(r.Context(), params)
+	if err != nil {
+		return
+	}
+	var res struct {
+		Status int ` + "`json:\"status\"`" + `
+	}
+	json.Unmarshal(raw, &res)
+}
+`,
+	})
+	assertNot(t, ds, contracts.RuleRawJSONBodyDecode,
+		"raw is the module's response; the body only shaped the request params")
+}
+
 // The documented silences: core/handler owns the strict binder and decodes
 // raw bytes by design; an outbound response body is not a request body; a
 // function with no *http.Request parameter never sees one; _test.go is

--- a/framework/contracts/analyzers/rawjsonbody_test.go
+++ b/framework/contracts/analyzers/rawjsonbody_test.go
@@ -120,6 +120,44 @@ func update(req *http.Request) error {
 	}
 }
 
+// Pass-through reader constructors keep the body's bytes: a decoder
+// over a buffered, NopCloser-wrapped, or tee'd body is still decoding
+// the raw request. Constructors that return their own output
+// (peer.CallWithID) stay excluded — that is the distinction the
+// allow-list encodes.
+func TestRawJSONBodyDecodeThroughReaderConstructorsIsReported(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"wrapped.go": `package wrapped
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+func decodeBuffered(r *http.Request) error {
+	var v map[string]any
+	return json.NewDecoder(bufio.NewReader(r.Body)).Decode(&v)
+}
+
+func decodeNopCloser(r *http.Request) error {
+	var v map[string]any
+	return json.NewDecoder(io.NopCloser(r.Body)).Decode(&v)
+}
+
+func decodeTee(r *http.Request, w io.Writer) error {
+	var v map[string]any
+	return json.NewDecoder(io.TeeReader(r.Body, w)).Decode(&v)
+}
+`,
+	})
+	assertHas(t, ds, contracts.RuleRawJSONBodyDecode)
+	if got := rules(ds)[contracts.RuleRawJSONBodyDecode]; got != 3 {
+		t.Errorf("expected the buffered, NopCloser, and TeeReader spellings to fire, got %d findings", got)
+	}
+}
+
 // The body ferried through a helper: io.ReadAll wrapped in a one-line
 // local function is the same stdlib decode of raw request bytes — the
 // pass parses this file, so the helper's return is visible. One bounded

--- a/framework/contracts/analyzers/routing.go
+++ b/framework/contracts/analyzers/routing.go
@@ -361,32 +361,48 @@ func replaceLiteralFix(p *contracts.Pass, rel string, line int, oldText, newText
 // script scope matched the same shape earlier in v0.80. The rule is
 // shape-based, not stability-based: any path-like operand matched against
 // a boundary-less prefix is the finding.
+//
+// The rule keys on path-NAMED haystacks: an identifier in the first
+// operand matching path/route/url/uri/dir, exactly "rel", or a selection
+// through a .URL field. A path held in a neutrally named variable
+// (HasPrefix(s, p)) is out of reach for a parse-only pass — and key and
+// prefix are deliberately not path names (review 5): API keys, token
+// types, and versions are value spaces where matching every longer
+// sibling is the intent, so prefix checks on them stay quiet.
+//
 // Deliberately silent on:
 //   - a literal prefix that already ends in "/" ("internal/") and "/"
 //     and "" themselves: the boundary is written down — as is a value
 //     ending in ":" ("file:", a URL scheme literal: the colon
 //     terminates the scheme token, so every match has that exact
 //     scheme);
-//   - a literal or resolvable constant whose value contains no "/" at all
-//     ("x_", "dark.", "color-", "v", "&") UNLESS the haystack is strongly
-//     path-named (an identifier matching path/route/url/uri/dir, or
-//     exactly rel — the callee's package qualifier does not count: a
-//     call transforms its input, and filepath.ToSlash names the
-//     transform, not the value): key/prefix-named haystacks are
-//     namespace-ish value spaces (YAML keys, token names, versions)
-//     where every longer sibling IS the intent, but
-//     HasPrefix(importPath, "cmd") is the original bug wearing a
-//     literal — "cmd" matches cmdline/tools the moment the tree is
-//     slash-separated;
-//   - a prefix identifier that resolves to a local or package-level
-//     constant carrying its own boundary (const prefix =
-//     "/__gofastr/runtime/"): the boundary is written down one line up,
-//     in this file or any sibling file of the same package (consts.go /
-//     scope.go layout). Cross-package constants stay dynamic: their
-//     value is not visible without loading another package's files;
-//   - any prefix built by concatenation at the call (`root+"/"`,
-//     `base+sep`): the caller wrote a boundary decision down, and judging
-//     a runtime-computed one from the AST would be guessing;
+//   - a prefix identifier that resolves to a package-level CONSTANT
+//     (const prefix = "/__gofastr/runtime/"), in this file or any
+//     sibling file of the same package (consts.go / scope.go layout),
+//     or to a function local that is not a parameter and whose EVERY
+//     assignment in the function is a string literal (the same
+//     literal): both provably hold that one value at the call. A
+//     parameter conditionally defaulted to a bounded literal stays
+//     dynamic — the caller's value is what runs (review 5: "/api"
+//     claiming /apiary through a defaulted "/api/"), and so does any
+//     local with one non-literal or differently-valued assignment
+//     anywhere in the function. Cross-package constants stay dynamic
+//     (their value is not visible without loading another package's
+//     files), and package-level vars too (a var is assignable from any
+//     function of the package, which a one-file pass cannot see);
+//   - a binary + chain whose RIGHTMOST operand is a string literal (or
+//     resolves to one) ending in "/" (`root+"/"`): the final value
+//     provably stops at a segment boundary. Every other concatenation
+//     (`root+leaf`, `base+sep`) is runtime-computed and reports —
+//     review 5 ran root+leaf against "/api/users-old" under
+//     "/api/users" and it matched.
+//
+// A literal with no "/" at all ("cmd") fires whenever the haystack is
+// strongly path-named (an identifier matching path/route/url/uri/dir,
+// or exactly rel — judged without the callee of a call, which names
+// the transform: filepath.ToSlash on a filename is a value-space
+// match, not a first segment): a first segment is exactly how the
+// original bug was spelled, HasPrefix(importPath, "cmd").
 func checkPrefixBoundary(p *contracts.Pass) []contracts.Diagnostic {
 	var out []contracts.Diagnostic
 	// Package-level literals are resolved across every file of the
@@ -413,7 +429,7 @@ func checkPrefixBoundary(p *contracts.Pass) []contracts.Diagnostic {
 		aliases := importAliases(file)
 		fileLits := pkgLits[file.Name.Name]
 		for _, fn := range functionsIn(file) {
-			localLits := bodyScopedLits(fn.body)
+			localLits := bodyScopedLits(fn, aliases)
 			ast.Inspect(fn.body, func(n ast.Node) bool {
 				call, ok := qualifiedCall(n, aliases, "strings", "HasPrefix")
 				if !ok || len(call.Args) != 2 {
@@ -422,7 +438,7 @@ func checkPrefixBoundary(p *contracts.Pass) []contracts.Diagnostic {
 				if !pathishExpr(call.Args[0]) {
 					return true
 				}
-				if !unboundedPrefix(call.Args[1], call.Args[0], localLits, fileLits) {
+				if !unboundedPrefix(call.Args[1], call.Args[0], localLits, fileLits, aliases) {
 					return true
 				}
 				hay, needle := exprText(call.Args[0]), exprText(call.Args[1])
@@ -448,30 +464,109 @@ func checkPrefixBoundary(p *contracts.Pass) []contracts.Diagnostic {
 // value with no slash at all is a first segment, which only matters when
 // the haystack is strongly path-named (strongPathExpr) — against a
 // key/prefix-named value space a no-slash prefix is the intent, not a
-// boundary bug.
-func unboundedPrefix(e ast.Expr, haystack ast.Expr, localLits, fileLits map[string]string) bool {
+// boundary bug. A binary + chain is judged by its rightmost operand:
+// only a string literal (or resolvable name) ending in "/", or the
+// platform separator spelled string(os.PathSeparator) /
+// string(filepath.Separator) — directly or through a local whose every
+// assignment is exactly that — proves the final value stops at a
+// boundary (root+"/", absBase+string(os.PathSeparator), the
+// containment idiom the whole-repo run pinned); every other
+// concatenation is dynamic (review 5: root+leaf still matched
+// /api/users-old).
+func unboundedPrefix(e ast.Expr, haystack ast.Expr, local localLits, fileLits map[string]string, aliases map[string]string) bool {
 	strong := strongPathExpr(haystack)
 	switch v := e.(type) {
 	case *ast.BasicLit:
 		val, ok := stringLit(v)
 		return ok && segmentPrefixCandidate(val, strong)
 	case *ast.Ident:
-		if val, ok := localLits[v.Name]; ok {
-			return segmentPrefixCandidate(val, strong)
-		}
-		if val, ok := fileLits[v.Name]; ok {
+		if val, ok := resolveLit(v.Name, local, fileLits); ok {
 			return segmentPrefixCandidate(val, strong)
 		}
 		return true
 	case *ast.BinaryExpr:
-		// `root+"/"` and every runtime-computed prefix: the boundary
-		// decision was written at this call, which is what the rule
-		// asks for.
-		return false
+		if v.Op != token.ADD {
+			return true // arithmetic a prefix is not; treat as dynamic
+		}
+		chain := v
+		for {
+			inner, ok := chain.Y.(*ast.BinaryExpr)
+			if !ok {
+				break
+			}
+			chain = inner
+		}
+		switch last := chain.Y.(type) {
+		case *ast.BasicLit:
+			if val, ok := stringLit(last); ok {
+				return !strings.HasSuffix(val, "/")
+			}
+		case *ast.Ident:
+			if val, ok := resolveLit(last.Name, local, fileLits); ok {
+				return !strings.HasSuffix(val, "/")
+			}
+			if local.seps[last.Name] {
+				return false // root+sep, sep := string(filepath.Separator)
+			}
+		case *ast.CallExpr:
+			if separatorExpr(last, aliases) {
+				return false // base+string(os.PathSeparator)
+			}
+		}
+		return true
 	}
 	// Selectors (r.prefix, cfg.BasePath), calls, index expressions:
 	// dynamic.
 	return true
+}
+
+// separatorExpr reports whether e spells the platform path separator:
+// string(os.PathSeparator) or string(filepath.Separator), honouring the
+// file's import aliases. A one-byte delimiter on every GOOS, so a
+// chain ending in it ends at a segment boundary exactly like one
+// ending in "/" — the cross-platform containment idiom
+// (absBase+string(os.PathSeparator)) that a hardcoded "/" would break
+// on Windows. os spells the constant PathSeparator; filepath spells it
+// Separator.
+func separatorExpr(e ast.Expr, aliases map[string]string) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 {
+		return false
+	}
+	fun, ok := call.Fun.(*ast.Ident)
+	if !ok || fun.Name != "string" {
+		return false
+	}
+	sel, ok := call.Args[0].(*ast.SelectorExpr)
+	if !ok || sel.Sel == nil {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	switch aliases[pkg.Name] {
+	case "os":
+		return sel.Sel.Name == "PathSeparator"
+	case "path/filepath":
+		return sel.Sel.Name == "Separator"
+	}
+	return false
+}
+
+// resolveLit returns the string literal the name provably holds in this
+// function, falling back to the package-level constants. A name the
+// function made dynamic (a parameter, a non-literal or conflicting
+// assignment) never resolves: the local fact beats the file fact.
+func resolveLit(name string, local localLits, fileLits map[string]string) (string, bool) {
+	if local.dyn[name] {
+		return "", false
+	}
+	if val, ok := local.vals[name]; ok {
+		return val, true
+	}
+	val, ok := fileLits[name]
+	return val, ok
 }
 
 // segmentPrefixCandidate reports whether a known prefix value names part
@@ -493,15 +588,18 @@ func segmentPrefixCandidate(val string, strongHaystack bool) bool {
 	return strongHaystack
 }
 
-// fileScopedLits maps the package-level const/var names of ONE file
+// fileScopedLits maps the package-level CONST names of ONE file
 // initialized from a single string literal. Callers merge these per
 // package (see checkPrefixBoundary) so a constant resolves from sibling
-// files too.
+// files too. Package-level vars are deliberately not resolved: a var is
+// assignable from any function of the package, and one file's pass
+// cannot see the other files' assignments — review 5's stale-literal
+// finding at file scope.
 func fileScopedLits(file *ast.File) map[string]string {
 	lits := map[string]string{}
 	for _, decl := range file.Decls {
 		gd, ok := decl.(*ast.GenDecl)
-		if !ok || (gd.Tok != token.CONST && gd.Tok != token.VAR) {
+		if !ok || gd.Tok != token.CONST {
 			continue
 		}
 		for _, spec := range gd.Specs {
@@ -519,11 +617,79 @@ func fileScopedLits(file *ast.File) map[string]string {
 	return lits
 }
 
-// bodyScopedLits maps const/var/assignment names in one function body
-// (including nested literals) to a single string literal value.
-func bodyScopedLits(body ast.Node) map[string]string {
-	lits := map[string]string{}
-	ast.Inspect(body, func(n ast.Node) bool {
+// localLits is the literal resolution of one function body: names that
+// provably hold one string literal at every point of the body, names
+// that are provably dynamic (a parameter, or any assignment that is
+// not that one literal), and names whose every assignment spells the
+// platform separator (sep := string(filepath.Separator)) — a boundary
+// when such a name ends a concatenation.
+type localLits struct {
+	vals map[string]string
+	dyn  map[string]bool
+	seps map[string]bool
+}
+
+// bodyScopedLits resolves the string-literal locals of one function.
+// A name is resolvable only when it is not a parameter and EVERY
+// assignment to it in the function is the same string literal (review
+// 5: collecting literals by spelling let a parameter conditionally
+// defaulted to "/api/" silence the "/api" that actually ran, and a
+// later dynamic reassignment overwrote nothing). Any other fact about
+// the name — a non-literal assignment, a multi-value assignment, two
+// different literals — makes it dynamic, and dynamic is sticky so a
+// file-level constant can never launder it. The same every-assignment
+// rule recognizes separator locals (sep := string(filepath.Separator)).
+// Assignments inside nested function literals count too: name-based
+// resolution cannot tell scopes apart, and the ambiguity must resolve
+// toward dynamic.
+func bodyScopedLits(fn *funcScope, aliases map[string]string) localLits {
+	res := localLits{vals: map[string]string{}, dyn: map[string]bool{}, seps: map[string]bool{}}
+	isParam := map[string]bool{}
+	params := func(fl *ast.FieldList) {
+		if fl == nil {
+			return
+		}
+		for _, field := range fl.List {
+			for _, name := range field.Names {
+				res.dyn[name.Name] = true
+				isParam[name.Name] = true
+			}
+		}
+	}
+	switch v := fn.node.(type) {
+	case *ast.FuncDecl:
+		params(v.Type.Params)
+	case *ast.FuncLit:
+		params(v.Type.Params)
+	}
+	set := func(name, val string, literal bool) {
+		if res.dyn[name] {
+			return
+		}
+		if !literal || res.vals[name] != "" && res.vals[name] != val {
+			res.dyn[name] = true
+			delete(res.vals, name)
+			return
+		}
+		res.vals[name] = val
+	}
+	sepEvery := map[string]bool{} // every assignment so far is a separator call
+	setSep := func(name string, rhs ast.Expr) {
+		// A parameter never becomes a separator: its caller-supplied
+		// value can survive a conditional reassignment. A local that is
+		// merely dyn (its assignment is a call, not a literal) still
+		// counts — that is exactly the separator spelling. A nil rhs is
+		// any non one-to-one assignment and disqualifies.
+		if isParam[name] {
+			return
+		}
+		if rhs == nil || !separatorExpr(rhs, aliases) {
+			delete(sepEvery, name)
+			return
+		}
+		sepEvery[name] = true
+	}
+	ast.Inspect(fn.body, func(n ast.Node) bool {
 		switch v := n.(type) {
 		case *ast.GenDecl:
 			if v.Tok != token.CONST && v.Tok != token.VAR {
@@ -531,48 +697,90 @@ func bodyScopedLits(body ast.Node) map[string]string {
 			}
 			for _, spec := range v.Specs {
 				vs, ok := spec.(*ast.ValueSpec)
-				if !ok || len(vs.Values) != 1 || len(vs.Names) != 1 {
+				if !ok {
 					continue
 				}
-				if lit, ok := vs.Values[0].(*ast.BasicLit); ok {
-					if val, ok := stringLit(lit); ok {
-						lits[vs.Names[0].Name] = val
+				literal := len(vs.Values) == 1 && len(vs.Names) == 1
+				var val string
+				if literal {
+					if lit, ok := vs.Values[0].(*ast.BasicLit); ok {
+						val, literal = stringLit(lit)
+					} else {
+						literal = false
+					}
+				}
+				for _, name := range vs.Names {
+					set(name.Name, val, literal)
+					oneToOne := len(vs.Values) == 1 && len(vs.Names) == 1
+					if oneToOne {
+						setSep(name.Name, vs.Values[0])
+					} else {
+						setSep(name.Name, nil)
 					}
 				}
 			}
 		case *ast.AssignStmt:
-			if len(v.Lhs) != 1 || len(v.Rhs) != 1 {
-				return true
+			var val string
+			literal := len(v.Rhs) == 1
+			var rhs ast.Expr
+			if literal {
+				rhs = v.Rhs[0]
+				if lit, ok := v.Rhs[0].(*ast.BasicLit); ok {
+					val, literal = stringLit(lit)
+				} else {
+					literal = false
+				}
 			}
-			id, ok := v.Lhs[0].(*ast.Ident)
-			if !ok {
-				return true
-			}
-			if lit, ok := v.Rhs[0].(*ast.BasicLit); ok {
-				if val, ok := stringLit(lit); ok {
-					lits[id.Name] = val
+			single := literal && len(v.Lhs) == 1
+			oneToOne := len(v.Rhs) == 1 && len(v.Lhs) == 1
+			for _, lhs := range v.Lhs {
+				id, ok := lhs.(*ast.Ident)
+				if !ok {
+					continue // a field or index write, not this local
+				}
+				set(id.Name, val, single)
+				if oneToOne {
+					setSep(id.Name, rhs)
+				} else {
+					setSep(id.Name, nil)
 				}
 			}
 		}
 		return true
 	})
-	return lits
+	for name := range sepEvery {
+		// No !dyn filter: a separator local is dynamic by the
+		// string-literal rule (its assignment is a call), and sepEvery
+		// already holds only names whose every assignment spelled the
+		// separator.
+		res.seps[name] = true
+	}
+	return res
 }
 
 // rePathishName names what the first operand usually carries: a path, a
-// route, a relative path, a URL, a prefix, a directory, a key. Substring
-// match, because real code says importPath, baseURL, routePrefix, docKey.
-var rePathishName = regexp.MustCompile(`(?i)path|rel|route|url|uri|prefix|dir|key`)
+// route, a URL, a URI, a directory. Substring match, because real code
+// says importPath, baseURL, routePrefix. key and prefix are deliberately
+// absent (review 5): API keys, token types, and versions are value
+// spaces where matching every longer sibling is the intent, and
+// key/prefix-named haystacks turned every ordinary prefix check into a
+// finding. "rel" is not matched as a substring either — exactly "rel"
+// is Go's conventional spelling for a relative path, while
+// "related"/"release" name nothing of the sort.
+var rePathishName = regexp.MustCompile(`(?i)path|route|url|uri|dir`)
 
 // pathishExpr reports whether e names or reaches something path-like: an
-// identifier in the expression matches rePathishName, or the expression
-// selects through a URL field (r.URL.Path, r.URL.Query().Get(...)).
+// identifier in the expression matches rePathishName or is exactly
+// "rel", or the expression selects through a URL field (r.URL.Path,
+// r.URL.Query().Get(...)). This is the rule's reach: a path held in a
+// neutrally named variable (HasPrefix(s, p)) is out of scope for a
+// parse-only pass — declared, not missed.
 func pathishExpr(e ast.Expr) bool {
 	found := false
 	ast.Inspect(e, func(n ast.Node) bool {
 		switch v := n.(type) {
 		case *ast.Ident:
-			if rePathishName.MatchString(v.Name) {
+			if v.Name == "rel" || rePathishName.MatchString(v.Name) {
 				found = true
 			}
 		case *ast.SelectorExpr:
@@ -585,16 +793,9 @@ func pathishExpr(e ast.Expr) bool {
 	return found
 }
 
-// reStrongPathName names a haystack that is certainly a /-separated
-// tree: a path, a route, a URL, a URI, a directory — or Go's
-// conventional short spelling for one, exactly "rel". key and prefix do
-// not qualify: they name value spaces (YAML keys, token names,
-// versions) where a no-slash prefix is the intent, not a boundary bug.
-var reStrongPathName = regexp.MustCompile(`(?i)path|route|url|uri|dir`)
-
 // strongPathExpr reports whether the haystack is strongly path-named:
-// any identifier in it matches reStrongPathName or is exactly "rel".
-// The callee of a call is not judged — a call transforms its input, and
+// any identifier in it matches rePathishName or is exactly "rel". The
+// callee of a call is not judged — a call transforms its input, and
 // the package qualifier (filepath.ToSlash, url.PathEscape) names the
 // transform, not the value: the generator's screen_ file-namespace
 // check reads a filename through filepath.ToSlash and is a value-space
@@ -625,7 +826,7 @@ func strongPathExpr(e ast.Expr) bool {
 				}
 				return false
 			}
-			if id, ok := n.(*ast.Ident); ok && (id.Name == "rel" || reStrongPathName.MatchString(id.Name)) {
+			if id, ok := n.(*ast.Ident); ok && (id.Name == "rel" || rePathishName.MatchString(id.Name)) {
 				found = true
 				return false
 			}

--- a/framework/contracts/analyzers/routing.go
+++ b/framework/contracts/analyzers/routing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"path"
 	"regexp"
 	"sort"
 	"strings"
@@ -378,9 +379,11 @@ func replaceLiteralFix(p *contracts.Pass, rel string, line int, oldText, newText
 //     scheme);
 //   - a prefix identifier that resolves to a package-level CONSTANT
 //     (const prefix = "/__gofastr/runtime/"), in this file or any
-//     sibling file of the same package (consts.go / scope.go layout),
-//     or to a function local that is not a parameter and whose EVERY
-//     assignment in the function is a string literal (the same
+//     sibling file of the same directory (consts.go / scope.go layout;
+//     a same-named package in another directory is a different
+//     package and never resolves), or to a function local that is not
+//     a parameter and whose EVERY assignment in the function is a
+//     string literal (the same
 //     literal): both provably hold that one value at the call. A
 //     parameter conditionally defaulted to a bounded literal stays
 //     dynamic — the caller's value is what runs (review 5: "/api"
@@ -408,17 +411,22 @@ func checkPrefixBoundary(p *contracts.Pass) []contracts.Diagnostic {
 	// Package-level literals are resolved across every file of the
 	// package: consts.go/scope.go layout is standard, and a bounded
 	// constant must not turn "dynamic" by living in a sibling file.
+	// The key is the DIRECTORY: the pass walks every directory under
+	// the root, two directories can share a package name while being
+	// separate packages, and one directory's constant must never
+	// resolve (or overwrite) for another's identifiers.
 	pkgLits := map[string]map[string]string{}
 	for _, f := range p.AppFiles() {
 		file, ok := p.AST(f.Rel)
 		if !ok {
 			continue
 		}
-		if pkgLits[file.Name.Name] == nil {
-			pkgLits[file.Name.Name] = map[string]string{}
+		dir := path.Dir(f.Rel)
+		if pkgLits[dir] == nil {
+			pkgLits[dir] = map[string]string{}
 		}
 		for name, val := range fileScopedLits(file) {
-			pkgLits[file.Name.Name][name] = val
+			pkgLits[dir][name] = val
 		}
 	}
 	for _, f := range p.AppFiles() {
@@ -427,7 +435,7 @@ func checkPrefixBoundary(p *contracts.Pass) []contracts.Diagnostic {
 			continue
 		}
 		aliases := importAliases(file)
-		fileLits := pkgLits[file.Name.Name]
+		fileLits := pkgLits[path.Dir(f.Rel)]
 		for _, fn := range functionsIn(file) {
 			localLits := bodyScopedLits(fn, aliases)
 			ast.Inspect(fn.body, func(n ast.Node) bool {
@@ -674,17 +682,25 @@ func bodyScopedLits(fn *funcScope, aliases map[string]string) localLits {
 		res.vals[name] = val
 	}
 	sepEvery := map[string]bool{} // every assignment so far is a separator call
+	sepNever := map[string]bool{} // one assignment was not a separator: sticky
 	setSep := func(name string, rhs ast.Expr) {
 		// A parameter never becomes a separator: its caller-supplied
 		// value can survive a conditional reassignment. A local that is
 		// merely dyn (its assignment is a call, not a literal) still
 		// counts — that is exactly the separator spelling. A nil rhs is
-		// any non one-to-one assignment and disqualifies.
+		// any non one-to-one assignment and disqualifies. Disqualification
+		// is sticky, like the literal rule's: sep := cfgSep with a later
+		// conditional sep = string(filepath.Separator) must not re-qualify
+		// the name, because cfgSep is what runs when the caller sent one.
 		if isParam[name] {
 			return
 		}
 		if rhs == nil || !separatorExpr(rhs, aliases) {
+			sepNever[name] = true
 			delete(sepEvery, name)
+			return
+		}
+		if sepNever[name] {
 			return
 		}
 		sepEvery[name] = true

--- a/framework/contracts/analyzers/routing.go
+++ b/framework/contracts/analyzers/routing.go
@@ -362,34 +362,56 @@ func replaceLiteralFix(p *contracts.Pass, rel string, line int, oldText, newText
 // shape-based, not stability-based: any path-like operand matched against
 // a boundary-less prefix is the finding.
 // Deliberately silent on:
-//   - a literal prefix that already ends in "/" ("internal/"), "/" and ""
-//     themselves, and — narrowed after the first whole-repo run — any
-//     literal or resolvable constant whose value contains no "/" at all
-//     ("x_", "dark.", "color-", "v", "&"): those operate on namespace-ish
-//     value spaces (YAML keys, token names, versions) where every longer
-//     sibling IS the intent, not a confusion. The bug class is about
-//     slash-separated trees; a prefix that contains no slash, or one that
-//     ends in it, is either bounded or not about segments;
-//   - a prefix identifier that resolves to a local or file-scope constant
-//     carrying its own boundary (const prefix = "/__gofastr/runtime/"):
-//     the boundary is written down one line up;
+//   - a literal prefix that already ends in "/" ("internal/") and "/"
+//     and "" themselves: the boundary is written down — as is a value
+//     ending in ":" ("file:", a URL scheme literal: the colon
+//     terminates the scheme token, so every match has that exact
+//     scheme);
+//   - a literal or resolvable constant whose value contains no "/" at all
+//     ("x_", "dark.", "color-", "v", "&") UNLESS the haystack is strongly
+//     path-named (an identifier matching path/route/url/uri/dir, or
+//     exactly rel — the callee's package qualifier does not count: a
+//     call transforms its input, and filepath.ToSlash names the
+//     transform, not the value): key/prefix-named haystacks are
+//     namespace-ish value spaces (YAML keys, token names, versions)
+//     where every longer sibling IS the intent, but
+//     HasPrefix(importPath, "cmd") is the original bug wearing a
+//     literal — "cmd" matches cmdline/tools the moment the tree is
+//     slash-separated;
+//   - a prefix identifier that resolves to a local or package-level
+//     constant carrying its own boundary (const prefix =
+//     "/__gofastr/runtime/"): the boundary is written down one line up,
+//     in this file or any sibling file of the same package (consts.go /
+//     scope.go layout). Cross-package constants stay dynamic: their
+//     value is not visible without loading another package's files;
 //   - any prefix built by concatenation at the call (`root+"/"`,
 //     `base+sep`): the caller wrote a boundary decision down, and judging
 //     a runtime-computed one from the AST would be guessing;
-//   - a haystack whose name carries no path/route/prefix semantics
-//     (`HasPrefix(hash, "$argon2id$")`) — the shape is a PATH matched by
-//     PREFIX, and key/uri/dir naming is the net it uses to catch the
-//     ones that don't say "path" out loud;
-//   - _test.go and generated files (AppFiles already excludes both).
 func checkPrefixBoundary(p *contracts.Pass) []contracts.Diagnostic {
 	var out []contracts.Diagnostic
+	// Package-level literals are resolved across every file of the
+	// package: consts.go/scope.go layout is standard, and a bounded
+	// constant must not turn "dynamic" by living in a sibling file.
+	pkgLits := map[string]map[string]string{}
+	for _, f := range p.AppFiles() {
+		file, ok := p.AST(f.Rel)
+		if !ok {
+			continue
+		}
+		if pkgLits[file.Name.Name] == nil {
+			pkgLits[file.Name.Name] = map[string]string{}
+		}
+		for name, val := range fileScopedLits(file) {
+			pkgLits[file.Name.Name][name] = val
+		}
+	}
 	for _, f := range p.AppFiles() {
 		file, ok := p.AST(f.Rel)
 		if !ok {
 			continue
 		}
 		aliases := importAliases(file)
-		fileLits := fileScopedLits(file)
+		fileLits := pkgLits[file.Name.Name]
 		for _, fn := range functionsIn(file) {
 			localLits := bodyScopedLits(fn.body)
 			ast.Inspect(fn.body, func(n ast.Node) bool {
@@ -400,7 +422,7 @@ func checkPrefixBoundary(p *contracts.Pass) []contracts.Diagnostic {
 				if !pathishExpr(call.Args[0]) {
 					return true
 				}
-				if !unboundedPrefix(call.Args[1], localLits, fileLits) {
+				if !unboundedPrefix(call.Args[1], call.Args[0], localLits, fileLits) {
 					return true
 				}
 				hay, needle := exprText(call.Args[0]), exprText(call.Args[1])
@@ -421,19 +443,24 @@ func checkPrefixBoundary(p *contracts.Pass) []contracts.Diagnostic {
 // prefixes (params, fields, range variables) are always treated as
 // unbounded: their values are invisible to a parse-only pass, and the
 // stability bug lived in exactly one. Literals and resolvable constants
-// are judged by their value: no "/" at all is a namespace match, not a
-// segment match; a trailing "/" is a boundary.
-func unboundedPrefix(e ast.Expr, localLits, fileLits map[string]string) bool {
+// are judged by their value against the haystack: a value with an
+// interior slash and no trailing one is a segment candidate anywhere; a
+// value with no slash at all is a first segment, which only matters when
+// the haystack is strongly path-named (strongPathExpr) — against a
+// key/prefix-named value space a no-slash prefix is the intent, not a
+// boundary bug.
+func unboundedPrefix(e ast.Expr, haystack ast.Expr, localLits, fileLits map[string]string) bool {
+	strong := strongPathExpr(haystack)
 	switch v := e.(type) {
 	case *ast.BasicLit:
 		val, ok := stringLit(v)
-		return ok && segmentPrefixCandidate(val)
+		return ok && segmentPrefixCandidate(val, strong)
 	case *ast.Ident:
 		if val, ok := localLits[v.Name]; ok {
-			return segmentPrefixCandidate(val)
+			return segmentPrefixCandidate(val, strong)
 		}
 		if val, ok := fileLits[v.Name]; ok {
-			return segmentPrefixCandidate(val)
+			return segmentPrefixCandidate(val, strong)
 		}
 		return true
 	case *ast.BinaryExpr:
@@ -449,13 +476,27 @@ func unboundedPrefix(e ast.Expr, localLits, fileLits map[string]string) bool {
 
 // segmentPrefixCandidate reports whether a known prefix value names part
 // of a slash-separated tree without being bounded to it: it must contain
-// an interior or leading slash and not end in one.
-func segmentPrefixCandidate(val string) bool {
-	return val != "" && strings.Contains(val, "/") && !strings.HasSuffix(val, "/")
+// an interior or leading slash and not end in one — or, when the haystack
+// is strongly path-named, carry no slash at all (a first segment: "cmd"
+// matches cmdline the moment the tree is slash-separated). A value
+// ending in ":" is a URL scheme literal ("file:", isolation's DSN
+// check): the colon terminates the scheme token, so every string that
+// matches has that exact scheme — self-delimiting, like a trailing "/" —
+// and never a segment candidate.
+func segmentPrefixCandidate(val string, strongHaystack bool) bool {
+	if val == "" || strings.HasSuffix(val, "/") || strings.HasSuffix(val, ":") {
+		return false
+	}
+	if strings.Contains(val, "/") {
+		return true
+	}
+	return strongHaystack
 }
 
-// fileScopedLits maps package-level const/var names initialized from a
-// single string literal.
+// fileScopedLits maps the package-level const/var names of ONE file
+// initialized from a single string literal. Callers merge these per
+// package (see checkPrefixBoundary) so a constant resolves from sibling
+// files too.
 func fileScopedLits(file *ast.File) map[string]string {
 	lits := map[string]string{}
 	for _, decl := range file.Decls {
@@ -541,5 +582,56 @@ func pathishExpr(e ast.Expr) bool {
 		}
 		return !found
 	})
+	return found
+}
+
+// reStrongPathName names a haystack that is certainly a /-separated
+// tree: a path, a route, a URL, a URI, a directory — or Go's
+// conventional short spelling for one, exactly "rel". key and prefix do
+// not qualify: they name value spaces (YAML keys, token names,
+// versions) where a no-slash prefix is the intent, not a boundary bug.
+var reStrongPathName = regexp.MustCompile(`(?i)path|route|url|uri|dir`)
+
+// strongPathExpr reports whether the haystack is strongly path-named:
+// any identifier in it matches reStrongPathName or is exactly "rel".
+// The callee of a call is not judged — a call transforms its input, and
+// the package qualifier (filepath.ToSlash, url.PathEscape) names the
+// transform, not the value: the generator's screen_ file-namespace
+// check reads a filename through filepath.ToSlash and is a value-space
+// match, not a first segment. This is the gate for first-segment
+// (no-slash) prefixes — the original bug's literal spelling,
+// HasPrefix(importPath, "cmd") — so that widening the literal posture
+// cannot reach namespace matches.
+func strongPathExpr(e ast.Expr) bool {
+	found := false
+	var scan func(x ast.Expr)
+	scan = func(x ast.Expr) {
+		if found || x == nil {
+			return
+		}
+		if call, ok := x.(*ast.CallExpr); ok {
+			for _, a := range call.Args {
+				scan(a)
+			}
+			return
+		}
+		ast.Inspect(x, func(n ast.Node) bool {
+			if found {
+				return false
+			}
+			if c, ok := n.(*ast.CallExpr); ok {
+				for _, a := range c.Args {
+					scan(a)
+				}
+				return false
+			}
+			if id, ok := n.(*ast.Ident); ok && (id.Name == "rel" || reStrongPathName.MatchString(id.Name)) {
+				found = true
+				return false
+			}
+			return true
+		})
+	}
+	scan(e)
 	return found
 }

--- a/framework/contracts/analyzers/security.go
+++ b/framework/contracts/analyzers/security.go
@@ -468,16 +468,25 @@ func ruleHardcodedSecret(p *contracts.Pass, rel string, file *ast.File, lines []
 // Bug class: a reverse-proxy scheme header read with Header.Get and
 // spliced into output as a URL scheme. framework/uihost/agentready.go
 // resolveBaseURL shipped it (probe TestDiscoveryURLsIgnoreForwardedProto,
-// fixed a24928c1): the raw value reached the agent card's service URL and
-// the Link header, so one forged `X-Forwarded-Proto:
+// fixed a24928c1): the raw value reached the agent card's service URL
+// and the Link header, so one forged `X-Forwarded-Proto:
 // https://evil.example/p` painted an attacker-named origin into cacheable
 // discovery output. The fix — and framework/pluginhost/assets.go, which
 // never had the bug — is an exact "http"/"https" enum.
 //
+// The read is Get("X-Forwarded-Proto") on any receiver ending in .Header
+// AND on any bare identifier (h http.Header: the map handed to a helper
+// is the same header). The argument literal is the whole scope gate; the
+// reflection sink carries the precision, so a read that never reaches
+// output stays quiet.
+//
 // Deliberately silent on:
-//   - any function that compares the value against "http"/"https"
-//     anywhere in its body, however spelled: == / !=, strings.EqualFold,
-//     or a switch case. The enum is the contract; its position is not;
+//   - any function that compares THE VALUE — the get itself or one of
+//     its holders — against "http"/"https", however spelled: == / !=,
+//     strings.EqualFold, or a switch on the value. The enum is the
+//     contract; its position is not. A scheme comparison on any OTHER
+//     value (an outbound target.Scheme) is not a gate for this header
+//     and does not silence the rule;
 //   - Header.Set (writing the header outbound, as battery/relay does)
 //     and reads that are never reflected (a log line, a boolean);
 //   - values compared against any other literal ("", "HTTPS,http"):
@@ -493,11 +502,14 @@ func ruleForwardedProto(p *contracts.Pass, rel string, file *ast.File) []contrac
 			}
 			return true
 		})
-		if len(gets) == 0 || protoEnumChecked(fn.body) {
+		if len(gets) == 0 {
 			continue
 		}
 		for _, get := range gets {
 			holders := assignedIdents(fn.body, get)
+			if protoEnumChecked(fn.body, get, holders) {
+				continue
+			}
 			if !reflectedScheme(fn.body, get, holders) {
 				continue
 			}
@@ -510,15 +522,23 @@ func ruleForwardedProto(p *contracts.Pass, rel string, file *ast.File) []contrac
 	return out
 }
 
-// forwardedProtoGet matches `x.Header.Get("X-Forwarded-Proto")` for any
-// receiver expression ending in .Header.
+// forwardedProtoGet matches Get("X-Forwarded-Proto") on a receiver
+// expression ending in .Header (r.Header) or on any bare identifier
+// (h http.Header: the header map as a helper parameter).
 func forwardedProtoGet(n ast.Node) (*ast.CallExpr, bool) {
 	recv, method, call, ok := selectorCall(n)
 	if !ok || method != "Get" || len(call.Args) != 1 {
 		return nil, false
 	}
-	hdr, ok := recv.(*ast.SelectorExpr)
-	if !ok || hdr.Sel == nil || hdr.Sel.Name != "Header" {
+	switch r := recv.(type) {
+	case *ast.SelectorExpr:
+		if r.Sel == nil || r.Sel.Name != "Header" {
+			return nil, false
+		}
+	case *ast.Ident:
+		// h.Get("X-Forwarded-Proto"): the map passed as a parameter.
+		// The reflection sink keeps this precise.
+	default:
 		return nil, false
 	}
 	lit, ok := call.Args[0].(*ast.BasicLit)
@@ -532,12 +552,13 @@ func forwardedProtoGet(n ast.Node) (*ast.CallExpr, bool) {
 	return call, true
 }
 
-// protoEnumChecked reports whether the function body compares anything
-// against the literal "http" or "https": == / !=, strings.EqualFold, or a
-// switch case. Deliberately generous — presence of the enum anywhere in
-// the function is the documented silence condition, because the value is
-// usually checked once and then trusted.
-func protoEnumChecked(body ast.Node) bool {
+// protoEnumChecked reports whether the function body compares the header
+// value — the get call itself or one of its holders — against the
+// literal "http" or "https": == / !=, strings.EqualFold, or a switch
+// whose tag is the value. A scheme comparison on any other value does
+// not count: the gate must gate this value, not a neighbouring one.
+func protoEnumChecked(body ast.Node, call *ast.CallExpr, holders map[string]bool) bool {
+	touches := func(e ast.Expr) bool { return exprTouches(e, call, holders) }
 	checked := false
 	ast.Inspect(body, func(n ast.Node) bool {
 		if checked {
@@ -548,25 +569,40 @@ func protoEnumChecked(body ast.Node) bool {
 			if v.Op != token.EQL && v.Op != token.NEQ {
 				return true
 			}
-			if lit, ok := v.X.(*ast.BasicLit); ok && isSchemeLit(lit) {
+			if lit, ok := v.X.(*ast.BasicLit); ok && isSchemeLit(lit) && touches(v.Y) {
 				checked = true
 			}
-			if lit, ok := v.Y.(*ast.BasicLit); ok && isSchemeLit(lit) {
+			if lit, ok := v.Y.(*ast.BasicLit); ok && isSchemeLit(lit) && touches(v.X) {
 				checked = true
 			}
 		case *ast.CallExpr:
 			if sel, ok := v.Fun.(*ast.SelectorExpr); ok && sel.Sel != nil &&
 				strings.EqualFold(sel.Sel.Name, "EqualFold") {
-				for _, a := range v.Args {
-					if lit, ok := a.(*ast.BasicLit); ok && isSchemeLit(lit) {
-						checked = true
+				for i, a := range v.Args {
+					lit, ok := a.(*ast.BasicLit)
+					if !ok || !isSchemeLit(lit) {
+						continue
+					}
+					for j, b := range v.Args {
+						if j != i && touches(b) {
+							checked = true
+						}
 					}
 				}
 			}
-		case *ast.CaseClause:
-			for _, e := range v.List {
-				if lit, ok := e.(*ast.BasicLit); ok && isSchemeLit(lit) {
-					checked = true
+		case *ast.SwitchStmt:
+			if !touches(v.Tag) {
+				return true
+			}
+			for _, cl := range v.Body.List {
+				cc, ok := cl.(*ast.CaseClause)
+				if !ok {
+					continue
+				}
+				for _, e := range cc.List {
+					if lit, ok := e.(*ast.BasicLit); ok && isSchemeLit(lit) {
+						checked = true
+					}
 				}
 			}
 		}
@@ -611,8 +647,10 @@ func assignedIdents(body ast.Node, call *ast.CallExpr) map[string]bool {
 
 // reflectedScheme reports whether the header value reaches output: the
 // call itself inside a concatenation, an assignment into a scheme-named
-// variable (directly or one hop through a holder), or an argument to a
-// URL builder / the Scheme field of a composite literal.
+// variable (directly or one hop through a holder), an argument to a URL
+// builder / the Scheme field of a composite literal, or an argument of
+// fmt.Sprintf/fmt.Fprintf whose format literal splices a scheme
+// position ("%s://%s") — the most common spelling of a built origin.
 func reflectedScheme(body ast.Node, call *ast.CallExpr, holders map[string]bool) bool {
 	touches := func(e ast.Expr) bool { return exprTouches(e, call, holders) }
 	reflected := false
@@ -652,6 +690,22 @@ func reflectedScheme(body ast.Node, call *ast.CallExpr, holders map[string]bool)
 					}
 				}
 			}
+			// fmt.Sprintf("%s://%s", u, host): the concatenation
+			// bug's most common spelling. Only scheme-bearing formats
+			// count — a format that merely logs the value is not a
+			// reflection. fmt.Fprintf(w, ...) included: the w first
+			// argument is never the value.
+			if fun, ok := callFunName(v); ok && (fun == "Sprintf" || fun == "Fprintf") && len(v.Args) > 1 {
+				if lit, ok := v.Args[0].(*ast.BasicLit); ok {
+					if f, ok := stringLit(lit); ok && strings.Contains(f, "://") {
+						for _, a := range v.Args[1:] {
+							if touches(a) {
+								reflected = true
+							}
+						}
+					}
+				}
+			}
 		case *ast.CompositeLit:
 			for _, e := range v.Elts {
 				kv, ok := e.(*ast.KeyValueExpr)
@@ -666,6 +720,21 @@ func reflectedScheme(body ast.Node, call *ast.CallExpr, holders map[string]bool)
 		return !reflected
 	})
 	return reflected
+}
+
+// callFunName returns the callee name of a call expression: the selector
+// method (fmt.Sprintf → Sprintf) or the bare identifier, honouring
+// import aliases. Dot-imported calls read the same either way.
+func callFunName(call *ast.CallExpr) (string, bool) {
+	switch fun := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		if fun.Sel != nil {
+			return fun.Sel.Name, true
+		}
+	case *ast.Ident:
+		return fun.Name, true
+	}
+	return "", false
 }
 
 // exprTouches reports whether e contains the call node or one of the
@@ -714,7 +783,16 @@ func exprTouches(e ast.Expr, call *ast.CallExpr, holders map[string]bool) bool {
 //
 // The rule tracks r.Body through local assignments (io.ReadAll(r.Body),
 // http.MaxBytesReader(w, r.Body, n), one more hop for ReadAll of the
-// wrapped reader) so the wrapped spellings are the same finding.
+// wrapped reader) so the wrapped spellings are the same finding, plus
+// ONE bounded level of same-file helpers: raw, err := readBody(r), where
+// readBody is declared in this file and its return expressions are
+// body-derived, taints raw exactly as io.ReadAll(r.Body) would. Taint
+// reaches a call's RESULT only through those reader wrappers and the
+// helper ferry: an arbitrary call that merely receives tainted arguments
+// (the module proxy's peer.CallWithID(ctx, params)) returns its own
+// output, not the body. Helpers in other files are not loaded by this
+// pass, and helper-calling-helper chains are not followed — one level
+// keeps the walk terminating.
 //
 // Deliberately silent on:
 //   - core/handler/**, which owns handler.Bind and its duplicate-key
@@ -732,12 +810,13 @@ func ruleRawJSONBody(p *contracts.Pass, rel string, file *ast.File) []contracts.
 	}
 	var out []contracts.Diagnostic
 	aliases := importAliases(file)
+	helpers := sameFileBodyReaders(file, aliases)
 	for _, fn := range functionsIn(file) {
 		reqs := httpRequestParamNames(fn.node, aliases)
 		if len(reqs) == 0 {
 			continue
 		}
-		tainted := taintFromBody(fn.body, reqs)
+		tainted := taintFromBody(fn.body, reqs, helpers)
 		ast.Inspect(fn.body, func(n ast.Node) bool {
 			if call, ok := qualifiedCall(n, aliases, "encoding/json", "NewDecoder"); ok && len(call.Args) == 1 &&
 				exprFromRequestBody(call.Args[0], tainted, reqs) {
@@ -830,10 +909,13 @@ func httpRequestParamNames(fn ast.Node, aliases map[string]string) map[string]bo
 
 // taintFromBody computes which local identifiers hold bytes read from a
 // request body, to a fixpoint: body := MaxBytesReader(w, r.Body, n) then
-// raw, err := io.ReadAll(body) leaves both body and raw tainted. Only
-// plain assignments are tracked; a body ferried through a helper call is
-// invisible to a parse-only pass and stays unreported.
-func taintFromBody(body ast.Node, reqs map[string]bool) map[string]bool {
+// raw, err := io.ReadAll(body) leaves both body and raw tainted. Plain
+// assignments are tracked, plus one bounded level of same-file helpers
+// (helpers, from sameFileBodyReaders): raw, err := readBody(r) taints
+// raw when readBody's returns are body-derived. A body ferried through
+// a helper in ANOTHER file stays invisible — this pass never loads
+// another file's bodies — and stays unreported.
+func taintFromBody(body ast.Node, reqs map[string]bool, helpers map[string]bool) map[string]bool {
 	var assigns []*ast.AssignStmt
 	ast.Inspect(body, func(n ast.Node) bool {
 		if a, ok := n.(*ast.AssignStmt); ok {
@@ -848,6 +930,10 @@ func taintFromBody(body ast.Node, reqs map[string]bool) map[string]bool {
 			touched := false
 			for _, rhs := range a.Rhs {
 				if exprFromRequestBody(rhs, tainted, reqs) {
+					touched = true
+					break
+				}
+				if call, ok := rhs.(*ast.CallExpr); ok && len(helpers) > 0 && helperCallTainted(call, tainted, reqs, helpers) {
 					touched = true
 					break
 				}
@@ -866,6 +952,80 @@ func taintFromBody(body ast.Node, reqs map[string]bool) map[string]bool {
 	return tainted
 }
 
+// sameFileBodyReaders returns the same-file FUNCTIONS (bare-name calls
+// only; a method's receiver expression cannot be matched by name) whose
+// return expressions are request-body-derived given their own
+// *http.Request parameters: readBody(r) { return io.ReadAll(r.Body) }.
+// This is the one level of interprocedural tracking — a helper whose own
+// return calls another helper is not followed further.
+func sameFileBodyReaders(file *ast.File, aliases map[string]string) map[string]bool {
+	out := map[string]bool{}
+	for _, fn := range functionsIn(file) {
+		decl, ok := fn.node.(*ast.FuncDecl)
+		if !ok || decl.Name == nil || decl.Recv != nil {
+			continue // methods are not bare-name callable
+		}
+		reqs := httpRequestParamNames(fn.node, aliases)
+		if len(reqs) == 0 {
+			continue
+		}
+		tainted := taintFromBody(fn.body, reqs, nil)
+		derived := false
+		ast.Inspect(fn.body, func(n ast.Node) bool {
+			ret, ok := n.(*ast.ReturnStmt)
+			if !ok {
+				return true
+			}
+			for _, r := range ret.Results {
+				if exprFromRequestBody(r, tainted, reqs) {
+					derived = true
+					return false
+				}
+			}
+			return true
+		})
+		if derived {
+			out[decl.Name.Name] = true
+		}
+	}
+	return out
+}
+
+// helperCallTainted reports whether call is a call to a known same-file
+// body-reading helper whose arguments actually carry this request (the
+// request itself, its body, or an already-tainted value): the ferry must
+// carry bytes, not a coincidental name.
+func helperCallTainted(call *ast.CallExpr, tainted map[string]bool, reqs map[string]bool, helpers map[string]bool) bool {
+	id, ok := call.Fun.(*ast.Ident)
+	if !ok || !helpers[id.Name] {
+		return false
+	}
+	for _, a := range call.Args {
+		if exprFromRequestBody(a, tainted, reqs) {
+			return true
+		}
+		touches := false
+		ast.Inspect(a, func(n ast.Node) bool {
+			if arg, ok := n.(*ast.Ident); ok && reqs[arg.Name] {
+				touches = true
+			}
+			return !touches
+		})
+		if touches {
+			return true
+		}
+	}
+	return false
+}
+
+// readerWrapper names the calls whose RESULT is the request body's
+// bytes: the reader constructors and readers of the wrapped spellings.
+var readerWrapper = map[string]bool{
+	"ReadAll":        true,
+	"MaxBytesReader": true,
+	"LimitReader":    true,
+}
+
 // exprFromRequestBody reports whether e is, contains, or was assigned
 // from a request body: the <req>.Body selector itself, or a tainted
 // identifier in plain identifier position.
@@ -873,17 +1033,35 @@ func exprFromRequestBody(e ast.Expr, tainted map[string]bool, reqs map[string]bo
 	switch v := e.(type) {
 	case *ast.Ident:
 		return tainted[v.Name]
+	case *ast.CallExpr:
+		// Only reader-wrapping calls propagate taint to their RESULT
+		// (io.ReadAll, MaxBytesReader, LimitReader, and aliases): the
+		// result of an arbitrary call that merely receives tainted
+		// arguments is not the body (the module proxy's
+		// peer.CallWithID(ctx, params) returns the child's response).
+		switch fn := v.Fun.(type) {
+		case *ast.SelectorExpr:
+			if fn.Sel != nil && readerWrapper[fn.Sel.Name] {
+				for _, a := range v.Args {
+					if exprFromRequestBody(a, tainted, reqs) {
+						return true
+					}
+				}
+			}
+		case *ast.Ident:
+			if readerWrapper[fn.Name] {
+				for _, a := range v.Args {
+					if exprFromRequestBody(a, tainted, reqs) {
+						return true
+					}
+				}
+			}
+		}
 	case *ast.SelectorExpr:
 		if id, ok := v.X.(*ast.Ident); ok && reqs[id.Name] && v.Sel != nil && v.Sel.Name == "Body" {
 			return true
 		}
 		return exprFromRequestBody(v.X, tainted, reqs)
-	case *ast.CallExpr:
-		for _, a := range v.Args {
-			if exprFromRequestBody(a, tainted, reqs) {
-				return true
-			}
-		}
 	case *ast.BinaryExpr:
 		return exprFromRequestBody(v.X, tainted, reqs) || exprFromRequestBody(v.Y, tainted, reqs)
 	case *ast.ParenExpr:

--- a/framework/contracts/analyzers/security.go
+++ b/framework/contracts/analyzers/security.go
@@ -1020,10 +1020,17 @@ func helperCallTainted(call *ast.CallExpr, tainted map[string]bool, reqs map[str
 
 // readerWrapper names the calls whose RESULT is the request body's
 // bytes: the reader constructors and readers of the wrapped spellings.
+// NopCloser/TeeReader/NewReader return a reader over the SAME bytes —
+// bufio.NewReader(r.Body), bytes.NewReader(raw), io.NopCloser(r.Body) —
+// which is what distinguishes them from a call that returns its own
+// output (peer.CallWithID).
 var readerWrapper = map[string]bool{
 	"ReadAll":        true,
 	"MaxBytesReader": true,
 	"LimitReader":    true,
+	"NopCloser":      true,
+	"TeeReader":      true,
+	"NewReader":      true,
 }
 
 // exprFromRequestBody reports whether e is, contains, or was assigned

--- a/framework/contracts/catalog.go
+++ b/framework/contracts/catalog.go
@@ -319,7 +319,11 @@ func routingRules() []Rule {
 			"named inherited a sibling's tier, so the add-it-to-the-manifest gate stayed quiet), and the " +
 			"same shape matched a document-script scope past its `/`-terminated prefix in framework/uihost " +
 			"earlier in v0.80. Whatever the match decides — a tier, a scope, an exemption — it decides it " +
-			"for trees nobody named.",
+			"for trees nobody named. A literal (or resolved constant) whose value contains no `/` at all " +
+			"fires only when the haystack is strongly path-named (an identifier matching " +
+			"path/route/url/uri/dir, or exactly rel): `HasPrefix(importPath, \"cmd\")` is the original bug " +
+			"with the manifest entry spelled as a literal, while key/prefix-named haystacks are namespace " +
+			"value spaces where every longer sibling is the intent.",
 		Fix: `Compare equality for the exact match, then the boundary: rel == root || strings.HasPrefix(rel, root+"/").`,
 		Doc: "project-structure",
 		Examples: []Example{{

--- a/framework/contracts/catalog.go
+++ b/framework/contracts/catalog.go
@@ -319,11 +319,12 @@ func routingRules() []Rule {
 			"named inherited a sibling's tier, so the add-it-to-the-manifest gate stayed quiet), and the " +
 			"same shape matched a document-script scope past its `/`-terminated prefix in framework/uihost " +
 			"earlier in v0.80. Whatever the match decides — a tier, a scope, an exemption — it decides it " +
-			"for trees nobody named. A literal (or resolved constant) whose value contains no `/` at all " +
-			"fires only when the haystack is strongly path-named (an identifier matching " +
-			"path/route/url/uri/dir, or exactly rel): `HasPrefix(importPath, \"cmd\")` is the original bug " +
-			"with the manifest entry spelled as a literal, while key/prefix-named haystacks are namespace " +
-			"value spaces where every longer sibling is the intent.",
+			"for trees nobody named. The rule keys on path-NAMED haystacks: an identifier matching " +
+			"path/route/url/uri/dir, exactly rel, or a .URL field. A literal with no `/` at all fires on " +
+			"those haystacks (`HasPrefix(importPath, \"cmd\")` is the original bug with the manifest entry " +
+			"spelled as a literal); key- and prefix-named haystacks (API keys, token types, versions) are " +
+			"value spaces where every longer sibling is the intent, and a path held in a neutrally named " +
+			"variable is out of reach for a parse-only pass.",
 		Fix: `Compare equality for the exact match, then the boundary: rel == root || strings.HasPrefix(rel, root+"/").`,
 		Doc: "project-structure",
 		Examples: []Example{{

--- a/framework/cron/cron.go
+++ b/framework/cron/cron.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -283,7 +284,9 @@ func (s *Scheduler) reportError(jobName string, err error) {
 		return
 	}
 	defer func() {
-		_ = recover()
+		if rec := recover(); rec != nil {
+			slog.Default().Error("cron: OnError panicked", "job", jobName, "panic", rec, "err", err)
+		}
 	}()
 	s.OnError(jobName, err)
 }

--- a/framework/cron/cron.go
+++ b/framework/cron/cron.go
@@ -257,7 +257,7 @@ func (s *Scheduler) RunOnce(ctx context.Context, now time.Time) {
 	s.mu.RUnlock()
 
 	for _, job := range firing {
-		if s.gate != nil && !s.gate(job.Name) {
+		if s.gate != nil && !s.gateAllow(job.Name) {
 			continue
 		}
 		s.inflight.Add(1)
@@ -273,6 +273,20 @@ func (s *Scheduler) RunOnce(ctx context.Context, now time.Time) {
 			}
 		}(job)
 	}
+}
+
+// gateAllow evaluates the registered gate with the same net the job
+// run gets below: a panicking gate reports and denies the job instead
+// of killing the scheduler goroutine (recovercallback pins this —
+// RunOnce sits on the ticker-driven dispatch loop).
+func (s *Scheduler) gateAllow(name string) (allow bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.reportError(name, fmt.Errorf("panic in gate: %v\n%s", r, debug.Stack()))
+			allow = false
+		}
+	}()
+	return s.gate(name)
 }
 
 // reportError forwards a job failure to OnError under its own recover

--- a/framework/cron/cron.go
+++ b/framework/cron/cron.go
@@ -33,8 +33,8 @@ var ErrNilJobRun = errors.New("cron: job Run is nil")
 // runs at the next yield point.
 //
 // If Run returns an error it is forwarded to the scheduler's OnError
-// callback (if set); otherwise it is silently dropped, jobs should not
-// crash the process.
+// callback (if set); otherwise it is logged via slog.Default(), jobs
+// should not crash the process.
 type CronJob struct {
 	Name string
 	Spec string
@@ -240,24 +240,29 @@ func (s *Scheduler) StopContext(ctx context.Context) error {
 // (Register during tick) are safe because the mutex is held only for the
 // read, new jobs appear on the next tick.
 func (s *Scheduler) RunOnce(ctx context.Context, now time.Time) {
-	// Snapshot the firing jobs under the read lock, then evaluate the
-	// gate OUTSIDE it. Gates are registered callbacks (SetGate) free to
-	// do I/O, and a blocking gate holding s.mu stalls Register,
-	// NextRun and every other RunOnce — the same registry rule core/
-	// mcp's listing gates learned (b79942f7). Registered jobs are
-	// immutable values, so a snapshot is exact.
+	// Snapshot the firing jobs AND the gate under the read lock, then
+	// evaluate the gate OUTSIDE it. Gates are registered callbacks
+	// (SetGate) free to do I/O, and a blocking gate holding s.mu
+	// stalls Register, NextRun and every other RunOnce — the same
+	// registry rule core/mcp's listing gates learned (b79942f7).
+	// Registered jobs are immutable values, so a snapshot is exact.
+	// The gate is snapshotted too (not re-read in gateAllow): SetGate
+	// may swap or clear it concurrently, and a torn nil-check/invoke
+	// pair would call a gate that is already gone.
 	s.mu.RLock()
 	var firing []CronJob
+	var gate func(jobName string) bool
 	for i := range s.jobs {
 		sj := &s.jobs[i]
 		if sj.expr.matches(now) {
 			firing = append(firing, sj.job)
 		}
 	}
+	gate = s.gate
 	s.mu.RUnlock()
 
 	for _, job := range firing {
-		if s.gate != nil && !s.gateAllow(job.Name) {
+		if gate != nil && !s.gateAllow(gate, job.Name) {
 			continue
 		}
 		s.inflight.Add(1)
@@ -275,26 +280,31 @@ func (s *Scheduler) RunOnce(ctx context.Context, now time.Time) {
 	}
 }
 
-// gateAllow evaluates the registered gate with the same net the job
-// run gets below: a panicking gate reports and denies the job instead
-// of killing the scheduler goroutine (recovercallback pins this —
+// gateAllow evaluates the snapshot gate with the same net the job run
+// gets above: a panicking gate reports and denies the job instead of
+// killing the scheduler goroutine (recovercallback pins this —
 // RunOnce sits on the ticker-driven dispatch loop).
-func (s *Scheduler) gateAllow(name string) (allow bool) {
+func (s *Scheduler) gateAllow(gate func(jobName string) bool, name string) (allow bool) {
 	defer func() {
 		if r := recover(); r != nil {
 			s.reportError(name, fmt.Errorf("panic in gate: %v\n%s", r, debug.Stack()))
 			allow = false
 		}
 	}()
-	return s.gate(name)
+	return gate(name)
 }
 
 // reportError forwards a job failure to OnError under its own recover
 // guard: OnError is app-supplied callback code running on the scheduler
 // loop, which has no per-request net — a panicking error handler must
-// not take the scheduler (and the process) down with it.
+// not take the scheduler (and the process) down with it. With no
+// OnError configured the failure still lands somewhere observable: the
+// scheduler loop has no caller to hand it to, so it goes to
+// slog.Default() (a recovered gate panic used to drop the panic value
+// and stack on the floor while the job silently skipped).
 func (s *Scheduler) reportError(jobName string, err error) {
 	if s.OnError == nil {
+		slog.Default().Error("cron: job failed", "job", jobName, "err", err)
 		return
 	}
 	defer func() {

--- a/framework/cron/gate_test.go
+++ b/framework/cron/gate_test.go
@@ -1,7 +1,11 @@
 package cron
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 )
@@ -64,5 +68,67 @@ func TestSetGateNilIsNoop(t *testing.T) {
 	s.Stop()
 	if !ran {
 		t.Fatal("job did not run when gate is nil")
+	}
+}
+
+// TestGatePanicLoggedWithoutOnError: a recovered gate panic must reach
+// an observable sink even when no OnError callback is configured.
+// reportError used to return early on a nil OnError, so the panic
+// value and stack were dropped on the floor while the job silently
+// skipped.
+func TestGatePanicLoggedWithoutOnError(t *testing.T) {
+	s := NewScheduler()
+	s.SetGate(func(string) bool { panic("gate boom") })
+	ran := false
+	if err := s.Register(CronJob{
+		Name: "j",
+		Spec: "* * * * *",
+		Run:  func(ctx context.Context) error { ran = true; return nil },
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	s.RunOnce(context.Background(), time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	s.Stop()
+
+	if ran {
+		t.Fatal("a panicking gate must deny the job for this tick")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "gate boom") {
+		t.Fatalf("recovered gate panic dropped with OnError == nil; log = %q", out)
+	}
+}
+
+// TestJobErrorLoggedWithoutOnError pins the same contract for plain
+// job errors: with no OnError configured they go to slog.Default()
+// instead of vanishing.
+func TestJobErrorLoggedWithoutOnError(t *testing.T) {
+	s := NewScheduler()
+	if err := s.Register(CronJob{
+		Name: "failing",
+		Spec: "* * * * *",
+		Run:  func(ctx context.Context) error { return errors.New("kaboom") },
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	s.RunOnce(context.Background(), time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	s.Stop()
+
+	// The job goroutine logs asynchronously; Stop() joins it, so the
+	// log line has landed by the time Stop returns.
+	if !strings.Contains(buf.String(), "kaboom") {
+		t.Fatalf("job error dropped with OnError == nil; log = %q", buf.String())
 	}
 }

--- a/framework/experimental/harness/control/resources/resources.go
+++ b/framework/experimental/harness/control/resources/resources.go
@@ -138,8 +138,11 @@ func (c *Catalog) ListProviders(ctx context.Context) []ProviderInfo {
 		if err != nil {
 			// The catalog is display-only; a refused listing degrades
 			// to an empty model list rather than a failed page, but
-			// the refusal is logged rather than dropped.
+			// the refusal is logged rather than dropped. Models may
+			// come back partially built alongside the error — those
+			// entries are not vouched for, so drop them too.
 			slog.Warn("harness control: listing models", "provider", p.Name(), "error", err)
+			models = nil
 		}
 		out = append(out, ProviderInfo{Name: p.Name(), Models: models})
 	}

--- a/framework/experimental/harness/control/resources/resources.go
+++ b/framework/experimental/harness/control/resources/resources.go
@@ -9,6 +9,7 @@ package resources
 
 import (
 	"context"
+	"log/slog"
 	"sort"
 	"sync"
 
@@ -133,7 +134,13 @@ func (c *Catalog) ListSessions() []SessionInfo {
 func (c *Catalog) ListProviders(ctx context.Context) []ProviderInfo {
 	out := make([]ProviderInfo, 0, len(c.Providers))
 	for _, p := range c.Providers {
-		models, _ := p.Models(ctx)
+		models, err := p.Models(ctx)
+		if err != nil {
+			// The catalog is display-only; a refused listing degrades
+			// to an empty model list rather than a failed page, but
+			// the refusal is logged rather than dropped.
+			slog.Warn("harness control: listing models", "provider", p.Name(), "error", err)
+		}
 		out = append(out, ProviderInfo{Name: p.Name(), Models: models})
 	}
 	return out

--- a/framework/experimental/harness/control/resources/resources_test.go
+++ b/framework/experimental/harness/control/resources/resources_test.go
@@ -1,0 +1,47 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/framework/experimental/harness/provider"
+)
+
+// partialModelsProvider returns a half-built model catalog together
+// with an error (the shape a transport produces when the listing call
+// fails mid-page). The catalog is display-only: it must degrade to an
+// EMPTY model list, not present models the provider said it could not
+// vouch for.
+type partialModelsProvider struct{}
+
+func (partialModelsProvider) Name() string { return "partial" }
+
+func (partialModelsProvider) Chat(_ context.Context, _ *provider.Request) (<-chan provider.StreamEvent, error) {
+	return nil, errors.New("not implemented in test stub")
+}
+
+func (partialModelsProvider) Models(_ context.Context) ([]provider.Model, error) {
+	return []provider.Model{{ID: "half-listed"}}, errors.New("listing failed mid-page")
+}
+
+func (partialModelsProvider) TokenCount(_ context.Context, _ string, _ []provider.Message) (int, error) {
+	return 0, nil
+}
+
+func TestListProvidersClearsPartialModelsOnError(t *testing.T) {
+	cat := NewCatalog()
+	cat.Providers = append(cat.Providers, partialModelsProvider{})
+
+	out := cat.ListProviders(context.Background())
+	if len(out) != 1 {
+		t.Fatalf("providers = %d, want 1", len(out))
+	}
+	if out[0].Name != "partial" {
+		t.Fatalf("name = %q", out[0].Name)
+	}
+	if len(out[0].Models) != 0 {
+		t.Fatalf("partial model list shipped with the error: %d models (first = %q); want empty",
+			len(out[0].Models), out[0].Models[0].ID)
+	}
+}

--- a/framework/fanout/postgres.go
+++ b/framework/fanout/postgres.go
@@ -368,7 +368,7 @@ func (p *PostgresFanout) deliver(topic string, payload []byte) {
 	}
 	p.mu.RUnlock()
 	for _, s := range cbs {
-		s.deliverOne(payload)
+		s.deliverOne(topic, payload)
 	}
 }
 
@@ -376,8 +376,12 @@ func (p *PostgresFanout) deliver(topic string, payload []byte) {
 // guard: send is registered callback code running on the single
 // LISTEN/NOTIFY dispatcher goroutine, which has no per-request net — a
 // panicking subscriber must not freeze delivery to every other topic.
-func (s *pgSub) deliverOne(payload []byte) {
-	defer func() { _ = recover() }()
+func (s *pgSub) deliverOne(topic string, payload []byte) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			slog.Default().Error("fanout: subscriber panicked; delivery to it dropped", "topic", topic, "panic", rec)
+		}
+	}()
 	s.send(payload)
 }
 

--- a/framework/fanout/postgres_security_test.go
+++ b/framework/fanout/postgres_security_test.go
@@ -6,8 +6,10 @@ package fanout
 // Postgres — any transport touch on a zero-value fanout's nil db would
 // nil-pointer, which is exactly what makes "validated before transport"
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -54,6 +56,50 @@ func TestPublishValidatesBeforeTransport(t *testing.T) {
 	p.closed.Store(true)
 	if err := p.Publish(context.Background(), "orders", []byte(`{}`)); err == nil {
 		t.Error("SECURITY: [fanout] Publish on a closed fanout returned nil, want an error")
+	}
+}
+
+// Property: a subscriber whose send PANICS must not take the single
+// LISTEN/NOTIFY dispatch goroutine down with it — delivery to a
+// healthy subscriber on the SAME topic continues, and the panic is
+// logged rather than dropped. Subscribe wraps callbacks in
+// SubscriberQueue (whose send never panics); the panicking send here
+// is wired directly at the pgSub level, the extension point
+// deliverOne's recover guard exists for.
+func TestDeliverSurvivesPanickingSubscriber(t *testing.T) {
+	p := &PostgresFanout{subs: map[string]map[uint64]*pgSub{}}
+	p.mu.Lock()
+	p.subs["orders"] = map[uint64]*pgSub{
+		1: {send: func([]byte) { panic("subscriber boom") }, stop: func() {}},
+	}
+	p.mu.Unlock()
+
+	healthy := make(chan []byte, 1)
+	cancelHealthy, err := p.Subscribe("orders", func(b []byte) { healthy <- b })
+	if err != nil {
+		t.Fatalf("subscribe healthy: %v", err)
+	}
+	defer cancelHealthy()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	// deliver runs on this (the dispatch-shaped) goroutine: without
+	// the recover guard this call panics the dispatcher.
+	p.deliver("orders", []byte(`{"ok":1}`))
+
+	select {
+	case b := <-healthy:
+		if string(b) != `{"ok":1}` {
+			t.Fatalf("healthy subscriber got %q", b)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("SECURITY: [fanout] a panicking subscriber stopped delivery to a healthy subscriber on the same topic")
+	}
+	if !strings.Contains(buf.String(), "subscriber boom") {
+		t.Fatalf("panicking subscriber not logged; log = %q", buf.String())
 	}
 }
 

--- a/framework/processmodule_broker.go
+++ b/framework/processmodule_broker.go
@@ -822,7 +822,11 @@ func mapQueryResult(res any) (any, error) {
 	}
 	rows, _ := json.Marshal(env["data"])
 	total := 0
-	if t, ok := env["total"].(float64); ok {
+	if raw, present := env["total"]; present {
+		t, ok := raw.(float64)
+		if !ok {
+			return nil, fmt.Errorf("query result envelope: %q must be a number, got %T", "total", raw)
+		}
 		total = int(t)
 	}
 	return moduleproto.EntityQueryResult{Rows: rows, Total: total}, nil

--- a/framework/ui/resource/resource.go
+++ b/framework/ui/resource/resource.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"math"
 	"net/http"
 	"net/url"
@@ -399,7 +400,13 @@ func (c Config) List(ctx context.Context) render.HTML {
 	}
 	q := appui.QueryFromContext(ctx)
 	search := strings.TrimSpace(q.Get("q"))
-	total, _ := c.Crud.CountAll(ctx, crud.ListOptions{Filters: c.queryFilters(q, search)})
+	total, err := c.Crud.CountAll(ctx, crud.ListOptions{Filters: c.queryFilters(q, search)})
+	if err != nil {
+		// The count only feeds pagination chrome; a refused count
+		// degrades to unknown totals rather than a failed screen, but
+		// the refusal is logged rather than dropped.
+		slog.Warn("resource: count", "entity", c.Title, "error", err)
+	}
 
 	actionList := append([]render.HTML{}, c.ExtraActions...)
 	if c.CanCreate {
@@ -476,7 +483,12 @@ func (c Config) table(ctx context.Context, total int) render.HTML {
 	}
 
 	if total < 0 {
-		total, _ = c.Crud.CountAll(ctx, crud.ListOptions{Filters: filters})
+		var err error
+		total, err = c.Crud.CountAll(ctx, crud.ListOptions{Filters: filters})
+		if err != nil {
+			// Same as List: the count feeds pagination chrome only.
+			slog.Warn("resource: count", "entity", c.Title, "error", err)
+		}
 	}
 	// WithReadHooks: these rows are rendered to an end user.
 	rows, err := c.Crud.ListAll(crud.WithReadHooks(ctx), crud.ListOptions{Filters: filters, Sorts: sorts, Limit: limit, Offset: fwpagination.OffsetForPage(page, limit)})

--- a/framework/uihost/registry_css_test.go
+++ b/framework/uihost/registry_css_test.go
@@ -327,6 +327,73 @@ func TestComponentCSS_RejectsInvalidNames(t *testing.T) {
 	}
 }
 
+// registerUnsafeNameStyle registers a component whose NAME would
+// rewrite the /__gofastr/comp/<name>.css path ("/", the exact char the
+// marker charset and validNameRe refuse). registry.RegisterStyle
+// validates non-emptiness only, so such an entry can exist; the CSS
+// link generation and both CSS handlers must refuse to serve it.
+func registerUnsafeNameStyle(t *testing.T, name string, opts ...registry.Option) {
+	t.Helper()
+	registry.RegisterStyle(name, func(style.Theme) string {
+		return ".x{color:red}"
+	}, opts...)
+}
+
+// TestComponentCSS_DirectLinkRefusesUnsafeName: a LoadAlways entry
+// outside the marker charset reaches componentCSSTags via EagerNames
+// (Scan's marker regex cannot produce it). The direct-link path must
+// fail closed: no <link> for it at all, rather than a link whose href
+// the name rewrites.
+func TestComponentCSS_DirectLinkRefusesUnsafeName(t *testing.T) {
+	registry.IsolateForTest(t)
+	registerUnsafeNameStyle(t, "evil-a/../escape", registry.WithLoad(registry.LoadAlways))
+
+	ds := newTestUIHost()
+	body := pageBody(t, ds, "/")
+	if strings.Contains(body, `href="/__gofastr/comp/`) {
+		t.Errorf("unsafe component name must not emit a direct <link> (it rewrites the comp path):\n%s", truncate(body, 800))
+	}
+	if strings.Contains(body, "comp-bundle.css") {
+		t.Errorf("unsafe component name must not appear in a bundle URL either:\n%s", truncate(body, 800))
+	}
+}
+
+// TestComponentCSS_ServeRefusesRegisteredUnsafeName: unlike
+// TestComponentCSS_RejectsInvalidNames (unregistered names, where a
+// missing Lookup would 404 anyway), this registers the unsafe name so
+// ONLY validNameRe stands between the request and the stylesheet. The
+// guard, not the registry miss, must produce the 404.
+func TestComponentCSS_ServeRefusesRegisteredUnsafeName(t *testing.T) {
+	registry.IsolateForTest(t)
+	// The "/" is %2F-encoded in the request so the router does not
+	// path-clean it into a redirect before the handler runs.
+	registerUnsafeNameStyle(t, "serve-evil/a/b")
+
+	ds := newTestUIHost()
+	req := httptest.NewRequest("GET", "/__gofastr/comp/serve-evil%2Fa%2Fb.css", nil)
+	w := httptest.NewRecorder()
+	ds.ServeHTTP(w, req)
+	if w.Code != 404 {
+		t.Errorf("registered unsafe name must 404 (validNameRe), got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestComponentCSS_BundleRefusesRegisteredUnsafeName: same property on
+// the bundle handler — a REGISTERED unsafe name in ?names= must be
+// rejected by validNameRe, not served because Lookup succeeds.
+func TestComponentCSS_BundleRefusesRegisteredUnsafeName(t *testing.T) {
+	registry.IsolateForTest(t)
+	registerUnsafeNameStyle(t, "bundle-evil/a/../b")
+
+	ds := newTestUIHost()
+	req := httptest.NewRequest("GET", "/__gofastr/comp-bundle.css?names=bundle-evil/a/../b", nil)
+	w := httptest.NewRecorder()
+	ds.ServeHTTP(w, req)
+	if w.Code != 404 {
+		t.Errorf("registered unsafe name in bundle must 404 (validNameRe), got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
 func TestComponentCSS_BundleEmitsBundleAttr(t *testing.T) {
 	a := registerTestStyle(t, "battr-a")
 	b := registerTestStyle(t, "battr-b")

--- a/framework/uihost/uihost.go
+++ b/framework/uihost/uihost.go
@@ -3318,6 +3318,12 @@ func (ds *UIHost) componentCSSTags(page string, bundle bool) string {
 			if !ok {
 				continue
 			}
+			if !safeComponentName(n) {
+				// A name outside the marker charset would rewrite the
+				// /__gofastr/comp/<name>.css path instead of naming a
+				// component. Fail closed: no <link> for it.
+				continue
+			}
 			if i > 0 {
 				b.WriteByte('\n')
 			}
@@ -3342,6 +3348,25 @@ func (ds *UIHost) componentCSSTags(page string, bundle bool) string {
 	return fmt.Sprintf(
 		`<link rel="stylesheet" href="/__gofastr/comp-bundle.css?names=%s&v=%s" data-fui-bundle="%s">`,
 		joined, bundleV, joined)
+}
+
+// safeComponentName reports whether n is safe to interpolate as the
+// /__gofastr/comp/<name>.css path segment: exactly the charset the
+// data-fui-comp marker regex captures (registry/render.go), so any
+// name Scan can produce — and anything a registered component may
+// carry that would rewrite the path ('/', '?', '#', ".." tricks need
+// chars outside it) — is refused before it reaches the URL.
+func safeComponentName(n string) bool {
+	if n == "" {
+		return false
+	}
+	for _, r := range n {
+		if !(r == '_' || r == ':' || r == '.' || r == '-' ||
+			r >= '0' && r <= '9' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z') {
+			return false
+		}
+	}
+	return true
 }
 
 // catalogJSONScript returns the inline JSON block embedding the

--- a/internal/analyzers/asciifold/asciifold.go
+++ b/internal/analyzers/asciifold/asciifold.go
@@ -12,24 +12,39 @@
 //
 // The rule reports an index into a REGISTRY — a map whose values are
 // structs, struct pointers, or funcs — keyed by a strings.ToLower /
-// strings.ToUpper result (directly or through a local), and an
-// EqualFold against an ASCII constant whose branch performs a lookup.
+// strings.ToUpper result (directly, through a local, through a
+// one-line fold helper, or through a fold variable
+// `var lower = strings.ToUpper`), and an EqualFold against an ASCII
+// constant whose branch performs a lookup.
 //
 // The rule is deliberately silent on:
 //   - maps of plain values (string/int/bool): word counts and alias
 //     tables have no entry to impersonate.
-//   - deny-list membership tests (`_, sensitive := m[fold]`): folding
-//     look-alikes onto entries only makes a deny list stricter.
-//   - maps populated with folded keys (both sides fold: Postgres
-//     identifier semantics in the schema differ), and EqualFold whose
-//     branch does not key a lookup on the folded value itself.
+//   - membership tests that discard the value (`_, ok := m[fold]`)
+//     only when the posture reads as denial: the map or the enclosing
+//     function is named deny/block/sensitive/reserved/forbidden/
+//     reject/strip, or the ok result is used negated — folding
+//     look-alikes onto entries then only makes the list stricter. The
+//     same syntax over an allow list, where folding makes the grant
+//     weaker (a homoglyph inherits the entry's permission), is
+//     reported. `_ = m[fold]` discards presence too: dead code, silent
+//     unconditionally.
+//   - maps populated with folded keys (both sides fold, local or
+//     struct-held: put/get pairs behind methods fold identically), and
+//     EqualFold whose branch does not key a REGISTRY on the folded
+//     value itself.
 //   - folding that never indexes: ToLower for display, sorting, or
 //     substring search.
-//   - keys pinned ASCII first: an if in the same function that rejects
-//     the value on a >= 0x80 comparison (or an *ascii*-named check)
-//     before the lookup — the fixed lookupRuleLocked posture.
+//   - keys pinned ASCII first: an if in the same function rejecting
+//     the value on a comparison of a byte or rune VIEW of it — an
+//     index expression (`name[i]`), a rune/byte conversion of one
+//     (`rune(name[0])`), or a ContainsFunc/IndexFunc callback
+//     parameter — against 127/128/0x7f/0x80, or an *ascii*-named
+//     check taking the value. A len(...) bound shares no view with
+//     the bytes ("ſ" is two bytes long and passes it) and pins
+//     nothing.
 //   - user-facing text comparison: EqualFold on human strings is
-//     correct; only EqualFold guarding a lookup/grant is reported.
+//     correct; only EqualFold guarding a registry lookup is reported.
 package asciifold
 
 import (
@@ -51,36 +66,53 @@ var Analyzer = &analysis.Analyzer{
 const maxDepth = 6
 
 func run(pass *analysis.Pass) (any, error) {
+	helpers := foldHelpers(pass)
+	foldVars := foldVariables(pass)
 	for _, f := range pass.Files {
 		bound := boundExprs(pass, f)
 		pinned := asciiPinned(pass, f)
 		// Fold-populated maps: written somewhere in this file with a
 		// folded key. Both sides then fold (liveLower[ToLower(col)] =
-		// ...; byName[ToLower(f.Name)] = f), the symmetric comparison
+		// ...; r.byName[ToLower(f.Name)] = f), the symmetric comparison
 		// Postgres identifier semantics ask for — not a fixed registry
-		// an external input is folded ONTO.
-		foldPopulated := foldWrittenMaps(pass, f, bound)
+		// an external input is folded ONTO. Maps held in struct fields
+		// count: put/get pairs behind methods are where they live.
+		foldPopulated := foldWrittenMaps(pass, f, bound, helpers, foldVars)
 		// Discard lookups: `if _, sensitive := m[fold]; sensitive` — a
-		// deny-list membership test. Folding extra look-alikes onto
-		// entries only makes a deny list stricter; the value that would
-		// be impersonated is thrown away.
+		// membership test. Folding extra look-alikes onto entries only
+		// makes a deny list stricter, so the silence is kept only for
+		// denial-shaped postsures (see discardLookups).
 		discards := discardLookups(pass, f)
 		var ifStack []*ast.IfStmt
+		var nodeStack []ast.Node
 		ast.Inspect(f, func(n ast.Node) bool {
+			if n == nil {
+				// Inspect signals "children done" with a nil visit:
+				// pop the node (and any if it closed).
+				if len(nodeStack) > 0 {
+					done := nodeStack[len(nodeStack)-1]
+					nodeStack = nodeStack[:len(nodeStack)-1]
+					if _, ok := done.(*ast.IfStmt); ok && len(ifStack) > 0 {
+						ifStack = ifStack[:len(ifStack)-1]
+					}
+				}
+				return true
+			}
+			nodeStack = append(nodeStack, n)
 			switch e := n.(type) {
 			case *ast.IfStmt:
 				ifStack = append(ifStack, e)
 			case *ast.AssignStmt:
 				// A folded WRITE into a map is population, not lookup.
-				return e.Tok.String() != "=" || !isFoldWrite(pass, e, bound)
+				return e.Tok.String() != "=" || !isFoldWrite(pass, e, bound, helpers, foldVars)
 			case *ast.IndexExpr:
 				if !isRegistry(pass, e.X) || discards[e.Pos()] {
 					return true
 				}
-				if mapObj(pass, e.X); foldPopulated[mapObj(pass, e.X)] {
+				if foldPopulated[mapObj(pass, e.X)] {
 					return true
 				}
-				if inner := foldArg(pass, e.Index, bound, 0); inner != nil {
+				if inner := foldArg(pass, e.Index, bound, helpers, foldVars, 0); inner != nil {
 					if id, ok := inner.(*ast.Ident); !ok || !pinned[pass.TypesInfo.ObjectOf(id)] {
 						pass.Reportf(e.Pos(), "registry lookup folds Unicode case: ToLower/ToUpper map look-alikes onto ASCII (ſ → S), so a homoglyph resolves a real entry; fold ASCII only or refuse non-ASCII keys first")
 					}
@@ -92,14 +124,14 @@ func run(pass *analysis.Pass) (any, error) {
 				if !hasASCIIConstantArg(pass, e.Args) {
 					return true
 				}
-				// Only when the branch looks the FOLDED VALUE up (the
-				// same variable keys a registry inside the branch): a
-				// folded comparison over human text, or beside lookups
-				// keyed by other variables, is fine.
+				// Only when an ENCLOSING branch looks the FOLDED VALUE
+				// up in a registry (the same variable keys one inside
+				// the branch): a folded comparison over human text, or
+				// beside lookups keyed by other variables, is fine.
 				if len(ifStack) == 0 {
 					return true
 				}
-				if obj := foldedOperand(pass, e.Args, bound); obj != nil && branchKeysOn(pass, ifStack[len(ifStack)-1], obj, bound) {
+				if obj := foldedOperand(pass, e.Args, bound); obj != nil && branchKeysOn(pass, ifStack[len(ifStack)-1], obj, bound, helpers, foldVars) {
 					pass.Reportf(e.Pos(), "EqualFold against an ASCII constant guards a lookup: Unicode case folding maps look-alikes onto ASCII (ſ → S), so a homoglyph passes the guard; compare ASCII only or refuse non-ASCII keys first")
 				}
 			}
@@ -109,17 +141,29 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
-// mapObj is the variable object behind a map expression, when it has one.
+// mapObj is the object behind a map expression when it has one: the
+// variable for an identifier, the field for a selector (`r.byName`) —
+// both sides of a put/get pair behind methods key on the same field.
 func mapObj(pass *analysis.Pass, x ast.Expr) types.Object {
-	if id, ok := x.(*ast.Ident); ok {
-		return pass.TypesInfo.ObjectOf(id)
+	switch e := x.(type) {
+	case *ast.Ident:
+		return pass.TypesInfo.ObjectOf(e)
+	case *ast.SelectorExpr:
+		if id, ok := e.X.(*ast.Ident); ok {
+			if _, isPkg := pass.TypesInfo.Uses[id].(*types.PkgName); isPkg {
+				return nil
+			}
+		}
+		if obj := pass.TypesInfo.ObjectOf(e.Sel); obj != nil {
+			return obj
+		}
 	}
 	return nil
 }
 
 // foldWrittenMaps collects map objects written with a folded key in this
 // file.
-func foldWrittenMaps(pass *analysis.Pass, f *ast.File, bound map[types.Object]ast.Expr) map[types.Object]bool {
+func foldWrittenMaps(pass *analysis.Pass, f *ast.File, bound map[types.Object]ast.Expr, helpers map[*types.Func]int, foldVars map[types.Object]bool) map[types.Object]bool {
 	out := map[types.Object]bool{}
 	ast.Inspect(f, func(n ast.Node) bool {
 		st, ok := n.(*ast.AssignStmt)
@@ -128,7 +172,7 @@ func foldWrittenMaps(pass *analysis.Pass, f *ast.File, bound map[types.Object]as
 		}
 		for _, lhs := range st.Lhs {
 			if idx, ok := lhs.(*ast.IndexExpr); ok {
-				if foldArg(pass, idx.Index, bound, 0) != nil {
+				if foldArg(pass, idx.Index, bound, helpers, foldVars, 0) != nil {
 					if obj := mapObj(pass, idx.X); obj != nil {
 						out[obj] = true
 					}
@@ -140,42 +184,102 @@ func foldWrittenMaps(pass *analysis.Pass, f *ast.File, bound map[types.Object]as
 	return out
 }
 
-// discardLookups collects the positions of folded lookups whose value is
-// discarded (`_, ok := m[fold]`).
+// discardLookups collects the positions of discard-shaped lookups the
+// rule stays silent on. `_ = m[k]` discards presence too — dead code,
+// silent unconditionally. The comma-ok shape (`_, ok := m[fold]`) is
+// silent only when the posture reads as denial: the map or the
+// enclosing function is named deny/block/sensitive/reserved/forbidden/
+// reject/strip, or the ok result is used negated. The syntax alone
+// cannot tell a deny list from an allow list, and folding makes an
+// allow list weaker — a homoglyph inherits the entry's permission —
+// so the undecided spellings are reported, not silenced.
 func discardLookups(pass *analysis.Pass, f *ast.File) map[token.Pos]bool {
 	out := map[token.Pos]bool{}
+	var funcs []*ast.FuncDecl
+	for _, d := range f.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Body != nil {
+			funcs = append(funcs, fd)
+		}
+	}
 	ast.Inspect(f, func(n ast.Node) bool {
 		st, ok := n.(*ast.AssignStmt)
 		if !ok {
 			return true
 		}
-		// Tuple (`_, v = m[k]`) and comma-ok (`_, ok := m[k]`) both.
-		pairs := make([][2]ast.Expr, 0, len(st.Lhs))
-		if len(st.Lhs) == len(st.Rhs) {
-			for i := range st.Lhs {
-				pairs = append(pairs, [2]ast.Expr{st.Lhs[i], st.Rhs[i]})
-			}
-		} else if len(st.Lhs) == 2 && len(st.Rhs) == 1 {
-			pairs = append(pairs, [2]ast.Expr{st.Lhs[0], st.Rhs[0]})
-		}
-		for _, p := range pairs {
-			if id, ok := p[0].(*ast.Ident); ok && id.Name == "_" {
-				if idx, ok := p[1].(*ast.IndexExpr); ok {
+		// Plain discard of value and presence alike: dead code.
+		if len(st.Lhs) == 1 && len(st.Rhs) == 1 {
+			if id, ok := st.Lhs[0].(*ast.Ident); ok && id.Name == "_" {
+				if idx, ok := st.Rhs[0].(*ast.IndexExpr); ok {
 					out[idx.Pos()] = true
 				}
 			}
+			return true
+		}
+		// Comma-ok: `_, ok := m[k]`.
+		if len(st.Lhs) != 2 || len(st.Rhs) != 1 {
+			return true
+		}
+		if id, ok := st.Lhs[0].(*ast.Ident); !ok || id.Name != "_" {
+			return true
+		}
+		idx, ok := st.Rhs[0].(*ast.IndexExpr)
+		if !ok {
+			return true
+		}
+		name := ""
+		if obj := mapObj(pass, idx.X); obj != nil {
+			name = obj.Name()
+		}
+		for _, fd := range funcs {
+			if fd.Pos() <= idx.Pos() && idx.Pos() <= fd.End() {
+				name += " " + fd.Name.Name
+			}
+		}
+		denial := false
+		for _, kw := range []string{"deny", "block", "sensitive", "reserved", "forbidden", "reject", "strip"} {
+			if strings.Contains(strings.ToLower(name), kw) {
+				denial = true
+				break
+			}
+		}
+		if !denial {
+			if okID, ok := st.Lhs[1].(*ast.Ident); ok && okID.Name != "_" {
+				if obj := pass.TypesInfo.ObjectOf(okID); obj != nil && usedNegated(pass, f, obj) {
+					denial = true
+				}
+			}
+		}
+		if denial {
+			out[idx.Pos()] = true
 		}
 		return true
 	})
 	return out
 }
 
+// usedNegated reports whether the object is read under a ! anywhere in
+// the file. Objects are function-scoped, so a file scan cannot cross
+// contaminate.
+func usedNegated(pass *analysis.Pass, f *ast.File, obj types.Object) bool {
+	found := false
+	ast.Inspect(f, func(n ast.Node) bool {
+		if u, ok := n.(*ast.UnaryExpr); ok && u.Op == token.NOT {
+			if id, ok := u.X.(*ast.Ident); ok && pass.TypesInfo.ObjectOf(id) == obj {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
 // isFoldWrite reports whether an assignment writes a folded key into a
 // map (`liveLower[ToLower(col)] = ...`).
-func isFoldWrite(pass *analysis.Pass, st *ast.AssignStmt, bound map[types.Object]ast.Expr) bool {
+func isFoldWrite(pass *analysis.Pass, st *ast.AssignStmt, bound map[types.Object]ast.Expr, helpers map[*types.Func]int, foldVars map[types.Object]bool) bool {
 	for _, lhs := range st.Lhs {
 		if idx, ok := lhs.(*ast.IndexExpr); ok {
-			if foldArg(pass, idx.Index, bound, 0) != nil {
+			if foldArg(pass, idx.Index, bound, helpers, foldVars, 0) != nil {
 				return true
 			}
 		}
@@ -212,9 +316,9 @@ func foldedOperand(pass *analysis.Pass, args []ast.Expr, bound map[types.Object]
 	return nil
 }
 
-// branchKeysOn reports whether the if's body indexes a map with the
-// object itself (or a fold of it).
-func branchKeysOn(pass *analysis.Pass, st *ast.IfStmt, obj types.Object, bound map[types.Object]ast.Expr) bool {
+// branchKeysOn reports whether the if's body indexes a REGISTRY with
+// the object itself (or a fold of it).
+func branchKeysOn(pass *analysis.Pass, st *ast.IfStmt, obj types.Object, bound map[types.Object]ast.Expr, helpers map[*types.Func]int, foldVars map[types.Object]bool) bool {
 	found := false
 	ast.Inspect(st.Body, func(n ast.Node) bool {
 		idx, ok := n.(*ast.IndexExpr)
@@ -222,11 +326,11 @@ func branchKeysOn(pass *analysis.Pass, st *ast.IfStmt, obj types.Object, bound m
 			return true
 		}
 		key := idx.Index
-		if foldArg(pass, key, bound, 0) != nil {
-			key = foldArg(pass, key, bound, 0)
+		if foldArg(pass, key, bound, helpers, foldVars, 0) != nil {
+			key = foldArg(pass, key, bound, helpers, foldVars, 0)
 		}
 		if id, ok := key.(*ast.Ident); ok && pass.TypesInfo.ObjectOf(id) == obj {
-			if _, isMap := mapUnderlying(pass, idx.X); isMap {
+			if isRegistry(pass, idx.X) {
 				found = true
 				return false
 			}
@@ -260,19 +364,41 @@ func isRegistry(pass *analysis.Pass, x ast.Expr) bool {
 	return false
 }
 
-// foldArg reports the argument of the strings.ToLower / strings.ToUpper
-// call x is (or resolves through locals to), or nil when x is not a fold.
-func foldArg(pass *analysis.Pass, x ast.Expr, bound map[types.Object]ast.Expr, depth int) ast.Expr {
+// foldArg reports the argument whose bytes the strings.ToLower /
+// strings.ToUpper call x folds (or resolves through locals, one-line
+// fold helpers, fold variables, and a TrimSpace around the fold to),
+// or nil when x is not a fold.
+func foldArg(pass *analysis.Pass, x ast.Expr, bound map[types.Object]ast.Expr, helpers map[*types.Func]int, foldVars map[types.Object]bool, depth int) ast.Expr {
 	if depth > maxDepth {
 		return nil
 	}
 	switch e := x.(type) {
 	case *ast.ParenExpr:
-		return foldArg(pass, e.X, bound, depth+1)
+		return foldArg(pass, e.X, bound, helpers, foldVars, depth+1)
 	case *ast.CallExpr:
 		switch qualifiedCallee(pass, e.Fun) {
 		case "strings.ToLower", "strings.ToUpper":
 			if len(e.Args) == 1 {
+				return e.Args[0]
+			}
+		case "strings.TrimSpace":
+			// A trim around the fold is still a folded key.
+			if len(e.Args) == 1 {
+				if inner := foldArg(pass, e.Args[0], bound, helpers, foldVars, depth+1); inner != nil {
+					return inner
+				}
+			}
+		}
+		// A one-line fold helper: `func norm(s string) string {
+		// return strings.ToLower(s) }` keyed as gadgets[norm(name)].
+		if fn, ok := calleeFunc(pass, e.Fun); ok {
+			if pi, ok := helpers[fn]; ok && pi < len(e.Args) {
+				return e.Args[pi]
+			}
+		}
+		// A fold variable: `var lower = strings.ToUpper`.
+		if id, ok := e.Fun.(*ast.Ident); ok && len(e.Args) == 1 {
+			if obj := pass.TypesInfo.ObjectOf(id); obj != nil && foldVars[obj] {
 				return e.Args[0]
 			}
 		}
@@ -280,12 +406,119 @@ func foldArg(pass *analysis.Pass, x ast.Expr, bound map[types.Object]ast.Expr, d
 	case *ast.Ident:
 		if obj := pass.TypesInfo.ObjectOf(e); obj != nil {
 			if src, ok := bound[obj]; ok {
-				return foldArg(pass, src, bound, depth+1)
+				return foldArg(pass, src, bound, helpers, foldVars, depth+1)
 			}
 		}
 		return nil
 	}
 	return nil
+}
+
+// foldHelpers maps one-result functions whose body is a single return
+// of a fold (through trims) to the index of the parameter the fold
+// wraps: `func norm(s string) string { return strings.ToLower(s) }`.
+func foldHelpers(pass *analysis.Pass) map[*types.Func]int {
+	out := map[*types.Func]int{}
+	for _, f := range pass.Files {
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Body == nil || fd.Type.Results == nil {
+				continue
+			}
+			if len(fd.Type.Results.List) != 1 || len(fd.Body.List) != 1 {
+				continue
+			}
+			ret, ok := fd.Body.List[0].(*ast.ReturnStmt)
+			if !ok || len(ret.Results) != 1 {
+				continue
+			}
+			fn, ok := pass.TypesInfo.Defs[fd.Name].(*types.Func)
+			if !ok {
+				continue
+			}
+			if pi, ok := foldParamIndex(pass, ret.Results[0], fn); ok {
+				out[fn] = pi
+			}
+		}
+	}
+	return out
+}
+
+// foldParamIndex peels folds and trims down to a parameter of fn and
+// returns that parameter's index.
+func foldParamIndex(pass *analysis.Pass, e ast.Expr, fn *types.Func) (int, bool) {
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok {
+		return 0, false
+	}
+	params := sig.Params()
+	for range maxDepth {
+		switch x := e.(type) {
+		case *ast.ParenExpr:
+			e = x.X
+		case *ast.CallExpr:
+			switch qualifiedCallee(pass, x.Fun) {
+			case "strings.ToLower", "strings.ToUpper", "strings.TrimSpace":
+				if len(x.Args) != 1 {
+					return 0, false
+				}
+				e = x.Args[0]
+			default:
+				return 0, false
+			}
+		case *ast.Ident:
+			if obj := pass.TypesInfo.ObjectOf(x); obj != nil {
+				for i := range params.Len() {
+					if params.At(i) == obj {
+						return i, true
+					}
+				}
+			}
+			return 0, false
+		default:
+			return 0, false
+		}
+	}
+	return 0, false
+}
+
+// foldVariables collects package-level `var f = strings.ToLower` (or
+// ToUpper) bindings: a fold reached through a function variable.
+func foldVariables(pass *analysis.Pass) map[types.Object]bool {
+	out := map[types.Object]bool{}
+	for _, f := range pass.Files {
+		for _, decl := range f.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.VAR {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok || len(vs.Names) != 1 || len(vs.Values) != 1 {
+					continue
+				}
+				switch qualifiedCallee(pass, vs.Values[0]) {
+				case "strings.ToLower", "strings.ToUpper":
+					if obj := pass.TypesInfo.ObjectOf(vs.Names[0]); obj != nil {
+						out[obj] = true
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+func calleeFunc(pass *analysis.Pass, fun ast.Expr) (*types.Func, bool) {
+	switch f := fun.(type) {
+	case *ast.Ident:
+		fn, ok := pass.TypesInfo.Uses[f].(*types.Func)
+		return fn, ok
+	case *ast.SelectorExpr:
+		fn, ok := pass.TypesInfo.Uses[f.Sel].(*types.Func)
+		return fn, ok
+	}
+	return nil, false
 }
 
 // hasASCIIConstantArg reports whether one EqualFold argument is a
@@ -314,11 +547,17 @@ func hasASCIIConstantArg(pass *analysis.Pass, args []ast.Expr) bool {
 	return false
 }
 
-// asciiPinned collects objects an if-statement has pinned to ASCII: the
-// condition both references the object and rejects on a >= 0x80 / 0x7f /
-// 127 comparison or an *ascii*-named check — the
+// asciiPinned collects objects an if-statement has pinned to ASCII: a
+// comparison of a byte or rune VIEW of the value against the ASCII
+// boundary (127/128/0x7f/0x80) — an index expression (`name[i]`), a
+// rune/byte conversion of one (`rune(name[0])`), or a
+// ContainsFunc/IndexFunc callback parameter ranging over it, the
 // strings.ContainsFunc(key, func(r rune) bool { return r >= 0x80 })
-// posture the rule.go fix shipped.
+// posture the rule.go fix shipped — or an *ascii*-named check taking
+// the value directly. A bare len(...) bound shares no view with the
+// value's bytes — "ſ" is two bytes long and passes it — so it pins
+// nothing, and neither do the other identifiers that merely share the
+// condition.
 func asciiPinned(pass *analysis.Pass, f *ast.File) map[types.Object]bool {
 	pinned := map[types.Object]bool{}
 	ast.Inspect(f, func(n ast.Node) bool {
@@ -326,30 +565,61 @@ func asciiPinned(pass *analysis.Pass, f *ast.File) map[types.Object]bool {
 		if !ok || st.Cond == nil {
 			return true
 		}
-		marker := false
+		// Callback parameters of ContainsFunc/IndexFunc over a
+		// variable stand for that variable's runes.
+		cb := map[types.Object]types.Object{}
 		ast.Inspect(st.Cond, func(c ast.Node) bool {
-			switch e := c.(type) {
-			case *ast.BasicLit:
-				marker = marker || isASCIIBound(e)
-			case *ast.CallExpr:
-				name := ""
-				switch fun := e.Fun.(type) {
-				case *ast.Ident:
-					name = fun.Name
-				case *ast.SelectorExpr:
-					name = fun.Sel.Name
+			call, ok := c.(*ast.CallExpr)
+			if !ok || len(call.Args) != 2 {
+				return true
+			}
+			switch calleeName(call.Fun) {
+			case "ContainsFunc", "IndexFunc":
+			default:
+				return true
+			}
+			src, ok := call.Args[0].(*ast.Ident)
+			if !ok {
+				return true
+			}
+			lit, ok := call.Args[1].(*ast.FuncLit)
+			if !ok || len(lit.Type.Params.List) != 1 {
+				return true
+			}
+			srcObj := pass.TypesInfo.ObjectOf(src)
+			for _, name := range lit.Type.Params.List[0].Names {
+				if obj := pass.TypesInfo.ObjectOf(name); obj != nil {
+					cb[obj] = srcObj
 				}
-				marker = marker || containsFoldASCII(name)
 			}
 			return true
 		})
-		if !marker {
-			return true
-		}
 		ast.Inspect(st.Cond, func(c ast.Node) bool {
-			if id, ok := c.(*ast.Ident); ok {
-				if obj := pass.TypesInfo.ObjectOf(id); obj != nil {
-					pinned[obj] = true
+			switch e := c.(type) {
+			case *ast.BinaryExpr:
+				switch e.Op {
+				case token.LSS, token.LEQ, token.GTR, token.GEQ, token.EQL, token.NEQ:
+				default:
+					return true
+				}
+				for _, side := range [2]struct{ view, lit ast.Expr }{{e.X, e.Y}, {e.Y, e.X}} {
+					lit, ok := side.lit.(*ast.BasicLit)
+					if !ok || !isASCIIBound(lit) {
+						continue
+					}
+					if obj := byteRuneView(pass, side.view, cb); obj != nil {
+						pinned[obj] = true
+					}
+				}
+			case *ast.CallExpr:
+				if containsFoldASCII(calleeName(e.Fun)) {
+					for _, a := range e.Args {
+						if id, ok := a.(*ast.Ident); ok {
+							if obj := pass.TypesInfo.ObjectOf(id); obj != nil {
+								pinned[obj] = true
+							}
+						}
+					}
 				}
 			}
 			return true
@@ -357,6 +627,45 @@ func asciiPinned(pass *analysis.Pass, f *ast.File) map[types.Object]bool {
 		return true
 	})
 	return pinned
+}
+
+// byteRuneView resolves an expression that exposes the bytes or runes
+// of a variable to that variable's object: a ContainsFunc/IndexFunc
+// callback parameter mapped to it, an index expression on it
+// (`name[i]`), or a rune/byte conversion of such an index
+// (`rune(name[0])`). Anything else computed over the variable — len
+// above all — is not a view and pins nothing.
+func byteRuneView(pass *analysis.Pass, x ast.Expr, cb map[types.Object]types.Object) types.Object {
+	switch e := x.(type) {
+	case *ast.ParenExpr:
+		return byteRuneView(pass, e.X, cb)
+	case *ast.Ident:
+		if obj := pass.TypesInfo.ObjectOf(e); obj != nil {
+			if src, ok := cb[obj]; ok && src != nil {
+				return src
+			}
+		}
+		return nil
+	case *ast.IndexExpr:
+		if id, ok := e.X.(*ast.Ident); ok {
+			return pass.TypesInfo.ObjectOf(id)
+		}
+	case *ast.CallExpr:
+		if id, ok := e.Fun.(*ast.Ident); ok && (id.Name == "rune" || id.Name == "byte") && len(e.Args) == 1 {
+			return byteRuneView(pass, e.Args[0], cb)
+		}
+	}
+	return nil
+}
+
+func calleeName(fun ast.Expr) string {
+	switch f := fun.(type) {
+	case *ast.Ident:
+		return f.Name
+	case *ast.SelectorExpr:
+		return f.Sel.Name
+	}
+	return ""
 }
 
 // isASCIIBound reports whether a literal is the ASCII boundary (0x80,

--- a/internal/analyzers/asciifold/asciifold.go
+++ b/internal/analyzers/asciifold/asciifold.go
@@ -99,12 +99,23 @@ func run(pass *analysis.Pass) (any, error) {
 				return true
 			}
 			nodeStack = append(nodeStack, n)
+			pop := func() { nodeStack = nodeStack[:len(nodeStack)-1] }
 			switch e := n.(type) {
 			case *ast.IfStmt:
 				ifStack = append(ifStack, e)
 			case *ast.AssignStmt:
 				// A folded WRITE into a map is population, not lookup.
-				return e.Tok.String() != "=" || !isFoldWrite(pass, e, bound, helpers, foldVars)
+				// Inspect calls f(nil) only after a visit that returned
+				// true, so the children of this assignment will never
+				// produce their "children done" visits: pop the node here
+				// or the stack stays misaligned for the rest of the file
+				// and a later close pops a stale node instead of the one
+				// that actually ended — an IfStmt miss leaves ifStack
+				// pointing at an if that no longer encloses the call.
+				if e.Tok.String() == "=" && isFoldWrite(pass, e, bound, helpers, foldVars) {
+					pop()
+					return false
+				}
 			case *ast.IndexExpr:
 				if !isRegistry(pass, e.X) || discards[e.Pos()] {
 					return true

--- a/internal/analyzers/asciifold/testdata/src/afalt/afalt.go
+++ b/internal/analyzers/asciifold/testdata/src/afalt/afalt.go
@@ -69,3 +69,104 @@ func plainValues(alias string, m map[string]string) string {
 func displayFold(name string) string {
 	return strings.ToUpper(name)
 }
+
+// ---- one indirection deeper -------------------------------------------
+
+// norm is the one-line fold helper any package that normalizes more
+// than once factors; upper is the func-variable spelling.
+func norm(s string) string { return strings.ToLower(s) }
+
+var upper = strings.ToUpper
+
+func viaHelper(name string) *gadget {
+	return gadgets[norm(name)] // want `registry lookup folds Unicode case`
+}
+
+func viaVar(name string) *gadget {
+	return gadgets[upper(name)] // want `registry lookup folds Unicode case`
+}
+
+// ---- struct-held registries -------------------------------------------
+
+type gadgetRegistry struct {
+	byName map[string]*gadget
+}
+
+// put/get fold on both sides: the symmetric comparison the both-sides
+// silence covers — field-held like local.
+func (r *gadgetRegistry) put(n string, g *gadget) {
+	r.byName[strings.ToLower(n)] = g
+}
+
+func (r *gadgetRegistry) get(n string) *gadget {
+	return r.byName[strings.ToLower(n)]
+}
+
+// widgetIndex is populated with plain keys and read with a fold.
+var widgetIndex = struct{ m map[string]*gadget }{m: map[string]*gadget{"slider": {}}}
+
+func lookupWidget(name string) *gadget {
+	return widgetIndex.m[strings.ToLower(name)] // want `registry lookup folds Unicode case`
+}
+
+// ---- EqualFold on human text -------------------------------------------
+
+var wordcount = map[string]int{}
+
+// humanText: the EqualFold compares what the user typed against a
+// word; the earlier if merely counts words and must not leak onto it.
+func humanText(name string) bool {
+	if name != "" {
+		wordcount[name]++
+	}
+	return strings.EqualFold(name, "slider")
+}
+
+// ---- membership tests --------------------------------------------------
+
+type perm struct{ Level int }
+
+var allowlist = map[string]perm{"deploy": {3}}
+var denylist = map[string]perm{"drop": {0}}
+var grants = map[string]perm{"rollback": {1}}
+
+// allowedAllowlist: folding an allow-list lookup makes the grant
+// weaker — a homoglyph inherits the entry's permission.
+func allowedAllowlist(action string) bool {
+	_, ok := allowlist[strings.ToLower(action)] // want `registry lookup folds Unicode case`
+	return ok
+}
+
+// blockedDenylist: folding onto a deny list only makes it stricter —
+// declared silence, the map name says denial.
+func blockedDenylist(action string) bool {
+	_, ok := denylist[strings.ToLower(action)]
+	return ok
+}
+
+// allowedNegated: the ok result is used negated, the deny posture —
+// declared silence.
+func allowedNegated(action string) bool {
+	_, ok := grants[strings.ToLower(action)]
+	return !ok
+}
+
+// ---- length guards are not ASCII pins ----------------------------------
+
+// longGuard: a length bound shares nothing with the value's bytes —
+// "ſ" is two bytes long and passes — so it pins nothing.
+func longGuard(name string) *gadget {
+	if len(name) >= 128 {
+		return nil
+	}
+	return gadgets[strings.ToLower(name)] // want `registry lookup folds Unicode case`
+}
+
+// bytePin: an index view against the boundary pins — the fixed
+// posture, byte spelling.
+func bytePin(name string, i int) *gadget {
+	if name[i] >= 0x80 {
+		return nil
+	}
+	return gadgets[strings.ToLower(name)]
+}

--- a/internal/analyzers/asciifold/testdata/src/afalt/afalt.go
+++ b/internal/analyzers/asciifold/testdata/src/afalt/afalt.go
@@ -39,12 +39,20 @@ func build(kind string) *gadget {
 }
 
 // equalFoldGrant is the EqualFold arm: an ASCII constant guards a
-// registry lookup, so a homoglyph passes the guard.
-func equalFoldGrant(action string) *gadget {
+// registry lookup, so a homoglyph passes the guard. The folded map
+// write inside the arm and the trailing human-text comparison pin the
+// visitor's ifStack exit tracking: the write cuts the walk, and a
+// stale enclosing if must not leak onto the EqualFold after it.
+func equalFoldGrant(action string, seen map[string]bool) *gadget {
 	if strings.EqualFold(action, "slider") { // want `EqualFold against an ASCII constant`
 		if g, ok := gadgets[action]; ok {
 			return g
 		}
+		seen[strings.ToLower(action)] = true // population, not a lookup
+	}
+	grid := strings.EqualFold(action, "grid") // human text: never keyed on a registry
+	if grid {
+		return nil
 	}
 	return nil
 }

--- a/internal/analyzers/callbackunderlock/callbackunderlock.go
+++ b/internal/analyzers/callbackunderlock/callbackunderlock.go
@@ -34,17 +34,29 @@
 // sync.RWMutex selectors count); calls inside nested function literals
 // (a closure deferred or handed to `go` does not run in the linear
 // region, and a synchronous comparator's own lock behavior is its
-// business); and context.CancelFunc fields (moduleproto's cancel
-// slots): CancelFunc never re-enters user code — it is documented
-// safe to call concurrently and only touches context internals — so
-// holding p.mu across it cannot deadlock on a callback that re-takes
-// the lock; and the deliberately-serialized one-shot — a callback on
-// the SAME object as the mutex, called at most once outside any loop,
-// under a DEFERRED release (battery/setup's run-one-step-under-lock,
-// where the lock IS the exactly-once guarantee, and the style cache's
-// compute-under-entry-lock) — because a panic unwinds through the
-// deferred unlock and the blocked parties are the same object's own
-// callers, not a shared registry's every reader.
+// business); callees launched with `go` or deferred between Lock and
+// Unlock (`go sub(ev)`, `defer h.done()`) — the launch is
+// non-blocking and the callee runs on its own stack outside the held
+// region; printf-shaped logger fields
+// (func(format string, args ...any) — the logf/Logger fields the
+// webhook manager, static builder and process supervisor inject),
+// which are logging plumbing, not app callbacks, per the sibling
+// recovercallback analyzer's classification; and context.CancelFunc
+// fields (moduleproto's cancel slots): CancelFunc never re-enters user
+// code — it is documented safe to call concurrently and only touches
+// context internals — so holding p.mu across it cannot deadlock on a
+// callback that re-takes the lock; and the deliberately-serialized
+// one-shot — a callback on the SAME object as the mutex (the callee's
+// root identifier is the receiver the mutex hangs off; a callback on
+// any OTHER object, parameter or not, never qualifies — a blocking
+// foreign callback wedges this registry's lock regardless), called at
+// most once outside any loop, under a DEFERRED release (the style
+// cache's compute-under-entry-lock, where the lock IS the
+// exactly-once guarantee; battery/setup's runner used this shape too
+// until its step callback moved outside the lock with an in-flight
+// flag) — because a panic unwinds through the deferred unlock and the
+// blocked parties are the same object's own callers, not a shared
+// registry's every reader.
 package callbackunderlock
 
 import (
@@ -89,7 +101,6 @@ func checkBody(pass *analysis.Pass, fn *ast.FuncDecl, body *ast.BlockStmt) {
 	mapDerived := mapDerivedBindings(pass, body)
 	recv := receiverName(fn)
 	inLoop, ownBatch := callsInsideLoops(pass, body, recv)
-	params := paramObjects(pass, fn)
 
 	for i := range calls {
 		call := &calls[i]
@@ -101,7 +112,7 @@ func checkBody(pass *analysis.Pass, fn *ast.FuncDecl, body *ast.BlockStmt) {
 		if !held {
 			continue
 		}
-		if serializedOneShot(deferredRelease, inLoop, ownBatch, key, desc, call, params) {
+		if serializedOneShot(deferredRelease, inLoop, ownBatch, key, desc, call) {
 			continue
 		}
 		pass.Reportf(call.Pos(),
@@ -113,14 +124,16 @@ func checkBody(pass *analysis.Pass, fn *ast.FuncDecl, body *ast.BlockStmt) {
 // serializedOneShot recognizes the deliberately-serialized pattern this
 // rule stays out of: the callback belongs to the SAME object as the
 // mutex, is invoked at most once (not inside a loop), and the release
-// is deferred — the setup runner runs one step under the lock because
-// the lock is the exactly-once guarantee, and the style cache computes
-// under the entry lock for the same reason. A panic there unwinds
+// is deferred — the style cache computes under the entry lock because
+// the lock is the exactly-once guarantee, and battery/setup's runner
+// ran its step the same way until the step moved outside the lock
+// (claim under the lock, run outside, advance under the lock). A
+// panic there unwinds
 // through the deferred unlock; nothing is wedged. The shape this rule
 // exists for is the SHARED registry: per-item callbacks in a loop
 // (mcp's listing gates, cron's per-job gate) or any explicit lock/
 // unlock span a panicking callback can skip past.
-func serializedOneShot(deferredRelease map[string]bool, inLoop, ownBatch map[token.Pos]bool, key, desc string, call *ast.CallExpr, params map[string]bool) bool {
+func serializedOneShot(deferredRelease map[string]bool, inLoop, ownBatch map[token.Pos]bool, key, desc string, call *ast.CallExpr) bool {
 	if !deferredRelease[key] {
 		return false
 	}
@@ -140,7 +153,7 @@ func serializedOneShot(deferredRelease map[string]bool, inLoop, ownBatch map[tok
 		return false
 	}
 	calleeRoot, _, _ := strings.Cut(desc, ".")
-	return calleeRoot == lockRoot || params[calleeRoot]
+	return calleeRoot == lockRoot
 }
 
 // rootIdent is the leftmost identifier of a selector chain (r.cfg.Steps
@@ -168,30 +181,6 @@ func receiverName(fn *ast.FuncDecl) string {
 		return ""
 	}
 	return names[0].Name
-}
-
-// paramObjects collects the enclosing function's parameter names
-// (receiver included).
-func paramObjects(pass *analysis.Pass, fn *ast.FuncDecl) map[string]bool {
-	out := map[string]bool{}
-	if fn == nil {
-		return out
-	}
-	if fn.Recv != nil {
-		for _, f := range fn.Recv.List {
-			for _, n := range f.Names {
-				out[n.Name] = true
-			}
-		}
-	}
-	if fn.Type.Params != nil {
-		for _, f := range fn.Type.Params.List {
-			for _, n := range f.Names {
-				out[n.Name] = true
-			}
-		}
-	}
-	return out
 }
 
 // callsInsideLoops marks every call position lexically inside a loop,
@@ -277,6 +266,14 @@ func scanLocks(pass *analysis.Pass, body *ast.BlockStmt) ([]lockEvent, []ast.Cal
 		if !ok {
 			return true
 		}
+		if async[call.Pos()] {
+			// A `go`-launched or deferred callee does not run in the
+			// linear region: the launch is non-blocking and the
+			// callback runs on its own stack outside it (the same
+			// reason closures handed to `go` are out of scope), and a
+			// deferred release fires at function exit, not here.
+			return true
+		}
 		sel, ok := unparen(call.Fun).(*ast.SelectorExpr)
 		if !ok {
 			calls = append(calls, *call)
@@ -298,12 +295,6 @@ func scanLocks(pass *analysis.Pass, body *ast.BlockStmt) ([]lockEvent, []ast.Cal
 			// Not sync's own method: a wrapper type redefining
 			// Lock/Unlock is out of scope.
 			calls = append(calls, *call)
-			return true
-		}
-		if async[call.Pos()] {
-			// The deferred/go release: not an event. A deferred
-			// Lock would be too, but that shape cannot guard the
-			// statements above it anyway.
 			return true
 		}
 		events = append(events, lockEvent{
@@ -350,7 +341,7 @@ func funcValueCallee(pass *analysis.Pass, call *ast.CallExpr, mapDerived map[typ
 		if !isSignature(s.Type()) {
 			return nil, "", false
 		}
-		if field, ok := s.Obj().(*types.Var); ok && (isCancelFunc(field.Type()) || isClockFunc(field.Type())) {
+		if field, ok := s.Obj().(*types.Var); ok && (isCancelFunc(field.Type()) || isClockFunc(field.Type()) || isPrintfFunc(field.Type())) {
 			return nil, "", false
 		}
 		return s.Obj(), types.ExprString(fun), true
@@ -448,6 +439,30 @@ func isClockFunc(t types.Type) bool {
 	}
 	n, ok := sig.Results().At(0).Type().(*types.Named)
 	return ok && n.Obj().Pkg() != nil && n.Obj().Pkg().Path() == "time" && n.Obj().Name() == "Time"
+}
+
+// isPrintfFunc: a printf-shaped logger field —
+// func(format string, args ...any) — the same plumbing shape the
+// sibling recovercallback analyzer classifies as infrastructure. A
+// log line never blocks on app code long enough to wedge a registry.
+func isPrintfFunc(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+	sig, ok := t.Underlying().(*types.Signature)
+	if !ok || !sig.Variadic() || sig.Params().Len() != 2 || sig.Results().Len() != 0 {
+		return false
+	}
+	b, ok := sig.Params().At(0).Type().Underlying().(*types.Basic)
+	if !ok || b.Info()&types.IsString == 0 {
+		return false
+	}
+	sl, ok := sig.Params().At(1).Type().Underlying().(*types.Slice)
+	if !ok {
+		return false
+	}
+	e, ok := sl.Elem().Underlying().(*types.Interface)
+	return ok && e.Empty()
 }
 
 func isCancelFunc(t types.Type) bool {

--- a/internal/analyzers/callbackunderlock/callbackunderlock_test.go
+++ b/internal/analyzers/callbackunderlock/callbackunderlock_test.go
@@ -10,5 +10,5 @@ import (
 
 func TestCallbackUnderLock(t *testing.T) {
 	analysistest.Run(t, analysistest.TestData(), callbackunderlock.Analyzer,
-		"registry", "subhub", "pipeline")
+		"registry", "subhub", "pipeline", "golaunch", "wnparam", "logfield")
 }

--- a/internal/analyzers/callbackunderlock/testdata/src/golaunch/golaunch.go
+++ b/internal/analyzers/callbackunderlock/testdata/src/golaunch/golaunch.go
@@ -1,0 +1,49 @@
+// Package golaunch pins the go-launch posture (review finding B1): a
+// callback launched on its own goroutine between Lock and Unlock does
+// not run in the linear held region — the launch is non-blocking and
+// the callback runs on its own stack after the region — so it is quiet
+// exactly like a closure handed to `go`. The synchronous spelling
+// beside it still fires.
+package golaunch
+
+import "sync"
+
+type Hub struct {
+	mu   sync.Mutex
+	subs map[string]func(ev string)
+	done func()
+}
+
+// asyncFanout launches each subscriber under the lock. Quiet.
+func (h *Hub) asyncFanout(ev string) {
+	h.mu.Lock()
+	for _, sub := range h.subs {
+		go sub(ev)
+	}
+	h.mu.Unlock()
+}
+
+// asyncDone launches a func field under the lock. Quiet.
+func (h *Hub) asyncDone() {
+	h.mu.Lock()
+	go h.done()
+	h.mu.Unlock()
+}
+
+// asyncDefer: the release is deferred and the callback is still only
+// launched, never run, inside the region. Quiet.
+func (h *Hub) asyncDefer() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	go h.done()
+}
+
+// syncFanout is the control: the same map callbacks invoked
+// synchronously under the lock.
+func (h *Hub) syncFanout(ev string) {
+	h.mu.Lock()
+	for _, sub := range h.subs {
+		sub(ev) // want `callbackunderlock: sub is called while h\.mu is held`
+	}
+	h.mu.Unlock()
+}

--- a/internal/analyzers/callbackunderlock/testdata/src/logfield/logfield.go
+++ b/internal/analyzers/callbackunderlock/testdata/src/logfield/logfield.go
@@ -1,0 +1,34 @@
+// Package logfield pins the printf-logger posture (review finding B3):
+// a func(format string, args ...any)-shaped field is logging plumbing,
+// not an app callback — the sibling analyzer recovercallback already
+// classifies those fields as infrastructure — so progress-logging
+// inside a locked walk is quiet. A func field of any other shape under
+// the lock still fires.
+package logfield
+
+import "sync"
+
+type Reg struct {
+	mu      sync.Mutex
+	entries map[string]int
+	logf    func(format string, args ...any)
+	gate    func(name string) error
+}
+
+// flushed is the standard idiom: log each entry while walking the
+// registry under its lock. Quiet.
+func (r *Reg) flushed() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for name := range r.entries {
+		r.logf("flushing %s", name)
+	}
+}
+
+// gated: a non-printf func field invoked under the lock. Fires.
+func (r *Reg) gated(name string) error {
+	r.mu.Lock()
+	err := r.gate(name) // want `callbackunderlock: r\.gate is called while r\.mu is held`
+	r.mu.Unlock()
+	return err
+}

--- a/internal/analyzers/callbackunderlock/testdata/src/wnparam/wnparam.go
+++ b/internal/analyzers/callbackunderlock/testdata/src/wnparam/wnparam.go
@@ -1,0 +1,48 @@
+// Package wnparam pins the one-shot exemption's shape (review finding
+// B2): the exemption covers a callback on the SAME object as the mutex
+// under a deferred release — never a foreign object's callback merely
+// because it is rooted at a parameter of the enclosing function. A
+// blocking callback on a foreign object still wedges THIS registry's
+// lock no matter how the release is spelled.
+package wnparam
+
+import "sync"
+
+type Entry struct {
+	Name string
+	Gate func() error
+}
+
+type Reg struct {
+	mu sync.Mutex
+}
+
+// oneShotPlain: a foreign callback under an explicit release. Fires.
+func (r *Reg) oneShotPlain(e *Entry) error {
+	r.mu.Lock()
+	err := e.Gate() // want `callbackunderlock: e\.Gate is called while r\.mu is held`
+	r.mu.Unlock()
+	return err
+}
+
+// oneShotDeferred: the same foreign callback, deferred release. The
+// exemption never covered a foreign object; it fires too.
+func (r *Reg) oneShotDeferred(e *Entry) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return e.Gate() // want `callbackunderlock: e\.Gate is called while r\.mu is held`
+}
+
+// sameObjectOneShot is the sanctioned shape: the callback belongs to
+// the same object as the mutex, called once, under a deferred release
+// (battery/setup's run-one-step-under-lock). Quiet.
+type selfreg struct {
+	mu   sync.Mutex
+	gate func() error
+}
+
+func (s *selfreg) sameObjectOneShot() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.gate()
+}

--- a/internal/analyzers/compositekey/compositekey.go
+++ b/internal/analyzers/compositekey/compositekey.go
@@ -110,8 +110,9 @@ func joinHelpers(pass *analysis.Pass) map[*types.Func]ast.Expr {
 }
 
 // rebindsOnly reports whether every statement only rebinds parameters
-// of fn: assignments to the parameters, and ifs whose branches contain
-// nothing but such assignments.
+// of fn: `=` assignments to the parameters, and ifs whose branches
+// contain nothing but such assignments. A `:=` declares a NEW binding
+// (never a parameter of fn) and disqualifies the helper.
 func rebindsOnly(pass *analysis.Pass, stmts []ast.Stmt, fn *types.Func) bool {
 	sig, ok := fn.Type().(*types.Signature)
 	if !ok {
@@ -130,7 +131,9 @@ func rebindsOnly(pass *analysis.Pass, stmts []ast.Stmt, fn *types.Func) bool {
 	for _, st := range stmts {
 		switch s := st.(type) {
 		case *ast.AssignStmt:
-			if s.Tok != token.ASSIGN && s.Tok != token.DEFINE {
+			// token.ASSIGN only: a := declares a new binding, whose
+			// object is never one of fn's parameters.
+			if s.Tok != token.ASSIGN {
 				return false
 			}
 			for _, lhs := range s.Lhs {

--- a/internal/analyzers/compositekey/compositekey.go
+++ b/internal/analyzers/compositekey/compositekey.go
@@ -13,6 +13,13 @@
 // ("a", "b\x00c") collapsed onto one claim and cross-poisoned
 // fingerprints). Both were fixed in b79942f7: the store moved to struct
 // keys, the shard to a length-prefixed encoding.
+
+// The join is recognized through the indirections a real bug wears: a
+// local or struct field bound from it, a one-result helper whose body
+// reduces to returning it (statements that only rebind the helper's
+// parameters in front of the return do not hide it), and the one-arg
+// string-preserving normalizers around it at the sink
+// (strings.ToLower/ToUpper/TrimSpace — the usual key normalizers).
 //
 // The rule is deliberately silent on:
 //   - printable separators (":", ".", " ", "|", "-", "/"...): those key
@@ -24,6 +31,15 @@
 //     not a collision.
 //   - fmt.Sprintf keys: interpolation belongs to the emitident /
 //     GOFASTR1401 families, not this one.
+//   - keyed-store arguments whose callee parameter name does not say
+//     "key": the Store.Begin/Finish leg fires only when the parameter
+//     name contains "key" (key, storeKey, cacheKey). A keyed store
+//     behind an interface leaves no type-level trace that an argument
+//     is used as a key — the parameter name is the only intent signal
+//     available — so a store naming it claim/name/id stays silent by
+//     declaration, not by oversight. A join that also reaches a map,
+//     map-literal key, or prefix scan in this package is reported
+//     regardless of the name.
 //   - length-prefixed joins: any operand of the form strconv.Itoa(len(x))
 //     or fmt.Sprint(len(x)) with x also an operand pins the boundary and
 //     makes the join injective (the fixed idempotency shard).
@@ -58,8 +74,11 @@ func run(pass *analysis.Pass) (any, error) {
 }
 
 // joinHelpers collects package functions with exactly one result whose
-// body is a single `return <delimiter join>`: the taskKey/pushKey shape,
-// where the join hides behind a helper call at the sink.
+// body reduces to a single `return <delimiter join>` — the taskKey/
+// pushKey shape, where the join hides behind a helper call at the sink.
+// Statements in front of the return are allowed while they only rebind
+// the parameters: the guarded `if owner == "" { owner = "anon" }`
+// prefix is the realistic spelling of such a helper.
 func joinHelpers(pass *analysis.Pass) map[*types.Func]ast.Expr {
 	out := map[*types.Func]ast.Expr{}
 	for _, f := range pass.Files {
@@ -68,18 +87,18 @@ func joinHelpers(pass *analysis.Pass) map[*types.Func]ast.Expr {
 			if !ok || fd.Body == nil || fd.Type.Results == nil {
 				continue
 			}
-			if len(fd.Type.Results.List) != 1 {
+			if len(fd.Type.Results.List) != 1 || len(fd.Body.List) == 0 {
 				continue
 			}
-			if len(fd.Body.List) != 1 {
-				continue
-			}
-			ret, ok := fd.Body.List[0].(*ast.ReturnStmt)
+			ret, ok := fd.Body.List[len(fd.Body.List)-1].(*ast.ReturnStmt)
 			if !ok || len(ret.Results) != 1 {
 				continue
 			}
 			fn, ok := pass.TypesInfo.Defs[fd.Name].(*types.Func)
 			if !ok {
+				continue
+			}
+			if !rebindsOnly(pass, fd.Body.List[:len(fd.Body.List)-1], fn) {
 				continue
 			}
 			if joinSeparator(pass, ret.Results[0], nil) != "" {
@@ -88,6 +107,58 @@ func joinHelpers(pass *analysis.Pass) map[*types.Func]ast.Expr {
 		}
 	}
 	return out
+}
+
+// rebindsOnly reports whether every statement only rebinds parameters
+// of fn: assignments to the parameters, and ifs whose branches contain
+// nothing but such assignments.
+func rebindsOnly(pass *analysis.Pass, stmts []ast.Stmt, fn *types.Func) bool {
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok {
+		return false
+	}
+	params := sig.Params()
+	isParam := func(id *ast.Ident) bool {
+		obj := pass.TypesInfo.ObjectOf(id)
+		for i := range params.Len() {
+			if params.At(i) == obj {
+				return true
+			}
+		}
+		return false
+	}
+	for _, st := range stmts {
+		switch s := st.(type) {
+		case *ast.AssignStmt:
+			if s.Tok != token.ASSIGN && s.Tok != token.DEFINE {
+				return false
+			}
+			for _, lhs := range s.Lhs {
+				id, ok := lhs.(*ast.Ident)
+				if !ok || !isParam(id) {
+					return false
+				}
+			}
+		case *ast.IfStmt:
+			if s.Init != nil {
+				return false
+			}
+			branch := append([]ast.Stmt{}, s.Body.List...)
+			if s.Else != nil {
+				eb, ok := s.Else.(*ast.BlockStmt)
+				if !ok {
+					return false
+				}
+				branch = append(branch, eb.List...)
+			}
+			if !rebindsOnly(pass, branch, fn) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // checkFile reports every delimiter join that reaches a keyed sink. Each
@@ -211,10 +282,34 @@ func keyOrigin(pass *analysis.Pass, x ast.Expr, bound map[types.Object]ast.Expr,
 			}
 		}
 		return nil
+	case *ast.SelectorExpr:
+		// A join parked on a struct field (`h.k = a + SEP + b`) and
+		// keyed later: boundExprs binds the field object.
+		obj := pass.TypesInfo.ObjectOf(e.Sel)
+		if obj == nil {
+			return nil
+		}
+		if src, ok := bound[obj]; ok {
+			if o := keyOrigin(pass, src, bound, helpers, depth+1); o != nil {
+				if o.obj != nil {
+					return o // a helper or upstream binding is the origin
+				}
+				return &keySource{obj: obj, join: o.join, node: src}
+			}
+		}
+		return nil
 	case *ast.CallExpr:
 		if fn, ok := calleeFunc(pass, e.Fun); ok {
 			if join, ok := helpers[fn]; ok {
 				return &keySource{obj: fn, join: join, node: e}
+			}
+		}
+		// Peel the one-argument string-preserving normalizers — the
+		// most common key wrapper is strings.ToLower around the join.
+		switch qualifiedCallee(pass, e.Fun) {
+		case "strings.ToLower", "strings.ToUpper", "strings.TrimSpace":
+			if len(e.Args) == 1 {
+				return keyOrigin(pass, e.Args[0], bound, helpers, depth+1)
 			}
 		}
 		return nil
@@ -383,8 +478,17 @@ func boundExprs(pass *analysis.Pass, f *ast.File) map[types.Object]ast.Expr {
 			if len(st.Lhs) != 1 || len(st.Rhs) != 1 {
 				return true
 			}
-			if id, ok := st.Lhs[0].(*ast.Ident); ok && id.Name != "_" {
-				if obj := pass.TypesInfo.ObjectOf(id); obj != nil {
+			switch lhs := st.Lhs[0].(type) {
+			case *ast.Ident:
+				if lhs.Name != "_" {
+					if obj := pass.TypesInfo.ObjectOf(lhs); obj != nil {
+						m[obj] = st.Rhs[0]
+					}
+				}
+			case *ast.SelectorExpr:
+				// `h.k = a + SEP + b`: bind the field's object, so a join
+				// parked on a struct field and keyed later is recognized.
+				if obj := pass.TypesInfo.ObjectOf(lhs.Sel); obj != nil {
 					m[obj] = st.Rhs[0]
 				}
 			}

--- a/internal/analyzers/compositekey/testdata/src/ck/ck.go
+++ b/internal/analyzers/compositekey/testdata/src/ck/ck.go
@@ -181,3 +181,15 @@ func SprintfKey(owner, id string, m map[string]int) bool {
 func LogOnlyHelper(a, b string) string {
 	return a + "\x00" + b
 }
+
+// ClaimStore pins the keyed-store leg's declared name gate: the join
+// feeds a keyed store behind an interface whose parameter is named
+// claim, not "key" — this leg is name-gated (see the package doc), so
+// it stays silent; the join itself is visible to no map sink here.
+type ClaimStore interface {
+	Put(ctx context.Context, claim string, v []byte) error
+}
+
+func putJoin(cs ClaimStore, ctx context.Context, owner, id string) error {
+	return cs.Put(ctx, owner+"\x00"+id, nil)
+}

--- a/internal/analyzers/compositekey/testdata/src/ckalt/ckalt.go
+++ b/internal/analyzers/compositekey/testdata/src/ckalt/ckalt.go
@@ -72,3 +72,34 @@ func StaticKey(m map[string]int) bool {
 	_, ok := m["fixed"+"\x00"+"key"]
 	return ok
 }
+
+// ---- indirections a real bug wears -----------------------------------
+
+// loweredGet wraps the join in the standard key normalizer: the join
+// still reaches the sink, one call deeper.
+func loweredGet(r *sessionRegistry, user, token string) *session {
+	return r.sessions[strings.ToLower(user+"\x00"+token)] // want `this concatenation joins parts with the "\\x00" separator into a key`
+}
+
+// holder parks the join on a struct field before keying.
+type holder struct {
+	k string // want `k joins parts with the "\\x00" separator into a key`
+}
+
+func fieldKey(r *sessionRegistry, h *holder, user, token string) {
+	h.k = user + "\x00" + token
+	r.sessions[h.k] = &session{user: user, token: token}
+}
+
+// guardedShard is the helper shape with a guard in front of the join:
+// statements that only rebind parameters do not hide the join.
+func guardedShard(tenant, shard string) string { // want `guardedShard joins parts with the "\\t" separator into a key`
+	if tenant == "" {
+		tenant = "anon"
+	}
+	return tenant + "\t" + shard
+}
+
+func claimedGuarded(claims map[string]bool, tenant, shard string) bool {
+	return claims[guardedShard(tenant, shard)]
+}

--- a/internal/analyzers/controlbytes/controlbytes.go
+++ b/internal/analyzers/controlbytes/controlbytes.go
@@ -273,10 +273,14 @@ func testedValues(pass *analysis.Pass, body *ast.BlockStmt) map[types.Object][]g
 				}
 			}
 		case *ast.IfStmt:
-			markMembership(out, pass, n.Cond, n.End())
+			// Only the THEN arm runs for members; the else arm runs
+			// for NON-members and is not vetted.
+			markMembership(out, pass, n.Cond, n.Body.End())
 			markNegatedDenial(out, pass, n)
 		case *ast.SwitchStmt:
-			markMembership(out, pass, n.Tag, n.End())
+			// A tag lookup gates each non-default case body; the
+			// default clause runs for non-members. Credit is taken
+			// per CaseClause below.
 		case *ast.CaseClause:
 			// A case expression gates only that case's own body.
 			for _, e := range n.List {

--- a/internal/analyzers/controlbytes/controlbytes.go
+++ b/internal/analyzers/controlbytes/controlbytes.go
@@ -20,27 +20,66 @@
 //   - framework/uihost's Link-header alternate path (probe
 //     TestLinkAlternatePathControlBytes, fixed a24928c1).
 //
+// Log sinks are: slog.String/slog.Any values; the key-value logger
+// calls (Debug/Info/Warn/Error and their *Context forms, plus Log) on
+// a *slog.Logger receiver AND package-level slog.* (the default logger
+// writes to stderr); the log MESSAGE as well as the values — a CRLF in
+// a message forges log lines exactly like one in a value; fmt print
+// calls — Fprint* to os.Stdout/os.Stderr and Print/Printf/Println,
+// which write to os.Stdout unconditionally; and the std log package's
+// Print/Printf/Println, package-level or on a *log.Logger receiver.
+//
 // A value counts as scrubbed when it passes through a callee whose name
-// says so (scrub/sanitize/clean/escape/quote/redact — r.URL.EscapedPath
+// says so (scrub/sanitize/escape/quote/redact — r.URL.EscapedPath
 // and url.QueryEscape qualify) or through a same-package helper that
 // inspects the value byte by byte (the byte-filter loop the uihost fix
 // shipped inside markdownAlternate; a pass-through helper like
 // TrimRight or truncate never looks at individual bytes and does not
-// clear taint).
+// clear taint). A name whose only scrub evidence is the substring
+// "clean" does NOT clear on the name: path.Clean and its kin are
+// separator normalizers, not scrubbers, so a clean-named callee —
+// foreign or local — must show the byte-level body evidence instead.
+// Qualified calls into the stdlib path and path/filepath packages
+// (Clean, Base, Dir, Join) never clear taint at all.
+//
+// A tested value is clean for that variable when a validator-named
+// call (validRequestID(id)) vetted it anywhere earlier in the
+// function, or when a map membership (allowed[origin]) appears in the
+// condition of an if statement or switch case that lexically encloses
+// the sink — the sink then runs only for members of the configured
+// set, and a control byte cannot be in that set. The negated-denial
+// spelling counts as the same vetting — membership tested with `!`
+// (directly or through comma-ok) in an if whose denial arm diverges
+// (returns or panics), so code after the if runs only for members
+// (battery/auth's BFF origin guard). A positive dedup/seen lookup
+// gates nothing anywhere else in the function: that sink runs exactly
+// for values the map has never vetted. Residual: a DEDUP map spelled
+// with the negated-diverging form (`if _, dup := seen[p]; !dup {
+// return }`) is lexically indistinguishable from an allowlist and is
+// granted the same credit — the names differ, the shape does not.
 //
 // Postures it deliberately stays silent on, because they are not this
 // bug: JSON and HTML encoders escape structurally (encoding/json,
 // html/template), so encoder arguments are left alone; the response
 // BODY is not a sink — it is the response; span NAMES (tracer.Start,
-// span.SetName) and log keys are left alone, only VALUES are checked;
-// fmt.Sprint* without a writer, and Fprint* to any writer other than
-// os.Stdout/os.Stderr (an http.ResponseWriter or a bytes.Buffer has its
-// own framing); taint does not cross function boundaries — a
-// request-derived argument to a helper is the helper's business, and
+// span.SetName) and log keys are left alone, only messages and VALUES
+// are checked; fmt.Sprint* without a writer, and Fprint* to any writer
+// other than os.Stdout/os.Stderr (an http.ResponseWriter or a
+// bytes.Buffer has its own framing); Header.Set/Add on a map whose
+// provenance is an OUTBOUND *http.Request — an
+// http.NewRequest/NewRequestWithContext result, or any request-typed
+// value that is not the inbound handler parameter — because the client
+// transport validates header bytes at write time and rejects control
+// bytes (the response writer's header map, and the inbound
+// parameter's, still fire); taint does not cross function boundaries —
+// a request-derived argument to a helper is the helper's business, and
 // the byte-indexing form above is the whole interprocedural
 // concession; and structured values like a whole *http.Request or an
 // ErrorReport struct are not sources, only the string-bearing request
-// selectors are.
+// selectors are (Method/Host/RemoteAddr/RequestURI/URL.Path/
+// URL.RawQuery, the Header.Get/FormValue/PathValue/PostFormValue/
+// Referer/UserAgent/BasicAuth accessors, url.Values.Get, and the
+// Value field of a cookie bound from r.Cookie).
 package controlbytes
 
 import (
@@ -48,6 +87,7 @@ import (
 	"go/token"
 	"go/types"
 	"regexp"
+	"strings"
 
 	"golang.org/x/tools/go/analysis"
 )
@@ -63,6 +103,29 @@ var Analyzer = &analysis.Analyzer{
 // construction, and recognizing scrubbing by body shape across package
 // boundaries is beyond a one-pass analyzer.
 var scrubName = regexp.MustCompile(`(?i)scrub|sanitiz|clean|escape|quote|redact`)
+
+// strongScrubName matches the unambiguous re-encoders; cleanOnlyName
+// matches names whose ONLY scrub evidence is the substring "clean".
+// path.Clean and friends normalize separators and dots and pass every
+// control byte through, so a clean-named callee must show byte-level
+// body evidence instead of clearing on the name.
+var (
+	strongScrubName = regexp.MustCompile(`(?i)scrub|sanitiz|escape|quote|redact`)
+	cleanOnlyName   = regexp.MustCompile(`(?i)clean`)
+)
+
+// scrubTrusted: the name clears taint on the name alone.
+func scrubTrusted(name string) bool {
+	return scrubName.MatchString(name) && (strongScrubName.MatchString(name) || !cleanOnlyName.MatchString(name))
+}
+
+// isStdlibNormalizer: a qualified call into the stdlib path or
+// path/filepath packages. Clean/Base/Dir/Join there reorder separators
+// and dots; they never remove a control byte, so they clear nothing.
+func isStdlibNormalizer(pass *analysis.Pass, sel *ast.SelectorExpr) bool {
+	p := pkgPathOf(pass, sel)
+	return p == "path" || p == "path/filepath"
+}
 
 func run(pass *analysis.Pass) (any, error) {
 	// Package-local function decls, for the byte-indexing scrub check.
@@ -125,7 +188,7 @@ func checkBody(pass *analysis.Pass, decls map[types.Object]*ast.FuncDecl, body *
 	}
 }
 
-func walkStmt(pass *analysis.Pass, decls map[types.Object]*ast.FuncDecl, t *taint, guards map[types.Object]token.Pos, stmt ast.Stmt) {
+func walkStmt(pass *analysis.Pass, decls map[types.Object]*ast.FuncDecl, t *taint, guards map[types.Object][]guard, stmt ast.Stmt) {
 	ast.Inspect(stmt, func(n ast.Node) bool {
 		switch n := n.(type) {
 		case *ast.FuncLit:
@@ -133,16 +196,16 @@ func walkStmt(pass *analysis.Pass, decls map[types.Object]*ast.FuncDecl, t *tain
 			return false
 		case *ast.CallExpr:
 			for _, s := range sinks {
-				if !s.matches(pass, n) {
+				if !s.matches(t, n) {
 					continue
 				}
-				for _, arg := range s.args(n) {
+				for _, arg := range s.args(t, n) {
 					if id, ok := unparen(arg).(*ast.Ident); ok {
-						if at, tested := guards[pass.TypesInfo.ObjectOf(id)]; tested && at < n.Pos() {
+						if testedAt(guards[pass.TypesInfo.ObjectOf(id)], n.Pos()) {
 							// The value already passed a validator or
-							// allowlist on its way here; the guard is
-							// the sanitizer (requestid's validRequestID,
-							// CORS's originSet[origin]).
+							// an enclosing allowlist on its way here;
+							// the guard is the sanitizer (requestid's
+							// validRequestID, CORS's originSet[origin]).
 							continue
 						}
 					}
@@ -161,14 +224,34 @@ func walkStmt(pass *analysis.Pass, decls map[types.Object]*ast.FuncDecl, t *tain
 
 var validatorName = regexp.MustCompile(`(?i)valid|allow|permit|accept|match|safe`)
 
+// guard is one recorded vetting of a variable: it fired at pos, and it
+// covers sinks up to end (end == 0 means the rest of the function).
+type guard struct {
+	pos, end token.Pos
+}
+
+// testedAt: some guard on obj fired before pos and still covers it.
+func testedAt(gs []guard, pos token.Pos) bool {
+	for _, g := range gs {
+		if g.pos < pos && (g.end == 0 || pos < g.end) {
+			return true
+		}
+	}
+	return false
+}
+
 // testedValues records where each variable was TESTED before use: an
 // argument of a validator-named call (validRequestID(id),
-// isSafePartialRedirect(u)) or the key of a membership lookup
-// (originSet[origin], allowed[origin]). A value the code has already
-// vetted cannot smuggle control bytes past that vetting, so a sink
-// after the test is clean for that variable.
-func testedValues(pass *analysis.Pass, body *ast.BlockStmt) map[types.Object]token.Pos {
-	out := map[types.Object]token.Pos{}
+// isSafePartialRedirect(u)) vets the variable for the rest of the
+// function; a membership lookup (allowed[origin]) vets it only when
+// the lookup keys a value the code gates on — the index appears in the
+// condition of an if statement or switch case that lexically encloses
+// the sink, so the sink runs only for members of the configured set.
+// A value the code has already vetted cannot smuggle control bytes
+// past that vetting; a dedup/seen lookup anywhere else proves nothing
+// about the bytes and does not vet.
+func testedValues(pass *analysis.Pass, body *ast.BlockStmt) map[types.Object][]guard {
+	out := map[types.Object][]guard{}
 	ast.Inspect(body, func(n ast.Node) bool {
 		switch n := n.(type) {
 		case *ast.CallExpr:
@@ -185,19 +268,19 @@ func testedValues(pass *analysis.Pass, body *ast.BlockStmt) map[types.Object]tok
 			for _, a := range n.Args {
 				if id, ok := unparen(a).(*ast.Ident); ok {
 					if obj := pass.TypesInfo.ObjectOf(id); obj != nil {
-						recordMin(out, obj, n.Pos())
+						out[obj] = append(out[obj], guard{pos: n.Pos()})
 					}
 				}
 			}
-		case *ast.IndexExpr:
-			if id, ok := n.Index.(*ast.Ident); ok {
-				if t := pass.TypesInfo.TypeOf(n.X); t != nil {
-					if _, ok := t.Underlying().(*types.Map); ok {
-						if obj := pass.TypesInfo.ObjectOf(id); obj != nil {
-							recordMin(out, obj, n.Pos())
-						}
-					}
-				}
+		case *ast.IfStmt:
+			markMembership(out, pass, n.Cond, n.End())
+			markNegatedDenial(out, pass, n)
+		case *ast.SwitchStmt:
+			markMembership(out, pass, n.Tag, n.End())
+		case *ast.CaseClause:
+			// A case expression gates only that case's own body.
+			for _, e := range n.List {
+				markMembership(out, pass, e, n.End())
 			}
 		}
 		return true
@@ -205,29 +288,123 @@ func testedValues(pass *analysis.Pass, body *ast.BlockStmt) map[types.Object]tok
 	return out
 }
 
-func recordMin(out map[types.Object]token.Pos, obj types.Object, pos token.Pos) {
-	if prev, ok := out[obj]; !ok || pos < prev {
-		out[obj] = pos
+// markMembership records map-membership lookups inside cond as guards
+// covering sinks lexically inside [lookup, end).
+func markMembership(out map[types.Object][]guard, pass *analysis.Pass, cond ast.Expr, end token.Pos) {
+	if cond == nil {
+		return
 	}
+	ast.Inspect(cond, func(n ast.Node) bool {
+		idx, ok := n.(*ast.IndexExpr)
+		if !ok {
+			return true
+		}
+		id, ok := idx.Index.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if t := pass.TypesInfo.TypeOf(idx.X); t != nil {
+			if _, ok := t.Underlying().(*types.Map); ok {
+				if obj := pass.TypesInfo.ObjectOf(id); obj != nil {
+					out[obj] = append(out[obj], guard{pos: idx.Pos(), end: end})
+				}
+			}
+		}
+		return true
+	})
+}
+
+// markNegatedDenial covers the allowlist shape the repo's BFF guard
+// uses: the membership is tested NEGATED and the denial arm diverges
+// (`if _, ok := allowed[origin]; !ok { http.Error(...); return }`,
+// `if !allowed[origin] { return }`). Everything after the if runs only
+// for MEMBERS of the configured set — the vetting the enclosing-if
+// form gets — so the lookup guards the rest of the function. The
+// positive spellings (`if seen[p] { return }`) stay unguarded: there
+// the sink runs only for values the map has never vetted.
+func markNegatedDenial(out map[types.Object][]guard, pass *analysis.Pass, ifst *ast.IfStmt) {
+	if ifst.Body == nil || !diverges(ifst.Body) {
+		return
+	}
+	var idx *ast.IndexExpr
+	cond := unparen(ifst.Cond)
+	negated := false
+	if u, ok := cond.(*ast.UnaryExpr); ok && u.Op == token.NOT {
+		negated = true
+		cond = unparen(u.X)
+	}
+	// Comma-ok: `v, ok := m[k]` in Init, `!ok` in Cond.
+	if as, ok := ifst.Init.(*ast.AssignStmt); ok && len(as.Lhs) == 2 && len(as.Rhs) == 1 {
+		if i, ok := unparen(as.Rhs[0]).(*ast.IndexExpr); ok {
+			if okID, ok := as.Lhs[1].(*ast.Ident); ok && negated {
+				if id, ok := unparen(cond).(*ast.Ident); ok && pass.TypesInfo.ObjectOf(id) == pass.TypesInfo.ObjectOf(okID) {
+					idx = i
+				}
+			}
+		}
+	}
+	// Direct: `!allowed[origin]` in Cond.
+	if idx == nil && negated {
+		if i, ok := cond.(*ast.IndexExpr); ok {
+			idx = i
+		}
+	}
+	if idx == nil {
+		return
+	}
+	id, ok := idx.Index.(*ast.Ident)
+	if !ok {
+		return
+	}
+	t := pass.TypesInfo.TypeOf(idx.X)
+	if t == nil {
+		return
+	}
+	if _, isMap := t.Underlying().(*types.Map); isMap {
+		if obj := pass.TypesInfo.ObjectOf(id); obj != nil {
+			out[obj] = append(out[obj], guard{pos: idx.Pos()})
+		}
+	}
+}
+
+// diverges: the block exits the function here (return or panic), so
+// code AFTER the enclosing statement runs only when the condition was
+// false.
+func diverges(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.FuncLit:
+			return false
+		case *ast.ReturnStmt:
+			found = true
+		case *ast.CallExpr:
+			if id, ok := unparen(x.Fun).(*ast.Ident); ok && id.Name == "panic" {
+				found = true
+			}
+		}
+		return !found
+	})
+	return found
 }
 
 // ---- sinks -------------------------------------------------------------
 
 type sink struct {
 	name    string
-	args    func(call *ast.CallExpr) []ast.Expr
-	matches func(pass *analysis.Pass, call *ast.CallExpr) bool
+	args    func(t *taint, call *ast.CallExpr) []ast.Expr
+	matches func(t *taint, call *ast.CallExpr) bool
 }
 
 var sinks = []sink{
 	{
 		name: "slog.String/slog.Any",
-		matches: func(pass *analysis.Pass, call *ast.CallExpr) bool {
+		matches: func(t *taint, call *ast.CallExpr) bool {
 			sel, ok := unparen(call.Fun).(*ast.SelectorExpr)
 			if !ok {
 				return false
 			}
-			switch qualifiedFunc(pass, sel) {
+			switch qualifiedFunc(t.pass, sel) {
 			case "slog.String", "slog.Any":
 				return true
 			}
@@ -237,36 +414,96 @@ var sinks = []sink{
 	},
 	{
 		name: "attribute.String",
-		matches: func(pass *analysis.Pass, call *ast.CallExpr) bool {
+		matches: func(t *taint, call *ast.CallExpr) bool {
 			sel, ok := unparen(call.Fun).(*ast.SelectorExpr)
 			if !ok {
 				return false
 			}
-			return qualifiedFunc(pass, sel) == "attribute.String"
+			return qualifiedFunc(t.pass, sel) == "attribute.String"
 		},
 		args: valueArg1,
 	},
 	{
-		name: "logger.Info/Warn/Error key-value",
-		matches: func(pass *analysis.Pass, call *ast.CallExpr) bool {
+		name: "logger.Debug/Info/Warn/Error key-value",
+		matches: func(t *taint, call *ast.CallExpr) bool {
 			sel, ok := unparen(call.Fun).(*ast.SelectorExpr)
 			if !ok {
 				return false
 			}
 			switch sel.Sel.Name {
-			case "Info", "Warn", "Error":
+			case "Debug", "Info", "Warn", "Error",
+				"DebugContext", "InfoContext", "WarnContext", "ErrorContext":
 			default:
 				return false
 			}
-			tv, ok := pass.TypesInfo.Types[sel.X]
+			tv, ok := t.pass.TypesInfo.Types[sel.X]
 			if !ok {
 				return false
 			}
 			return isNamed(deref(tv.Type), "log/slog", "Logger")
 		},
-		// Info(msg, k1, v1, k2, v2, ...): values sit at odd offsets of
-		// the variadic tail.
-		args: func(call *ast.CallExpr) []ast.Expr {
+		// Warn(msg, k1, v1, k2, v2): the message and the values sit at
+		// even offsets — msg at 0 for the plain form, 1 for *Context.
+		args: func(t *taint, call *ast.CallExpr) []ast.Expr {
+			sel, _ := unparen(call.Fun).(*ast.SelectorExpr)
+			start := 0
+			if sel != nil && strings.HasSuffix(sel.Sel.Name, "Context") {
+				start = 1
+			}
+			var out []ast.Expr
+			for i := start; i < len(call.Args); i += 2 {
+				out = append(out, call.Args[i])
+			}
+			return out
+		},
+	},
+	{
+		// Package-level slog.* writes to the default logger (stderr).
+		name: "slog.Debug/Info/Warn/Error key-value",
+		matches: func(t *taint, call *ast.CallExpr) bool {
+			sel, ok := unparen(call.Fun).(*ast.SelectorExpr)
+			if !ok {
+				return false
+			}
+			switch sel.Sel.Name {
+			case "Debug", "Info", "Warn", "Error",
+				"DebugContext", "InfoContext", "WarnContext", "ErrorContext":
+			default:
+				return false
+			}
+			return pkgPathOf(t.pass, sel) == "log/slog"
+		},
+		// msg, k1, v1: message and values at even offsets from 0; the
+		// *Context forms shift one for ctx.
+		args: func(t *taint, call *ast.CallExpr) []ast.Expr {
+			sel, _ := unparen(call.Fun).(*ast.SelectorExpr)
+			start := 0
+			if sel != nil && strings.HasSuffix(sel.Sel.Name, "Context") {
+				start = 1
+			}
+			var out []ast.Expr
+			for i := start; i < len(call.Args); i += 2 {
+				out = append(out, call.Args[i])
+			}
+			return out
+		},
+	},
+	{
+		// Log(ctx, level, msg, k1, v1) on a receiver or package-level:
+		// message and values at even offsets from 2.
+		name: "slog.Log key-value",
+		matches: func(t *taint, call *ast.CallExpr) bool {
+			sel, ok := unparen(call.Fun).(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Log" {
+				return false
+			}
+			if pkgPathOf(t.pass, sel) == "log/slog" {
+				return true
+			}
+			tv, ok := t.pass.TypesInfo.Types[sel.X]
+			return ok && isNamed(deref(tv.Type), "log/slog", "Logger")
+		},
+		args: func(t *taint, call *ast.CallExpr) []ast.Expr {
 			var out []ast.Expr
 			for i := 2; i < len(call.Args); i += 2 {
 				out = append(out, call.Args[i])
@@ -276,7 +513,7 @@ var sinks = []sink{
 	},
 	{
 		name: "http.Header.Set/Add",
-		matches: func(pass *analysis.Pass, call *ast.CallExpr) bool {
+		matches: func(t *taint, call *ast.CallExpr) bool {
 			sel, ok := unparen(call.Fun).(*ast.SelectorExpr)
 			if !ok {
 				return false
@@ -284,22 +521,54 @@ var sinks = []sink{
 			if sel.Sel.Name != "Set" && sel.Sel.Name != "Add" {
 				return false
 			}
-			s, ok := pass.TypesInfo.Selections[sel]
+			s, ok := t.pass.TypesInfo.Selections[sel]
 			if !ok {
 				return false
 			}
-			return isNamed(deref(s.Recv()), "net/http", "Header")
+			if !isNamed(deref(s.Recv()), "net/http", "Header") {
+				return false
+			}
+			// A header map provenance-typed to an OUTBOUND request is
+			// not a sink: the client transport rejects control bytes
+			// at write time. See outboundHeaderMap.
+			return !t.outboundHeaderMap(sel.X)
 		},
 		args: valueArg1,
 	},
 	{
-		name: "stdout/stderr print",
-		matches: func(pass *analysis.Pass, call *ast.CallExpr) bool {
+		name: "std log print",
+		matches: func(t *taint, call *ast.CallExpr) bool {
 			sel, ok := unparen(call.Fun).(*ast.SelectorExpr)
 			if !ok {
 				return false
 			}
-			switch qualifiedFunc(pass, sel) {
+			switch sel.Sel.Name {
+			case "Print", "Printf", "Println":
+			default:
+				return false
+			}
+			// Package-level log.Print* (default logger → stderr), or
+			// the same methods on a *log.Logger receiver.
+			if pkgPathOf(t.pass, sel) == "log" {
+				return true
+			}
+			tv, ok := t.pass.TypesInfo.Types[sel.X]
+			return ok && isNamed(deref(tv.Type), "log", "Logger")
+		},
+		args: func(t *taint, call *ast.CallExpr) []ast.Expr { return call.Args },
+	},
+	{
+		name: "stdout/stderr print",
+		matches: func(t *taint, call *ast.CallExpr) bool {
+			sel, ok := unparen(call.Fun).(*ast.SelectorExpr)
+			if !ok {
+				return false
+			}
+			switch qualifiedFunc(t.pass, sel) {
+			case "fmt.Print", "fmt.Printf", "fmt.Println":
+				// No writer argument: these write to os.Stdout
+				// outright, which is the terminal sink.
+				return true
 			case "fmt.Fprint", "fmt.Fprintf", "fmt.Fprintln":
 			default:
 				return false
@@ -317,18 +586,20 @@ var sinks = []sink{
 			if wsel.Sel.Name != "Stdout" && wsel.Sel.Name != "Stderr" {
 				return false
 			}
-			pkgID, ok := wsel.X.(*ast.Ident)
-			if !ok {
-				return false
-			}
-			pkg, ok := pass.TypesInfo.Uses[pkgID].(*types.PkgName)
-			return ok && pkg.Imported().Path() == "os"
+			return pkgPathOf(t.pass, wsel) == "os"
 		},
-		args: func(call *ast.CallExpr) []ast.Expr { return call.Args[1:] },
+		// The F forms carry the writer at offset 0; the bare Print
+		// forms check every argument, format string included.
+		args: func(t *taint, call *ast.CallExpr) []ast.Expr {
+			if sel, ok := unparen(call.Fun).(*ast.SelectorExpr); ok && strings.HasPrefix(sel.Sel.Name, "F") {
+				return call.Args[1:]
+			}
+			return call.Args
+		},
 	},
 }
 
-func valueArg1(call *ast.CallExpr) []ast.Expr {
+func valueArg1(t *taint, call *ast.CallExpr) []ast.Expr {
 	if len(call.Args) >= 2 {
 		return call.Args[1:2]
 	}
@@ -348,6 +619,21 @@ type taint struct {
 	bind map[types.Object][]ast.Expr
 }
 
+// bindable: string-carrying variables are taint carriers. A
+// *http.Request or *http.Cookie variable is bound only so provenance
+// walks can see through the local (the outbound-header split, the
+// cookie .Value source); the variable itself is never a source.
+func bindable(t types.Type) bool {
+	if carriesStrings(t) {
+		return true
+	}
+	n, ok := deref(t).(*types.Named)
+	if !ok {
+		return false
+	}
+	return isNamed(n, "net/http", "Request") || isNamed(n, "net/http", "Cookie")
+}
+
 func newTaint(pass *analysis.Pass, decls map[types.Object]*ast.FuncDecl, body *ast.BlockStmt, parent *taint) *taint {
 	t := &taint{pass: pass, decls: decls, bind: map[types.Object][]ast.Expr{}}
 	if parent != nil {
@@ -359,52 +645,92 @@ func newTaint(pass *analysis.Pass, decls map[types.Object]*ast.FuncDecl, body *a
 		}
 	}
 	ast.Inspect(body, func(n ast.Node) bool {
-		assign, ok := n.(*ast.AssignStmt)
-		if !ok {
-			// FuncLits fall through here: their bodies are visited by
-			// checkBody separately, and their locals must not bind in
-			// the enclosing function's map.
-			if _, ok := n.(*ast.FuncLit); ok {
-				return false
-			}
+		switch n := n.(type) {
+		case *ast.AssignStmt:
+			bindAssign(t, pass, n)
 			return true
-		}
-		if len(assign.Lhs) == len(assign.Rhs) {
-			for i, lhs := range assign.Lhs {
-				id, ok := lhs.(*ast.Ident)
-				if !ok {
+		case *ast.RangeStmt:
+			// for k, v := range x declares its variables through the
+			// statement, not an assignment: key and value are exactly
+			// as derived as the ranged expression, whichever spelling
+			// splits the request-derived value.
+			for _, e := range []ast.Expr{n.Key, n.Value} {
+				id := rangeIdent(e)
+				if id == nil {
 					continue
 				}
-				// ObjectOf, not Defs: a plain `x = rhs` assignment
-				// has no Defs entry — the lhs is a use of the object
-				// declared elsewhere, and those rebindings are
-				// exactly the append/join chains this rule follows.
 				obj, ok := pass.TypesInfo.ObjectOf(id).(*types.Var)
 				if !ok || !carriesStrings(obj.Type()) {
-					// Control bytes live in string data. A
-					// non-string variable — most importantly err,
-					// but also a fetch response struct that merely
-					// received a tainted URL — is not a taint
-					// carrier: the wrapper rule is for strings that
-					// COME OUT of calls, not values that come back
-					// from doing I/O with them.
 					continue
 				}
-				t.bind[obj] = append(t.bind[obj], assign.Rhs[i])
+				t.bind[obj] = append(t.bind[obj], n.X)
 			}
 			return true
-		}
-		// v, ok := m[k] / v, ok := x.Field — bind the value slot.
-		if len(assign.Lhs) == 2 && len(assign.Rhs) == 1 {
-			if id, ok := assign.Lhs[0].(*ast.Ident); ok {
-				if obj, ok := pass.TypesInfo.ObjectOf(id).(*types.Var); ok && carriesStrings(obj.Type()) {
-					t.bind[obj] = append(t.bind[obj], assign.Rhs[0])
-				}
-			}
+		case *ast.FuncLit:
+			// FuncLits are visited by checkBody separately, and their
+			// locals must not bind in the enclosing function's map.
+			return false
 		}
 		return true
 	})
 	return t
+}
+
+func bindAssign(t *taint, pass *analysis.Pass, assign *ast.AssignStmt) {
+	if len(assign.Lhs) == len(assign.Rhs) {
+		for i, lhs := range assign.Lhs {
+			id, ok := lhs.(*ast.Ident)
+			if !ok {
+				continue
+			}
+			// ObjectOf, not Defs: a plain `x = rhs` assignment
+			// has no Defs entry — the lhs is a use of the object
+			// declared elsewhere, and those rebindings are
+			// exactly the append/join chains this rule follows.
+			obj, ok := pass.TypesInfo.ObjectOf(id).(*types.Var)
+			if !ok || !bindable(obj.Type()) {
+				// Control bytes live in string data. A
+				// non-string variable — most importantly err,
+				// but also a fetch response struct that merely
+				// received a tainted URL — is not a taint
+				// carrier: the wrapper rule is for strings that
+				// COME OUT of calls, not values that come back
+				// from doing I/O with them.
+				continue
+			}
+			t.bind[obj] = append(t.bind[obj], assign.Rhs[i])
+		}
+		return
+	}
+	// v, ok := m[k] / user, pass, _ := r.BasicAuth() / c, err :=
+	// r.Cookie(...) — bind every value slot of a multi-result
+	// assignment to the single call on the right.
+	if len(assign.Lhs) > 1 && len(assign.Rhs) == 1 {
+		for _, lhs := range assign.Lhs {
+			id, ok := lhs.(*ast.Ident)
+			if !ok {
+				continue
+			}
+			obj, ok := pass.TypesInfo.ObjectOf(id).(*types.Var)
+			if !ok || !bindable(obj.Type()) {
+				continue
+			}
+			t.bind[obj] = append(t.bind[obj], assign.Rhs[0])
+		}
+	}
+}
+
+// rangeIdent unwraps a range key/value identifier, nil for _ and for
+// non-identifier expressions.
+func rangeIdent(e ast.Expr) *ast.Ident {
+	if e == nil {
+		return nil
+	}
+	id, ok := unparen(e).(*ast.Ident)
+	if !ok || id.Name == "_" {
+		return nil
+	}
+	return id
 }
 
 // source reports whether e carries a request-derived value, following
@@ -450,7 +776,24 @@ func (t *taint) orig(e ast.Expr, seen map[types.Object]bool, depth int) bool {
 		if isRequestSelector(t.pass, e) {
 			return true
 		}
+		if e.Sel.Name == "Value" && t.boundToCookie(e.X) {
+			// c.Value where c was assigned from r.Cookie(...): the
+			// cookie's Value is request bytes.
+			return true
+		}
 		return t.orig(e.X, seen, depth+1)
+	case *ast.CompositeLit:
+		// A map or slice literal built from tainted values carries
+		// them onward ({"xff": r.Header.Get(...)} wraps the same
+		// bytes).
+		for _, elt := range e.Elts {
+			if t.orig(elt, seen, depth+1) {
+				return true
+			}
+		}
+		return false
+	case *ast.KeyValueExpr:
+		return t.orig(e.Value, seen, depth+1)
 	case *ast.IndexExpr:
 		return t.orig(e.X, seen, depth+1)
 	default:
@@ -471,14 +814,15 @@ func (t *taint) callCleared(call *ast.CallExpr, seen map[types.Object]bool, dept
 	case *ast.SelectorExpr:
 		if sel, ok := t.pass.TypesInfo.Selections[fun]; ok {
 			fn = sel.Obj()
-		} else if scrubName.MatchString(fun.Sel.Name) {
+		} else if scrubTrusted(fun.Sel.Name) && !isStdlibNormalizer(t.pass, fun) {
 			return true
 		}
 	default:
 		return false
 	}
-	if fn == nil || scrubName.MatchString(fn.Name()) {
-		return fn != nil && scrubName.MatchString(fn.Name())
+	trusted := fn != nil && scrubTrusted(fn.Name())
+	if fn == nil || trusted {
+		return trusted
 	}
 	decl, ok := t.decls[fn]
 	if !ok || decl.Body == nil {
@@ -531,9 +875,14 @@ func returnsScrubOf(fn *ast.FuncDecl, pass *analysis.Pass, p *types.Var) bool {
 			case *ast.Ident:
 				name = fun.Name
 			case *ast.SelectorExpr:
+				if isStdlibNormalizer(pass, fun) {
+					// path.Clean(p) is not a scrub; a wrapper around
+					// it carries no scrub either.
+					continue
+				}
 				name = fun.Sel.Name
 			}
-			if !scrubName.MatchString(name) {
+			if !scrubTrusted(name) {
 				continue
 			}
 			for _, a := range call.Args {
@@ -570,11 +919,12 @@ func indexesBytes(fn *ast.FuncDecl, pass *analysis.Pass, p *types.Var) bool {
 
 // ---- source expressions ------------------------------------------------
 
-// isRequestSelector: r.Method, r.Host, r.RemoteAddr, r.URL.Path,
-// r.URL.RawQuery on an *http.Request (or an http.Request value).
+// isRequestSelector: r.Method, r.Host, r.RemoteAddr, r.RequestURI,
+// r.URL.Path, r.URL.RawQuery on an *http.Request (or an http.Request
+// value).
 func isRequestSelector(pass *analysis.Pass, e *ast.SelectorExpr) bool {
 	switch e.Sel.Name {
-	case "Method", "Host", "RemoteAddr":
+	case "Method", "Host", "RemoteAddr", "RequestURI":
 		return isRequestTyped(pass, e.X)
 	case "Path", "RawQuery":
 		inner, ok := e.X.(*ast.SelectorExpr)
@@ -590,10 +940,12 @@ func isRequestSelector(pass *analysis.Pass, e *ast.SelectorExpr) bool {
 	return false
 }
 
-// isRequestSourceCall: r.Header.Get, r.FormValue, r.PathValue, and .Get
-// on a url.Values receiver (r.URL.Query().Get is covered by type: a
-// Values is practically always the parsed query). A Get on a bare
-// http.Header is a source only when that header is a request's
+// isRequestSourceCall: the request accessors — r.Header.Get,
+// r.FormValue, r.PathValue, r.PostFormValue, r.Referer, r.UserAgent,
+// r.BasicAuth (the wrapper accessors are r.Header.Get in disguise) —
+// and .Get on a url.Values receiver (r.URL.Query().Get is covered by
+// type: a Values is practically always the parsed query). A Get on a
+// bare http.Header is a source only when that header is a request's
 // (r.Header); w.Header().Get reads back what the SERVER wrote, which
 // this rule does not treat as request-derived.
 func isRequestSourceCall(pass *analysis.Pass, call *ast.CallExpr) bool {
@@ -602,7 +954,7 @@ func isRequestSourceCall(pass *analysis.Pass, call *ast.CallExpr) bool {
 		return false
 	}
 	switch sel.Sel.Name {
-	case "FormValue", "PathValue":
+	case "FormValue", "PathValue", "PostFormValue", "Referer", "UserAgent", "BasicAuth":
 		return isRequestTyped(pass, sel.X)
 	case "Get":
 		tv, ok := pass.TypesInfo.Types[sel.X]
@@ -628,6 +980,104 @@ func isRequestTyped(pass *analysis.Pass, e ast.Expr) bool {
 		return false
 	}
 	return isNamed(deref(tv.Type), "net/http", "Request")
+}
+
+// isRequestCookieCall: r.Cookie(name) — the *http.Cookie it returns
+// carries request bytes in its Value field.
+func isRequestCookieCall(pass *analysis.Pass, call *ast.CallExpr) bool {
+	sel, ok := unparen(call.Fun).(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "Cookie" && isRequestTyped(pass, sel.X)
+}
+
+// boundToCookie: e is a variable whose binding came from an
+// r.Cookie(...) call.
+func (t *taint) boundToCookie(e ast.Expr) bool {
+	id, ok := unparen(e).(*ast.Ident)
+	if !ok {
+		return false
+	}
+	obj, ok := t.pass.TypesInfo.ObjectOf(id).(*types.Var)
+	if !ok {
+		return false
+	}
+	for _, b := range t.bind[obj] {
+		if call, ok := unparen(b).(*ast.CallExpr); ok && isRequestCookieCall(t.pass, call) {
+			return true
+		}
+	}
+	return false
+}
+
+// outboundHeaderMap reports whether e provenance-traces to the header
+// map of an OUTBOUND *http.Request — one built by
+// http.NewRequest/NewRequestWithContext, or otherwise held in a value
+// that is not the inbound handler parameter. The client transport
+// validates header bytes at write time and rejects control bytes
+// (net/http: invalid header field value for ...), so those maps are
+// not forgery sinks; the response writer's map, and the inbound
+// parameter's, are.
+func (t *taint) outboundHeaderMap(e ast.Expr) bool {
+	var hdr *ast.SelectorExpr
+	if s, ok := unparen(e).(*ast.SelectorExpr); ok && s.Sel.Name == "Header" {
+		hdr = s
+	} else if id, ok := unparen(e).(*ast.Ident); ok {
+		if obj, ok := t.pass.TypesInfo.ObjectOf(id).(*types.Var); ok {
+			for _, b := range t.bind[obj] {
+				if s, ok := unparen(b).(*ast.SelectorExpr); ok && s.Sel.Name == "Header" {
+					hdr = s
+					break
+				}
+			}
+		}
+	}
+	if hdr == nil {
+		return false
+	}
+	return t.requestNotParam(hdr.X, map[types.Object]bool{})
+}
+
+// requestNotParam: e is a *http.Request-typed value that is not the
+// inbound (parameter) request. A parameter-rooted request — directly
+// or through locals bound from it — is inbound; anything else (a
+// NewRequest result, a stored field, a clone) is outbound.
+func (t *taint) requestNotParam(e ast.Expr, seen map[types.Object]bool) bool {
+	if !requestTypedExpr(t.pass, e) {
+		return false
+	}
+	id, ok := unparen(e).(*ast.Ident)
+	if !ok {
+		return true
+	}
+	obj, ok := t.pass.TypesInfo.ObjectOf(id).(*types.Var)
+	if !ok || obj.Kind() == types.ParamVar {
+		return false
+	}
+	if seen[obj] {
+		return false
+	}
+	seen[obj] = true
+	for _, b := range t.bind[obj] {
+		if t.requestNotParam(b, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+// requestTypedExpr: e is *http.Request-typed, tolerating a multi-result
+// call whose first result is the request (out, err :=
+// http.NewRequest(...)) — the call expression itself carries the tuple
+// type, not the request.
+func requestTypedExpr(pass *analysis.Pass, e ast.Expr) bool {
+	tv, ok := pass.TypesInfo.Types[e]
+	if !ok {
+		return false
+	}
+	t := tv.Type
+	if tup, ok := t.(*types.Tuple); ok && tup.Len() > 0 {
+		t = tup.At(0).Type()
+	}
+	return isNamed(deref(t), "net/http", "Request")
 }
 
 // ---- small helpers -----------------------------------------------------
@@ -696,4 +1146,18 @@ func qualifiedFunc(pass *analysis.Pass, sel *ast.SelectorExpr) string {
 		return ""
 	}
 	return pkg.Imported().Name() + "." + sel.Sel.Name
+}
+
+// pkgPathOf renders the imported package path behind a selector's X,
+// "" when X is not a package identifier.
+func pkgPathOf(pass *analysis.Pass, sel *ast.SelectorExpr) string {
+	id, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	pkg, ok := pass.TypesInfo.Uses[id].(*types.PkgName)
+	if !ok {
+		return ""
+	}
+	return pkg.Imported().Path()
 }

--- a/internal/analyzers/controlbytes/controlbytes_test.go
+++ b/internal/analyzers/controlbytes/controlbytes_test.go
@@ -10,5 +10,6 @@ import (
 
 func TestControlBytes(t *testing.T) {
 	analysistest.Run(t, analysistest.TestData(), controlbytes.Analyzer,
-		"logsink", "otelsink", "httpsink", "stdiosink", "gateway", "traceprinter")
+		"logsink", "otelsink", "httpsink", "stdiosink", "gateway", "traceprinter",
+		"rangesink", "srcapi", "outboundhdr", "pathnorm", "seenguard")
 }

--- a/internal/analyzers/controlbytes/testdata/src/gateway/gateway.go
+++ b/internal/analyzers/controlbytes/testdata/src/gateway/gateway.go
@@ -19,7 +19,7 @@ type EdgeFilter struct {
 func (e *EdgeFilter) observe(r *http.Request) {
 	ua := r.Header.Get("User-Agent")
 	traceparent := r.Header.Get("Traceparent")
-	e.log.Warn("gateway: rejected at edge", // want `controlbytes: request-derived value reaches logger.Info/Warn/Error key-value unscrubbed`
+	e.log.Warn("gateway: rejected at edge", // want `controlbytes: request-derived value reaches logger.Debug/Info/Warn/Error key-value unscrubbed`
 		"user_agent", ua,
 		"traceparent", traceparent,
 		"route", r.PathValue("route"),

--- a/internal/analyzers/controlbytes/testdata/src/logsink/logsink.go
+++ b/internal/analyzers/controlbytes/testdata/src/logsink/logsink.go
@@ -99,7 +99,7 @@ func goodAccess(logger *slog.Logger, w http.ResponseWriter, r *http.Request, sta
 func badKv(logger *slog.Logger, r *http.Request) error {
 	key := r.Header.Get("Idempotency-Key")
 	if err := storeFinish(key); err != nil {
-		logger.Error("idempotency: Finish failed", "key", key, "error", err) // want `controlbytes: request-derived value reaches logger.Info/Warn/Error key-value unscrubbed`
+		logger.Error("idempotency: Finish failed", "key", key, "error", err) // want `controlbytes: request-derived value reaches logger.Debug/Info/Warn/Error key-value unscrubbed`
 		return err
 	}
 	return nil
@@ -119,7 +119,7 @@ func mixedKv(logger *slog.Logger, r *http.Request) {
 	// The diagnostic lands on the Warn call: r.Method taints the
 	// entry, while EscapedPath re-encodes and does not clear what is
 	// already reported once per call.
-	logger.Warn("relay: upstream unreachable", // want `controlbytes: request-derived value reaches logger.Info/Warn/Error key-value unscrubbed`
+	logger.Warn("relay: upstream unreachable", // want `controlbytes: request-derived value reaches logger.Debug/Info/Warn/Error key-value unscrubbed`
 		"method", r.Method,
 		"path", r.URL.EscapedPath(),
 		"remote", net.JoinHostPort(r.Host, "1"),
@@ -127,3 +127,34 @@ func mixedKv(logger *slog.Logger, r *http.Request) {
 }
 
 func storeFinish(key string) error { return nil }
+
+// badPackageSlog: package-level slog.* writes to the default logger
+// (stderr) — the same sink class as the receiver form (review finding
+// C2).
+func badPackageSlog(r *http.Request) {
+	slog.Info("rejected", "path", r.URL.Path)                    // want `controlbytes: request-derived value reaches slog.Debug/Info/Warn/Error key-value unscrubbed`
+	slog.Error("failed", "key", r.Header.Get("Idempotency-Key")) // want `controlbytes: request-derived value reaches slog.Debug/Info/Warn/Error key-value unscrubbed`
+}
+
+// badDebugAndLog: Debug and Log are logger methods of the same class;
+// the message of Log sits at the same offsets as its values.
+func badDebugAndLog(logger *slog.Logger, r *http.Request) {
+	logger.Debug("trace", "path", r.URL.Path)                      // want `controlbytes: request-derived value reaches logger.Debug/Info/Warn/Error key-value unscrubbed`
+	logger.Log(nil, slog.LevelError, "failed", "path", r.URL.Path) // want `controlbytes: request-derived value reaches slog.Log key-value unscrubbed`
+	slog.Log(nil, slog.LevelError, "failed", "path", r.URL.Path)   // want `controlbytes: request-derived value reaches slog.Log key-value unscrubbed`
+}
+
+// badMessage: the MESSAGE argument forges log lines exactly like a
+// value does (review finding C5). The stdio arm already checked its
+// format string; the key-value arms now agree.
+func badMessage(logger *slog.Logger, r *http.Request) {
+	logger.Error("request failed: " + r.URL.Path) // want `controlbytes: request-derived value reaches logger.Debug/Info/Warn/Error key-value unscrubbed`
+	slog.Warn("denied " + r.URL.Path)             // want `controlbytes: request-derived value reaches slog.Debug/Info/Warn/Error key-value unscrubbed`
+}
+
+func goodSlogWide(logger *slog.Logger, r *http.Request) {
+	slog.Info("rejected", "path", scrubCtl(r.URL.Path))
+	logger.Debug("trace", "path", scrubCtl(r.URL.Path))
+	logger.Log(nil, slog.LevelError, "failed: "+scrubCtl(r.URL.Path), "path", scrubCtl(r.URL.Path))
+	logger.Error("request failed: " + scrubCtl(r.URL.Path))
+}

--- a/internal/analyzers/controlbytes/testdata/src/outboundhdr/outboundhdr.go
+++ b/internal/analyzers/controlbytes/testdata/src/outboundhdr/outboundhdr.go
@@ -1,0 +1,50 @@
+// Package outboundhdr pins the outbound-request header posture (review
+// finding C6): http.Header.Set/Add on a map whose provenance is an
+// OUTBOUND *http.Request — an http.NewRequest/NewRequestWithContext
+// result, or any request-typed value that is not the inbound handler
+// parameter — is silent, because the client transport rejects control
+// bytes at write time (net/http: invalid header field value for ...).
+// The response writer's header map, directly or through a local, and
+// the inbound parameter's map, still fire: writing those is the
+// terminal sink this rule exists for.
+package outboundhdr
+
+import (
+	"net/http"
+)
+
+// forward is the reverse-proxy/API-gateway idiom: inbound headers
+// copied onto an outbound request. Quiet by decision C6.
+func forward(r *http.Request) error {
+	out, err := http.NewRequest(http.MethodGet, "https://upstream.example", nil)
+	if err != nil {
+		return err
+	}
+	out.Header.Set("X-Request-Id", r.Header.Get("X-Request-Id"))
+	out.Header.Set("X-Forwarded-For", r.RemoteAddr)
+	_, err = http.DefaultClient.Do(out)
+	return err
+}
+
+// forwardedLocal is the same silence through a local header map and a
+// NewRequestWithContext provenance.
+func forwardedLocal(r *http.Request) error {
+	out, _ := http.NewRequestWithContext(r.Context(), http.MethodGet, "https://upstream.example", nil)
+	hdr := out.Header
+	hdr.Add("X-Request-Id", r.Header.Get("X-Request-Id"))
+	_, err := http.DefaultClient.Do(out)
+	return err
+}
+
+// responseStillFires: w.Header() directly and through a local.
+func responseStillFires(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Debug-Path", r.URL.Path) // want `controlbytes: request-derived value reaches http.Header.Set/Add unscrubbed`
+	h := w.Header()
+	h.Add("X-Debug-Host", r.Host) // want `controlbytes: request-derived value reaches http.Header.Set/Add unscrubbed`
+}
+
+// inboundParamStillFires: a *http.Request handler parameter is inbound,
+// not outbound provenance, so its header map keeps firing.
+func inboundParamStillFires(r *http.Request) {
+	r.Header.Set("X-Debug-Path", r.URL.Path) // want `controlbytes: request-derived value reaches http.Header.Set/Add unscrubbed`
+}

--- a/internal/analyzers/controlbytes/testdata/src/pathnorm/pathnorm.go
+++ b/internal/analyzers/controlbytes/testdata/src/pathnorm/pathnorm.go
@@ -1,0 +1,48 @@
+// Package pathnorm pins the normalizer posture (review finding C7):
+// qualified calls into the stdlib path and path/filepath packages never
+// clear taint — Clean, Base, Dir, Join reorder separators and dots and
+// pass every control byte through — and a same-package helper named
+// clean* clears only with the byte-level body evidence (a byte-indexed
+// filter, or every return handing the parameter to a genuinely
+// scrub-named call) the doc already requires.
+package pathnorm
+
+import (
+	"net/http"
+	"path"
+	"path/filepath"
+)
+
+func redirects(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Location", path.Clean(r.URL.Path))  // want `controlbytes: request-derived value reaches http.Header.Set/Add unscrubbed`
+	w.Header().Set("X-Dir", filepath.Clean(r.URL.Path)) // want `controlbytes: request-derived value reaches http.Header.Set/Add unscrubbed`
+}
+
+// cleanBytes walks the value as bytes: the body evidence the doc
+// requires, so the clean-only name is earned. Quiet.
+func cleanBytes(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := range s {
+		if c := s[i]; c >= 0x20 && c != 0x7f {
+			out = append(out, c)
+		}
+	}
+	return string(out)
+}
+
+// cleanPassthrough shares the name but never looks at bytes: the name
+// alone does not clear it.
+func cleanPassthrough(s string) string { return s + "" }
+
+// cleanViaStdlib is a one-line wrapper whose every return hands the
+// parameter to path.Clean — the wrapper carries no scrub either.
+func cleanViaStdlib(p string) string { return path.Clean(p) }
+
+func cleanedHelpers(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Location", cleanBytes(r.URL.Path))       // quiet: byte-indexed body
+	w.Header().Set("Location", cleanPassthrough(r.URL.Path)) // want `controlbytes: request-derived value reaches http.Header.Set/Add unscrubbed`
+	w.Header().Set("Location", cleanViaStdlib(r.URL.Path))   // want `controlbytes: request-derived value reaches http.Header.Set/Add unscrubbed`
+	w.Header().Set("Location", sanitizeIt(r.URL.Path))       // quiet: strong scrub name
+}
+
+func sanitizeIt(s string) string { return s }

--- a/internal/analyzers/controlbytes/testdata/src/rangesink/rangesink.go
+++ b/internal/analyzers/controlbytes/testdata/src/rangesink/rangesink.go
@@ -1,0 +1,50 @@
+// Package rangesink pins the range-value binding (review finding C3):
+// a `for _, seg := range segs` value variable is exactly as
+// request-derived as segs[i] — only the spelling differs — so both must
+// reach the sink, and a scrub over the range value must still clear.
+package rangesink
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+func xff(r *http.Request) {
+	segs := strings.Split(r.Header.Get("X-Forwarded-For"), ",")
+	for i := range segs {
+		_ = slog.String("xff_index", segs[i]) // want `controlbytes: request-derived value reaches slog.String/slog.Any unscrubbed`
+	}
+	for _, seg := range segs {
+		_ = slog.String("xff_range", seg) // want `controlbytes: request-derived value reaches slog.String/slog.Any unscrubbed`
+	}
+}
+
+func rangeScrubbed(r *http.Request) {
+	segs := strings.Split(r.Header.Get("X-Forwarded-For"), ",")
+	for _, seg := range segs {
+		_ = slog.String("xff_range", scrubCtl(seg))
+	}
+}
+
+// mapRange: the value variable of a range over a request-derived map is
+// bound the same way.
+func mapRange(r *http.Request) {
+	copied := map[string]string{"xff": r.Header.Get("X-Forwarded-For")}
+	for _, v := range copied {
+		_ = slog.String("copied", v) // want `controlbytes: request-derived value reaches slog.String/slog.Any unscrubbed`
+	}
+}
+
+func scrubCtl(s string) string {
+	if !strings.ContainsAny(s, "\x00\x01\x1b\x7f\r\n") {
+		return s
+	}
+	var b strings.Builder
+	for i := range s {
+		if c := s[i]; c >= 0x20 && c != 0x7f {
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}

--- a/internal/analyzers/controlbytes/testdata/src/seenguard/seenguard.go
+++ b/internal/analyzers/controlbytes/testdata/src/seenguard/seenguard.go
@@ -1,0 +1,92 @@
+// Package seenguard pins the membership-guard posture (review finding
+// C8): a map membership counts as an allowlist only when the lookup
+// keys a value the code has already vetted — the index appears in the
+// condition of an if statement or switch case that lexically encloses
+// the sink, so the sink runs only for values that ARE members of the
+// configured set. A dedup/seen map gates nothing about the bytes: the
+// sink runs exactly when the value was never vetted.
+package seenguard
+
+import (
+	"net/http"
+)
+
+var seen = map[string]bool{}
+var allowed = map[string]bool{}
+
+// dedupEcho: seen[p] is a dedup guard, not an allowlist — the sink
+// after the closed if runs only for FIRST-SEEN values, which no vetting
+// ever covered. Fires.
+func dedupEcho(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Path
+	if seen[p] {
+		return
+	}
+	seen[p] = true
+	w.Header().Set("X-Debug-Path", p) // want `controlbytes: request-derived value reaches http.Header.Set/Add unscrubbed`
+}
+
+// allowEcho: allowed[p] in the enclosing if's condition — the value
+// reached the sink only by being a member of the configured set. Quiet.
+func allowEcho(w http.ResponseWriter, r *http.Request) {
+	p := r.Header.Get("Origin")
+	if allowed[p] {
+		w.Header().Set("Access-Control-Allow-Origin", p)
+	}
+}
+
+// afterIf: membership tested in an if that CLOSES before the sink —
+// the vetting does not cover the later use. Fires.
+func afterIf(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Path
+	if allowed[p] {
+		_ = p
+	}
+	w.Header().Set("X-Debug-Path", p) // want `controlbytes: request-derived value reaches http.Header.Set/Add unscrubbed`
+}
+
+// switchAllow: membership in a switch case's expression gates only that
+// case's body. The default arm is not covered. Fires there, quiet in
+// the case.
+func switchAllow(w http.ResponseWriter, r *http.Request) {
+	p := r.Header.Get("Origin")
+	switch {
+	case allowed[p]:
+		w.Header().Set("Access-Control-Allow-Origin", p)
+	default:
+		w.Header().Set("X-Other", p) // want `controlbytes: request-derived value reaches http.Header.Set/Add unscrubbed`
+	}
+}
+
+// negatedCommaOkAllow is the repo's BFF spelling: membership tested
+// negated, the denial arm diverges before the sink. Everything after
+// the if runs only for members of the configured set, so it is the
+// same vetting the enclosing-if form gets. Quiet.
+func negatedCommaOkAllow(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if _, ok := allowed[origin]; !ok {
+		http.Error(w, "origin not allowed", http.StatusForbidden)
+		return
+	}
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+}
+
+// negatedDirectAllow: the same denial without comma-ok. Quiet.
+func negatedDirectAllow(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if !allowed[origin] {
+		http.Error(w, "origin not allowed", http.StatusForbidden)
+		return
+	}
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+}
+
+// negatedNoDenial: negated membership whose arm does NOT diverge gates
+// nothing after it. Fires.
+func negatedNoDenial(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if !allowed[origin] {
+		_ = origin
+	}
+	w.Header().Set("Access-Control-Allow-Origin", origin) // want `controlbytes: request-derived value reaches http.Header.Set/Add unscrubbed`
+}

--- a/internal/analyzers/controlbytes/testdata/src/seenguard/seenguard.go
+++ b/internal/analyzers/controlbytes/testdata/src/seenguard/seenguard.go
@@ -90,3 +90,15 @@ func negatedNoDenial(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Access-Control-Allow-Origin", origin) // want `controlbytes: request-derived value reaches http.Header.Set/Add unscrubbed`
 }
+
+// elseArmEcho: the else arm runs for NON-members — exactly the
+// unvetted values the allowlist never covered. The membership guard
+// covers only the arm the condition selects.
+func elseArmEcho(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if allowed[origin] {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+	} else {
+		w.Header().Set("X-Rejected-Origin", origin) // want `controlbytes: request-derived value reaches http.Header.Set/Add unscrubbed`
+	}
+}

--- a/internal/analyzers/controlbytes/testdata/src/srcapi/srcapi.go
+++ b/internal/analyzers/controlbytes/testdata/src/srcapi/srcapi.go
@@ -1,0 +1,47 @@
+// Package srcapi pins the request-source surface (review finding C4):
+// the header wrapper accessors (Referer, UserAgent, PostFormValue,
+// BasicAuth) are r.Header.Get in disguise, RequestURI is the raw
+// undecoded request line, and a cookie bound from r.Cookie is
+// request-derived through its .Value field.
+package srcapi
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+func wrappers(r *http.Request) {
+	_ = slog.String("referer", r.Referer())       // want `controlbytes: request-derived value reaches slog.String/slog.Any unscrubbed`
+	_ = slog.String("agent", r.UserAgent())       // want `controlbytes: request-derived value reaches slog.String/slog.Any unscrubbed`
+	_ = slog.String("post", r.PostFormValue("x")) // want `controlbytes: request-derived value reaches slog.String/slog.Any unscrubbed`
+	user, pass, _ := r.BasicAuth()
+	_ = slog.String("user", user) // want `controlbytes: request-derived value reaches slog.String/slog.Any unscrubbed`
+	_ = slog.String("pass", pass) // want `controlbytes: request-derived value reaches slog.String/slog.Any unscrubbed`
+}
+
+func rawLine(r *http.Request) {
+	_ = slog.String("uri", r.RequestURI) // want `controlbytes: request-derived value reaches slog.String/slog.Any unscrubbed`
+}
+func cookies(r *http.Request) {
+	c, err := r.Cookie("session")
+	if err == nil {
+		_ = slog.String("sid2", c.Value) // want `controlbytes: request-derived value reaches slog.String/slog.Any unscrubbed`
+	}
+}
+
+func scrubbed(r *http.Request) {
+	_ = slog.String("referer", scrubCtl(r.Referer()))
+	_ = slog.String("uri", scrubCtl(r.RequestURI))
+	c, _ := r.Cookie("session")
+	_ = slog.String("sid", scrubCtl(c.Value))
+}
+
+func scrubCtl(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := range s {
+		if c := s[i]; c >= 0x20 && c != 0x7f {
+			out = append(out, c)
+		}
+	}
+	return string(out)
+}

--- a/internal/analyzers/controlbytes/testdata/src/stdiosink/stdiosink.go
+++ b/internal/analyzers/controlbytes/testdata/src/stdiosink/stdiosink.go
@@ -1,11 +1,15 @@
-// Package stdiosink pins the fmt.Fprint* arm: only writes to
-// os.Stdout/os.Stderr are sinks; any other writer (a response writer, a
-// buffer) has its own framing and stays quiet.
+// Package stdiosink pins the fmt print arms: writes to
+// os.Stdout/os.Stderr are sinks — including fmt.Print/Printf/Println,
+// which have no writer argument and write to os.Stdout unconditionally
+// — and so is the std log package's Print* (the default logger writes
+// to stderr). Any other writer (a response writer, a buffer) has its
+// own framing and stays quiet.
 package stdiosink
 
 import (
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 )
@@ -21,8 +25,8 @@ func goodStdout(r *http.Request) {
 }
 
 // otherWritersAreQuiet: an http.ResponseWriter and an io.Writer are not
-// the terminal sinks this rule means, and a print with no writer at all
-// is not one either.
+// the terminal sinks this rule means, and fmt.Sprint* build a string
+// rather than print one.
 func otherWritersAreQuiet(w http.ResponseWriter, out io.Writer, r *http.Request) {
 	fmt.Fprintf(w, "echo %s", r.URL.Path)
 	fmt.Fprint(out, r.URL.Path)
@@ -40,3 +44,29 @@ func escapeClearance(r *http.Request) {
 func escapeQuery(q string) string { return q }
 
 func quoteCtl(s string) string { return "\"" + s + "\"" }
+
+// badBarePrint: fmt.Print/Printf/Println write to os.Stdout with no
+// writer argument to inspect — they are the terminal sink outright.
+func badBarePrint(r *http.Request) {
+	fmt.Printf("serving %s\n", r.URL.Path) // want `controlbytes: request-derived value reaches stdout/stderr print unscrubbed`
+	fmt.Println("remote", r.RemoteAddr)    // want `controlbytes: request-derived value reaches stdout/stderr print unscrubbed`
+	fmt.Print(r.Host)                      // want `controlbytes: request-derived value reaches stdout/stderr print unscrubbed`
+}
+
+func goodBarePrint(r *http.Request) {
+	fmt.Printf("serving %q\n", quoteCtl(r.URL.Path))
+	fmt.Println("static line")
+}
+
+// badLogPrint: log.Print/Printf/Println write to the default logger
+// (stderr); a *log.Logger receiver is the same sink.
+func badLogPrint(lg *log.Logger, r *http.Request) {
+	log.Printf("bad path %s", r.URL.Path) // want `controlbytes: request-derived value reaches std log print unscrubbed`
+	log.Println("remote", r.RemoteAddr)   // want `controlbytes: request-derived value reaches std log print unscrubbed`
+	lg.Print(r.Host)                      // want `controlbytes: request-derived value reaches std log print unscrubbed`
+}
+
+func goodLogPrint(lg *log.Logger, r *http.Request) {
+	log.Printf("bad path %q", quoteCtl(r.URL.Path))
+	lg.Print("static line")
+}

--- a/internal/analyzers/discardederr/discardederr.go
+++ b/internal/analyzers/discardederr/discardederr.go
@@ -14,6 +14,9 @@
 // Silent postures, deliberately:
 //   - `_ = f()` and `_, _ = f()`: discarding everything is a
 //     statement, and an idiomatic one;
+//   - database/sql result accessors (Result.RowsAffected,
+//     Result.LastInsertId): reads after an already-checked Exec whose
+//     count is display-only;
 //   - assignments where no kept value is ever used: nothing marches on
 //     with the refusal hidden;
 //   - _test.go files.
@@ -23,7 +26,13 @@
 // result and the call is a method on a receiver — the subscribeImpl
 // posture, where the error is a refusal back-channel beside usable
 // results. Package-function drops (strconv.Atoi and friends) are not
-// this rule's to police.
+// this rule's to police. The arity gate (≥3 results) was dropped the
+// same day: the bug-class paragraph's own "empty list that reads as
+// 'nothing found'" is a two-result shape. Measured with the gate open
+// and the sql accessors excluded: 165 broad, 33 at last+method (25 of
+// them RowsAffected), 8 two-result method drops — all 8 genuine
+// swallowed refusals, fixed in their packages — and the tree now vets
+// clean at 0.
 package discardederr
 
 import (
@@ -68,6 +77,9 @@ func run(pass *analysis.Pass) (any, error) {
 
 func checkFunc(pass *analysis.Pass, body *ast.BlockStmt) {
 	ast.Inspect(body, func(n ast.Node) bool {
+		if _, isLit := n.(*ast.FuncLit); isLit {
+			return false // nested closures get their own checkFunc pass
+		}
 		st, ok := n.(*ast.AssignStmt)
 		if !ok || len(st.Lhs) < 2 || len(st.Rhs) != 1 {
 			return true
@@ -102,14 +114,12 @@ func checkFunc(pass *analysis.Pass, body *ast.BlockStmt) {
 		if !ok || isPkgName(pass, sel.X) {
 			return true
 		}
-		// And the call must hand back a RESOURCE with its cleanup, not a
-		// plain (value, error): 2-result drops degrade to an observable
-		// zero value (stats panels, catalogs, counts), while dropping the
-		// refusal beside a channel+cancel pair leaves a consumer waiting
-		// on something that will never deliver. Measured 2026-09-02:
-		// 165 broad, 33 at last+method (25 of them the RowsAffected
-		// accessor after an already-checked Exec), 0 at ≥3 results.
-		if tuple.Len() < 3 {
+		// The ≥3-result requirement was dropped 2026-09-02: the doc's
+		// own bug class names the two-result refusal ("an empty list
+		// that reads as 'nothing found'"), and the 25 RowsAffected
+		// drops that motivated the arity gate are a nameable stdlib
+		// accessor, excluded below instead of by arity.
+		if isSQLResultMethod(pass, call) {
 			return true
 		}
 		if !keepsUsedValue(pass, body, st) {
@@ -184,6 +194,36 @@ func calleeName(call *ast.CallExpr) string {
 		return fun.Sel.Name + "()"
 	}
 	return "call"
+}
+
+// isSQLResultMethod reports whether the call is a database/sql result
+// accessor (Result.RowsAffected, Result.LastInsertId): reads after an
+// already-checked Exec whose count is display-only. The 2026-09-02
+// run measured 25 such drops — the noise the old arity gate shed by
+// discarding the whole two-result class.
+func isSQLResultMethod(pass *analysis.Pass, call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	switch sel.Sel.Name {
+	case "RowsAffected", "LastInsertId":
+	default:
+		return false
+	}
+	t := pass.TypesInfo.TypeOf(sel.X)
+	if t == nil {
+		return false
+	}
+	if p, ok := t.(*types.Pointer); ok {
+		t = p.Elem()
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Pkg() != nil && obj.Pkg().Path() == "database/sql"
 }
 
 var errorIface = types.Universe.Lookup("error").Type().Underlying().(*types.Interface)

--- a/internal/analyzers/discardederr/discardederr_test.go
+++ b/internal/analyzers/discardederr/discardederr_test.go
@@ -9,5 +9,5 @@ import (
 )
 
 func TestDiscardedErr(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), discardederr.Analyzer, "a", "b", "c")
+	analysistest.Run(t, analysistest.TestData(), discardederr.Analyzer, "a", "b", "c", "d")
 }

--- a/internal/analyzers/discardederr/testdata/src/d/d.go
+++ b/internal/analyzers/discardederr/testdata/src/d/d.go
@@ -1,0 +1,42 @@
+// Package d holds the discardederr spelling the 2026-09-02 adversarial
+// review showed was out of contract: a refused two-result method whose
+// kept value marches on, and the database/sql accessor exclusion.
+package d
+
+import (
+	"database/sql"
+	"errors"
+)
+
+var errRefused = errors.New("refused")
+
+type conn struct{ fd int }
+
+type pool struct{}
+
+func (p *pool) acquire(tag string) (*conn, error) { return nil, errRefused }
+
+// grab keeps the connection and drops a two-result refusal: a nil conn
+// marches on. The doc's own bug class ("an empty list that reads as
+// 'nothing found'") is this shape.
+func grab(p *pool, tag string) *conn {
+	c, _ := p.acquire(tag) // want `assignment discards the error from acquire`
+	return c
+}
+
+// grabChecked is the fix posture.
+func grabChecked(p *pool, tag string) (*conn, error) {
+	c, err := p.acquire(tag)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// rowsTouched reads a database/sql result accessor after an
+// already-checked Exec: the count is display-only, and the accessor's
+// error duplicates the statement's. Excluded by receiver type.
+func rowsTouched(res sql.Result) int64 {
+	n, _ := res.RowsAffected()
+	return n
+}

--- a/internal/analyzers/divlimit/divlimit.go
+++ b/internal/analyzers/divlimit/divlimit.go
@@ -92,6 +92,11 @@ func checkFunc(pass *analysis.Pass, fnType *ast.FuncType, body *ast.BlockStmt) {
 	parents := dominance.Parents(body)
 
 	ast.Inspect(body, func(n ast.Node) bool {
+		if _, isLit := n.(*ast.FuncLit); isLit {
+			// Closures are judged by their own checkFunc call from
+			// run; descending here reports their divisions twice.
+			return false
+		}
 		bin, ok := n.(*ast.BinaryExpr)
 		if !ok {
 			return true

--- a/internal/analyzers/divlimit/divlimit.go
+++ b/internal/analyzers/divlimit/divlimit.go
@@ -11,15 +11,25 @@
 // OffsetForPage already guarded its own division.
 //
 // Silent postures, deliberately:
-//   - any comparison of the divisor against 0 or 1 earlier in the
-//     function (the fix posture, including `limit <= 0 { return }`);
+//   - a comparison of the divisor against 0 or 1 that DOMINATES the
+//     division: it sits in the same block before it, in an enclosing
+//     block before the statement holding it, or is the condition of an
+//     enclosing if whose then-branch holds it (the fix posture,
+//     including `limit <= 0 { return }`). A guard inside a nested
+//     conditional body of an earlier statement (a flag-gated check)
+//     executes only when the flag is set and dominates nothing;
 //   - divisors not named in the limit/perPage/pageSize/size/count/n
-//     family: a divisor called `rows` or `stride` is not recognizably
-//     caller pagination, and this rule refuses to guess;
+//     family (parameters, or struct fields of that family — a limit
+//     decoded into a request struct is the standard handler spelling):
+//     a divisor called `rows` or `stride` is not recognizably caller
+//     pagination, and this rule refuses to guess;
 //   - constants and len(...) results: they cannot become 0 from
 //     outside;
 //   - float division: no panic, no rule;
 //   - _test.go files.
+//
+// Every function body is examined, including divisions inside
+// package-level function literals (the handler-table spelling).
 package divlimit
 
 import (
@@ -31,6 +41,8 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
+
+	"github.com/DonaldMurillo/gofastr/internal/analyzers/internal/dominance"
 )
 
 var Analyzer = &analysis.Analyzer{
@@ -50,23 +62,26 @@ func run(pass *analysis.Pass) (any, error) {
 		if strings.HasSuffix(pass.Fset.Position(f.Pos()).Filename, "_test.go") {
 			continue
 		}
-		for _, d := range f.Decls {
-			fn, ok := d.(*ast.FuncDecl)
-			if !ok || fn.Body == nil {
-				continue
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch fn := n.(type) {
+			case *ast.FuncDecl:
+				if fn.Body != nil {
+					checkFunc(pass, fn.Type, fn.Body)
+				}
+			case *ast.FuncLit:
+				checkFunc(pass, fn.Type, fn.Body)
 			}
-			checkFunc(pass, fn)
-		}
+			return true
+		})
 	}
 	return nil, nil
 }
 
-func checkFunc(pass *analysis.Pass, fn *ast.FuncDecl) {
-	body := fn.Body
+func checkFunc(pass *analysis.Pass, fnType *ast.FuncType, body *ast.BlockStmt) {
 	bound := bindings(pass, body)
 	params := map[types.Object]bool{}
-	if fn.Type.Params != nil {
-		for _, f := range fn.Type.Params.List {
+	if fnType.Params != nil {
+		for _, f := range fnType.Params.List {
 			for _, name := range f.Names {
 				if obj := pass.TypesInfo.ObjectOf(name); obj != nil {
 					params[obj] = true
@@ -74,6 +89,7 @@ func checkFunc(pass *analysis.Pass, fn *ast.FuncDecl) {
 			}
 		}
 	}
+	parents := dominance.Parents(body)
 
 	ast.Inspect(body, func(n ast.Node) bool {
 		bin, ok := n.(*ast.BinaryExpr)
@@ -87,57 +103,88 @@ func checkFunc(pass *analysis.Pass, fn *ast.FuncDecl) {
 		if divisor == nil || !isInteger(pass, bin.X) || !isInteger(pass, bin.Y) {
 			return true
 		}
-		if guardedBefore(pass, body, divisor, bin) {
+		if guardedBefore(pass, body, parents, divisor, bin) {
 			return true
 		}
 		pass.Reportf(bin.Pos(),
 			"integer division by %s, a caller-supplied value, with no zero-or-one guard: it panics when 0; compare it against 0 (or 1) before dividing",
-			divisor.Name())
+			types.ExprString(divisor))
 		return true
 	})
 }
 
-// guardedBefore reports whether the divisor was compared against 0 or 1
-// anywhere in the function before the division.
-func guardedBefore(pass *analysis.Pass, body *ast.BlockStmt, divisor types.Object, div *ast.BinaryExpr) bool {
-	guarded := false
-	ast.Inspect(body, func(n ast.Node) bool {
-		if guarded {
-			return false
+// guardedBefore reports whether the divisor was compared against 0 or
+// 1 in a statement or condition that dominates the division: the same
+// block before it, an enclosing block before it, or the condition of
+// an enclosing if whose then-branch holds it. A comparison inside the
+// body of a nested conditional of an earlier statement runs only when
+// that branch is taken and is not a guard.
+func guardedBefore(pass *analysis.Pass, body *ast.BlockStmt, parents map[ast.Node]ast.Node, divisor ast.Expr, div *ast.BinaryExpr) bool {
+	if spineComparesDivisor(pass, dominance.Spine(divisor), divisor) {
+		return true
+	}
+	for _, stmts := range dominance.Prefix(div, parents, body) {
+		for _, st := range stmts {
+			if spineComparesDivisor(pass, dominance.Spine(st), divisor) {
+				return true
+			}
 		}
+	}
+	for _, cond := range dominance.EnclosingIfConds(div, parents, body) {
+		if spineComparesDivisor(pass, dominance.Spine(cond), divisor) {
+			return true
+		}
+	}
+	return false
+}
+
+// spineComparesDivisor reports whether any comparison in nodes matches
+// the divisor expression against a constant 0 or 1.
+func spineComparesDivisor(pass *analysis.Pass, nodes []ast.Node, divisor ast.Expr) bool {
+	for _, n := range nodes {
 		bin, ok := n.(*ast.BinaryExpr)
 		if !ok {
-			return true
+			continue
 		}
 		switch bin.Op {
 		case token.EQL, token.NEQ, token.LSS, token.LEQ, token.GTR, token.GEQ:
 		default:
-			return true
-		}
-		if bin.Pos() >= div.Pos() {
-			return true
+			continue
 		}
 		var other ast.Expr
 		switch {
-		case isIdentObj(pass, bin.X, divisor):
+		case isDivisorExpr(pass, bin.X, divisor):
 			other = bin.Y
-		case isIdentObj(pass, bin.Y, divisor):
+		case isDivisorExpr(pass, bin.Y, divisor):
 			other = bin.X
 		default:
-			return true
+			continue
 		}
 		if isZeroOrOne(pass, other) {
-			guarded = true
+			return true
 		}
-		return true
-	})
-	return guarded
+	}
+	return false
+}
+
+// isDivisorExpr reports whether e spells the divisor expression: the
+// same identifier object, or the same printed selector (`q.Limit`).
+func isDivisorExpr(pass *analysis.Pass, e ast.Expr, divisor ast.Expr) bool {
+	switch d := divisor.(type) {
+	case *ast.Ident:
+		return isIdentObj(pass, e, pass.TypesInfo.ObjectOf(d))
+	case *ast.SelectorExpr:
+		ds, ok := e.(*ast.SelectorExpr)
+		return ok && types.ExprString(ds) == types.ExprString(d)
+	}
+	return false
 }
 
 // divisorCandidate resolves the divisor to a limit-named function
-// parameter, or a local of that name bound to a query/param accessor.
-// Constants and len(...) locals are not caller-supplied.
-func divisorCandidate(pass *analysis.Pass, e ast.Expr, bound map[types.Object]ast.Expr, params map[types.Object]bool) types.Object {
+// parameter, a limit-named struct field, or a local of that name bound
+// to a query/param accessor. Constants and len(...) locals are not
+// caller-supplied.
+func divisorCandidate(pass *analysis.Pass, e ast.Expr, bound map[types.Object]ast.Expr, params map[types.Object]bool) ast.Expr {
 	switch x := e.(type) {
 	case *ast.BasicLit:
 		return nil // constants cannot become 0 from outside
@@ -151,7 +198,7 @@ func divisorCandidate(pass *analysis.Pass, e ast.Expr, bound map[types.Object]as
 		}
 		if params[obj] {
 			if limitName.MatchString(x.Name) {
-				return obj
+				return x
 			}
 			return nil
 		}
@@ -167,7 +214,15 @@ func divisorCandidate(pass *analysis.Pass, e ast.Expr, bound map[types.Object]as
 		}
 		switch qualifiedFunc(pass, call.Fun) {
 		case "strconv.Atoi", "strconv.ParseInt", "strconv.ParseUint":
-			return obj
+			return x
+		}
+		return nil
+	case *ast.SelectorExpr:
+		// A limit-named field of anything the caller filled in: the
+		// decoded-request spelling (`q.Total / q.Limit`).
+		obj, ok := pass.TypesInfo.ObjectOf(x.Sel).(*types.Var)
+		if ok && obj.IsField() && limitName.MatchString(x.Sel.Name) {
+			return x
 		}
 		return nil
 	case *ast.CallExpr:

--- a/internal/analyzers/divlimit/divlimit_test.go
+++ b/internal/analyzers/divlimit/divlimit_test.go
@@ -9,5 +9,5 @@ import (
 )
 
 func TestDivLimit(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), divlimit.Analyzer, "a", "b", "c")
+	analysistest.Run(t, analysistest.TestData(), divlimit.Analyzer, "a", "b", "c", "d")
 }

--- a/internal/analyzers/divlimit/testdata/src/d/d.go
+++ b/internal/analyzers/divlimit/testdata/src/d/d.go
@@ -65,3 +65,36 @@ func condGuardFixed(total, limit int, strict bool) int {
 	}
 	return total
 }
+
+// nestedClosureDivision: the closure is judged by its own checkFunc
+// pass; the enclosing function's walk must cut at the FuncLit or the
+// selector-shaped division reports twice (identical diagnostics go
+// deduped by vet and analysistest — a no-dedupe driver shows the pair).
+func nestedClosureDivision(r *http.Request) int {
+	q := decode(r)
+	apply := func(v int) int {
+		return v / q.Limit // want `integer division by q.Limit`
+	}
+	return apply(q.Total)
+}
+
+// postGuardBreaks: the guard comparison sits in the loop's Post, which
+// runs only after a NORMAL iteration — the immediate break skips it,
+// and the division after the loop sees the unvetted limit.
+func postGuardBreaks(total, limit int, clamps map[bool]int) int {
+	for i := 0; i < 3; i, limit = i+1, clamps[limit == 0] {
+		if i == 0 {
+			break
+		}
+	}
+	return total / limit // want `integer division by limit`
+}
+
+// keyGuardEmptyRange: the guard comparison sits in the range's KEY
+// expression, evaluated only when the range yields an element — an
+// empty range never vets the divisor.
+func keyGuardEmptyRange(total, limit int, xs []int, clamps map[bool]int) int {
+	for clamps[limit == 0] = range xs {
+	}
+	return total / limit // want `integer division by limit`
+}

--- a/internal/analyzers/divlimit/testdata/src/d/d.go
+++ b/internal/analyzers/divlimit/testdata/src/d/d.go
@@ -1,0 +1,67 @@
+// Package d holds the divlimit spellings the 2026-09-02 adversarial
+// review showed were missing or mis-scoped: struct-field divisors,
+// divisions inside package-level function literals, and guards that
+// do not dominate the division.
+package d
+
+import "net/http"
+
+type ListQuery struct {
+	Total  int
+	Limit  int
+	Offset int
+}
+
+// pagesOfQuery divides by a field of a decoded request struct: the
+// standard handler spelling of a caller-supplied limit.
+func pagesOfQuery(r *http.Request) int {
+	q := decode(r)
+	return q.Total / q.Limit // want `integer division by q.Limit`
+}
+
+func decode(r *http.Request) ListQuery { return ListQuery{} }
+
+type pager struct{ total, Limit int }
+
+// rem divides by the receiver's Limit field.
+func (p pager) rem() int {
+	return p.total % p.Limit // want `integer division by p.Limit`
+}
+
+// fieldGuarded compares the field divisor before dividing: the fix
+// posture, recognized wherever it dominates.
+func fieldGuarded(q ListQuery) int {
+	if q.Limit == 0 {
+		return 0
+	}
+	return q.Total / q.Limit
+}
+
+// Pages is a package-level function literal: the handler-table
+// spelling, examined like any function declaration.
+var Pages = func(total, limit int) int {
+	return total / limit // want `integer division by limit`
+}
+
+// condGuard: the zero guard sits inside a nested conditional body of
+// an earlier statement — it executes only when strict, so the division
+// still panics on limit=0 with strict=false.
+func condGuard(total, limit int, strict bool) int {
+	if strict {
+		if limit == 0 {
+			return 0
+		}
+	}
+	return total / limit // want `integer division by limit`
+}
+
+// condGuardFixed hoists the guard: now it dominates.
+func condGuardFixed(total, limit int, strict bool) int {
+	if limit == 0 {
+		return 0
+	}
+	if strict {
+		return total / limit
+	}
+	return total
+}

--- a/internal/analyzers/emitident/emitident.go
+++ b/internal/analyzers/emitident/emitident.go
@@ -23,8 +23,9 @@
 // sqlType...), a strconv/strings result, a constant, a local that an
 // isXIdent/token.IsIdentifier check in the same function guards —
 // guarding means the emit site is inside the check's success arm or
-// after a failure arm that diverges (return/panic/continue/os.Exit);
-// a warn-and-continue check gates nothing — or a derivation rooted at
+// after a failure arm that diverges (return/panic/os.Exit, or a
+// continue confined to emits inside the same loop body); a
+// warn-and-continue check gates nothing — or a derivation rooted at
 // a struct field the SAME PACKAGE identifier-checks somewhere
 // (validate-side gates count: the check may live in the validator
 // while the emitter only renders), or at a field whose own name states
@@ -243,7 +244,8 @@ func run(pass *analysis.Pass) (any, error) {
 // function-local guard is computed per emit site: a check-named call
 // gates its arguments only where it dominates the emit — the emit
 // inside the check's success arm, or after a failure arm that diverges
-// (return/panic/continue/os.Exit). A check that only warns and falls
+// (return/panic/os.Exit, or a continue guarding emits inside the same
+// loop body only). A check that only warns and falls
 // through gates nothing: the hostile name still reaches the format.
 func checkFile(pass *analysis.Pass, f *ast.File, helperDecls map[*types.Func]*ast.FuncDecl, memo map[string]bool, paramGate map[*types.Var]bool) {
 	bound := boundExprs(pass, f)
@@ -256,6 +258,7 @@ func checkFile(pass *analysis.Pass, f *ast.File, helperDecls map[*types.Func]*as
 	var processBody func(body *ast.BlockStmt)
 	processBody = func(body *ast.BlockStmt) {
 		var ifs []*ast.IfStmt
+		var loops []ast.Node
 		var emits []*ast.CallExpr
 		ast.Inspect(body, func(n ast.Node) bool {
 			switch e := n.(type) {
@@ -264,6 +267,8 @@ func checkFile(pass *analysis.Pass, f *ast.File, helperDecls map[*types.Func]*as
 				return false
 			case *ast.IfStmt:
 				ifs = append(ifs, e)
+			case *ast.ForStmt, *ast.RangeStmt:
+				loops = append(loops, e)
 			case *ast.CallExpr:
 				if _, ok := fmtCalls[qualifiedCallee(pass, e.Fun)]; ok {
 					emits = append(emits, e)
@@ -308,8 +313,18 @@ func checkFile(pass *analysis.Pass, f *ast.File, helperDecls map[*types.Func]*as
 						guarded[g.obj] = true
 						continue
 					}
-					if emit.Pos() > g.st.End() && bodyDiverges(pass, g.st.Body) {
-						guarded[g.obj] = true
+					if emit.Pos() > g.st.End() {
+						if bodyDiverges(pass, g.st.Body) {
+							guarded[g.obj] = true
+						} else if bodyContinues(g.st.Body) && sameLoopBody(loops, g.st, emit) {
+							// A continue only skips the current
+							// iteration: it guards emits inside the
+							// same loop body, never an emit after the
+							// loop — the value that hit the continue
+							// is exactly the unchecked one a post-loop
+							// emit can format.
+							guarded[g.obj] = true
+						}
 					}
 					continue
 				}
@@ -350,18 +365,15 @@ func collectCondChecks(pass *analysis.Pass, x ast.Expr, neg int, add func(call *
 }
 
 // bodyDiverges reports whether the block's control flow unconditionally
-// leaves the function or loop: a top-level return, panic, continue, or
-// os.Exit. Statements nested in inner conditionals do not count — their
-// other paths fall through.
+// leaves the FUNCTION: a top-level return, panic, or os.Exit. Statements
+// nested in inner conditionals do not count — their other paths fall
+// through. A continue does not count either: it only skips to the next
+// iteration (see bodyContinues).
 func bodyDiverges(pass *analysis.Pass, body *ast.BlockStmt) bool {
 	for _, st := range body.List {
 		switch s := st.(type) {
 		case *ast.ReturnStmt:
 			return true
-		case *ast.BranchStmt:
-			if s.Tok == token.CONTINUE {
-				return true
-			}
 		case *ast.ExprStmt:
 			if call, ok := s.X.(*ast.CallExpr); ok {
 				if id, ok := call.Fun.(*ast.Ident); ok && id.Name == "panic" {
@@ -374,6 +386,41 @@ func bodyDiverges(pass *analysis.Pass, body *ast.BlockStmt) bool {
 		}
 	}
 	return false
+}
+
+// bodyContinues reports whether the block's top level is a continue.
+func bodyContinues(body *ast.BlockStmt) bool {
+	for _, st := range body.List {
+		if s, ok := st.(*ast.BranchStmt); ok && s.Tok == token.CONTINUE {
+			return true
+		}
+	}
+	return false
+}
+
+// sameLoopBody reports whether st and emit sit inside the same loop's
+// BODY: the innermost loop enclosing st, with emit lexically inside
+// that loop's body. A continue divergence guards only there.
+func sameLoopBody(loops []ast.Node, st *ast.IfStmt, emit *ast.CallExpr) bool {
+	var innermost ast.Node
+	for _, lp := range loops {
+		if st.Pos() >= lp.Pos() && st.End() <= lp.End() {
+			if innermost == nil || lp.End()-lp.Pos() < innermost.End()-innermost.Pos() {
+				innermost = lp
+			}
+		}
+	}
+	if innermost == nil {
+		return false
+	}
+	var body *ast.BlockStmt
+	switch l := innermost.(type) {
+	case *ast.ForStmt:
+		body = l.Body
+	case *ast.RangeStmt:
+		body = l.Body
+	}
+	return body != nil && emit.Pos() >= body.Pos() && emit.End() <= body.End()
 }
 
 // checkEmit scans one Sprintf-family call's format for identifier slots
@@ -587,6 +634,11 @@ func declFollows(format string, after int, kw string) bool {
 	rest = rest[spaces:]
 	switch kw {
 	case "func":
+		// The parenthesis follows the identifier RUN, not the verb:
+		// "func %sHandler(ctx context.Context) error {".
+		for len(rest) > 0 && isIdentByte(rest[0]) {
+			rest = rest[1:]
+		}
 		return strings.HasPrefix(rest, "(") &&
 			(strings.IndexByte(rest, '{') >= 0 || strings.IndexByte(rest, '\n') >= 0)
 	case "type", "var":

--- a/internal/analyzers/emitident/emitident.go
+++ b/internal/analyzers/emitident/emitident.go
@@ -21,13 +21,21 @@
 // from: a call whose name says identifier/quote/slug/sanitize/safe/escape
 // (query.QuoteIdent, SlugifyWidgetID, quotedSlotSanitized, url.PathEscape,
 // sqlType...), a strconv/strings result, a constant, a local that an
-// isXIdent/token.IsIdentifier check in the same function guards, or a
-// derivation rooted at a struct field the SAME PACKAGE identifier-checks
-// somewhere (validate-side gates count: the check may live in the
-// validator while the emitter only renders). toCamelCase and kin are
-// deliberately NOT gates: they transform, they do not validate — that is
-// precisely the miss the CLI probe drove, and why the fix wrapped the
-// derivation in token.IsIdentifier rather than trusting the casing.
+// isXIdent/token.IsIdentifier check in the same function guards —
+// guarding means the emit site is inside the check's success arm or
+// after a failure arm that diverges (return/panic/continue/os.Exit);
+// a warn-and-continue check gates nothing — or a derivation rooted at
+// a struct field the SAME PACKAGE identifier-checks somewhere
+// (validate-side gates count: the check may live in the validator
+// while the emitter only renders), or at a field whose own name states
+// the value's TREATMENT (quotedTable, sanitizedSlot). A struct field
+// whose name is a noun for what the value IS (HandlerType, FieldType,
+// Ident, SafeWord) is NOT a gate: the schema's word for a value says
+// nothing about how it was treated.
+// toCamelCase and kin are deliberately NOT gates: they transform, they
+// do not validate — that is precisely the miss the CLI probe drove,
+// and why the fix wrapped the derivation in token.IsIdentifier rather
+// than trusting the casing.
 //
 // The rule is deliberately silent on:
 //   - format slots that are not identifier positions: plain %s/%q in
@@ -41,11 +49,31 @@
 //   - concatenation into SQL (`"SELECT ..." + x`): GOFASTR1401 owns that
 //     shape; this rule only sees the Sprintf family, so the two cannot
 //     double-report.
+//   - format-INITIAL func/type/var keywords without code evidence:
+//     lowercase messages start with the same nouns ("type %s is not a
+//     struct", "func %s(ctx) was replaced"). A format-initial keyword
+//     is code only with positive evidence after the verb: for func, a
+//     parenthesis immediately after the identifier run plus a '{' or
+//     newline later in the format; for type, one of struct/interface/
+//     map/func/chan/'='/'['/'*' next; for var, '='/':=' or one of
+//     those keywords. After a real code boundary (newline, tab, brace,
+//     paren, semicolon, colon, equals) the keyword alone is evidence.
+//   - SQL statement shapes outside the anchored phrase list (alter/add/
+//     create/drop table, create unique index/index, drop index, create
+//     view/trigger, insert (or replace) into, delete from, pragma
+//     table_info), with the verb allowed to complete an identifier the
+//     phrase began (`create index idx_%s`): a shape not in the list is
+//     silent until its phrase is added.
+//   - verbs after '?' or '#' inside a '/'-leading quoted string: route
+//     slots cover the PATH portion only. A query parameter is a
+//     different grammar with a different escaper (url.QueryEscape),
+//     not an identifier slot.
 package emitident
 
 import (
 	"go/ast"
 	"go/constant"
+	"go/token"
 	"go/types"
 	"regexp"
 	"strings"
@@ -69,6 +97,15 @@ var gateNameRe = regexp.MustCompile(`(?i)ident|quote|slug|sanit|safe|escape|type
 // or quoting it (query.QuoteIdent, query.SafeIdent). Used for the
 // function-local guard tracking and the package field memo.
 var checkNameRe = regexp.MustCompile(`(?i)ident|quote|safe|validat`)
+
+// treatedFieldRe matches field names that state the VALUE'S TREATMENT
+// (quoted, sanitized, escaped): the store constructed the value through
+// a quoting/validation helper and named the field for what was done to
+// it — the battery stores' quotedTable shape. This is deliberately
+// narrower than gateNameRe: noun families like HandlerType/FieldType/
+// Ident describe what a value IS, not how it was treated, and gate
+// nothing.
+var treatedFieldRe = regexp.MustCompile(`(?i)quoted|sanit|escap`)
 
 // isCheckCall reports whether a call is treated as an identifier gate:
 // named for checking/quoting identifiers, and not one of the stdlib
@@ -202,71 +239,171 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
+// checkFile reports ungated names formatted into identifier slots. The
+// function-local guard is computed per emit site: a check-named call
+// gates its arguments only where it dominates the emit — the emit
+// inside the check's success arm, or after a failure arm that diverges
+// (return/panic/continue/os.Exit). A check that only warns and falls
+// through gates nothing: the hostile name still reaches the format.
 func checkFile(pass *analysis.Pass, f *ast.File, helperDecls map[*types.Func]*ast.FuncDecl, memo map[string]bool, paramGate map[*types.Var]bool) {
 	bound := boundExprs(pass, f)
 
-	// Function-local ident guards: objects checked by an isXIdent-style
-	// call in some if-statement of the same function.
-	guarded := map[types.Object]bool{}
-	ast.Inspect(f, func(n ast.Node) bool {
-		if st, ok := n.(*ast.IfStmt); ok {
-			// A check in the if's INIT counts too:
-			// `if _, err := query.SafeIdent(table); err != nil`.
-			for _, root := range []ast.Node{st.Init, st.Cond} {
-				if root == nil {
-					continue
+	type guard struct {
+		obj        types.Object
+		st         *ast.IfStmt
+		bodyIsFail bool // check negated (or in the if's INIT): the Body is the failure arm
+	}
+	var processBody func(body *ast.BlockStmt)
+	processBody = func(body *ast.BlockStmt) {
+		var ifs []*ast.IfStmt
+		var emits []*ast.CallExpr
+		ast.Inspect(body, func(n ast.Node) bool {
+			switch e := n.(type) {
+			case *ast.FuncLit:
+				processBody(e.Body) // a closure may run later: separate scope
+				return false
+			case *ast.IfStmt:
+				ifs = append(ifs, e)
+			case *ast.CallExpr:
+				if _, ok := fmtCalls[qualifiedCallee(pass, e.Fun)]; ok {
+					emits = append(emits, e)
 				}
-				ast.Inspect(root, func(c ast.Node) bool {
-					call, ok := c.(*ast.CallExpr)
-					if !ok || !isCheckCall(pass, call.Fun) {
-						return true
+			}
+			return true
+		})
+		var guards []guard
+		addGuards := func(call *ast.CallExpr, st *ast.IfStmt, bodyIsFail bool) {
+			for _, a := range call.Args {
+				if id, ok := a.(*ast.Ident); ok {
+					if obj := pass.TypesInfo.ObjectOf(id); obj != nil {
+						guards = append(guards, guard{obj: obj, st: st, bodyIsFail: bodyIsFail})
 					}
-					for _, a := range call.Args {
-						if id, ok := a.(*ast.Ident); ok {
-							if obj := pass.TypesInfo.ObjectOf(id); obj != nil {
-								guarded[obj] = true
-							}
-						}
+				}
+			}
+		}
+		for _, st := range ifs {
+			if st.Cond != nil {
+				collectCondChecks(pass, st.Cond, 0, func(call *ast.CallExpr, neg int) {
+					addGuards(call, st, neg%2 == 1)
+				})
+			}
+			if st.Init != nil {
+				// A check in the if's INIT:
+				// `if _, err := query.SafeIdent(table); err != nil`
+				// — the Body tests the check's failure.
+				ast.Inspect(st.Init, func(c ast.Node) bool {
+					if call, ok := c.(*ast.CallExpr); ok && isCheckCall(pass, call.Fun) {
+						addGuards(call, st, true)
 					}
 					return true
 				})
 			}
 		}
-		return true
-	})
+		for _, emit := range emits {
+			guarded := map[types.Object]bool{}
+			for _, g := range guards {
+				if g.bodyIsFail {
+					// The else arm of a negated check is its success arm.
+					if g.st.Else != nil && emit.Pos() >= g.st.Else.Pos() && emit.Pos() <= g.st.Else.End() {
+						guarded[g.obj] = true
+						continue
+					}
+					if emit.Pos() > g.st.End() && bodyDiverges(pass, g.st.Body) {
+						guarded[g.obj] = true
+					}
+					continue
+				}
+				if emit.Pos() >= g.st.Body.Pos() && emit.Pos() <= g.st.Body.End() {
+					guarded[g.obj] = true
+				}
+			}
+			checkEmit(pass, emit, bound, helperDecls, guarded, memo, paramGate)
+		}
+	}
+	for _, decl := range f.Decls {
+		if fd, ok := decl.(*ast.FuncDecl); ok && fd.Body != nil {
+			processBody(fd.Body)
+		}
+	}
+}
 
-	ast.Inspect(f, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
+// collectCondChecks finds check-named calls in an if condition, tracking
+// how many negations wrap each (the parity decides which arm is the
+// check's success arm).
+func collectCondChecks(pass *analysis.Pass, x ast.Expr, neg int, add func(call *ast.CallExpr, neg int)) {
+	switch e := x.(type) {
+	case *ast.ParenExpr:
+		collectCondChecks(pass, e.X, neg, add)
+	case *ast.UnaryExpr:
+		n := neg
+		if e.Op == token.NOT {
+			n++
+		}
+		collectCondChecks(pass, e.X, n, add)
+	case *ast.BinaryExpr:
+		collectCondChecks(pass, e.X, neg, add)
+		collectCondChecks(pass, e.Y, neg, add)
+	}
+	if call, ok := x.(*ast.CallExpr); ok && isCheckCall(pass, call.Fun) {
+		add(call, neg)
+	}
+}
+
+// bodyDiverges reports whether the block's control flow unconditionally
+// leaves the function or loop: a top-level return, panic, continue, or
+// os.Exit. Statements nested in inner conditionals do not count — their
+// other paths fall through.
+func bodyDiverges(pass *analysis.Pass, body *ast.BlockStmt) bool {
+	for _, st := range body.List {
+		switch s := st.(type) {
+		case *ast.ReturnStmt:
 			return true
-		}
-		formatIndex, ok := fmtCalls[qualifiedCallee(pass, call.Fun)]
-		if !ok || formatIndex >= len(call.Args) {
-			return true
-		}
-		format, ok := stringLiteralValue(pass, call.Args[formatIndex])
-		if !ok {
-			return true
-		}
-		for _, s := range scanSlots(format) {
-			argIndex := formatIndex + 1 + s.verbIndex
-			if argIndex >= len(call.Args) {
-				break
+		case *ast.BranchStmt:
+			if s.Tok == token.CONTINUE {
+				return true
 			}
-			if s.quoted {
-				continue // %q is the quoting mechanism in this slot's grammar
+		case *ast.ExprStmt:
+			if call, ok := s.X.(*ast.CallExpr); ok {
+				if id, ok := call.Fun.(*ast.Ident); ok && id.Name == "panic" {
+					return true
+				}
+				if qualifiedCallee(pass, call.Fun) == "os.Exit" {
+					return true
+				}
 			}
-			gated, fields := resolveArg(pass, call.Args[argIndex], bound, helperDecls, guarded, memo, paramGate, 0)
-			if gated || allInMemo(fields, memo) {
-				continue
-			}
-			pass.Reportf(call.Pos(),
-				"fmt format substitutes an ungated value into identifier slot %q of emitted code: a name carrying quotes, operators, or keywords changes what the emitted code does; validate it (isGoIdentifier/token.IsIdentifier) or quote it for that grammar",
-				s.text)
-			break // one report per call
 		}
-		return true
-	})
+	}
+	return false
+}
+
+// checkEmit scans one Sprintf-family call's format for identifier slots
+// and reports the first ungated one.
+func checkEmit(pass *analysis.Pass, call *ast.CallExpr, bound map[types.Object]ast.Expr, helperDecls map[*types.Func]*ast.FuncDecl, guarded map[types.Object]bool, memo map[string]bool, paramGate map[*types.Var]bool) {
+	formatIndex, ok := fmtCalls[qualifiedCallee(pass, call.Fun)]
+	if !ok || formatIndex >= len(call.Args) {
+		return
+	}
+	format, ok := stringLiteralValue(pass, call.Args[formatIndex])
+	if !ok {
+		return
+	}
+	for _, s := range scanSlots(format) {
+		argIndex := formatIndex + 1 + s.verbIndex
+		if argIndex >= len(call.Args) {
+			break
+		}
+		if s.quoted {
+			continue // %q is the quoting mechanism in this slot's grammar
+		}
+		gated, fields := resolveArg(pass, call.Args[argIndex], bound, helperDecls, guarded, memo, paramGate, 0)
+		if gated || allInMemo(fields, memo) {
+			continue
+		}
+		pass.Reportf(call.Pos(),
+			"fmt format substitutes an ungated value into identifier slot %q of emitted code: a name carrying quotes, operators, or keywords changes what the emitted code does; validate it (isGoIdentifier/token.IsIdentifier) or quote it for that grammar",
+			s.text)
+		break // one report per call
+	}
 }
 
 // ---- format scanning ----------------------------------------------------
@@ -360,22 +497,39 @@ func identSlotText(format string, i int, quoted bool) (string, bool) {
 	for _, kw := range []string{"func", "type", "var"} {
 		kwStart := pb - len(kw)
 		if kwStart >= 0 && strings.HasSuffix(lower[:pb], kw) && (kwStart == 0 || !isIdentByte(lower[kwStart-1])) {
-			// The keyword must start a code context, not English prose:
-			// at the format's start or after a code boundary
-			// (newline, tab, brace, paren, semicolon, colon, equals).
-			// "component type %s from another package" is prose.
-			if kwStart == 0 || strings.IndexByte("\n\t{;(:=", lower[kwStart-1]) >= 0 {
+			if kwStart == 0 {
+				// A format-INITIAL keyword is not evidence by itself:
+				// lowercase messages start with the same nouns
+				// ("type %s is not a struct"). Demand positive code
+				// evidence after the verb (declFollows).
+				if declFollows(format, after, kw) {
+					return kw + " " + format[b:after], true
+				}
+				continue
+			}
+			// After a code boundary (newline, tab, brace, paren,
+			// semicolon, colon, equals) the keyword alone is evidence:
+			// "component type %s from another package" is prose, but
+			// nothing but code follows a boundary.
+			if strings.IndexByte("\n\t{;(:=", lower[kwStart-1]) >= 0 {
 				return kw + " " + format[b:after], true
 			}
 		}
 	}
 
-	// SQL DDL identifier slots. %q here IS the quoting mechanism
-	// (SQLite/Postgres double-quoted identifiers).
+	// SQL identifier slots. %q here IS the quoting mechanism
+	// (SQLite/Postgres double-quoted identifiers). This is an anchored
+	// phrase list, declared as such: a statement shape outside it is
+	// silent until its phrase is added. The verb may complete an
+	// identifier the phrase began (`create index idx_%s`).
 	if !quoted {
 		for _, phrase := range []string{
 			"alter table ", "add column if not exists ", "add column ",
-			"create table if not exists ", "create table ", "drop table ",
+			"create table if not exists ", "create table ",
+			"drop table if exists ", "drop table ",
+			"create unique index ", "create index ", "drop index ",
+			"create view ", "create trigger ",
+			"insert or replace into ", "insert into ", "delete from ",
 			"pragma table_info(",
 		} {
 			if slotAfterPhrase(lower, i, phrase) {
@@ -384,31 +538,102 @@ func identSlotText(format string, i int, quoted bool) (string, bool) {
 		}
 	}
 
-	// CSS string slots inside an @font-face rule: any verb inside a
-	// single-quoted run opened after a colon or paren —
-	// `font-family: '%s'`, `url('%s/%s.woff2')`. An odd quote count alone
-	// would let an apostrophe in prose ("the app's fonts") open a run.
-	if !quoted && strings.Contains(lower, "@font-face") && strings.Count(lower[:i], "'")%2 == 1 { //gofastr:allow(GOFASTR1801) the analyzer names the CSS at-rule it inspects; no CSS is emitted here
+	// CSS string slots: any verb inside a single-quoted run opened as a
+	// CSS string — after a property name and colon (`content: '%s'`,
+	// `font-family: '%s'`) or inside a function call (`url('...')`).
+	// @font-face is only where these slots first appeared. The property
+	// prefix is what keeps an apostrophe in prose ("the app's fonts")
+	// from opening a run; an odd quote count alone would let one.
+	if !quoted && strings.Count(lower[:i], "'")%2 == 1 {
 		q := strings.LastIndexByte(lower[:i], '\'')
-		if q > 0 && (lower[q-1] == '(' || (lower[q-1] == ' ' && q >= 2 && lower[q-2] == ':')) {
+		if q > 0 && cssStringOpen(lower[:q]) {
 			return "'%s'", true
 		}
 	}
 
-	// Route path literals: `"/%s` (a quoted path whose first segment is
-	// the name) and the widget behavior URL shape.
-	if !quoted && i >= 2 && strings.HasPrefix(format[i-2:], "\"/") && b == i {
-		return `"/%s`, true
-	}
+	// The widget behavior URL shape, then route path literals generally:
+	// a verb that starts a path segment anywhere inside a double-quoted
+	// string beginning with "/" — `"/%s"` and `"/api/v1/%s"` alike; a
+	// deeper segment rewrites the route the same way the first does.
 	if !quoted && strings.Contains(lower, "/__gofastr/widget/") {
 		return "/__gofastr/widget/%s", true
+	}
+	if !quoted && b == i {
+		if q := strings.LastIndexByte(format[:i], '"'); q >= 0 && format[q+1] == '/' {
+			// The PATH portion only: a verb after '?' or '#' sits in
+			// the query string or fragment, a different grammar with a
+			// different escaper.
+			if frag := format[q:i]; !strings.ContainsAny(frag, "?#") {
+				return frag + "%s", true
+			}
+		}
 	}
 	return "", false
 }
 
+// declFollows reports whether the text after a format-initial
+// func/type/var keyword's identifier slot is positive evidence of a
+// declaration rather than prose: for func, a parenthesis immediately
+// after the identifier run plus a brace or newline later in the format
+// ("func %s(ctx context.Context) error {", not "func %s(ctx) was
+// replaced"); for type/var, the next word being struct/interface/map/
+// func/chan (or '*'/'[') or an assignment operator.
+func declFollows(format string, after int, kw string) bool {
+	rest := format[after:]
+	spaces := 0
+	for spaces < len(rest) && (rest[spaces] == ' ' || rest[spaces] == '\t') {
+		spaces++
+	}
+	rest = rest[spaces:]
+	switch kw {
+	case "func":
+		return strings.HasPrefix(rest, "(") &&
+			(strings.IndexByte(rest, '{') >= 0 || strings.IndexByte(rest, '\n') >= 0)
+	case "type", "var":
+		for _, t := range []string{"struct", "interface", "map", "func", "chan"} {
+			if strings.HasPrefix(rest, t) && (len(rest) == len(t) || !isIdentByte(rest[len(t)])) {
+				return true
+			}
+		}
+		return strings.HasPrefix(rest, "=") || strings.HasPrefix(rest, "[") ||
+			strings.HasPrefix(rest, "*") || (kw == "var" && strings.HasPrefix(rest, ":="))
+	}
+	return false
+}
+
+// cssStringOpen reports whether the text before a single quote opens a
+// CSS string: a property name then a colon (`content: '`), or an open
+// paren (`url('`).
+func cssStringOpen(before string) bool {
+	j := len(before)
+	for j > 0 && (before[j-1] == ' ' || before[j-1] == '\t') {
+		j--
+	}
+	if j == 0 {
+		return false
+	}
+	switch before[j-1] {
+	case '(':
+		return true
+	case ':':
+		n := 0
+		for j--; j > 0 && isPropByte(before[j-1]); j-- {
+			n++
+		}
+		return n > 0
+	}
+	return false
+}
+
+func isPropByte(c byte) bool {
+	return c >= 'a' && c <= 'z' || c >= '0' && c <= '9' || c == '-'
+}
+
 // slotAfterPhrase reports whether the verb at offset i is the identifier
-// slot directly following the given (lowercased) phrase, allowing only
-// spaces between.
+// slot directly following the given (lowercased) phrase: whitespace,
+// then optionally an identifier prefix the verb completes
+// (`create index idx_%s`). Prose words between phrase and verb (a word
+// followed by more space) disqualify the slot.
 func slotAfterPhrase(lower string, i int, phrase string) bool {
 	start := 0
 	for {
@@ -421,11 +646,26 @@ func slotAfterPhrase(lower string, i int, phrase string) bool {
 		if end > i {
 			return false
 		}
-		if strings.TrimRight(lower[end:i], " \t") == "" {
+		if gapOK(lower[end:i]) {
 			return true
 		}
 		start = p + 1
 	}
+}
+
+// gapOK reports whether the text between a phrase and its verb is only
+// whitespace followed by identifier bytes glued to the verb.
+func gapOK(s string) bool {
+	i := 0
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	for ; i < len(s); i++ {
+		if !isIdentByte(s[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 func isIdentByte(c byte) bool { return strings.IndexByte(identChars, c) >= 0 }
@@ -472,8 +712,8 @@ func resolveArg(pass *analysis.Pass, x ast.Expr, bound map[types.Object]ast.Expr
 		_, sub := resolveArg(pass, e.X, bound, helperDecls, guarded, memo, paramGate, depth+1)
 		collect(sub)
 		fields[e.Sel.Name] = true
-		if gateNameRe.MatchString(e.Sel.Name) {
-			return true, fields // quotedTable, safeIdent: self-describing
+		if treatedFieldRe.MatchString(e.Sel.Name) {
+			return true, fields // quotedTable, sanitizedSlot: the name states the VALUE'S TREATMENT
 		}
 		if literalField(pass, e, bound, helperDecls, depth) {
 			return true, fields // a field fixed to a literal: no input to smuggle

--- a/internal/analyzers/emitident/testdata/src/ei/ei.go
+++ b/internal/analyzers/emitident/testdata/src/ei/ei.go
@@ -162,6 +162,25 @@ func e8(d decl) string {
 	return fmt.Sprintf("func %s(ctx context.Context) error {\n", d.HandlerType) // want `identifier slot "func %s"`
 }
 
+// e9: a suffix on the emitted identifier — "func %sHandler(ctx
+// context.Context) error {" — is the same declaration slot; the
+// parenthesis follows the identifier RUN, not the verb.
+func e9(hook string) string {
+	return fmt.Sprintf("func %sHandler(ctx context.Context) error {\n", hook) // want `identifier slot "func %s"`
+}
+
+// e10: continue only skips the current iteration. The post-loop emit
+func e10(names []string, sb *strings.Builder) {
+	var n string
+	for _, n = range names {
+		if !isGoIdentifier(n) {
+			continue
+		}
+		fmt.Fprintf(sb, "func %s(ctx context.Context) error {\n", n)
+	}
+	fmt.Sprintf("func %s(ctx context.Context) error {\n", n) // want `identifier slot "func %s"`
+}
+
 // emitType/emitVar: format-initial declarations WITH code evidence
 // after the verb still fire.
 func emitType(name string) string {

--- a/internal/analyzers/emitident/testdata/src/ei/ei.go
+++ b/internal/analyzers/emitident/testdata/src/ei/ei.go
@@ -97,3 +97,77 @@ func renderPath(table string) string {
 func renderBehaviorURL(id string) string {
 	return fmt.Sprintf("data-behavior=\"/__gofastr/widget/%s.js\"", id) // want `identifier slot "/__gofastr/widget/%s"`
 }
+
+// ---- round 2: prose defenses and deeper slots -------------------------
+
+// e1/e2: a format-INITIAL keyword in a lowercase message is prose, not
+// a declaration — no positive code evidence after the verb.
+func e1(kind string) string {
+	return fmt.Sprintf("type %s is not a struct", kind)
+}
+
+func e2(fn string) string {
+	return fmt.Sprintf("func %s(ctx) was replaced by New; kept for compat", fn)
+}
+
+// e3: a deeper route segment rewrites the route the same way the
+// first one does.
+func e3(table string) string {
+	return fmt.Sprintf("path := \"/api/v1/%s\"\n", table) // want `identifier slot ".*/api/v1/%s"`
+}
+
+// e4/e5: index and INSERT identifier positions are the same breakout
+// slot the table spellings are.
+func e4(table string) string {
+	return fmt.Sprintf("CREATE INDEX idx_%s ON %s(col)", table, table) // want `identifier slot "create index %s"`
+}
+
+func e5(table string) string {
+	return fmt.Sprintf("INSERT INTO %s(a) VALUES (1)", table) // want `identifier slot "insert into %s"`
+}
+
+// e6: a CSS string slot outside @font-face — the quote-breakout works
+// identically in content.
+func e6(text string) string {
+	return fmt.Sprintf("a.hint::after { content: '%s' }", text) // want `identifier slot "'%s'"`
+}
+
+func isGoIdentifier(value string) bool {
+	for _, r := range value {
+		if !(r == '_' || r >= '0' && r <= '9' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z') {
+			return false
+		}
+	}
+	return value != ""
+}
+
+func warned(format string, args ...any) {}
+
+// e7: a check that only warns does not gate — warn-and-continue is
+// not rejection; the hostile name still reaches the Fprintf.
+func e7(sb *strings.Builder, hook string) {
+	if !isGoIdentifier(hook) {
+		warned("ignoring invalid hook name %q", hook)
+	}
+	fmt.Fprintf(sb, "func %s(ctx context.Context, data any) error {\n", hook) // want `identifier slot "func %s"`
+}
+
+// e8: a struct field whose NAME says type is not a gate — nothing
+// validated the value.
+type decl struct {
+	HandlerType string
+}
+
+func e8(d decl) string {
+	return fmt.Sprintf("func %s(ctx context.Context) error {\n", d.HandlerType) // want `identifier slot "func %s"`
+}
+
+// emitType/emitVar: format-initial declarations WITH code evidence
+// after the verb still fire.
+func emitType(name string) string {
+	return fmt.Sprintf("type %s struct {\n\tID string\n}\n", name) // want `identifier slot "type %s"`
+}
+
+func emitVar(name string) string {
+	return fmt.Sprintf("var %s = 1\n", name) // want `identifier slot "var %s"`
+}

--- a/internal/analyzers/emitident/testdata/src/eifix/eifix.go
+++ b/internal/analyzers/emitident/testdata/src/eifix/eifix.go
@@ -167,3 +167,31 @@ func callShape(kind, cond string) string {
 func apostropheProse(slot string) string {
 	return fmt.Sprintf("// fontFaceCSS holds the app's fonts.\nvar fontFaceCSS = style.FontFaceCSS(\"\"%s)\n", slot)
 }
+
+// renderHookStubSuccessArm: the emit sits inside the check's success
+// arm, so every path to it is dominated by the check — silent without
+// any diverging statement.
+func renderHookStubSuccessArm(sb *strings.Builder, h hook) {
+	handler := strings.TrimSpace(h.Handler)
+	if isGoIdentifier(handler) {
+		fmt.Sprintf("func %s(ctx context.Context) error {\n", handler)
+	}
+}
+
+// queryParamVerb: a verb after '?' parameterizes the query string, not
+// the path — a different grammar (QueryEscape), not scanned.
+func queryParamVerb(names string) string {
+	return fmt.Sprintf(`<link href="/__gofastr/comp-bundle.css?names=%s&v=%s">`, names, "1")
+}
+
+// quotedTableFixture: the treatment-named field gate. A store that
+// constructed the value through a quoting helper and named the field
+// for what was done to it (quoted/sanitized/escaped) is trusted; the
+// noun-named fields in package ei are not.
+type quotedTableFixture struct {
+	quotedTable string
+}
+
+func emitDDL(q quotedTableFixture) string {
+	return fmt.Sprintf(`DELETE FROM %s WHERE id = ?`, q.quotedTable)
+}

--- a/internal/analyzers/internal/dominance/dominance.go
+++ b/internal/analyzers/internal/dominance/dominance.go
@@ -132,12 +132,15 @@ func Spine(n ast.Node) []ast.Node {
 			out = append(out, x)
 			stmt(x.Init)
 			expr(x.Cond)
-			stmt(x.Post)
+			// x.Post is excluded: it runs only after a NORMAL
+			// iteration, so an immediate break reaches later
+			// statements without it.
 		case *ast.RangeStmt:
 			out = append(out, x)
 			expr(x.X)
-			expr(x.Key)
-			expr(x.Value)
+			// x.Key and x.Value are excluded: they are assigned (and
+			// their expressions evaluated) only when the range yields,
+			// so an empty range reaches later statements without them.
 		case *ast.SwitchStmt:
 			out = append(out, x)
 			stmt(x.Init)

--- a/internal/analyzers/internal/dominance/dominance.go
+++ b/internal/analyzers/internal/dominance/dominance.go
@@ -1,0 +1,216 @@
+// Package dominance provides the statement-dominance walk shared by
+// the analyzers under internal/analyzers: which statements and
+// conditions of a function body are guaranteed to execute before a
+// given node.
+//
+// Dominance here is lexical. A statement dominates node when it sits
+// in the same block before the statement holding node, or in an
+// enclosing block before the statement on the path down to node. A
+// comparison buried inside the body of a nested conditional of an
+// earlier statement (a flag-gated guard) dominates nothing: it runs
+// only when the branch is taken. The one exception in the other
+// direction: the Init and Cond of an enclosing if whose then-branch
+// holds node always ran by the time node executes, and the cond held.
+package dominance
+
+import "go/ast"
+
+// Parents maps every node in body to its parent node.
+func Parents(body ast.Node) map[ast.Node]ast.Node {
+	parents := map[ast.Node]ast.Node{}
+	var stack []ast.Node
+	ast.Inspect(body, func(n ast.Node) bool {
+		if n == nil {
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+			return true
+		}
+		if len(stack) > 0 {
+			parents[n] = stack[len(stack)-1]
+		}
+		stack = append(stack, n)
+		return true
+	})
+	return parents
+}
+
+// Prefix returns the statement lists that dominate node: for each
+// enclosing block (BlockStmt, case or comm clause) on the path from
+// node up to body, the statements before the one on the path.
+func Prefix(node ast.Node, parents map[ast.Node]ast.Node, body ast.Node) [][]ast.Stmt {
+	var out [][]ast.Stmt
+	cur := node
+	for {
+		p, ok := parents[cur]
+		if !ok || p == nil {
+			break
+		}
+		var stmts []ast.Stmt
+		switch b := p.(type) {
+		case *ast.BlockStmt:
+			stmts = b.List
+		case *ast.CaseClause:
+			stmts = b.Body
+		case *ast.CommClause:
+			stmts = b.Body
+		}
+		if stmts != nil {
+			for i, st := range stmts {
+				if st == cur || containsPath(st, node, parents) {
+					out = append(out, stmts[:i])
+					break
+				}
+			}
+		}
+		if p == body {
+			break
+		}
+		cur = p
+	}
+	return out
+}
+
+// EnclosingIfConds returns the conditions of the enclosing if
+// statements whose then-branch holds node: node executes only when
+// each such condition held, so a bound in one of them dominates.
+// Else-branches contribute nothing (they run when the condition is
+// false).
+func EnclosingIfConds(node ast.Node, parents map[ast.Node]ast.Node, body ast.Node) []ast.Expr {
+	var out []ast.Expr
+	cur := node
+	for {
+		p, ok := parents[cur]
+		if !ok || p == nil {
+			break
+		}
+		if iff, ok := p.(*ast.IfStmt); ok && cur == iff.Body && p != body && iff.Cond != nil {
+			out = append(out, iff.Cond)
+		}
+		if p == body {
+			break
+		}
+		cur = p
+	}
+	return out
+}
+
+// Spine returns the parts of n that execute whenever n is reached: for
+// an if, its Init and Cond; for loops and switches, their controlling
+// expressions; for plain statements, their expressions — never the
+// bodies of nested conditionals, select clauses, or function literals.
+// A comparison found by walking Spine of a dominating statement is a
+// dominating comparison; one found only inside a skipped body is not.
+func Spine(n ast.Node) []ast.Node {
+	var out []ast.Node
+	var expr func(ast.Node)
+	var stmt func(ast.Stmt)
+
+	expr = func(e ast.Node) {
+		if e == nil {
+			return
+		}
+		ast.Inspect(e, func(c ast.Node) bool {
+			if c == nil {
+				return true
+			}
+			if _, ok := c.(*ast.FuncLit); ok {
+				return false
+			}
+			out = append(out, c)
+			return true
+		})
+	}
+
+	stmt = func(s ast.Stmt) {
+		switch x := s.(type) {
+		case *ast.IfStmt:
+			out = append(out, x)
+			stmt(x.Init)
+			expr(x.Cond)
+		case *ast.ForStmt:
+			out = append(out, x)
+			stmt(x.Init)
+			expr(x.Cond)
+			stmt(x.Post)
+		case *ast.RangeStmt:
+			out = append(out, x)
+			expr(x.X)
+			expr(x.Key)
+			expr(x.Value)
+		case *ast.SwitchStmt:
+			out = append(out, x)
+			stmt(x.Init)
+			expr(x.Tag)
+		case *ast.TypeSwitchStmt:
+			out = append(out, x)
+			stmt(x.Init)
+			stmt(x.Assign)
+		case *ast.BlockStmt:
+			out = append(out, x)
+			for _, inner := range x.List {
+				stmt(inner)
+			}
+		case *ast.AssignStmt:
+			out = append(out, x)
+			for _, e := range x.Lhs {
+				expr(e)
+			}
+			for _, e := range x.Rhs {
+				expr(e)
+			}
+		case *ast.ExprStmt:
+			out = append(out, x)
+			expr(x.X)
+		case *ast.ReturnStmt:
+			out = append(out, x)
+			for _, e := range x.Results {
+				expr(e)
+			}
+		case *ast.DeferStmt:
+			out = append(out, x)
+			expr(x.Call)
+		case *ast.GoStmt:
+			out = append(out, x)
+			expr(x.Call)
+		case *ast.SendStmt:
+			out = append(out, x)
+			expr(x.Chan)
+			expr(x.Value)
+		case *ast.IncDecStmt:
+			out = append(out, x)
+			expr(x.X)
+		case *ast.DeclStmt:
+			out = append(out, x)
+			expr(x.Decl)
+		case *ast.LabeledStmt:
+			stmt(x.Stmt)
+		case nil:
+		default:
+			out = append(out, s)
+		}
+	}
+
+	if st, ok := n.(ast.Stmt); ok {
+		stmt(st)
+	} else {
+		expr(n)
+	}
+	return out
+}
+
+// containsPath reports whether node sits inside st per the parent map,
+// for when the path child is nested below statement level.
+func containsPath(st ast.Node, node ast.Node, parents map[ast.Node]ast.Node) bool {
+	for c := node; c != nil; {
+		p, ok := parents[c]
+		if !ok || p == nil {
+			return false
+		}
+		if p == st {
+			return true
+		}
+		c = p
+	}
+	return false
+}

--- a/internal/analyzers/intwrap/intwrap.go
+++ b/internal/analyzers/intwrap/intwrap.go
@@ -221,13 +221,13 @@ const (
 func dominatingBound(pass *analysis.Pass, node ast.Node, parents map[ast.Node]ast.Node, body *ast.BlockStmt, subj subject, family string) bool {
 	for _, stmts := range dominance.Prefix(node, parents, body) {
 		for _, st := range stmts {
-			if spineBounds(pass, dominance.Spine(st), subj, family) {
+			if spineBounds(pass, dominance.Spine(st), subj, family, false) {
 				return true
 			}
 		}
 	}
 	for _, cond := range dominance.EnclosingIfConds(node, parents, body) {
-		if spineBounds(pass, dominance.Spine(cond), subj, family) {
+		if spineBounds(pass, dominance.Spine(cond), subj, family, true) {
 			return true
 		}
 	}
@@ -237,20 +237,30 @@ func dominatingBound(pass *analysis.Pass, node ast.Node, parents map[ast.Node]as
 // spineBounds reports whether nodes compare obj against the bound
 // family: math.MaxInt/MaxInt32/MaxInt64 or math.MinInt/MinInt64
 // (resolved by import path, not spelling), or an integer literal of
-// bound size.
-func spineBounds(pass *analysis.Pass, nodes []ast.Node, subj subject, family string) bool {
+// bound size. thenBranch selects the comparison direction a condition
+// must have when the node sits in the if's THEN-branch: the condition
+// HELD there, so only operators that establish the safe range dominate
+// — u > math.MaxInt64 in the branch that converts selects exactly the
+// values that wrap. Statement positions (thenBranch false) keep the
+// early-return reading: `if u > math.MaxInt64 { return }` before the
+// node leaves only in-range values behind, whatever the operator.
+func spineBounds(pass *analysis.Pass, nodes []ast.Node, subj subject, family string, thenBranch bool) bool {
 	for _, n := range nodes {
 		bin, ok := n.(*ast.BinaryExpr)
 		if !ok || !isComparison(bin.Op) {
 			continue
 		}
 		var other ast.Expr
+		subjectOnLeft := matchesSubject(pass, bin.X, subj)
 		switch {
-		case matchesSubject(pass, bin.X, subj):
+		case subjectOnLeft:
 			other = bin.Y
 		case matchesSubject(pass, bin.Y, subj):
 			other = bin.X
 		default:
+			continue
+		}
+		if thenBranch && !establishesSafeRange(bin.Op, subjectOnLeft, family) {
 			continue
 		}
 		if isMathBound(pass, other, family) || isBoundLiteral(pass, other, family) {
@@ -258,6 +268,28 @@ func spineBounds(pass *analysis.Pass, nodes []ast.Node, subj subject, family str
 		}
 	}
 	return false
+}
+
+// establishesSafeRange reports whether the comparison, held TRUE in an
+// enclosing if's then-branch, puts the subject inside the safe range
+// for the family: at most the max bound (equality fits exactly), or
+// strictly above the min bound (equality is MinInt, which still wraps
+// under negation).
+func establishesSafeRange(op token.Token, subjectOnLeft bool, family string) bool {
+	if family == boundMax {
+		switch {
+		case subjectOnLeft:
+			return op == token.LSS || op == token.LEQ || op == token.EQL
+		default:
+			return op == token.GTR || op == token.GEQ || op == token.EQL
+		}
+	}
+	switch {
+	case subjectOnLeft:
+		return op == token.GTR
+	default:
+		return op == token.LSS
+	}
 }
 
 func isMathBound(pass *analysis.Pass, e ast.Expr, family string) bool {

--- a/internal/analyzers/intwrap/intwrap.go
+++ b/internal/analyzers/intwrap/intwrap.go
@@ -17,9 +17,13 @@
 //
 // A bound counts only when it DOMINATES the conversion: it must sit in
 // the same block, or an enclosing block, before the statement holding
-// the conversion. A check in a sibling case arm of the same type switch
-// guards nothing — that is exactly how the uint arm shipped without the
-// check its uint64 sibling had.
+// the conversion — inspected only over the parts of that statement
+// that always execute — or be the condition of an enclosing if whose
+// then-branch holds the conversion. A check in a sibling case arm of
+// the same type switch guards nothing — that is exactly how the uint
+// arm shipped without the check its uint64 sibling had — and neither
+// does a check inside a flag-gated nested body of an earlier
+// statement.
 //
 // Silent postures, deliberately:
 //   - uint8/uint16 sources: they fit every signed target this rule
@@ -34,13 +38,14 @@
 //   - _test.go files.
 //
 // Narrowed 2026-09-02 after the whole-repo run: both shapes fire only
-// when the operand is a case variable of a type switch over an
-// any/empty-interface tag — the genuinely unbounded source. Every
-// other hit in the repo was semantically bounded by its caller (Unix
-// seconds, read-capped frame lengths, float exponents ≤ 324, counter
-// values, ULID timestamps ≤ 2^48, generated hex ids), and the only
-// unbounded one — core/i18n's JSON number coercion — was any-boxed,
-// exactly the toInt64 shape.
+// when the operand is unboxed from an any/empty-interface — a case
+// variable of a type switch over one, or the value variable of a
+// comma-ok assertion from one (`if u, ok := box.(uint64); ok`) — the
+// genuinely unbounded sources. Every other hit in the repo was
+// semantically bounded by its caller (Unix seconds, read-capped frame
+// lengths, float exponents ≤ 324, counter values, ULID timestamps ≤
+// 2^48, generated hex ids), and the only unbounded one — core/i18n's
+// JSON number coercion — was any-boxed, exactly the toInt64 shape.
 package intwrap
 
 import (
@@ -51,6 +56,8 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
+
+	"github.com/DonaldMurillo/gofastr/internal/analyzers/internal/dominance"
 )
 
 var Analyzer = &analysis.Analyzer{
@@ -69,9 +76,9 @@ func run(pass *analysis.Pass) (any, error) {
 			if !ok || fn.Body == nil {
 				continue
 			}
-			parents := recordParents(fn.Body)
+			parents := dominance.Parents(fn.Body)
 			abs := isAbsFunc(fn)
-			anyVars := anySwitchVars(pass, fn.Body)
+			anyVars := unboundedSources(pass, fn.Body)
 			ast.Inspect(fn.Body, func(n ast.Node) bool {
 				switch x := n.(type) {
 				case *ast.CallExpr:
@@ -126,7 +133,7 @@ func checkUnsignedConv(pass *analysis.Pass, call *ast.CallExpr, parents map[ast.
 		return // the compiler rejects out-of-range constant conversions
 	}
 	if !anyVars[obj] {
-		return // bounded source: narrowed 2026-09-02, see anySwitchVars
+		return // bounded source: narrowed 2026-09-02, see unboundedSources
 	}
 	src, ok := pass.TypesInfo.TypeOf(arg).Underlying().(*types.Basic)
 	if !ok || src.Info()&types.IsUnsigned == 0 {
@@ -159,7 +166,7 @@ func checkAbsNeg(pass *analysis.Pass, un *ast.UnaryExpr, parents map[ast.Node]as
 	}
 	subj := subjectOf(pass, un.X)
 	if subj.str == "" || subj.obj == nil || !anyVars[subj.obj] {
-		return // narrowed 2026-09-02 to unbounded sources; see anySwitchVars
+		return // narrowed 2026-09-02 to unbounded sources; see unboundedSources
 	}
 	if dominatingBound(pass, un, parents, body, subj, boundMin) {
 		return
@@ -207,79 +214,35 @@ const (
 // dominatingBound reports whether node is dominated by a comparison of
 // obj against a bound: the comparison must sit in the same block as the
 // node, or an enclosing block, in a statement before the one holding
-// the node. Sibling branches (other case arms) guard nothing.
+// the node — inspected only over the parts of that statement that
+// always execute — or be the condition of an enclosing if whose
+// then-branch holds the node. Sibling branches (other case arms) and
+// flag-gated nested bodies guard nothing.
 func dominatingBound(pass *analysis.Pass, node ast.Node, parents map[ast.Node]ast.Node, body *ast.BlockStmt, subj subject, family string) bool {
-	for _, stmts := range dominatingPrefix(node, parents, body) {
+	for _, stmts := range dominance.Prefix(node, parents, body) {
 		for _, st := range stmts {
-			if stmtBounds(pass, st, subj, family) {
+			if spineBounds(pass, dominance.Spine(st), subj, family) {
 				return true
 			}
 		}
 	}
-	return false
-}
-
-// dominatingPrefix returns the statement lists that dominate node: for
-// each enclosing block (BlockStmt / case or comm clause), the
-// statements before the one on the path down to node.
-func dominatingPrefix(node ast.Node, parents map[ast.Node]ast.Node, body *ast.BlockStmt) [][]ast.Stmt {
-	var out [][]ast.Stmt
-	cur := node
-	for {
-		p, ok := parents[cur]
-		if !ok || p == nil {
-			break
-		}
-		var stmts []ast.Stmt
-		switch b := p.(type) {
-		case *ast.BlockStmt:
-			stmts = b.List
-		case *ast.CaseClause:
-			stmts = b.Body
-		case *ast.CommClause:
-			stmts = b.Body
-		}
-		if stmts != nil {
-			for i, st := range stmts {
-				if st == cur || containsPath(st, node, parents) {
-					out = append(out, stmts[:i])
-					break
-				}
-			}
-		}
-		if p == body {
-			break
-		}
-		cur = p
-	}
-	return out
-}
-
-// containsPath reports whether node sits inside st per the parent map,
-// for when the path child is nested below statement level.
-func containsPath(st ast.Node, node ast.Node, parents map[ast.Node]ast.Node) bool {
-	for c := node; c != nil; {
-		p, ok := parents[c]
-		if !ok || p == nil {
-			return false
-		}
-		if p == st {
+	for _, cond := range dominance.EnclosingIfConds(node, parents, body) {
+		if spineBounds(pass, dominance.Spine(cond), subj, family) {
 			return true
 		}
-		c = p
 	}
 	return false
 }
 
-// stmtBounds reports whether st compares obj against the bound family:
-// math.MaxInt/MaxInt32/MaxInt64 or math.MinInt/MinInt64 (resolved by
-// import path, not spelling), or an integer literal of bound size.
-func stmtBounds(pass *analysis.Pass, st ast.Stmt, subj subject, family string) bool {
-	found := false
-	ast.Inspect(st, func(n ast.Node) bool {
+// spineBounds reports whether nodes compare obj against the bound
+// family: math.MaxInt/MaxInt32/MaxInt64 or math.MinInt/MinInt64
+// (resolved by import path, not spelling), or an integer literal of
+// bound size.
+func spineBounds(pass *analysis.Pass, nodes []ast.Node, subj subject, family string) bool {
+	for _, n := range nodes {
 		bin, ok := n.(*ast.BinaryExpr)
 		if !ok || !isComparison(bin.Op) {
-			return true
+			continue
 		}
 		var other ast.Expr
 		switch {
@@ -288,14 +251,13 @@ func stmtBounds(pass *analysis.Pass, st ast.Stmt, subj subject, family string) b
 		case matchesSubject(pass, bin.Y, subj):
 			other = bin.X
 		default:
-			return true
+			continue
 		}
 		if isMathBound(pass, other, family) || isBoundLiteral(pass, other, family) {
-			found = true
+			return true
 		}
-		return true
-	})
-	return found
+	}
+	return false
 }
 
 func isMathBound(pass *analysis.Pass, e ast.Expr, family string) bool {
@@ -386,27 +348,50 @@ func isIdentObj(pass *analysis.Pass, e ast.Expr, obj types.Object) bool {
 	return ok && pass.TypesInfo.ObjectOf(id) == obj
 }
 
-// recordParents maps every node in the body to its parent node.
-func recordParents(body ast.Node) map[ast.Node]ast.Node {
-	parents := map[ast.Node]ast.Node{}
-	var visit func(n ast.Node)
-	visit = func(n ast.Node) {
-		if n == nil {
-			return
-		}
-		ast.Inspect(n, func(c ast.Node) bool {
-			if c == n {
-				return true
-			}
-			if c != nil {
-				parents[c] = n
-				visit(c)
-			}
-			return false
-		})
+// unboundedSources collects the objects of the genuinely unbounded
+// operands: case variables of a type switch over an any/empty-interface
+// tag (anySwitchVars), and the value variables of comma-ok assertions
+// from one (anyAssertVars) — the same JSON-box value obtained with
+// `if u, ok := box.(uint64); ok` instead of a switch arm. A conversion
+// or negation of a plain int parameter is usually semantically bounded
+// by its caller (Unix seconds, frame lengths under a read cap, float
+// exponents ≤ 324), and the 2026-09-02 whole-repo run measured exactly
+// that: every non-any-boxed hit was bounded, the only unbounded one
+// (core/i18n's JSON number coercion) was any-boxed.
+func unboundedSources(pass *analysis.Pass, body *ast.BlockStmt) map[types.Object]bool {
+	out := anySwitchVars(pass, body)
+	for obj := range anyAssertVars(pass, body) {
+		out[obj] = true
 	}
-	visit(body)
-	return parents
+	return out
+}
+
+// anyAssertVars collects the value variables of comma-ok type
+// assertions whose operand has an empty-interface type.
+func anyAssertVars(pass *analysis.Pass, body *ast.BlockStmt) map[types.Object]bool {
+	out := map[types.Object]bool{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		st, ok := n.(*ast.AssignStmt)
+		if !ok || len(st.Lhs) != 2 || len(st.Rhs) != 1 {
+			return true
+		}
+		ta, ok := st.Rhs[0].(*ast.TypeAssertExpr)
+		if !ok || ta.Type == nil {
+			return true // `x.(type)` or a single-value assert
+		}
+		if t := pass.TypesInfo.TypeOf(ta.X); t == nil {
+			return true
+		} else if iface, ok := t.Underlying().(*types.Interface); !ok || iface.NumMethods() != 0 {
+			return true
+		}
+		if id, ok := st.Lhs[0].(*ast.Ident); ok && id.Name != "_" {
+			if obj := pass.TypesInfo.ObjectOf(id); obj != nil {
+				out[obj] = true
+			}
+		}
+		return true
+	})
+	return out
 }
 
 // anySwitchVars collects the objects of case variables whose type

--- a/internal/analyzers/intwrap/intwrap_test.go
+++ b/internal/analyzers/intwrap/intwrap_test.go
@@ -9,5 +9,5 @@ import (
 )
 
 func TestIntWrap(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), intwrap.Analyzer, "a", "b", "c")
+	analysistest.Run(t, analysistest.TestData(), intwrap.Analyzer, "a", "b", "c", "d")
 }

--- a/internal/analyzers/intwrap/testdata/src/d/d.go
+++ b/internal/analyzers/intwrap/testdata/src/d/d.go
@@ -79,3 +79,31 @@ func nestedGuardFixed(box any, strict bool) (int64, bool) {
 	}
 	return 0, false
 }
+
+// wrongDirectionBound: the then-branch holds exactly the values that
+// WRAP — u > math.MaxInt64 selects them — so a comparison that does
+// not establish the safe range dominates nothing. Only u < / u <= /
+// u == the bound (mirrored when the subject is on the right) count in
+// a branch the conversion sits in.
+func wrongDirectionBound(box any) int64 {
+	if u, ok := box.(uint64); ok && u > math.MaxInt64 {
+		return int64(u) // want `conversion uint64 → int64 without a dominating bound check`
+	}
+	return 0
+}
+
+// postBoundBreaks: the bound comparison sits in the loop's Post — it
+// runs only after a normal iteration, and the immediate break skips
+// it, so the conversion after the loop sees the unbounded value.
+func postBoundBreaks(box any, flags map[bool]uint64) int64 {
+	u, ok := box.(uint64)
+	if !ok {
+		return 0
+	}
+	for i := 0; i < 3; i, u = i+1, flags[u <= math.MaxInt64] {
+		if i == 0 {
+			break
+		}
+	}
+	return int64(u) // want `conversion uint64 → int64 without a dominating bound check`
+}

--- a/internal/analyzers/intwrap/testdata/src/d/d.go
+++ b/internal/analyzers/intwrap/testdata/src/d/d.go
@@ -1,0 +1,81 @@
+// Package d holds the intwrap spellings the 2026-09-02 adversarial
+// review showed were missing or mis-scoped: comma-ok assertions from
+// an any box (as unbounded as a type-switch case variable), and
+// bounds that sit inside a nested conditional body of an earlier
+// statement.
+package d
+
+import "math"
+
+// coerceComma: a comma-ok assertion from an any is the same unbounded
+// JSON-box value the type-switch arm is.
+func coerceComma(box any) (int64, bool) {
+	if u, ok := box.(uint64); ok {
+		return int64(u), true // want `conversion uint64 → int64 without a dominating bound check`
+	}
+	return 0, false
+}
+
+// coerceCommaFixed bounds before converting.
+func coerceCommaFixed(box any) (int64, bool) {
+	if u, ok := box.(uint64); ok && u <= math.MaxInt64 {
+		return int64(u), true
+	}
+	return 0, false
+}
+
+// absComma negates a comma-ok asserted int64: MinInt64 wraps.
+func absComma(box any) int64 {
+	if v, ok := box.(int64); ok && v < 0 {
+		return -v // want `negation of v in an abs without a MinInt check`
+	}
+	if v, ok := box.(int64); ok {
+		return v
+	}
+	return 0
+}
+
+// absCommaFixed saturates at the magnitude limit.
+func absCommaFixed(box any) int64 {
+	if v, ok := box.(int64); ok {
+		if v == math.MinInt64 {
+			return math.MaxInt64
+		}
+		if v < 0 {
+			return -v
+		}
+		return v
+	}
+	return 0
+}
+
+// nestedGuard: the bound check runs only when strict is set — the
+// conversion still wraps with strict=false.
+func nestedGuard(box any, strict bool) (int64, bool) {
+	switch n := box.(type) {
+	case uint64:
+		if strict {
+			if n > math.MaxInt64 {
+				return 0, false
+			}
+		}
+		return int64(n), true // want `conversion uint64 → int64 without a dominating bound check`
+	}
+	return 0, false
+}
+
+// nestedGuardFixed hoists the bound out of the flag-gated branch: now
+// it dominates every path to the conversion.
+func nestedGuardFixed(box any, strict bool) (int64, bool) {
+	switch n := box.(type) {
+	case uint64:
+		if n > math.MaxInt64 {
+			return 0, false
+		}
+		if strict {
+			return int64(n), true
+		}
+		return 0, true
+	}
+	return 0, false
+}

--- a/internal/analyzers/laxcoerce/laxcoerce.go
+++ b/internal/analyzers/laxcoerce/laxcoerce.go
@@ -1,7 +1,7 @@
 // Package laxcoerce catches a wrong type masquerading as absence: a
-// comma-ok type assertion on a map[string]any entry whose failure branch
-// returns zero values with a nil error — or continues — as though the key
-// had never been sent.
+// comma-ok type assertion on a map[string]any entry whose failure path
+// returns zero values with a nil error — or continues — as though the
+// key had never been sent.
 //
 // The bug class: MCP tool args / JSON payloads arrive as
 // map[string]any, and `v, ok := m[k].(T)` collapses two distinct states —
@@ -12,26 +12,41 @@
 // supplied", so the response quietly contained the unfiltered window
 // while the agent believed it had narrowed the search.
 //
+// The failure path is collected in every spelling: the then-branch of
+// `if !ok`, the else of a bare `if ok`, the statements after a bare
+// `if ok` with no else (the early-return fall-through), the body of a
+// `case !ok:` clause, and the !ok branch that rebinds the asserted
+// variable to its zero value and falls through. Each function literal
+// is judged by its own pass with its own error-result flag.
+//
 // Silent postures, deliberately:
 //   - a !ok branch that returns or assigns a value of error type: the
 //     wrong type is surfaced, not swallowed (the fix posture);
 //   - the function already separates presence from type with a comma-ok
-//     map index (`v, present := m[k]`) on the same map;
+//     map index (`v, present := m[k]`) — for a literal key, on the
+//     same (map, key); checking one key's presence says nothing about
+//     another's, so the silence is per key. For a non-literal key the
+//     whole map is taken, the pre-2026-09-02 posture: the function has
+//     demonstrated it knows the distinction on this map;
 //   - maps whose element type is not any/empty interface — a typed map
 //     cannot hold a wrong type, so !ok genuinely means absent;
-//   - zero returns in functions with no error result: no channel exists
-//     to surface the problem, and the shape here is the nil error that
-//     says "fine" when it is not fine;
+//   - zero returns in functions with no error result (including
+//     closures inside one that has): no channel exists to surface the
+//     problem, and the shape here is the nil error that says "fine"
+//     when it is not fine;
 //   - _test.go files.
 package laxcoerce
 
 import (
 	"go/ast"
+	"go/constant"
 	"go/token"
 	"go/types"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
+
+	"github.com/DonaldMurillo/gofastr/internal/analyzers/internal/dominance"
 )
 
 var Analyzer = &analysis.Analyzer{
@@ -58,7 +73,10 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
-// checkFunc examines one function body.
+// checkFunc examines one function body. Nested function literals are
+// cut here and judged by their own invocation from run, with their own
+// error-result flag: descending with the outer flag misattributes
+// reports (or silences) to a function that has no such channel.
 func checkFunc(pass *analysis.Pass, fnType *ast.FuncType, body *ast.BlockStmt) {
 	if body == nil {
 		return
@@ -76,13 +94,21 @@ func checkFunc(pass *analysis.Pass, fnType *ast.FuncType, body *ast.BlockStmt) {
 	// the local resolves back to the map access.
 	bound := map[types.Object]ast.Expr{}
 	// Maps that already get a comma-ok index (`v, present := m[k]`)
-	// somewhere in this function: presence is separated from type there.
-	present := map[string]bool{}
+	// somewhere in this function: presence is separated from type
+	// there. With a literal key the separation is recorded per
+	// (map, key) — checking "fmt" says nothing about "region"; with a
+	// non-literal key the map itself is recorded, the pre-2026-09-02
+	// posture.
+	presentByKey := map[presenceKey]bool{}
+	presentByMap := map[string]bool{}
 
 	var asserts []*ast.AssignStmt
 	var assertOK []types.Object
 
 	ast.Inspect(body, func(n ast.Node) bool {
+		if _, isLit := n.(*ast.FuncLit); isLit {
+			return false // nested closures get their own checkFunc pass
+		}
 		st, ok := n.(*ast.AssignStmt)
 		if !ok {
 			return true
@@ -101,7 +127,11 @@ func checkFunc(pass *analysis.Pass, fnType *ast.FuncType, body *ast.BlockStmt) {
 		switch rhs := st.Rhs[0].(type) {
 		case *ast.IndexExpr:
 			if m := mapOperand(pass, rhs.X); m != "" {
-				present[m] = true
+				if key, ok := literalKey(pass, rhs.Index); ok {
+					presentByKey[presenceKey{m: m, key: key}] = true
+				} else {
+					presentByMap[m] = true
+				}
 			}
 		case *ast.TypeAssertExpr:
 			asserts = append(asserts, st)
@@ -123,14 +153,25 @@ func checkFunc(pass *analysis.Pass, fnType *ast.FuncType, body *ast.BlockStmt) {
 			continue
 		}
 		m := mapOperand(pass, idx.X)
-		if m == "" || present[m] {
+		if m == "" {
+			continue
+		}
+		if key, isLit := literalKey(pass, idx.Index); isLit {
+			if presentByKey[presenceKey{m: m, key: key}] {
+				continue
+			}
+		} else if presentByMap[m] {
 			continue
 		}
 		if assertOK[i] == nil {
 			continue
 		}
+		var asserted types.Object
+		if id, ok := st.Lhs[0].(*ast.Ident); ok && id.Name != "_" {
+			asserted = pass.TypesInfo.ObjectOf(id)
+		}
 		for _, br := range notOKBranches(pass, body, assertOK[i]) {
-			if branchIsLax(pass, br, hasErrorResult) {
+			if branchIsLax(pass, br, hasErrorResult, asserted) {
 				pass.Reportf(st.Pos(),
 					"type assertion on %s treated as absence: a key present with the wrong type falls into the not-found branch and silently drops the caller's input; separate presence (v, present := m[k]) or return an error",
 					m)
@@ -139,6 +180,23 @@ func checkFunc(pass *analysis.Pass, fnType *ast.FuncType, body *ast.BlockStmt) {
 		}
 	}
 }
+
+// literalKey returns the value of a string basic literal, or false for
+// every other key expression.
+func literalKey(pass *analysis.Pass, e ast.Expr) (string, bool) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	if tv, ok := pass.TypesInfo.Types[lit]; ok && tv.Value != nil {
+		return tv.Value.ExactString(), true
+	}
+	return lit.Value, true
+}
+
+// presenceKey identifies a (map, string-literal key) pair whose
+// presence was separated from type.
+type presenceKey struct{ m, key string }
 
 // mapOperand returns a stable identity for a map[string]any expression —
 // its printed form — or "" when the expression is not such a map. Only
@@ -182,11 +240,17 @@ func okVar(pass *analysis.Pass, e ast.Expr) types.Object {
 
 // notOKBranches returns the branch bodies that execute when the comma-ok
 // variable is false: the then-branch of `if !ok ...` (in any boolean
-// combination), and the else-branch of a bare `if ok`.
+// combination), the else-branch of a bare `if ok`, the fall-through
+// statements after a bare `if ok` with no else, and the body of a
+// `case !ok:` / `switch ok { case false: }` clause.
 func notOKBranches(pass *analysis.Pass, body *ast.BlockStmt, okObj types.Object) []*ast.BlockStmt {
+	parents := dominance.Parents(body)
 	var out []*ast.BlockStmt
 	ast.Inspect(body, func(n ast.Node) bool {
-		if st, ok := n.(*ast.IfStmt); ok {
+		switch st := n.(type) {
+		case *ast.FuncLit:
+			return false // closures carry their own ok variables, or none
+		case *ast.IfStmt:
 			if mentionsNotOK(pass, st.Cond, okObj) {
 				out = append(out, st.Body)
 			}
@@ -195,10 +259,91 @@ func notOKBranches(pass *analysis.Pass, body *ast.BlockStmt, okObj types.Object)
 					out = append(out, els)
 				}
 			}
+			// A bare `if ok` (or `ok && …`) with no else: the statements
+			// after it in its enclosing block are the not-ok path — the
+			// early-return layout's other half.
+			if st.Else == nil && mentionsOK(pass, st.Cond, okObj) {
+				if ft := fallThroughRegion(parents, st); ft != nil {
+					out = append(out, ft)
+				}
+			}
+		case *ast.SwitchStmt:
+			for _, cc := range st.Body.List {
+				clause, ok := cc.(*ast.CaseClause)
+				if !ok {
+					continue
+				}
+				for _, e := range clause.List {
+					if mentionsNotOK(pass, e, okObj) ||
+						(st.Tag != nil && isIdentObj(pass, st.Tag, okObj) && isFalse(e)) {
+						out = append(out, &ast.BlockStmt{List: clause.Body})
+						break
+					}
+				}
+			}
 		}
 		return true
 	})
 	return out
+}
+
+// mentionsOK reports whether the condition asserts the comma-ok
+// variable positively: the bare `ok` ident, or a conjunction
+// (`ok && …`) whose fall-through includes !ok.
+func mentionsOK(pass *analysis.Pass, cond ast.Expr, okObj types.Object) bool {
+	switch c := cond.(type) {
+	case *ast.Ident:
+		return isIdentObj(pass, c, okObj)
+	case *ast.ParenExpr:
+		return mentionsOK(pass, c.X, okObj)
+	case *ast.BinaryExpr:
+		return c.Op == token.LAND &&
+			(mentionsOK(pass, c.X, okObj) || mentionsOK(pass, c.Y, okObj))
+	default:
+		return false
+	}
+}
+
+// fallThroughRegion returns the statements after st in its enclosing
+// block, up to and including the first one that diverges: the prefix
+// an !ok execution falls into.
+func fallThroughRegion(parents map[ast.Node]ast.Node, st *ast.IfStmt) *ast.BlockStmt {
+	blk, ok := parents[st].(*ast.BlockStmt)
+	if !ok {
+		return nil
+	}
+	idx := -1
+	for i, s := range blk.List {
+		if s == st {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return nil
+	}
+	var list []ast.Stmt
+	for _, s := range blk.List[idx+1:] {
+		list = append(list, s)
+		if diverges(s) {
+			break
+		}
+	}
+	return &ast.BlockStmt{List: list}
+}
+
+func diverges(s ast.Stmt) bool {
+	switch x := s.(type) {
+	case *ast.ReturnStmt, *ast.BranchStmt:
+		return true
+	case *ast.ExprStmt:
+		if call, ok := x.X.(*ast.CallExpr); ok {
+			if id, ok := call.Fun.(*ast.Ident); ok && id.Name == "panic" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // mentionsNotOK reports whether the condition is, or contains as a
@@ -239,53 +384,145 @@ func isFalse(e ast.Expr) bool {
 
 // branchIsLax reports whether the !ok branch silently swallows the wrong
 // type: it continues, or (in a function with an error result to speak
-// through) returns without any operand carrying an error.
-func branchIsLax(pass *analysis.Pass, br *ast.BlockStmt, hasErrorResult bool) bool {
-	lax := false
+// through) returns without any operand carrying an error — counting
+// only statements at the branch's own top level, since a lax statement
+// nested under another condition executes only when that condition
+// holds; or neither diverges nor records an error but rebinds the
+// asserted variable to its zero value and falls through.
+func branchIsLax(pass *analysis.Pass, br *ast.BlockStmt, hasErrorResult bool, asserted types.Object) bool {
+	// An error surfaced or recorded anywhere in the branch — nested or
+	// not — precludes laxness.
+	surfaced := false
 	ast.Inspect(br, func(n ast.Node) bool {
+		if surfaced {
+			return false
+		}
 		switch st := n.(type) {
-		case *ast.BranchStmt:
-			if st.Tok == token.CONTINUE {
-				lax = true
-			}
+		case *ast.FuncLit:
+			return false // the closure's returns are not this branch's
 		case *ast.ReturnStmt:
-			if !hasErrorResult {
-				return true
-			}
-			if len(st.Results) == 0 {
-				// Bare return: the named error result holds whatever the
-				// branch left it, which is nil unless an error was
-				// assigned before the return.
-				lax = true
-			}
 			for _, res := range st.Results {
 				if carriesError(pass, res) {
-					return false // error surfaced: not lax
+					surfaced = true
+					return false
 				}
-			}
-			if len(st.Results) > 0 {
-				lax = true
 			}
 		case *ast.AssignStmt:
 			for _, rhs := range st.Rhs {
 				if carriesError(pass, rhs) {
-					return false // an error is recorded: not lax
+					surfaced = true
+					return false
 				}
 			}
 		}
 		return true
 	})
-	return lax
+	if surfaced {
+		return false
+	}
+	diverges := false
+	for _, st := range br.List {
+		switch x := st.(type) {
+		case *ast.ReturnStmt:
+			diverges = true
+			if !hasErrorResult {
+				continue
+			}
+			if len(x.Results) == 0 {
+				// Bare return: the named error result holds whatever the
+				// branch left it, which is nil unless an error was
+				// assigned before the return.
+				return true
+			}
+			for _, res := range x.Results {
+				if carriesError(pass, res) {
+					return false // error surfaced: not lax
+				}
+			}
+			return true
+		case *ast.BranchStmt:
+			diverges = true
+			if x.Tok == token.CONTINUE {
+				return true
+			}
+		case *ast.ExprStmt:
+			if call, ok := x.X.(*ast.CallExpr); ok {
+				if id, ok := call.Fun.(*ast.Ident); ok && id.Name == "panic" {
+					diverges = true
+				}
+			}
+		}
+	}
+	// A branch that neither diverges nor records an error, but rebinds
+	// the asserted variable to its zero value, falls through with the
+	// wrong type already erased — the zero default reads as "not
+	// supplied" while the nil error says fine.
+	return !diverges && hasErrorResult && zeroesAsserted(pass, br, asserted)
+}
+
+// zeroesAsserted reports whether the branch assigns the asserted
+// variable a zero literal (0, "", false).
+func zeroesAsserted(pass *analysis.Pass, br *ast.BlockStmt, asserted types.Object) bool {
+	if asserted == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(br, func(n ast.Node) bool {
+		st, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for i, lhs := range st.Lhs {
+			id, ok := lhs.(*ast.Ident)
+			if !ok || pass.TypesInfo.ObjectOf(id) != asserted {
+				continue
+			}
+			if i < len(st.Rhs) && isZeroLiteral(pass, st.Rhs[i]) {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// isZeroLiteral reports whether e is the constant zero of its type.
+func isZeroLiteral(pass *analysis.Pass, e ast.Expr) bool {
+	tv, ok := pass.TypesInfo.Types[e]
+	if !ok || tv.Value == nil {
+		return false
+	}
+	switch tv.Value.Kind() {
+	case constant.Int:
+		return tv.Value.ExactString() == "0"
+	case constant.String:
+		return tv.Value.ExactString() == `""`
+	case constant.Bool:
+		return !constant.BoolVal(tv.Value)
+	}
+	return false
 }
 
 // carriesError reports whether e is a non-nil value of error type: the
-// wrong type is being surfaced rather than swallowed.
+// wrong type is being surfaced rather than swallowed. A multi-value
+// call return carries an error when any result does (`return
+// t.Render(...)`, where the call's second result is the error).
 func carriesError(pass *analysis.Pass, e ast.Expr) bool {
 	if id, ok := e.(*ast.Ident); ok && id.Name == "nil" {
 		return false
 	}
 	t := pass.TypesInfo.TypeOf(e)
 	if t == nil {
+		return false
+	}
+	if tup, ok := t.(*types.Tuple); ok {
+		for i := range tup.Len() {
+			et := tup.At(i).Type()
+			if types.Implements(et, errorIface) || types.Identical(et, errorIface) {
+				return true
+			}
+		}
 		return false
 	}
 	return types.Implements(t, errorIface) || types.Identical(t, errorIface)

--- a/internal/analyzers/laxcoerce/laxcoerce_test.go
+++ b/internal/analyzers/laxcoerce/laxcoerce_test.go
@@ -9,5 +9,5 @@ import (
 )
 
 func TestLaxCoerce(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), laxcoerce.Analyzer, "a", "b", "c")
+	analysistest.Run(t, analysistest.TestData(), laxcoerce.Analyzer, "a", "b", "c", "d")
 }

--- a/internal/analyzers/laxcoerce/testdata/src/d/d.go
+++ b/internal/analyzers/laxcoerce/testdata/src/d/d.go
@@ -6,6 +6,8 @@
 // another.
 package d
 
+import "errors"
+
 // fallThrough: with no else, the statements after `if ok` ARE the
 // not-ok path; a wrong-typed value lands in the nil-error return and
 // reads as "not supplied".
@@ -104,4 +106,46 @@ func presentSameKey(m map[string]any) (string, error) {
 		return "", nil // wrong type surfaces as absence-by-design here
 	}
 	return region, nil
+}
+
+// ---- silent counterparts of the not-ok forms ----------------------------
+
+// fallThroughFixed: the same fall-through shape, but the not-ok path
+// returns an error — the wrong type is surfaced, not swallowed.
+func fallThroughFixed(m map[string]any, k string) (string, bool, error) {
+	s, ok := m[k].(string)
+	if ok {
+		return s, true, nil
+	}
+	return "", false, errors.New("entry has wrong type")
+}
+
+// zeroAssignFixed: the zero-rebind still ends in an error return.
+func zeroAssignFixed(m map[string]any, k string) (string, error) {
+	s, ok := m[k].(string)
+	if !ok {
+		s = ""
+		return process(s), errors.New("entry has wrong type")
+	}
+	return process(s), nil
+}
+
+// switchCaseFixed: `case !ok:` returning an error.
+func switchCaseFixed(m map[string]any, k string) (string, bool, error) {
+	s, ok := m[k].(string)
+	switch {
+	case !ok:
+		return "", false, errors.New("entry has wrong type")
+	}
+	return s, true, nil
+}
+
+// switchTagFalseFixed: `case false:` returning an error.
+func switchTagFalseFixed(m map[string]any, k string) (string, bool, error) {
+	s, ok := m[k].(string)
+	switch ok {
+	case false:
+		return "", false, errors.New("entry has wrong type")
+	}
+	return s, true, nil
 }

--- a/internal/analyzers/laxcoerce/testdata/src/d/d.go
+++ b/internal/analyzers/laxcoerce/testdata/src/d/d.go
@@ -1,0 +1,107 @@
+// Package d holds the laxcoerce spellings the 2026-09-02 adversarial
+// review showed were missing or mis-scoped: the fall-through after a
+// bare `if ok`, a zero-value assignment in the !ok branch, switch-case
+// guards, closures judged under their own error-result flag, and
+// presence separated on one key of a map silencing an assert on
+// another.
+package d
+
+// fallThrough: with no else, the statements after `if ok` ARE the
+// not-ok path; a wrong-typed value lands in the nil-error return and
+// reads as "not supplied".
+func fallThrough(m map[string]any, k string) (string, bool, error) {
+	s, ok := m[k].(string) // want `type assertion on m treated as absence`
+	if ok {
+		return s, true, nil
+	}
+	return "", false, nil
+}
+
+// zeroAssign: the !ok branch rebinds the asserted variable to its zero
+// value and falls through — in a function with an error result, the
+// wrong type is erased before the nil error goes out.
+func zeroAssign(m map[string]any, k string) (string, error) {
+	s, ok := m[k].(string) // want `type assertion on m treated as absence`
+	if !ok {
+		s = ""
+	}
+	return process(s), nil
+}
+
+func process(s string) string { return s + "!" }
+
+// switchCase: `switch { case !ok: }` is the same not-ok branch.
+func switchCase(m map[string]any, k string) (string, bool, error) {
+	s, ok := m[k].(string) // want `type assertion on m treated as absence`
+	switch {
+	case !ok:
+		return "", false, nil
+	}
+	return s, true, nil
+}
+
+// switchTagFalse: `switch ok { case false: }` likewise.
+func switchTagFalse(m map[string]any, k string) (string, bool, error) {
+	s, ok := m[k].(string) // want `type assertion on m treated as absence`
+	switch ok {
+	case false:
+		return "", false, nil
+	}
+	return s, true, nil
+}
+
+// outerNoChannel: the closure has no error result of its own, and the
+// outer function's error flag must not be applied to it (documented
+// silence: zero returns in functions with no error result).
+func outerNoChannel(m map[string]any, k string) (int, error) {
+	apply := func(k string) int {
+		n, ok := m[k].(int)
+		if !ok {
+			return 0 // closure has no error result: silent
+		}
+		return n
+	}
+	return apply(k), nil
+}
+
+// closureOwnError: the closure has its own error result and its own
+// lax branch — judged by the closure's own pass, exactly once.
+func closureOwnError(m map[string]any, k string) (int, error) {
+	apply := func(k string) (int, error) {
+		n, ok := m[k].(int) // want `type assertion on m treated as absence`
+		if !ok {
+			return 0, nil
+		}
+		return n, nil
+	}
+	return apply(k)
+}
+
+// presentOtherKey: presence was separated for "fmt", never for
+// "region" — the presence silence is per key, not per map, when the
+// key is a literal.
+func presentOtherKey(m map[string]any) (string, error) {
+	_, present := m["fmt"]
+	if !present {
+		return "", nil
+	}
+	region, ok := m["region"].(string) // want `type assertion on m treated as absence`
+	if !ok {
+		return "", nil // wrong-typed region reads as "no filter"
+	}
+	return region, nil
+}
+
+// presentSameKey: the assert's own key was presence-checked, so
+// presence and type are genuinely separated for it: silent.
+func presentSameKey(m map[string]any) (string, error) {
+	_, present := m["region"]
+	if !present {
+		return "", nil
+	}
+	region, ok := m["region"].(string)
+	if !ok {
+		return "", nil // wrong type surfaces as absence-by-design here
+	}
+	return region, nil
+}

--- a/internal/analyzers/recovercallback/recovercallback.go
+++ b/internal/analyzers/recovercallback/recovercallback.go
@@ -198,18 +198,20 @@ func (g *graph) link(pass *analysis.Pass, n *node) {
 		g.markAsync(goStmt.Call.Fun, n)
 		return true
 	})
-	// R5: a deferred package-local guard whose body recovers (a direct
-	// recover() call, or its own deferred recover) protects this node
-	// exactly like the inline literal — recover works when called
-	// directly by the deferred function, and the guard IS the deferred
-	// function.
+	// R5: a deferred package-local guard whose body calls recover()
+	// DIRECTLY protects this node exactly like the inline literal —
+	// recover works when called directly by the deferred function, and
+	// the guard IS the deferred function. A guard whose OWN body defers
+	// its recover does not: that nested recover runs on the guard's
+	// frame and cannot catch a panic from this node, so only
+	// directRecover counts here.
 	ast.Inspect(n.body, func(x ast.Node) bool {
 		def, ok := x.(*ast.DeferStmt)
 		if !ok {
 			return true
 		}
 		if target, ok := g.byObj[g.callTarget(def.Call.Fun)]; ok {
-			if target.hasRecover || directRecover(target.body) {
+			if directRecover(target.body) {
 				n.hasRecover = true
 			}
 		}

--- a/internal/analyzers/recovercallback/recovercallback.go
+++ b/internal/analyzers/recovercallback/recovercallback.go
@@ -2,30 +2,47 @@
 // recover in scope on a dispatch path that has no net.
 //
 // The bug class is one panic killing a whole process: a handler or
-// gate obtained from a registry map or a struct field is app-supplied
-// code, and the dispatch sites that run it are transport loops — a
-// stdio JSON-RPC loop, a peer read loop, a goroutine spawned per
-// frame — where net/http's per-request recover net does not exist.
-// The 419-probe audit found this shape twice (both fixed b79942f7):
-// moduleproto's Peer served inbound requests and notifications by
-// calling the map-registered handler directly, so a panicking module
-// handler crashed the host process instead of answering a paired error
-// (probe TestHandlerPanicBecomesErrorResponse, fixed by runHandler's
-// recover guard), and core/mcp's callTool evaluated a tool's Gate
-// callback with no guard, so a panicking gate unwound the transport
-// (probe TestPanickingGateFailsClosedEverywhere, fixed by
-// checkToolGate's recover guard).
+// gate obtained from a registry map, a struct field, or a local copied
+// from one (`gate := t.Gate; gate()` — the nil-check-and-call spelling
+// any careful author writes) is app-supplied code, and the dispatch
+// sites that run it are transport loops — a stdio JSON-RPC loop, a
+// peer read loop, a goroutine spawned per frame, a ticker-driven
+// periodic dispatcher — where net/http's per-request recover net does
+// not exist. The 419-probe audit found this shape twice (both fixed
+// b79942f7): moduleproto's Peer served inbound requests and
+// notifications by calling the map-registered handler directly, so a
+// panicking module handler crashed the host process instead of
+// answering a paired error (probe TestHandlerPanicBecomesErrorResponse,
+// fixed by runHandler's recover guard), and core/mcp's callTool
+// evaluated a tool's Gate callback with no guard, so a panicking gate
+// unwound the transport (probe TestPanickingGateFailsClosedEverywhere,
+// fixed by checkToolGate's recover guard).
 //
 // "Dispatch path" is condition (a) of the shape, computed across the
 // package rather than lexically: a function is on a dispatch path if
 // it is reachable within the package from a goroutine literal, from a
 // `go`/time.AfterFunc target, or from a function whose body contains a
-// for-loop that blocks on input (a channel receive or a
-// Read/Scan/Recv/Decode-style call). The lexical reading alone — "runs
-// in a goroutine literal or is a method whose body contains the loop"
-// — misses the real callTool site, whose loop (ServeStdio) sits three
-// call frames above it; the transitive reading is what the probes
-// actually exercised, so that is what ships.
+// for-loop that blocks on input (a channel receive — including a bare
+// receive on a *time.Ticker/*time.Timer channel, `for { <-w.t.C; ... }`,
+// which is a timer-driven dispatcher, not a coordination wait — or a
+// Read/Scan/Recv/Decode-style call). A method call through an
+// interface declared in this package adds edges to every package-local
+// method with the same name and arity, so interface dispatch keeps the
+// flood honest for the ordinary Go way to decouple a transport from
+// its handlers. The lexical reading alone — "runs in a goroutine
+// literal or is a method whose body contains the loop" — misses the
+// real callTool site, whose loop (ServeStdio) sits three call frames
+// above it; the transitive reading is what the probes actually
+// exercised, so that is what ships.
+//
+// A recover counts when it runs on the panicking frame: the node's own
+// deferred recover (the inline `defer func(){ recover() }()` literal,
+// or `defer guard()` where the package-local guard function or method
+// recovers — recover works when called directly by the deferred
+// function, and the guard IS the deferred function), or the enclosing
+// owner's for a literal that runs synchronously. A recover inside a
+// nested function literal does NOT count: it runs on that literal's
+// own stack (a goroutine's recover cannot catch the parent's panic).
 //
 // Postures it deliberately stays silent on, because they are not this
 // bug: http.Handler-shaped callbacks — a value whose type is
@@ -34,12 +51,16 @@
 // request, and likewise an http-handler-shaped function never seeds
 // hotness even when its body loops (an SSE hold loop inside a handler
 // still runs under the server's recover net); context.CancelFunc
-// fields (never user code); named function calls (their guards are
-// their own business); callbacks reached only from ordinary
-// synchronous call sites, goroutine or no goroutine elsewhere in the
-// package — reachability, not adjacency, is the test; and everything
-// in _test.go, where a panic failing the test is the intended
-// outcome.
+// fields (never user code), including func(error)-shaped cancel-cause
+// slots under a cancel-named field (cancelFn, cancelFunc — the
+// context.WithCancelCause cancels kiln's AdapterStore stores) and
+// locals copied from them; clock and printf-shaped fields (test seams
+// and logging plumbing, not app callbacks) — including locals copied
+// from them; named function calls (their guards are their own
+// business); callbacks reached only from ordinary synchronous call
+// sites, goroutine or no goroutine elsewhere in the package —
+// reachability, not adjacency, is the test; and everything in
+// _test.go, where a panic failing the test is the intended outcome.
 package recovercallback
 
 import (
@@ -75,7 +96,7 @@ type node struct {
 	hasRecover  bool
 	readLoop    bool
 	handlerShpd bool
-	mapDerived  map[types.Object]bool // locals whose value came out of a map
+	derived     map[types.Object]bool // locals whose value came out of a map or a func-typed field
 	calls       []callbackCall
 	edges       []*node
 }
@@ -139,7 +160,7 @@ func (g *graph) makeNode(body *ast.BlockStmt, typ types.Type, owner *node) *node
 		owner:      owner,
 		hasRecover: hasRecover(body),
 		readLoop:   containsReadLoop(g.pass, body),
-		mapDerived: mapDerivedVars(g.pass, body),
+		derived:    derivedVars(g.pass, body),
 	}
 	if sig, ok := typ.(*types.Signature); ok {
 		n.handlerShpd = isHandlerShape(sig)
@@ -177,6 +198,23 @@ func (g *graph) link(pass *analysis.Pass, n *node) {
 		g.markAsync(goStmt.Call.Fun, n)
 		return true
 	})
+	// R5: a deferred package-local guard whose body recovers (a direct
+	// recover() call, or its own deferred recover) protects this node
+	// exactly like the inline literal — recover works when called
+	// directly by the deferred function, and the guard IS the deferred
+	// function.
+	ast.Inspect(n.body, func(x ast.Node) bool {
+		def, ok := x.(*ast.DeferStmt)
+		if !ok {
+			return true
+		}
+		if target, ok := g.byObj[g.callTarget(def.Call.Fun)]; ok {
+			if target.hasRecover || directRecover(target.body) {
+				n.hasRecover = true
+			}
+		}
+		return true
+	})
 	ast.Inspect(n.body, func(x ast.Node) bool {
 		call, ok := x.(*ast.CallExpr)
 		if !ok || goCalls[call] {
@@ -187,12 +225,64 @@ func (g *graph) link(pass *analysis.Pass, n *node) {
 			return true
 		}
 		if obj := g.callTarget(call.Fun); obj != nil {
-			if target, ok := g.byObj[obj]; ok && target != n {
-				n.edges = append(n.edges, target)
+			if target, ok := g.byObj[obj]; ok {
+				if target != n {
+					n.edges = append(n.edges, target)
+				}
+			} else {
+				// R1: a method call through an interface declared in
+				// this package resolves to the interface's method, not
+				// any implementation. Add an edge to every
+				// package-local method with the same name and arity —
+				// a cheap dispatch approximation that keeps the
+				// reachability flood honest for the ordinary Go way to
+				// decouple a transport from its handlers.
+				for _, target := range g.interfaceImplementations(obj.(*types.Func)) {
+					if target != n {
+						n.edges = append(n.edges, target)
+					}
+				}
 			}
 		}
 		return true
 	})
+}
+
+// interfaceImplementations: the package-local method nodes with the
+// same name and parameter count as the interface method m, when m
+// belongs to an interface declared in this package.
+func (g *graph) interfaceImplementations(m *types.Func) []*node {
+	sig, ok := m.Type().(*types.Signature)
+	if !ok || sig.Recv() == nil {
+		return nil
+	}
+	recv := sig.Recv().Type()
+	if ptr, ok := recv.(*types.Pointer); ok {
+		recv = ptr.Elem()
+	}
+	named, ok := recv.(*types.Named)
+	if !ok {
+		return nil
+	}
+	if _, ok := named.Underlying().(*types.Interface); !ok {
+		return nil
+	}
+	if p := named.Obj().Pkg(); p == nil || p.Path() != g.pass.Pkg.Path() {
+		return nil
+	}
+	var out []*node
+	for obj, target := range g.byObj {
+		fn, ok := obj.(*types.Func)
+		if !ok || fn.Name() != m.Name() {
+			continue
+		}
+		s2, ok := fn.Type().(*types.Signature)
+		if !ok || s2.Recv() == nil || s2.Params().Len() != sig.Params().Len() {
+			continue
+		}
+		out = append(out, target)
+	}
+	return out
 }
 
 // markAsync marks a `go`/AfterFunc target: the literal (matched by
@@ -235,7 +325,9 @@ func (g *graph) callTarget(fun ast.Expr) types.Object {
 
 // callbackCallee reports whether call invokes a registry callback —
 // through a func-typed struct field, a map element, or a local whose
-// value came out of a map — and its printed description.
+// value came out of a map or was copied from a func-typed field (the
+// nil-check-and-call spelling any careful author writes) — and its
+// printed description.
 func (g *graph) callbackCallee(call *ast.CallExpr, n *node) (string, bool) {
 	pass := g.pass
 	switch fun := unparen(call.Fun).(type) {
@@ -244,7 +336,7 @@ func (g *graph) callbackCallee(call *ast.CallExpr, n *node) (string, bool) {
 		if !ok || s.Kind() != types.FieldVal {
 			return "", false
 		}
-		if !isCallbackType(s.Type()) {
+		if !isCallbackType(s.Type()) || isCancelNamed(s.Obj().Name()) {
 			return "", false
 		}
 		return types.ExprString(fun), true
@@ -255,21 +347,38 @@ func (g *graph) callbackCallee(call *ast.CallExpr, n *node) (string, bool) {
 		if _, isMap := underlyingMap(pass.TypesInfo.TypeOf(fun.X)); !isMap {
 			return "", false
 		}
+
 		if isCallbackType(pass.TypesInfo.TypeOf(fun)) {
 			return types.ExprString(fun), true
 		}
 	case *ast.Ident:
 		obj := pass.TypesInfo.ObjectOf(fun)
-		if obj != nil && n.mapDerived[obj] {
+		if obj != nil && n.derived[obj] {
 			return fun.Name, true
 		}
 	}
 	return "", false
 }
 
-// mapDerivedVars records the variables whose value comes out of a
-// map: `v, ok := m[k]` and the value variable of `for _, v := range m`.
-func mapDerivedVars(pass *analysis.Pass, body *ast.BlockStmt) map[types.Object]bool {
+var cancelFieldName = regexp.MustCompile(`(?i)^cancel`)
+
+// isCancelNamed: a func-typed field whose name says cancel (cancel,
+// cancelFn, cancelFunc, cancelTurn, ...). The cancel-cause slots the
+// repo stores (context.WithCancelCause cancels — kiln's AdapterStore
+// cancelFn) are context plumbing exactly like context.CancelFunc:
+// they never run app code, however func(error)-shaped they look, and
+// locals copied from them inherit that.
+func isCancelNamed(name string) bool {
+	return cancelFieldName.MatchString(name)
+}
+
+// derivedVars records the variables whose value comes out of a map
+// (`v, ok := m[k]`, the value variable of `for _, v := range m`) or is
+// copied from a callback-typed struct field (`gate := t.Gate`). Those
+// are registry callbacks even when called through the local's name;
+// infrastructure-shaped fields (printf loggers, handlers, clocks,
+// CancelFuncs) copied to a local stay plumbing.
+func derivedVars(pass *analysis.Pass, body *ast.BlockStmt) map[types.Object]bool {
 	out := map[types.Object]bool{}
 	ast.Inspect(body, func(x ast.Node) bool {
 		switch x := x.(type) {
@@ -283,16 +392,27 @@ func mapDerivedVars(pass *analysis.Pass, body *ast.BlockStmt) map[types.Object]b
 			}
 		case *ast.AssignStmt:
 			for i, rhs := range x.Rhs {
-				idx, ok := unparen(rhs).(*ast.IndexExpr)
-				if !ok || i >= len(x.Lhs) {
+				if i >= len(x.Lhs) {
 					continue
 				}
-				if _, isMap := underlyingMap(pass.TypesInfo.TypeOf(idx.X)); !isMap {
+				if idx, ok := unparen(rhs).(*ast.IndexExpr); ok {
+					if _, isMap := underlyingMap(pass.TypesInfo.TypeOf(idx.X)); !isMap {
+						continue
+					}
+					if id, ok := x.Lhs[i].(*ast.Ident); ok {
+						if obj := pass.TypesInfo.Defs[id]; obj != nil {
+							out[obj] = true
+						}
+					}
 					continue
 				}
-				if id, ok := x.Lhs[i].(*ast.Ident); ok {
-					if obj := pass.TypesInfo.Defs[id]; obj != nil {
-						out[obj] = true
+				if sel, ok := unparen(rhs).(*ast.SelectorExpr); ok {
+					if s, ok := pass.TypesInfo.Selections[sel]; ok && s.Kind() == types.FieldVal && isCallbackType(s.Type()) && !isCancelNamed(s.Obj().Name()) {
+						if id, ok := x.Lhs[i].(*ast.Ident); ok {
+							if obj := pass.TypesInfo.Defs[id]; obj != nil {
+								out[obj] = true
+							}
+						}
 					}
 				}
 			}
@@ -356,18 +476,43 @@ func (g *graph) protected(n *node) bool {
 func hasRecover(body *ast.BlockStmt) bool {
 	found := false
 	ast.Inspect(body, func(x ast.Node) bool {
-		def, ok := x.(*ast.DeferStmt)
-		if !ok {
-			return true
-		}
-		ast.Inspect(def.Call, func(y ast.Node) bool {
-			if call, ok := y.(*ast.CallExpr); ok {
-				if id, ok := unparen(call.Fun).(*ast.Ident); ok && id.Name == "recover" {
-					found = true
+		switch x := x.(type) {
+		case *ast.FuncLit:
+			// A recover deferred inside a nested literal runs on that
+			// literal's own stack — a goroutine's recover cannot catch
+			// a panic in this body. Deferred literals are visited from
+			// their DeferStmt below.
+			return false
+		case *ast.DeferStmt:
+			ast.Inspect(x.Call, func(y ast.Node) bool {
+				if call, ok := y.(*ast.CallExpr); ok {
+					if id, ok := unparen(call.Fun).(*ast.Ident); ok && id.Name == "recover" {
+						found = true
+					}
 				}
+				return !found
+			})
+		}
+		return !found
+	})
+	return found
+}
+
+// directRecover: a recover() call in the node's own linear body, not
+// under a defer and not inside a nested literal. Useless for the node
+// itself, but effective when the node is the DEFERRED function —
+// that is the named-guard spelling (defer guard()).
+func directRecover(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(x ast.Node) bool {
+		if _, ok := x.(*ast.FuncLit); ok {
+			return false
+		}
+		if call, ok := x.(*ast.CallExpr); ok {
+			if id, ok := unparen(call.Fun).(*ast.Ident); ok && id.Name == "recover" {
+				found = true
 			}
-			return !found
-		})
+		}
 		return !found
 	})
 	return found
@@ -375,9 +520,11 @@ func hasRecover(body *ast.BlockStmt) bool {
 
 // containsReadLoop reports whether body has a for (or channel-range)
 // loop that blocks on input: a Read/Scan/Recv/Decode-style call in the
-// condition, a channel range, a receive ASSIGNED in the body, or a
-// select inside the loop. A bare discard receive (`<-ready`) alone
-// does not count — that is a coordination wait, not a dispatch.
+// condition, a channel range, a receive ASSIGNED in the body, a
+// select inside the loop, or a bare receive on the channel of a
+// *time.Ticker/*time.Timer (`<-w.t.C`). A bare discard receive on an
+// ordinary channel (`<-ready`) alone does not count — that is a
+// coordination wait, not a dispatch.
 func containsReadLoop(pass *analysis.Pass, body *ast.BlockStmt) bool {
 	found := false
 	ast.Inspect(body, func(x ast.Node) bool {
@@ -413,8 +560,13 @@ func forLoopReads(pass *analysis.Pass, loop *ast.ForStmt) bool {
 			// A bare DISCARD receive (`<-ready`) does not make a loop
 			// a dispatcher: that is a coordination wait (the cached
 			// resolver's singleflight), and every real dispatch loop
-			// in this repo selects or reads instead.
-			_ = y
+			// in this repo selects or reads instead — UNLESS the
+			// channel is a ticker's or timer's .C, which no
+			// coordination wait looks like: that is a timer-driven
+			// dispatcher whose callback panic kills the process.
+			if u, ok := unparen(y.X).(*ast.UnaryExpr); ok && isReceive(u) && isTimerChan(pass, u.X) {
+				reads = true
+			}
 		case *ast.AssignStmt:
 			for _, rhs := range y.Rhs {
 				if u, ok := unparen(rhs).(*ast.UnaryExpr); ok && isReceive(u) {
@@ -432,6 +584,25 @@ func forLoopReads(pass *analysis.Pass, loop *ast.ForStmt) bool {
 		return !reads
 	})
 	return reads
+}
+
+// isTimerChan: `<-w.t.C` — the channel of a *time.Ticker or
+// *time.Timer. A periodic dispatch loop written over a ticker is a
+// timer-driven dispatcher; no singleflight coordination wait receives
+// on a .C selector.
+func isTimerChan(pass *analysis.Pass, e ast.Expr) bool {
+	sel, ok := unparen(e).(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "C" {
+		return false
+	}
+	t := pass.TypesInfo.TypeOf(sel.X)
+	if t == nil {
+		return false
+	}
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	return isNamed(t, "time", "Ticker") || isNamed(t, "time", "Timer")
 }
 
 func isReceive(u *ast.UnaryExpr) bool { return u.Op.String() == "<-" }

--- a/internal/analyzers/recovercallback/recovercallback_test.go
+++ b/internal/analyzers/recovercallback/recovercallback_test.go
@@ -10,5 +10,6 @@ import (
 
 func TestRecoverCallback(t *testing.T) {
 	analysistest.Run(t, analysistest.TestData(), recovercallback.Analyzer,
-		"peerish", "toolgate", "broker", "watcher")
+		"peerish", "toolgate", "broker", "watcher",
+		"ifacedisp", "fieldlocal", "nestedrec", "tickerloop", "helperguard")
 }

--- a/internal/analyzers/recovercallback/testdata/src/fieldlocal/fieldlocal.go
+++ b/internal/analyzers/recovercallback/testdata/src/fieldlocal/fieldlocal.go
@@ -1,0 +1,58 @@
+// Package fieldlocal pins the local-copy leg (review finding R2): a
+// func field copied to a local and called through the local — the
+// nil-check-and-call spelling any careful author writes — is the same
+// registry callback as the direct field call one line earlier.
+package fieldlocal
+
+import (
+	"bufio"
+	"context"
+)
+
+type Tool struct {
+	Gate func(ctx context.Context) error
+}
+
+type S struct{ tools map[string]Tool }
+
+func (s *S) Serve(in *bufio.Reader) {
+	scanner := bufio.NewScanner(in)
+	for scanner.Scan() {
+		s.Handle(scanner.Bytes())
+	}
+	_ = scanner.Err()
+}
+
+func (s *S) Handle(line []byte) {
+	t, ok := s.tools[string(line)]
+	if !ok {
+		return
+	}
+	s.Call(t)
+	s.callDirect(t)
+}
+
+func (s *S) Call(t Tool) {
+	gate := t.Gate
+	if gate != nil {
+		_ = gate(context.Background()) // want `recovercallback: gate is invoked with no recover in scope`
+	}
+}
+
+// callDirect is the flagship spelling beside it: the field itself.
+func (s *S) callDirect(t Tool) {
+	_ = t.Gate(context.Background()) // want `recovercallback: t\.Gate is invoked with no recover in scope`
+}
+
+// infraLocal: a printf-shaped field copied to a local is still
+// plumbing, not an app callback. Quiet.
+type L struct {
+	logf func(format string, args ...any)
+}
+
+func (l *L) run(reqs <-chan string) {
+	for r := range reqs {
+		logf := l.logf
+		logf("seen %s", r)
+	}
+}

--- a/internal/analyzers/recovercallback/testdata/src/helperguard/helperguard.go
+++ b/internal/analyzers/recovercallback/testdata/src/helperguard/helperguard.go
@@ -1,0 +1,65 @@
+// Package helperguard pins the named-guard leg (review finding R5):
+// a deferred call to a package-local function or method whose body
+// recovers is as much a recover as the inline literal — recover works
+// when called directly by the deferred function, and the guard IS the
+// deferred function. Deferring a named guard is the standard idiom in
+// codebases that centralize panic handling.
+package helperguard
+
+import (
+	"bufio"
+	"context"
+)
+
+type Tool struct {
+	Gate func(ctx context.Context) error
+}
+
+type S struct{ tools map[string]Tool }
+
+func (s *S) Serve(in *bufio.Reader) {
+	scanner := bufio.NewScanner(in)
+	for scanner.Scan() {
+		s.Handle(scanner.Bytes())
+	}
+	_ = scanner.Err()
+}
+
+func (s *S) Handle(line []byte) {
+	t, ok := s.tools[string(line)]
+	if !ok {
+		return
+	}
+	s.CallGuarded(t)
+	s.CallGuardedMethod(t)
+	s.CallUnguarded(t)
+}
+
+// CallGuarded defers the named guard: quiet.
+func (s *S) CallGuarded(t Tool) {
+	defer guard()
+	_ = t.Gate(context.Background())
+}
+
+// CallGuardedMethod defers a method guard: quiet.
+func (s *S) CallGuardedMethod(t Tool) {
+	defer s.guard()
+	_ = t.Gate(context.Background())
+}
+
+// CallUnguarded is the control: same path, no guard anywhere.
+func (s *S) CallUnguarded(t Tool) {
+	_ = t.Gate(context.Background()) // want `recovercallback: t\.Gate is invoked with no recover in scope`
+}
+
+func guard() {
+	if r := recover(); r != nil {
+		_ = r
+	}
+}
+
+func (s *S) guard() {
+	if r := recover(); r != nil {
+		_ = r
+	}
+}

--- a/internal/analyzers/recovercallback/testdata/src/helperguard/helperguard.go
+++ b/internal/analyzers/recovercallback/testdata/src/helperguard/helperguard.go
@@ -32,6 +32,7 @@ func (s *S) Handle(line []byte) {
 	}
 	s.CallGuarded(t)
 	s.CallGuardedMethod(t)
+	s.CallNestedDeferGuard(t)
 	s.CallUnguarded(t)
 }
 
@@ -45,6 +46,15 @@ func (s *S) CallGuarded(t Tool) {
 func (s *S) CallGuardedMethod(t Tool) {
 	defer s.guard()
 	_ = t.Gate(context.Background())
+}
+
+// CallNestedDeferGuard defers a named guard whose OWN body defers its
+// recover: recover must be called directly by the deferred function to
+// catch the CALLER's panic, and the nested one runs on the guard's own
+// frame. Fires.
+func (s *S) CallNestedDeferGuard(t Tool) {
+	defer nestedDeferGuard()
+	_ = t.Gate(context.Background()) // want `recovercallback: t\.Gate is invoked with no recover in scope`
 }
 
 // CallUnguarded is the control: same path, no guard anywhere.
@@ -62,4 +72,13 @@ func (s *S) guard() {
 	if r := recover(); r != nil {
 		_ = r
 	}
+}
+
+// nestedDeferGuard recovers only ITS OWN panics: the recover call is
+// one defer deeper than the guard, so a panic in the deferring caller
+// escapes it.
+func nestedDeferGuard() {
+	defer func() {
+		_ = recover()
+	}()
 }

--- a/internal/analyzers/recovercallback/testdata/src/ifacedisp/ifacedisp.go
+++ b/internal/analyzers/recovercallback/testdata/src/ifacedisp/ifacedisp.go
@@ -1,0 +1,42 @@
+// Package ifacedisp pins the interface-dispatch leg (review finding
+// R1): a method call through an interface declared in this package
+// reaches every package-local method with the same name and arity —
+// the ordinary Go way to decouple a transport from its handlers, and
+// precisely how a dispatch path is structured once a peer grows past
+// one file's coupling.
+package ifacedisp
+
+type Frame struct{ Method string }
+
+type Reader interface{ ReadFrame() (Frame, error) }
+
+type Disp interface{ Dispatch(Frame) }
+
+type Peer struct {
+	r Reader
+	d Disp
+}
+
+func (p *Peer) Serve() error {
+	for {
+		f, err := p.r.ReadFrame()
+		if err != nil {
+			return err
+		}
+		p.d.Dispatch(f)
+	}
+}
+
+type Impl struct{ gate func(Frame) error }
+
+func (i *Impl) Dispatch(f Frame) {
+	_ = i.gate(f) // want `recovercallback: i\.gate is invoked with no recover in scope`
+}
+
+// Unrelated Dispatch-arity methods are not edges: same name, different
+// arity.
+type Other struct{}
+
+func (o *Other) Dispatch(f Frame, extra int) {
+	_ = f
+}

--- a/internal/analyzers/recovercallback/testdata/src/nestedrec/nestedrec.go
+++ b/internal/analyzers/recovercallback/testdata/src/nestedrec/nestedrec.go
@@ -1,0 +1,45 @@
+// Package nestedrec pins the recover boundary (review finding R3): a
+// recover deferred inside a nested function literal runs on that
+// literal's own stack and cannot catch a panic in the enclosing
+// function's linear body — only the function's own deferred recovers
+// protect it.
+package nestedrec
+
+import (
+	"bufio"
+	"context"
+)
+
+type Tool struct {
+	Gate func(ctx context.Context) error
+}
+
+type S struct{ tools map[string]Tool }
+
+func (s *S) Serve(in *bufio.Reader) {
+	scanner := bufio.NewScanner(in)
+	for scanner.Scan() {
+		s.Handle(scanner.Bytes())
+	}
+	_ = scanner.Err()
+}
+
+func (s *S) Handle(line []byte) {
+	t, ok := s.tools[string(line)]
+	if !ok {
+		return
+	}
+	s.Call(t)
+}
+
+func (s *S) Call(t Tool) {
+	go func() {
+		defer func() {
+			_ = recover()
+		}()
+		s.Keepalive()
+	}()
+	_ = t.Gate(context.Background()) // want `recovercallback: t\.Gate is invoked with no recover in scope`
+}
+
+func (s *S) Keepalive() {}

--- a/internal/analyzers/recovercallback/testdata/src/tickerloop/tickerloop.go
+++ b/internal/analyzers/recovercallback/testdata/src/tickerloop/tickerloop.go
@@ -1,0 +1,43 @@
+// Package tickerloop pins the timer-dispatch leg (review finding R4):
+// a bare receive whose channel expression is a .C selector on a
+// *time.Ticker or *time.Timer is a timer-driven dispatch loop — the
+// callback panic kills the process exactly as a read-loop panic would.
+// A bare receive on an ordinary channel stays a coordination wait.
+package tickerloop
+
+import "time"
+
+type Worker struct {
+	t   *time.Ticker
+	tm  *time.Timer
+	sub func(ev string)
+
+	ready chan struct{}
+	fin   func()
+}
+
+// runTicker dispatches on every tick with no net. Fires.
+func (w *Worker) runTicker() {
+	for {
+		<-w.t.C
+		w.sub("tick") // want `recovercallback: w\.sub is invoked with no recover in scope`
+	}
+}
+
+// runTimer: the one-shot Timer spelling. Fires.
+func (w *Worker) runTimer() {
+	for {
+		<-w.tm.C
+		w.sub("tock") // want `recovercallback: w\.sub is invoked with no recover in scope`
+	}
+}
+
+// coordination is quiet: a bare receive on a plain channel inside a
+// loop is a coordination wait (the cached resolver's singleflight),
+// not a dispatch loop.
+func (w *Worker) coordination() {
+	for {
+		<-w.ready
+		w.fin()
+	}
+}

--- a/internal/analyzers/recovercallback/testdata/src/watcher/watcher.go
+++ b/internal/analyzers/recovercallback/testdata/src/watcher/watcher.go
@@ -7,6 +7,7 @@ package watcher
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 )
@@ -63,3 +64,28 @@ func (w *Watcher) cancelFunc() {
 		w.cancel()
 	})
 }
+
+// cancelCauseSlot is quiet: a func(error)-shaped field under a
+// cancel-named slot is a context.WithCancelCause cancel — context
+// plumbing like CancelFunc, never user code — including through the
+// local copy.
+type turn struct {
+	cancelFn  func(cause error)
+	onFailure func(cause error)
+}
+
+func (t *turn) cancelPrev() {
+	prev := t.cancelFn
+	if prev != nil {
+		prev(errSwitched)
+	}
+}
+
+func startTurn(t *turn) {
+	go func() {
+		t.cancelPrev()
+		t.onFailure(errSwitched) // want `recovercallback: t\.onFailure is invoked with no recover in scope`
+	}()
+}
+
+var errSwitched = errors.New("switched")

--- a/internal/analyzers/reflectset/reflectset.go
+++ b/internal/analyzers/reflectset/reflectset.go
@@ -14,20 +14,25 @@
 // Silent postures, deliberately:
 //   - any CanSet() call in the function on the same value (directly or
 //     through the same local) — the fix posture;
-//   - named-field access (FieldByName/FieldByNameFunc): narrowed out
-//     on 2026-09-02, when the whole-repo run measured all eight such
-//     sites (core-ui/style tokenmap.go) walking the package's OWN token
-//     structs with named exported fields — a deliberate field pick,
-//     not the indexed every-field walk that bit Inject;
-//   - receivers that do not come from Field()/FieldByIndex(): a Set on
-//     an addressable Value obtained another way (Elem, Index, a
-//     function result) has its own rules and its own failures;
+//   - named-field access with the name WRITTEN HERE: FieldByName with
+//     a string-literal name, or FieldByNameFunc with an inline
+//     predicate func. Narrowed 2026-09-02, when the whole-repo run
+//     measured all eight such sites (core-ui/style tokenmap.go)
+//     walking the package's OWN token structs — a deliberate field
+//     pick. A caller-supplied name (or predicate) is not written here:
+//     it is the same one-unexported-field panic the index spelling
+//     carries, and fires;
+//   - receivers that do not come from Field()/FieldByIndex()/
+//     FieldByName()/FieldByNameFunc(): a Set on an addressable Value
+//     obtained another way (Elem, Index, a function result) has its
+//     own rules and its own failures;
 //   - non-reflect.Value receivers (a type with its own Set method);
 //   - _test.go files.
 package reflectset
 
 import (
 	"go/ast"
+	"go/token"
 	"go/types"
 	"strings"
 
@@ -100,9 +105,10 @@ func checkFunc(pass *analysis.Pass, body *ast.BlockStmt) {
 	})
 }
 
-// fieldOrigin returns the printed form of the receiver's indexed field
-// origin — Field(i) / FieldByIndex — or "" otherwise. One level of
-// local binding is resolved.
+// fieldOrigin returns the printed form of the receiver's field origin —
+// Field(i) / FieldByIndex, or FieldByName / FieldByNameFunc with a
+// non-literal name argument — or "" otherwise. One level of local
+// binding is resolved.
 func fieldOrigin(pass *analysis.Pass, recv ast.Expr, bound map[types.Object]ast.Expr) string {
 	e := recv
 	for range 8 {
@@ -121,6 +127,18 @@ func fieldOrigin(pass *analysis.Pass, recv ast.Expr, bound map[types.Object]ast.
 			switch sel.Sel.Name {
 			case "Field", "FieldByIndex":
 				return types.ExprString(e)
+			case "FieldByName":
+				if len(x.Args) == 1 && isStringLiteral(x.Args[0]) {
+					return "" // a deliberate named pick, written here
+				}
+				return types.ExprString(e)
+			case "FieldByNameFunc":
+				if len(x.Args) == 1 {
+					if _, ok := x.Args[0].(*ast.FuncLit); ok {
+						return "" // an inline predicate: the pick is written here
+					}
+				}
+				return types.ExprString(e)
 			}
 			return ""
 		default:
@@ -128,6 +146,11 @@ func fieldOrigin(pass *analysis.Pass, recv ast.Expr, bound map[types.Object]ast.
 		}
 	}
 	return ""
+}
+
+func isStringLiteral(e ast.Expr) bool {
+	lit, ok := e.(*ast.BasicLit)
+	return ok && lit.Kind == token.STRING
 }
 
 // canSetChecked reports whether the function calls CanSet on the same

--- a/internal/analyzers/reflectset/reflectset_test.go
+++ b/internal/analyzers/reflectset/reflectset_test.go
@@ -9,5 +9,5 @@ import (
 )
 
 func TestReflectSet(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), reflectset.Analyzer, "a", "b", "c")
+	analysistest.Run(t, analysistest.TestData(), reflectset.Analyzer, "a", "b", "c", "d")
 }

--- a/internal/analyzers/reflectset/testdata/src/b/b.go
+++ b/internal/analyzers/reflectset/testdata/src/b/b.go
@@ -4,11 +4,12 @@ package b
 
 import "reflect"
 
-// stamp overwrites a caller-NAMED field: FieldByName access on a known
-// package type is deliberately outside the rule since the 2026-09-02
-// narrowing (the tokenmap posture), kept as the documented negative.
+// stamp overwrites a caller-NAMED field: FieldByName with a
+// non-literal name is the same one-unexported-field panic as an index
+// (widened 2026-09-02 after the adversarial review); literal names
+// remain the tokenmap silence.
 func stamp(v reflect.Value, name string, val string) error {
-	v.FieldByName(name).SetString(val)
+	v.FieldByName(name).SetString(val) // want `reflect SetString on a field value without a CanSet check`
 	return nil
 }
 

--- a/internal/analyzers/reflectset/testdata/src/d/d.go
+++ b/internal/analyzers/reflectset/testdata/src/d/d.go
@@ -1,0 +1,42 @@
+// Package d holds the reflectset spelling the 2026-09-02 adversarial
+// review showed was silenced too broadly: a field picked by a
+// caller-supplied name is the same one-unexported-field panic as an
+// index.
+package d
+
+import "reflect"
+
+// applyColumn: the name comes from outside — FieldByName with a
+// non-literal name, no CanSet.
+func applyColumn(row reflect.Value, column string, val any) error {
+	row.FieldByName(column).Set(reflect.ValueOf(val)) // want `reflect Set on a field value without a CanSet check`
+	return nil
+}
+
+// applyColumnFixed checks settability first.
+func applyColumnFixed(row reflect.Value, column string, val any) error {
+	fv := row.FieldByName(column)
+	if !fv.CanSet() {
+		return errUnsettable
+	}
+	fv.Set(reflect.ValueOf(val))
+	return nil
+}
+
+// applyLiteralName: a string-literal name is the deliberate pick the
+// tokenmap posture measured.
+func applyLiteralName(v reflect.Value, val string) {
+	v.FieldByName("Title").SetString(val)
+}
+
+// applyPredicateVar: FieldByNameFunc with a function from outside picks
+// the field no more deliberately than an index does.
+func applyPredicateVar(v reflect.Value, match func(string) bool, val any) {
+	v.FieldByNameFunc(match).Set(reflect.ValueOf(val)) // want `reflect Set on a field value without a CanSet check`
+}
+
+// applyPredicateLiteral: an inline predicate is written here, next to
+// the Set: the tokenmap posture.
+func applyPredicateLiteral(v reflect.Value, val any) {
+	v.FieldByNameFunc(func(s string) bool { return s == "ID" }).Set(reflect.ValueOf(val))
+}

--- a/internal/analyzers/reflectset/testdata/src/d/err.go
+++ b/internal/analyzers/reflectset/testdata/src/d/err.go
@@ -1,0 +1,6 @@
+// Package d's errors.
+package d
+
+import "errors"
+
+var errUnsettable = errors.New("field is not settable")

--- a/internal/analyzers/rootwrite/rootwrite.go
+++ b/internal/analyzers/rootwrite/rootwrite.go
@@ -66,8 +66,17 @@ var Analyzer = &analysis.Analyzer{
 }
 
 // validatorRe matches sanitizer/validator callee names: only their
-// RESULT replacing a path component shields a write.
-var validatorRe = regexp.MustCompile(`(?i)sanit|valid|clean|safe`)
+// RESULT replacing a path component shields a write. "clean" is NOT
+// here: path.Clean normalizes separators and dots and passes every
+// symlinked component through, so a clean-named callee shields only
+// when it resolves to a same-package declaration (cleanNamedRe below)
+// and never when it is a stdlib normalizer.
+var validatorRe = regexp.MustCompile(`(?i)sanit|valid|safe`)
+
+// cleanNamedRe matches the clean-shaped helper names that still shield
+// when the callee is a declaration of this package (cleanName), never
+// the stdlib Clean.
+var cleanNamedRe = regexp.MustCompile(`(?i)clean`)
 
 func run(pass *analysis.Pass) (any, error) {
 	pkgFuncs := map[string]*ast.FuncDecl{}
@@ -210,17 +219,37 @@ func argTouchesPath(pass *analysis.Pass, arg ast.Expr, bound map[types.Object]as
 // replaces a component of the built path: that is the only validator
 // posture that touches what reaches the disk. A validator consulted
 // for its boolean (validName(name) in a guard) cannot see symlinks
-// and shields nothing.
 func validatorShields(pass *analysis.Pass, pathArg ast.Expr, bound map[types.Object]ast.Expr) bool {
 	isValidator := func(c *ast.CallExpr) bool {
-		var name string
 		switch fun := c.Fun.(type) {
 		case *ast.Ident:
-			name = fun.Name
+			if validatorRe.MatchString(fun.Name) {
+				return true
+			}
+			// A clean-named bare callee shields only when it
+			// resolves to a declaration of this package: a local
+			// cleanName helper, not an import or a func variable.
+			if cleanNamedRe.MatchString(fun.Name) {
+				if fn, ok := pass.TypesInfo.ObjectOf(fun).(*types.Func); ok {
+					return fn.Pkg() == pass.Pkg
+				}
+			}
+			return false
 		case *ast.SelectorExpr:
-			name = fun.Sel.Name
+			if q := qualifiedFunc(pass, c.Fun); q == "path.Clean" || q == "path/filepath.Clean" {
+				return false // stdlib normalizer: passes symlinks through
+			}
+			if validatorRe.MatchString(fun.Sel.Name) {
+				return true
+			}
+			if cleanNamedRe.MatchString(fun.Sel.Name) {
+				if fn, ok := pass.TypesInfo.ObjectOf(fun.Sel).(*types.Func); ok {
+					return fn.Pkg() == pass.Pkg
+				}
+			}
+			return false
 		}
-		return name != "" && validatorRe.MatchString(name)
+		return false
 	}
 	r := resolve(pass, pathArg, bound, 0)
 	for _, comp := range pathComponents(r) {

--- a/internal/analyzers/rootwrite/rootwrite.go
+++ b/internal/analyzers/rootwrite/rootwrite.go
@@ -1,10 +1,11 @@
 // Package rootwrite catches writes whose containment under a root is
 // resolved lexically only: os.WriteFile / os.Create / os.OpenFile(write
-// flag) / os.MkdirAll on a path built with filepath.Join(root, …) where
-// root is a caller-supplied parameter or field — with no
-// filepath.EvalSymlinks anywhere on the path-producing chain — plus the
-// archive twin: zip.Writer entry names assembled from a parameter with
-// no path.Clean in the function.
+// flag) / os.MkdirAll on a path built under a root — filepath.Join, or
+// a flat `root + "/" + x` concatenation — where the root is a
+// caller-supplied parameter or field — with no filepath.EvalSymlinks
+// on that path's chain — plus the archive twin: zip.Writer entry names
+// assembled from a parameter with no path.Clean on the entry-name
+// chain.
 //
 // The bug class: lexical prefix checks cannot see symlinks. Probes
 // TestApplyRefusesSymlinkEscape (framework/contracts report.go
@@ -15,31 +16,37 @@
 // in 1501a555: a "../" prefix placed archive entries above the target
 // directory on extract).
 //
+// Every gate is per write and on the write's own dataflow: resolution,
+// validation, and cleaning on an unrelated path (or consulted for a
+// boolean and leaving the path components untouched) gate nothing.
+//
 // Silent postures, deliberately:
-//   - any filepath.EvalSymlinks on the chain (writing function, or the
-//     same-package helper that produced the path) — the fix posture;
-//   - roots that are not parameters or root/base/dir-named fields: a
+//   - the write's path (or a component of it, or the Join's root) is
+//     bound to a filepath.EvalSymlinks result, or an EvalSymlinks ran
+//     on this path expression — resolution on the chain (the fix
+//     posture);
+//   - calls to symlink-named guards (EnsureNoSymlinkPath): resolution
+//     by another name;
+//   - a sanitizer/validator whose RESULT replaces a joined component
+//     (sanitize(name) feeding the Join): the component that reaches
+//     the disk passed through it. A validator consulted for its
+//     boolean cannot see symlinks and gates nothing;
+//   - roots that are not parameters or root/base/dir-named fields (a
 //     constant or computed root has no caller-controlled boundary to
-//     defend;
-//   - joins whose every non-root argument is a literal: nothing
-//     caller-controlled is appended under the root;
+//     defend), including a rooty local resolved through one;
+//   - builds whose every non-root argument is a literal — nothing
+//     caller-controlled is appended under the root. This holds at the
+//     helper hop too: a same-package containment helper called with
+//     literal-only non-root arguments stays quiet, and a helper whose
+//     body resolves symlinks is the fix posture;
 //   - temp roots: a local bound to os.MkdirTemp or t.TempDir is
 //     throwaway by construction;
 //   - zip entry names assembled only from literals or non-parameter
-//     values, and any function that calls path.Clean / filepath.Clean;
+//     values (a wrapper forwarding its own name parameter composes
+//     nothing), and entry names whose assembly is bound to a
+//     path.Clean / filepath.Clean result;
 //   - reads (os.Open, os.ReadFile, O_RDONLY) by construction;
 //   - _test.go files.
-//
-// Narrowed 2026-09-02 after the whole-repo run: a direct Join must
-// carry a caller-controlled (parameter-derived) component beside the
-// root — formatted timestamps, counters, manifest literals, and
-// generated ids are not escape vectors — and zip entry names must be
-// COMPOSED from a parameter, not forwarded through a wrapper whose own
-// callers compose. Calls to symlink-named guards (EnsureNoSymlinkPath)
-// count as resolution. A same-package containment helper (rooty first
-// parameter joined with the rest) feeding a write still fires when
-// neither side resolves symlinks: that is the containedPath/Apply pair
-// this rule was born from.
 package rootwrite
 
 import (
@@ -57,6 +64,10 @@ var Analyzer = &analysis.Analyzer{
 	Doc:  "forbids writes under a root whose containment is lexical only: resolve with filepath.EvalSymlinks, and path.Clean zip entry names",
 	Run:  run,
 }
+
+// validatorRe matches sanitizer/validator callee names: only their
+// RESULT replacing a path component shields a write.
+var validatorRe = regexp.MustCompile(`(?i)sanit|valid|clean|safe`)
 
 func run(pass *analysis.Pass) (any, error) {
 	pkgFuncs := map[string]*ast.FuncDecl{}
@@ -86,15 +97,13 @@ func run(pass *analysis.Pass) (any, error) {
 }
 
 func checkFunc(pass *analysis.Pass, fn *ast.FuncDecl, pkgFuncs map[string]*ast.FuncDecl) {
-	guarded := callsQualified(fn.Body, pass, "path/filepath.EvalSymlinks") || callsSymlinkNamed(fn.Body)
-	cleans := callsQualified(fn.Body, pass, "path.Clean") || callsQualified(fn.Body, pass, "path/filepath.Clean")
 	bound := bindings(pass, fn.Body)
 	params := paramObjects(pass, fn)
-	// A function that runs its components through a validator or
-	// sanitizer (validateScaffoldName, sanitizeMigrationName) is doing
-	// its own containment: cmd/gofastr's scaffold and migrate's
-	// generator both sanitize before joining. Measured 2026-09-02.
-	validates := callsNamedLike(fn.Body, `(?i)sanit|valid|clean|safe`)
+	// Resolution and validation gates are per WRITE, not per function:
+	// an EvalSymlinks (or validator, or Clean) on an unrelated path
+	// resolves nothing for this one.
+	evals := evalSymlinkCalls(pass, fn.Body)
+	symlinkGuard := callsSymlinkNamed(pass, fn.Body)
 
 	ast.Inspect(fn.Body, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
@@ -111,12 +120,15 @@ func checkFunc(pass *analysis.Pass, fn *ast.FuncDecl, pkgFuncs map[string]*ast.F
 				pathArg = argAt(call, 0)
 			}
 		}
-		if pathArg != nil && !guarded && !validates &&
+		if pathArg != nil && !symlinkGuard &&
+			!symlinkResolved(pass, pathArg, bound, evals) &&
+			!validatorShields(pass, pathArg, bound) &&
 			joinsUnderRooty(pass, pathArg, bound, params, pkgFuncs) {
 			pass.Reportf(call.Pos(),
 				"write under a root with lexical containment only: a symlinked directory component escapes the root undetected; resolve with filepath.EvalSymlinks before writing")
 		}
-		// zip.Writer entries named from a parameter without a Clean.
+		// zip.Writer entries named from a parameter without a Clean on
+		// the entry-name chain.
 		sel, ok := call.Fun.(*ast.SelectorExpr)
 		if ok && (sel.Sel.Name == "Create" || sel.Sel.Name == "CreateHeader") && isZipWriter(pass, sel.X) {
 			var name ast.Expr
@@ -125,7 +137,7 @@ func checkFunc(pass *analysis.Pass, fn *ast.FuncDecl, pkgFuncs map[string]*ast.F
 			} else {
 				name = headerName(pass, argAt(call, 0), bound)
 			}
-			if name != nil && !cleans && composedFromParam(pass, name, bound, params) {
+			if name != nil && !cleanedEntryName(pass, name, bound) && composedFromParam(pass, name, bound, params) {
 				pass.Reportf(call.Pos(),
 					"zip entry name built from a parameter without path.Clean: an uncleaned name can place entries outside the target directory on extract; path.Clean and reject \"..\" segments")
 			}
@@ -134,15 +146,161 @@ func checkFunc(pass *analysis.Pass, fn *ast.FuncDecl, pkgFuncs map[string]*ast.F
 	})
 }
 
+// evalSymlinkCalls collects the filepath.EvalSymlinks calls in body.
+func evalSymlinkCalls(pass *analysis.Pass, body *ast.BlockStmt) []*ast.CallExpr {
+	var out []*ast.CallExpr
+	ast.Inspect(body, func(n ast.Node) bool {
+		if call, ok := n.(*ast.CallExpr); ok &&
+			qualifiedFunc(pass, call.Fun) == "path/filepath.EvalSymlinks" {
+			out = append(out, call)
+		}
+		return true
+	})
+	return out
+}
+
+// symlinkResolved reports whether the write's path is resolved against
+// symlinks ON THE CHAIN: the path itself is an EvalSymlinks result, a
+// resolved local feeds it, or an EvalSymlinks ran on this path
+// expression (directly or through a local). An EvalSymlinks on an
+// unrelated path resolves nothing.
+func symlinkResolved(pass *analysis.Pass, pathArg ast.Expr, bound map[types.Object]ast.Expr, evals []*ast.CallExpr) bool {
+	isEval := func(c *ast.CallExpr) bool {
+		return qualifiedFunc(pass, c.Fun) == "path/filepath.EvalSymlinks"
+	}
+	r := resolve(pass, pathArg, bound, 0)
+	if call, ok := r.(*ast.CallExpr); ok && isEval(call) {
+		return true
+	}
+	if mentionsCall(pass, pathArg, bound, isEval, 0) {
+		return true
+	}
+	for _, ev := range evals {
+		for _, a := range ev.Args {
+			if argTouchesPath(pass, a, bound, r) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// argTouchesPath reports whether an EvalSymlinks argument mentions a
+// local bound to the same expression as the write path — the resolved
+// leaf, its Dir, or the path itself.
+func argTouchesPath(pass *analysis.Pass, arg ast.Expr, bound map[types.Object]ast.Expr, r ast.Expr) bool {
+	found := false
+	ast.Inspect(arg, func(n ast.Node) bool {
+		id, ok := n.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if b, ok := bound[pass.TypesInfo.ObjectOf(id)]; ok {
+			if b == r || types.ExprString(b) == types.ExprString(r) {
+				found = true
+				return false
+			}
+		}
+		return !found
+	})
+	return found
+}
+
+// validatorShields reports whether a sanitizer/validator's RESULT
+// replaces a component of the built path: that is the only validator
+// posture that touches what reaches the disk. A validator consulted
+// for its boolean (validName(name) in a guard) cannot see symlinks
+// and shields nothing.
+func validatorShields(pass *analysis.Pass, pathArg ast.Expr, bound map[types.Object]ast.Expr) bool {
+	isValidator := func(c *ast.CallExpr) bool {
+		var name string
+		switch fun := c.Fun.(type) {
+		case *ast.Ident:
+			name = fun.Name
+		case *ast.SelectorExpr:
+			name = fun.Sel.Name
+		}
+		return name != "" && validatorRe.MatchString(name)
+	}
+	r := resolve(pass, pathArg, bound, 0)
+	for _, comp := range pathComponents(r) {
+		if mentionsCall(pass, comp, bound, isValidator, 0) {
+			return true
+		}
+	}
+	return false
+}
+
+// pathComponents returns the caller-facing components of a built path:
+// the arguments of the building call, or everything concatenated after
+// the leading operand.
+func pathComponents(r ast.Expr) []ast.Expr {
+	switch x := r.(type) {
+	case *ast.CallExpr:
+		return x.Args
+	case *ast.BinaryExpr:
+		if x.Op == token.ADD {
+			if ops := concatOperands(x, nil); len(ops) >= 2 {
+				return ops[1:]
+			}
+		}
+	}
+	return nil
+}
+
+// cleanedEntryName reports whether the zip entry name's assembly is
+// bound to a path.Clean / filepath.Clean result. A Clean on an
+// unrelated path cleans no entry name.
+func cleanedEntryName(pass *analysis.Pass, name ast.Expr, bound map[types.Object]ast.Expr) bool {
+	isClean := func(c *ast.CallExpr) bool {
+		q := qualifiedFunc(pass, c.Fun)
+		return q == "path.Clean" || q == "path/filepath.Clean"
+	}
+	return mentionsCall(pass, name, bound, isClean, 0)
+}
+
+// mentionsCall reports whether e's assembly involves (directly, or
+// through locals bound in this function) a call matching pred.
+func mentionsCall(pass *analysis.Pass, e ast.Expr, bound map[types.Object]ast.Expr, pred func(*ast.CallExpr) bool, depth int) bool {
+	if depth > 6 {
+		return false
+	}
+	found := false
+	ast.Inspect(e, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		if call, ok := n.(*ast.CallExpr); ok && pred(call) {
+			found = true
+			return false
+		}
+		if id, ok := n.(*ast.Ident); ok {
+			if obj := pass.TypesInfo.ObjectOf(id); obj != nil {
+				if b, ok := bound[obj]; ok && mentionsCall(pass, b, bound, pred, depth+1) {
+					found = true
+					return false
+				}
+			}
+		}
+		return !found
+	})
+	return found
+}
+
 // callsSymlinkNamed reports whether the body calls any function whose
 // name says symlink (EnsureNoSymlinkPath, EnsureNoSymlinkLeaf): the
 // codegen fileset posture, which refuses symlinked components without
-// spelling filepath.EvalSymlinks.
-func callsSymlinkNamed(body *ast.BlockStmt) bool {
+// spelling filepath.EvalSymlinks. filepath.EvalSymlinks itself is
+// excluded — its resolution is judged on the write's chain, not by
+// name presence.
+func callsSymlinkNamed(pass *analysis.Pass, body *ast.BlockStmt) bool {
 	found := false
 	ast.Inspect(body, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
+			return true
+		}
+		if qualifiedFunc(pass, call.Fun) == "path/filepath.EvalSymlinks" {
 			return true
 		}
 		var name string
@@ -176,12 +334,16 @@ func composedFromParam(pass *analysis.Pass, e ast.Expr, bound map[types.Object]a
 	}
 }
 
-// joinsUnderRooty reports whether e resolves — directly, through locals,
-// or through one same-package helper call — to filepath.Join(root, …)
-// with root a root/base/dir-named parameter or field and at least one
-// non-literal joined component after it.
+// joinsUnderRooty reports whether e resolves — directly, through
+// locals, or through one same-package helper call — to a path built
+// under a root/base/dir-named parameter or field: a filepath.Join, or
+// a flat `root + "/" + x` concatenation, with at least one
+// caller-controlled component after the root.
 func joinsUnderRooty(pass *analysis.Pass, e ast.Expr, bound map[types.Object]ast.Expr, params map[types.Object]bool, pkgFuncs map[string]*ast.FuncDecl) bool {
 	e = resolve(pass, e, bound, 0)
+	if be, ok := e.(*ast.BinaryExpr); ok && be.Op == token.ADD {
+		return concatUnderRooty(pass, be, bound, params)
+	}
 	call, ok := e.(*ast.CallExpr)
 	if !ok {
 		return false
@@ -190,7 +352,7 @@ func joinsUnderRooty(pass *analysis.Pass, e ast.Expr, bound map[types.Object]ast
 		if len(call.Args) < 2 {
 			return false
 		}
-		root := rootyParamOrField(pass, call.Args[0], bound, params)
+		root := rootyRoot(pass, call.Args[0], bound, params)
 		if root == nil {
 			return false
 		}
@@ -208,7 +370,9 @@ func joinsUnderRooty(pass *analysis.Pass, e ast.Expr, bound map[types.Object]ast
 		return false
 	}
 	// A helper that joins its own root parameter (e.g. containedPath).
-	// The non-root arguments at the call site must carry caller data.
+	// The non-root arguments at the call site must carry caller data:
+	// a helper called with literal-only components appends nothing
+	// caller-controlled under the root.
 	decl := calleeDecl(pass, call.Fun, pkgFuncs)
 	if decl == nil {
 		return false
@@ -217,10 +381,103 @@ func joinsUnderRooty(pass *analysis.Pass, e ast.Expr, bound map[types.Object]ast
 	if rootParam == "" || !helperJoinsParam(pass, decl, rootParam) {
 		return false
 	}
-	if callsQualified(decl.Body, pass, "path/filepath.EvalSymlinks") || callsSymlinkNamed(decl.Body) {
+	if callsQualified(decl.Body, pass, "path/filepath.EvalSymlinks") || callsSymlinkNamed(pass, decl.Body) {
 		return false // the helper resolves symlinks: the fix posture
 	}
-	return true
+	rootIdx := rootyParamIndex(decl, rootParam)
+	for i, a := range call.Args {
+		if i == rootIdx {
+			continue
+		}
+		if mentionsParam(pass, a, bound, params, 0) {
+			return true
+		}
+	}
+	return false
+}
+
+// rootyRoot resolves the Join's first argument to the root expression:
+// a rooty parameter or field directly, or a local whose binding is a
+// rooty param/field selector — including one passed through a
+// root-returning helper (root, err := resolveRoot(v.root)).
+func rootyRoot(pass *analysis.Pass, e ast.Expr, bound map[types.Object]ast.Expr, params map[types.Object]bool) ast.Expr {
+	if r := rootyParamOrField(pass, e, bound, params); r != nil {
+		return r
+	}
+	id, ok := e.(*ast.Ident)
+	if !ok {
+		return nil
+	}
+	b, ok := bound[pass.TypesInfo.ObjectOf(id)]
+	if !ok {
+		return nil
+	}
+	if r := rootyParamOrField(pass, b, bound, params); r != nil {
+		return r
+	}
+	if c, ok := b.(*ast.CallExpr); ok {
+		for _, a := range c.Args {
+			if r := rootyParamOrField(pass, a, bound, params); r != nil {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+// concatUnderRooty reports whether a flat ADD chain is rooted at a
+// rooty param/field with caller data concatenated after it — the same
+// lexical-only containment a Join spells.
+func concatUnderRooty(pass *analysis.Pass, be *ast.BinaryExpr, bound map[types.Object]ast.Expr, params map[types.Object]bool) bool {
+	ops := concatOperands(be, nil)
+	if len(ops) < 2 {
+		return false
+	}
+	root := rootyRoot(pass, ops[0], bound, params)
+	if root == nil {
+		return false
+	}
+	if isTempRoot(pass, root, bound) {
+		return false
+	}
+	for _, o := range ops[1:] {
+		if mentionsParam(pass, o, bound, params, 0) {
+			return true
+		}
+	}
+	return false
+}
+
+// concatOperands flattens a left-associated ADD chain, leftmost first.
+func concatOperands(be *ast.BinaryExpr, out []ast.Expr) []ast.Expr {
+	if inner, ok := be.X.(*ast.BinaryExpr); ok && inner.Op == token.ADD {
+		out = concatOperands(inner, out)
+	} else {
+		out = append(out, be.X)
+	}
+	return append(out, be.Y)
+}
+
+// rootyParamIndex returns the positional index of decl's parameter
+// named rootParam, or -1.
+func rootyParamIndex(decl *ast.FuncDecl, rootParam string) int {
+	if decl.Type.Params == nil {
+		return -1
+	}
+	idx := 0
+	for _, f := range decl.Type.Params.List {
+		if len(f.Names) == 0 {
+			idx++
+			continue
+		}
+		for _, name := range f.Names {
+			if name.Name == rootParam {
+				return idx
+			}
+			idx++
+		}
+	}
+	return -1
 }
 
 // rootyParamOrField returns the root expression when e is a parameter
@@ -540,30 +797,4 @@ func isLiteral(e ast.Expr) bool {
 	default:
 		return false
 	}
-}
-
-// callsNamedLike reports whether the body calls any function whose name
-// matches the pattern: validators and sanitizers that shield the path
-// components this function joins.
-func callsNamedLike(body *ast.BlockStmt, pattern string) bool {
-	re := regexp.MustCompile(pattern)
-	found := false
-	ast.Inspect(body, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		var name string
-		switch fun := call.Fun.(type) {
-		case *ast.Ident:
-			name = fun.Name
-		case *ast.SelectorExpr:
-			name = fun.Sel.Name
-		}
-		if name != "" && re.MatchString(name) {
-			found = true
-		}
-		return !found
-	})
-	return found
 }

--- a/internal/analyzers/rootwrite/rootwrite_test.go
+++ b/internal/analyzers/rootwrite/rootwrite_test.go
@@ -9,5 +9,5 @@ import (
 )
 
 func TestRootWrite(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), rootwrite.Analyzer, "a", "b", "c")
+	analysistest.Run(t, analysistest.TestData(), rootwrite.Analyzer, "a", "b", "c", "d")
 }

--- a/internal/analyzers/rootwrite/testdata/src/d/d.go
+++ b/internal/analyzers/rootwrite/testdata/src/d/d.go
@@ -1,0 +1,149 @@
+// Package d holds the rootwrite spellings the 2026-09-02 adversarial
+// review showed were missing or mis-scoped: a rooty field copied into
+// a local, a helper called with literal-only components, validator /
+// EvalSymlinks / Clean gates that never touch the write path, and
+// concatenation-built paths.
+package d
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// rootLocal: the rooty field is validated through a helper first and
+// the JOIN sees only the local — the write is still lexically
+// contained only.
+func rootLocal(token string, data []byte) error {
+	v := vault{}
+	root, err := resolveRoot(v.root)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(root, token), data, 0o600) // want `write under a root with lexical containment only`
+}
+
+type vault struct{ root string }
+
+func resolveRoot(s string) (string, error) {
+	if s == "" {
+		return "", errors.New("empty root")
+	}
+	return s, nil
+}
+
+// containedHelper joins and prefix-checks: lexical containment only.
+func containedHelper(root, rel string) (string, error) {
+	if filepath.IsAbs(rel) {
+		return "", fmt.Errorf("absolute")
+	}
+	abs := filepath.Join(root, filepath.FromSlash(rel))
+	base := filepath.Clean(root)
+	if abs != base && !strings.HasPrefix(abs, base+string(filepath.Separator)) {
+		return "", fmt.Errorf("escapes")
+	}
+	return abs, nil
+}
+
+// helperLiteral: every non-root argument of the helper call is a
+// literal — a fixed manifest name through a containment helper is a
+// real idiom and nothing caller-controlled is appended.
+func helperLiteral(r Report) error {
+	abs, err := containedHelper(r.Root, "manifest.json")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(abs, []byte("{}"), 0o644)
+}
+
+type Report struct{ Root string }
+
+// helperParam: the helper call carries a parameter beside the root:
+// fires like a direct Join.
+func helperParam(r Report, rel string) error {
+	abs, err := containedHelper(r.Root, rel)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(abs, []byte("{}"), 0o644) // want `write under a root with lexical containment only`
+}
+
+// validName is a name-FORMAT validator: it cannot see symlinks.
+func validName(s string) bool {
+	for _, r := range s {
+		if r == 0 || r > 127 {
+			return false
+		}
+	}
+	return s != ""
+}
+
+// validGate: a format validator consulted for its boolean does not
+// resolve the symlinked components of the join.
+func validGate(baseDir, name string) error {
+	if !validName(name) {
+		return errors.New("bad name")
+	}
+	return os.MkdirAll(filepath.Join(baseDir, "plugins", name), 0o755) // want `write under a root with lexical containment only`
+}
+
+// validResultFixed: the sanitizer's RESULT replaces the joined
+// component — that is the dataflow the silence is declared on.
+func validResultFixed(baseDir, name string) error {
+	safe := sanitizeName(name)
+	if safe == "" {
+		return errors.New("bad name")
+	}
+	return os.MkdirAll(filepath.Join(baseDir, "plugins", safe), 0o755)
+}
+
+func sanitizeName(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r > 0 && r <= 127 {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// evalAnywhere: EvalSymlinks resolved an unrelated path; the write's
+// own chain is untouched.
+func evalAnywhere(token string, data []byte) error {
+	v := vault{}
+	audit, err := filepath.EvalSymlinks(filepath.Join(v.root, "audit.log"))
+	if err != nil {
+		return err
+	}
+	_ = audit
+	return os.WriteFile(filepath.Join(v.root, token), data, 0o600) // want `write under a root with lexical containment only`
+}
+
+// zipClean: a Clean on an unrelated disk path cleans no entry name.
+func zipClean(session string, logs []string) ([]byte, error) {
+	cleanDisk := filepath.Clean("/var/tmp//x")
+	_ = cleanDisk
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	for _, l := range logs {
+		if _, err := w.Create(session + "/" + l); err != nil { // want `zip entry name built from a parameter without path.Clean`
+			return nil, err
+		}
+	}
+	return buf.Bytes(), w.Close()
+}
+
+// concatBuild: a flat root + "/" + x chain is the same lexical-only
+// containment as a Join.
+func concatBuild(root, name string, data []byte) error {
+	return os.WriteFile(root+"/"+name, data, 0o600) // want `write under a root with lexical containment only`
+}
+
+// concatLiteral: nothing caller-controlled after the root.
+func concatLiteral(root string) error {
+	return os.WriteFile(root+"/manifest.json", []byte("{}"), 0o644)
+}

--- a/internal/analyzers/rootwrite/testdata/src/d/d.go
+++ b/internal/analyzers/rootwrite/testdata/src/d/d.go
@@ -101,6 +101,24 @@ func validResultFixed(baseDir, name string) error {
 	return os.MkdirAll(filepath.Join(baseDir, "plugins", safe), 0o755)
 }
 
+// cleanShield: filepath.Clean normalizes separators and dot segments;
+// it resolves no symlink, so the symlinked-directory escape this rule
+// reports survives it untouched.
+func cleanShield(root, name string, data []byte) error {
+	return os.WriteFile(filepath.Join(root, filepath.Clean(name)), data, 0o600) // want `write under a root with lexical containment only`
+}
+
+// cleanNameKeep is a same-package helper whose RESULT replaces the
+// joined component — the local clean-named spelling that keeps
+// shielding (a stdlib Clean never does).
+func cleanNameKeep(s string) string {
+	return strings.TrimSuffix(s, "/")
+}
+
+func cleanLocalShield(root, name string, data []byte) error {
+	return os.WriteFile(filepath.Join(root, cleanNameKeep(name)), data, 0o600)
+}
+
 func sanitizeName(s string) string {
 	var b strings.Builder
 	for _, r := range s {


### PR DESCRIPTION
The three follow-ups from the v0.81.0 static-analysis assessment: the analyzer pass is timed, the silent recovers log, and the nineteen rules went through an adversarial review round with every finding proven by execution and fixed.

## Timing

On a fresh build cache the whole-tree `go vet` pass takes about 22 seconds with either the v0.80.0 or the v0.81.0 vettool; the difference is under a second and inside the run-to-run noise, and warm passes are one second for both. The twelve analyzers cost nothing measurable.

## Silent recovers

The five recover guards v0.81.0 added around app callbacks on dispatch loops swallowed the panic. Each now logs the panic value and where it happened through `slog` before continuing.

## The review round

Five reviewers (four GLM, one Sol) each took a slice of the rules with the intellectual-honesty rubric and one instruction: nothing goes in the report without a fixture, a command, and observed output, with a firing control in the same run. They produced around seventy-five findings across the twelve analyzers, the three contract rules, and the four runtime lints, and every one held up on merit:

- **False negatives on common spellings**: package-level `slog` calls and the log message itself were never sinks; range variables never carried taint; `fmt.Sprintf` splices and `http.Header` parameters were invisible to the forwarded-proto rule; template-literal URLs and `innerHTML +=` were invisible to the runtime lints; interface dispatch broke the recover reachability walk.
- **False positives that would block commits**: outbound request headers, `go cb()` under a lock, error messages starting with `type` or `func`, API-key prefix checks, `window.CSS.escape`, a guard hoisted into a boolean or formatted across lines, and code inside a string literal.
- **Narrowings a bug wears trivially**: `path.Clean` cleared control-byte taint, any map membership counted as an allowlist, the `in` operator counted as an own-property guard (it walks the prototype chain), any `.test(` regex counted as an anchored name gate, `.statusText` counted as a status check, and a recover in an unrelated goroutine protected its parent.

Four fixer workers, one per slice, turned each reviewer fixture into a permanent fixture, watched it fail, then changed the rule. Every widened rule was re-run over the whole tree and its new findings triaged on merit. Around twenty-five were real siblings and are fixed in their own packages ahead of the rule change, so every commit bisects clean: the MCP, cron, queue, and notify gates and routers now fail closed under recover; the setup wizard runs steps outside its lock with an in-flight flag keeping exactly-once; `uihost` refuses a style name that would rewrite the CSS link path; three runtime registries stop trusting `in`; wrong-typed A2A, process-module, and OpenAPI envelope fields are errors; dropped refusals in the admin, resource, and harness surfaces are logged or returned; `gofastr new` resolves symlinks before writing. Legitimate idioms narrowed the rule instead, each with the reason in the doc comment and a fixture pinning the silence.

Sol's structural point stands and is not addressed here: the runtime lints hand-roll JavaScript lexing, and the fixes to regex literals, string-literal code, and optional chaining patch that approach rather than replace it. A real tokenizer is the durable fix if the lints keep growing.

## Verification

Every worker diff read line by line and its packages re-run by me before commit; `go test ./internal/analyzers/... ./cmd/vettool/ ./framework/contracts/... ./core-ui/check/`, the full `core-ui/runtime` suite, `make analyze`, and `gofastr verify --no-vet --strict` clean on the merged tree; a whole-repo `go test -short ./...` sweep clean before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BLjmqxTmrgQgZg2S2wefZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Hardened component stylesheet paths and scaffold generation against unsafe path values.
  * Improved resilience for queues, scheduled jobs, tool calls, notifications, callbacks, and runtime registries.
  * Panic recovery now records actionable logs instead of silently suppressing failures.

* **Bug Fixes**
  * Malformed API, OpenAPI, and process-module fields now return clear errors.
  * Improved error handling and safe fallbacks across search, administration, providers, and resources.
  * Setup steps no longer hold locks while running.

* **Analyzer Improvements**
  * Improved accuracy across security, taint, routing, callback, and runtime lint rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->