### PR TITLE
Second review round on #388: guard direction, lint gates, MCP gate logging

### DIFF
--- a/core-ui/check/runtimeshapes.go
+++ b/core-ui/check/runtimeshapes.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -510,25 +511,36 @@ func isJSIdent(s string) bool {
 //   - a bare variable argument (querySelector(sel)) — provenance is
 //     not traceable line-locally, and the repo has no such site;
 //   - values wrapped in CSS.escape(…) — including dotted references
-//     like window.CSS.escape(…), the defensive spelling for browsers
-//     where the bare global is not bound — or a module-local
-//     cssEscape(…) shim;
-//   - arithmetic on a numeric literal (`index + 1` in an nth-child):
-//     every operand is an identifier, member access, or number and at
-//     least one is a number, so the value cannot carry selector
-//     metacharacters (review 5);
+//
+// like window.CSS.escape(…), the defensive spelling for browsers
+// where the bare global is not bound — or a module-local
+// cssEscape(…) shim: the escape call must be the WHOLE operand;
+// a trailing || or ?: operand (`CSS.escape(v) || el.dataset.t`)
+// still carries the raw value when the escape result is the
+// empty string (review 6);
+//   - arithmetic over numbers and identifiers PROVEN numeric at the
+//
+// use (`index + 1` in an nth-child): every operand is a number or
+// an identifier whose deciding assignment is one numeric literal
+// (a for-loop counter included), and at least one operand is a
+// number. An identifier from a DOM attribute is a string —
+// `idx + 1` is concatenation — so it reports (review 5 pinned
+// the numeric form, review 6 the provenance);
 //   - identifiers whose LAST assignment before the use, within the
-//     enclosing function, is from one string literal (dropdown.js's
-//     IS_OPEN, reveal.js's REVEAL_ATTR) or an escape call
-//     (rangeslider.js's `const sel = CSS.escape(id)`), and for-of
-//     loop variables iterating an array of string literals (boot.js's
-//     eventType): those provably hold a literal at the lookup point.
-//     A later reassignment from anything else (an attribute read, a
-//     concatenation, a compound append — review 5's
-//     `id = CSS.escape('fixed'); id = el.dataset.target`) revokes the
-//     status, and a same-named identifier in a different function
-//     never shares it — the safe set is per function scope, ordered by
-//     assignment position;
+//
+// enclosing function, is from one string literal (dropdown.js's
+// IS_OPEN, reveal.js's REVEAL_ATTR) or an escape call
+// (rangeslider.js's `const sel = CSS.escape(id)`), and for-of
+// loop variables iterating an array of string literals (boot.js's
+// eventType): those provably hold a literal at the lookup point.
+// A later reassignment from anything else (an attribute read, a
+// concatenation, a compound append — review 5's
+// `id = CSS.escape('fixed'); id = el.dataset.target`) revokes the
+// status, a same-named identifier in a different function never
+// shares it, a MEMBER assignment (obj.id = 'fixed') records
+// nothing for the bare name, and a function parameter shadows a
+// file-scope safe name inside that function — the safe set is per
+// function scope, ordered by assignment position (review 6);
 //   - getElementById (never scanned).
 //
 // Call tokens are matched on the Blank view and the argument text is
@@ -541,7 +553,7 @@ func LintSelectorInterpolation(roots ...string) (*Result, error) {
 		return nil, err
 	}
 	for _, f := range files {
-		events := safeIdentEvents(f.Code)
+		events := safeIdentEvents(f.Code, f.Blank)
 		for _, loc := range reSelectorCall.FindAllStringIndex(f.Blank, -1) {
 			if loc[0] > 0 && isJSIdentChar(f.Blank[loc[0]-1]) {
 				continue // part of a longer identifier (prefetch(, myMatches()
@@ -552,7 +564,8 @@ func LintSelectorInterpolation(roots ...string) (*Result, error) {
 				continue
 			}
 			safe := func(name string) bool { return safeAt(events, name, loc[0]) }
-			bad, ok := selectorUnsafeOperand(f.Code[open+1:close], safe)
+			numeric := func(name string) bool { return numericAt(events, name, loc[0]) }
+			bad, ok := selectorUnsafeOperand(f.Code[open+1:close], safe, numeric)
 			if !ok {
 				continue
 			}
@@ -569,12 +582,15 @@ var reSelectorCall = regexp.MustCompile(`(?:querySelectorAll|querySelector|close
 // function scope it happened in: an init from a string literal or an
 // escape call forms the safe set at that point; any later assignment
 // from something else (an attribute read, a concatenation, a compound
-// append) revokes it.
+// append) revokes it. numeric records the same event's numeric
+// provenance (an init from one numeric literal), the fact
+// isNumericArithExpr asks about arithmetic operands (review 6).
 type safeEvent struct {
 	name                 string
 	scopeStart, scopeEnd int
 	pos                  int
 	safe                 bool
+	numeric              bool
 }
 
 var (
@@ -594,77 +610,199 @@ var (
 )
 
 // safeIdentEvents collects the ordered assignment events of the file,
-// each tagged with its enclosing function scope. The safe set is per
-// function (plus the file's top level as one scope), so an identifier
-// escaped in one function never launders a same-named attribute read in
-// another. Function scopes are indexed ONCE per file and resolved by
-// binary search plus a parent walk: calling enclosingFunction per event
-// walked the source backward to the file start for top-level code,
-// which made a many-assignment file quadratic (measured 22.9s user on
-// the reviewer's 40k-line generated file before this index).
-func safeIdentEvents(code string) []safeEvent {
-	scopes, parents := functionScopes(code)
+// each tagged with its enclosing function scope, plus one
+// unsafe/non-numeric event per function PARAMETER at the function's
+// scope start: the safe set is per function (plus the file's top level
+// as one scope), so an identifier escaped in one function never
+// launders a same-named attribute read in another, and a file-scope
+// safe name never launders a same-named parameter inside a function
+// that shadows it (review 6). Member assignments (obj.id = …) are not
+// identifier assignments and record nothing (review 6). Function
+// scopes are indexed ONCE per file and resolved by binary search plus
+// a parent walk: calling enclosingFunction per event walked the source
+// backward to the file start for top-level code, which made a
+// many-assignment file quadratic (measured 22.9s user on the
+// reviewer's 40k-line generated file before this index).
+func safeIdentEvents(code, blank string) []safeEvent {
+	scopes, parents := functionScopes(blank)
 	var events []safeEvent
-	record := func(name string, pos int, safe bool) {
-		s, e := scopeOf(code, scopes, parents, pos)
-		events = append(events, safeEvent{name: name, scopeStart: s, scopeEnd: e, pos: pos, safe: safe})
+	record := func(name string, pos int, safe, numeric bool) {
+		s, e := scopeOf(blank, scopes, parents, pos)
+		events = append(events, safeEvent{name: name, scopeStart: s, scopeEnd: e, pos: pos, safe: safe, numeric: numeric})
 	}
 	for _, m := range reSafeAssign.FindAllStringSubmatchIndex(code, -1) {
 		name := code[m[2]:m[3]]
 		if jsKeywords[name] || m[4] != m[5] { // arrow parameter, not an assignment
 			continue
 		}
+		if m[2] > 0 && code[m[2]-1] == '.' {
+			continue // obj.id = … assigns the member, not a binding named id
+		}
 		rhs := strings.TrimSpace(code[m[6]:m[7]])
 		if strings.HasPrefix(rhs, "=") { // == / === read through the '='
 			continue
 		}
-		record(name, m[2], rhsSafeForm(rhs))
+		record(name, m[2], rhsSafeForm(rhs), isJSNumericLiteral(rhs))
 	}
 	for _, m := range reSafeCompound.FindAllStringSubmatchIndex(code, -1) {
+		if m[2] > 0 && code[m[2]-1] == '.' {
+			continue // obj.id += … compounds the member, not a binding named id
+		}
 		if name := code[m[2]:m[3]]; !jsKeywords[name] {
-			record(name, m[0], false)
+			record(name, m[0], false, false)
 		}
 	}
 	for _, m := range reSafeForOf.FindAllStringSubmatchIndex(code, -1) {
-		record(code[m[2]:m[3]], m[0], true)
+		record(code[m[2]:m[3]], m[0], true, false)
+	}
+	for _, span := range scopes {
+		for _, name := range paramNames(blank, span[0]) {
+			record(name, span[0], false, false)
+		}
 	}
 	return events
 }
 
+// paramNames extracts the parameter names of the function whose body
+// '{' sits at bodyOpen in view: the single identifier of a one-param
+// arrow (`x => {`) or, when a ')' precedes the '{', the comma-separated
+// parts of the parenthesized list — plain identifiers, rest params,
+// defaults, and destructuring bindings ({a, b: c} binds a and c). The
+// blank view carries the same offsets as the code view, so the offsets
+// recorded for these names line up with assignment events.
+func paramNames(view string, bodyOpen int) []string {
+	j := skipSpaceBack(view, bodyOpen-1)
+	if j < 0 {
+		return nil
+	}
+	if view[j] == '>' && j >= 1 && view[j-1] == '=' { // x => {
+		k := skipSpaceBack(view, j-2)
+		if k < 0 {
+			return nil
+		}
+		end := k + 1
+		for k >= 0 && isJSIdentChar(view[k]) {
+			k--
+		}
+		if name := view[k+1 : end]; name != "" && !jsKeywords[name] {
+			return []string{name}
+		}
+		return nil
+	}
+	if view[j] != ')' {
+		return nil // every other function form's header ends in a parameter list
+	}
+	p := matchDelimBack(view, j)
+	if p < 0 {
+		return nil
+	}
+	var out []string
+	for _, part := range splitTopLevel(view[p+1:j], ',') {
+		out = append(out, bindingNames(part)...)
+	}
+	return out
+}
+
+// bindingNames extracts the identifier(s) one parameter part binds:
+// `id`, `...rest`, `id = dflt`, and — recursively through one level of
+// destructuring braces — shorthand members and renamed members after
+// the colon ({a, b: c} binds a and c, not b).
+func bindingNames(part string) []string {
+	s := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(part), "..."))
+	if i := topLevelAssignIndex(s); i >= 0 {
+		s = strings.TrimSpace(s[:i]) // strip a default value
+	}
+	if s == "" {
+		return nil
+	}
+	if isJSIdent(s) {
+		if !jsKeywords[s] {
+			return []string{s}
+		}
+		return nil
+	}
+	var out []string
+	for _, m := range splitTopLevel(strings.Trim(s, "{}[]()"), ',') {
+		t := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(m), "..."))
+		if i := topLevelAssignIndex(t); i >= 0 {
+			t = strings.TrimSpace(t[:i])
+		}
+		if k := strings.Index(t, ":"); k >= 0 { // {id: renamed} binds renamed
+			t = strings.TrimSpace(t[k+1:])
+		}
+		if isJSIdent(t) && !jsKeywords[t] {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// topLevelAssignIndex returns the offset of a top-level '=' in s that
+// separates a parameter from its default value, or -1: comparisons
+// (==, ===, !=, <=, >=) and the arrow (=>) are not defaults.
+func topLevelAssignIndex(s string) int {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case '=':
+			if depth != 0 {
+				continue
+			}
+			if i+1 < len(s) && (s[i+1] == '=' || s[i+1] == '>') {
+				i++
+				continue
+			}
+			if i > 0 && strings.IndexByte("=!<>", s[i-1]) >= 0 {
+				continue
+			}
+			return i
+		}
+	}
+	return -1
+}
+
 // functionScopes returns the [start, end) span of every function body
-// in code, sorted by start, and, in parallel, each scope's parent (the
-// innermost function scope containing it; -1 at the top level). One
-// left-to-right pass; non-function braces do not open scopes, exactly
-// as isFunctionOpener defines them.
-func functionScopes(code string) ([][2]int, []int) {
+// in the given view, sorted by start, and, in parallel, each scope's
+// parent (the innermost function scope containing it; -1 at the top
+// level). One left-to-right pass; non-function braces do not open
+// scopes, exactly as isFunctionOpener defines them. The caller passes
+// the BLANK view (review 6): regex literals are blanked there, so a
+// '}' inside a pattern (/[}]/) cannot close the function early and
+// leave later statements out of their scope — the code view carries
+// regex bodies verbatim and matchDelimForward must match across them.
+func functionScopes(view string) ([][2]int, []int) {
 	var spans [][2]int
 	var parents []int
 	var stack []int // indices of currently open function scopes
-	for i := 0; i < len(code); i++ {
+	for i := 0; i < len(view); i++ {
 		for len(stack) > 0 && spans[stack[len(stack)-1]][1] <= i {
 			stack = stack[:len(stack)-1]
 		}
-		switch code[i] {
+		switch view[i] {
 		case '\'', '"', '`':
-			q := code[i]
+			q := view[i]
 			i++
-			for i < len(code) {
-				if code[i] == '\\' {
+			for i < len(view) {
+				if view[i] == '\\' {
 					i += 2
 					continue
 				}
-				if code[i] == q {
+				if view[i] == q {
 					break
 				}
 				i++
 			}
 		case '{':
-			if !isFunctionOpener(code, i) {
+			if !isFunctionOpener(view, i) {
 				continue
 			}
-			end := matchDelimForward(code, i)
+			end := matchDelimForward(view, i)
 			if end < 0 {
-				end = len(code) - 1
+				end = len(view) - 1
 			}
 			parent := -1
 			if len(stack) > 0 {
@@ -702,7 +840,8 @@ func scopeOf(code string, scopes [][2]int, parents []int, pos int) (int, int) {
 }
 
 // rhsSafeForm reports whether an assignment RHS provably cannot carry a
-// selector metacharacter: exactly one string literal, or an escape call.
+// selector metacharacter: exactly one string literal, or one whole
+// escape call (isEscapeCall).
 func rhsSafeForm(rhs string) bool {
 	if rhs == "" {
 		return false
@@ -710,36 +849,53 @@ func rhsSafeForm(rhs string) bool {
 	if isJSStringLiteral(rhs) {
 		return true
 	}
-	return reEscapeCall.MatchString(rhs)
+	return isEscapeCall(rhs)
 }
 
-// safeAt reports whether identifier name provably holds a literal or an
-// escape result at pos: among the events for name before pos whose
-// scope CONTAINS pos, the one from the innermost scope wins, and within
-// it the latest position wins. A module-level constant therefore covers
-// every function in the file, a same-named local in a sibling function
-// covers nothing outside itself, and a reassignment inside the scope
-// revokes the status from that point on. No event at all (a parameter,
-// an import) is not provable and stays unsafe.
-func safeAt(events []safeEvent, name string, pos int) bool {
+// latestEvent returns the event that decides name's provenance at pos:
+// among the events before pos whose scope CONTAINS pos, the one from
+// the innermost scope wins, and within it the latest position wins. A
+// module-level constant therefore covers every function in the file, a
+// same-named local in a sibling function covers nothing outside
+// itself, and a reassignment or parameter inside the scope decides from
+// that point on. No event at all (an import) is not provable.
+func latestEvent(events []safeEvent, name string, pos int) (safeEvent, bool) {
 	bestScope, bestPos := -1, -1
-	res := false
+	var best safeEvent
+	found := false
 	for _, e := range events {
 		if e.name != name || e.pos >= pos || e.scopeStart > pos || e.scopeEnd <= pos {
 			continue
 		}
 		if e.scopeStart > bestScope || (e.scopeStart == bestScope && e.pos > bestPos) {
-			bestScope, bestPos = e.scopeStart, e.pos
-			res = e.safe
+			bestScope, bestPos, best, found = e.scopeStart, e.pos, e, true
 		}
 	}
-	return res
+	return best, found
+}
+
+// safeAt reports whether identifier name provably holds a literal or an
+// escape result at pos (see latestEvent). A parameter shadows the
+// file-scope fact inside its function (review 6).
+func safeAt(events []safeEvent, name string, pos int) bool {
+	e, ok := latestEvent(events, name, pos)
+	return ok && e.safe
+}
+
+// numericAt reports whether identifier name provably holds a number at
+// pos: its deciding event (see latestEvent) is an init from one
+// numeric literal — the fact isNumericArithExpr needs about arithmetic
+// operands, since an attribute-borne identifier plus a number is
+// string concatenation (review 6).
+func numericAt(events []safeEvent, name string, pos int) bool {
+	e, ok := latestEvent(events, name, pos)
+	return ok && e.numeric
 }
 
 // selectorUnsafeOperand inspects one selector argument and reports an
 // unescaped interpolated value, if the argument is a composite selector
 // expression (concatenation or template interpolation) carrying one.
-func selectorUnsafeOperand(arg string, safe func(string) bool) (string, bool) {
+func selectorUnsafeOperand(arg string, safe, numeric func(string) bool) (string, bool) {
 	ops := splitTopLevel(arg, '+')
 	hasTemplate := false
 	for _, op := range ops {
@@ -753,7 +909,7 @@ func selectorUnsafeOperand(arg string, safe func(string) bool) (string, bool) {
 			if tpl[j] == '$' && tpl[j+1] == '{' {
 				body, close := templateExprEnd(tpl, j+2)
 				b := strings.TrimSpace(body)
-				if !selectorOperandSafe(b, safe) {
+				if !selectorOperandSafe(b, safe, numeric) {
 					return b, true
 				}
 				j = close
@@ -768,7 +924,7 @@ func selectorUnsafeOperand(arg string, safe func(string) bool) (string, bool) {
 		if strings.HasPrefix(t, "`") {
 			continue // template operands handled above
 		}
-		if !selectorOperandSafe(t, safe) {
+		if !selectorOperandSafe(t, safe, numeric) {
 			return t, true
 		}
 	}
@@ -777,31 +933,51 @@ func selectorUnsafeOperand(arg string, safe func(string) bool) (string, bool) {
 
 // selectorOperandSafe reports whether one concatenation operand or
 // interpolation body cannot carry a selector metacharacter.
-func selectorOperandSafe(op string, safe func(string) bool) bool {
+func selectorOperandSafe(op string, safe, numeric func(string) bool) bool {
 	op = strings.TrimSpace(op)
 	if op == "" {
 		return true
 	}
-	if reEscapeCall.MatchString(op) {
+	if isEscapeCall(op) {
 		return true // CSS.escape(…), window.CSS.escape(…), cssEscape(…)
 	}
 	if isJSStringLiteral(op) || isJSNumericLiteral(op) {
 		return true
 	}
-	if isNumericArithExpr(op) {
-		return true // `index + 1` in an nth-child: digits only, no metacharacters
+	if isNumericArithExpr(op, numeric) {
+		return true // `index + 1` on a proven-numeric index: digits only, no metacharacters
 	}
 	return isJSIdent(op) && safe(op)
 }
 
-// isNumericArithExpr reports whether s is arithmetic over a numeric
-// literal (`index + 1`, `i * 2`): every +-*/%-separated token is a
-// plain identifier or a number, and at least one operand is a number.
-// Such a value is a number at runtime and cannot carry a selector
-// metacharacter (review 5's li:nth-child(${index + 1})). Dots,
-// parentheses, quotes, and calls disqualify the token: a member access
-// or call result is not provably numeric.
-func isNumericArithExpr(s string) bool {
+// isEscapeCall reports whether op is EXACTLY one escape call —
+// CSS.escape(v), window.CSS.escape(v), a module-local cssEscape(v)
+// shim — with nothing after the closing paren but space. A trailing
+// logical or conditional operand (`CSS.escape(v) ||
+// el.dataset.target`) still carries the raw value whenever the escape
+// result is falsy (the empty string), so it is not an escape (review
+// 6).
+func isEscapeCall(op string) bool {
+	loc := reEscapeCall.FindStringIndex(op)
+	if loc == nil {
+		return false
+	}
+	close := matchDelimForward(op, loc[1]-1)
+	return close >= 0 && strings.TrimSpace(op[close+1:]) == ""
+}
+
+// isNumericArithExpr reports whether s is arithmetic that provably
+// yields a number: every +-*/%-separated token is a number, or an
+// identifier PROVEN numeric at the use (its deciding assignment event
+// is an init from one numeric literal — a for-loop counter included),
+// and at least one operand is a number (`index + 1`, `i * 2` on
+// so-bound index/i). An identifier from a DOM attribute is a string:
+// `idx + 1` is string concatenation, and the result carries selector
+// metacharacters into an nth-child (review 6; review 5 pinned the
+// numeric-literal form). Dots, parentheses, quotes, and calls
+// disqualify the token: a member access or call result is not provably
+// numeric.
+func isNumericArithExpr(s string, numeric func(string) bool) bool {
 	if !strings.ContainsAny(s, "+-*/%") {
 		return false
 	}
@@ -813,7 +989,9 @@ func isNumericArithExpr(s string) bool {
 		case isNumericDotToken(tok):
 			hasNumber = true
 		case isJSIdent(tok):
-			// an identifier: numeric only in combination with the literal
+			if !numeric(tok) {
+				return false // unproven identifier: string concatenation
+			}
 		default:
 			return false
 		}
@@ -1511,10 +1689,15 @@ func skipSpaceBack(s string, i int) int {
 // like swapCase( (review 5) — a name is not a markup sink.
 //
 // Silent on:
-//   - chains gated on the response: a whole-token .ok or .status read
-//     (word boundary — displaying r.statusText or r.okButton is not a
-//     check) used as a condition — negated, compared, inside an
-//     if/while condition, or feeding a ternary / && / ||;
+//   - chains gated on the response (review 6 split the forms): a
+//
+// whole-token .ok read used as a condition — negated (!r.ok),
+// compared, inside an if/while condition, or feeding a ternary /
+// && / || — or a .status COMPARISON that admits only a 2xx
+// response: === 2xx, an upper bound under 400 (< 300, <= 299),
+// or >= 200 conjoined with such an upper bound. Bare .status
+// truthiness passes for 404 and 500 and is not a gate, and
+// neither is < 400 (every redirect) nor a bare >= 200;
 //   - await/multi-statement flows (const r = await fetch(…); …) — the
 //     chain ends at the statement boundary and the mount lives in
 //     later statements; those sites are pinned individually by the
@@ -1611,14 +1794,33 @@ func namedThenBodies(blank, span string) string {
 // .statusText and .okButton do not match (\b after the property).
 var reResponseToken = regexp.MustCompile(`\.\s*(?:ok|status)\b`)
 
+// reStatusToken matches the .status member read alone, so .ok and
+// .status gates can be judged by different rules (review 6).
+var reStatusToken = regexp.MustCompile(`\.\s*status\b`)
+
 // responseGateIn reports whether the chain text actually gates on the
-// response: a whole-token .ok/.status read used as a condition —
-// negated (!r.ok), compared on either side (r.status !== 200,
-// 200 === r.status), inside an if/while condition (if (resp.ok)), or
-// feeding a ternary / && / ||. Displaying the value (r.statusText,
-// r.okButton) or passing it to a function is not a gate.
+// response. A whole-token .ok read used as a condition counts as
+// before — negated (!r.ok), compared, inside an if/while condition (if
+// (resp.ok)), or feeding a ternary / && / ||. A .status read counts
+// only as a comparison that admits ONLY a successful response (review
+// 6): equality to a 2xx literal (r.status === 200), an upper bound
+// under the client errors (r.status < 300, r.status <= 299), or a
+// lower bound of 200 conjoined with such an upper bound (r.status >=
+// 200 && r.status < 300). Bare .status truthiness (if (r.status)) is
+// true for 404 and 500 and is not a gate; r.status < 400 still admits
+// every redirect, and a bare r.status >= 200 admits the whole error
+// half of the range. Displaying the value (r.statusText, r.okButton)
+// or passing it to a function is not a gate.
 func responseGateIn(span string) bool {
 	for _, m := range reResponseToken.FindAllStringIndex(span, -1) {
+		if reStatusToken.MatchString(span[m[0]:m[1]]) {
+			// A .status token (the match is ".status", not ".ok").
+			if statusCompAdmitsOnly2xx(span, m[0], m[1]) {
+				return true
+			}
+			continue
+		}
+		// A .ok token: any condition use counts.
 		if i := skipSpace(span, m[1]); i < len(span) && gateOpRight(span, i) {
 			return true
 		}
@@ -1631,6 +1833,105 @@ func responseGateIn(span string) bool {
 		}
 	}
 	return false
+}
+
+// reCmpOpAt matches a comparison operator at the start of s.
+var reCmpOpAt = regexp.MustCompile(`^(===|!==|==|!=|<=|>=|<|>)`)
+
+// reNumAt matches a decimal number at the start of s.
+var reNumAt = regexp.MustCompile(`^(\d+)`)
+
+// reCmpNumBefore matches a number and comparison operator ending at
+// the end of s: "200 ===" of `200 === r.status`.
+var reCmpNumBefore = regexp.MustCompile(`(\d+)\s*(===|==|!==|!=|<=|>=|<|>)\s*$`)
+
+// statusCompAdmitsOnly2xx reports whether the .status member read at
+// span[start:end] is compared in a way only a 2xx response satisfies:
+// an exact 2xx equality (either polarity — `if (r.status !== 200)
+// throw` leaves exactly 200 on the continuing path), an upper bound
+// below 400, or a >= 200 lower bound conjoined (&&) with such an upper
+// bound later in the same statement. Everything else — truthiness,
+// weak bounds, inequalities against non-2xx literals — still admits a
+// response the mount must not see.
+func statusCompAdmitsOnly2xx(span string, start, end int) bool {
+	// Comparison to the right: r.status < 300 / === 200 / !== 200 / >= 200.
+	if i := skipSpace(span, end); i < len(span) {
+		if op := reCmpOpAt.FindStringSubmatch(span[i:]); op != nil {
+			j := skipSpace(span, i+len(op[1]))
+			if num := reNumAt.FindStringSubmatch(span[j:]); num != nil {
+				lit, _ := strconv.Atoi(num[1])
+				switch {
+				case op[1] == "===" || op[1] == "==" || op[1] == "!==" || op[1] == "!=":
+					if lit >= 200 && lit <= 299 {
+						return true
+					}
+				case op[1] == "<" || op[1] == "<=":
+					if lit <= 399 {
+						return true
+					}
+				case op[1] == ">" || op[1] == ">=":
+					return lowerBoundConjoined(span, j+len(num[1]), lit)
+				}
+			}
+		}
+	}
+	// Mirrored: 200 === r.status, 300 > r.status.
+	j := memberExprStart(span, start)
+	if m := reCmpNumBefore.FindStringSubmatch(span[:j]); m != nil {
+		lit, _ := strconv.Atoi(m[1])
+		switch mirror := mirrorCmp(m[2]); mirror {
+		case "===", "==", "!==", "!=":
+			return lit >= 200 && lit <= 299
+		case "<", "<=":
+			return lit <= 399
+		}
+	}
+	return false
+}
+
+// reStatusUpperBound matches a .status upper-bound comparison
+// (< 300, <= 299) — the partner a >= 200 lower bound needs to admit
+// only 2xx. Static and run-once, like every gate pattern here.
+var reStatusUpperBound = regexp.MustCompile(`\.\s*status\s*(?:<=|<)\s*(\d+)`)
+
+// lowerBoundConjoined reports whether a >= 200-style lower bound is
+// conjoined (&&) with an upper bound below 400 on the status in the
+// same statement: r.status >= 200 && r.status < 300 admits only 2xx,
+// while the bare lower bound admits every error status.
+func lowerBoundConjoined(span string, from, lit int) bool {
+	if lit < 200 {
+		return false
+	}
+	rest := span[from:]
+	if i := strings.IndexAny(rest, ";{}"); i >= 0 {
+		rest = rest[:i]
+	}
+	and := strings.Index(rest, "&&")
+	if and < 0 {
+		return false
+	}
+	for _, m := range reStatusUpperBound.FindAllStringSubmatch(rest[and:], -1) {
+		if n, err := strconv.Atoi(m[1]); err == nil && n <= 399 {
+			return true
+		}
+	}
+	return false
+}
+
+// mirrorCmp flips a comparison operator so the subject can be treated
+// as the left operand: 300 > r.status reads r.status < 300.
+func mirrorCmp(op string) string {
+	switch op {
+	case "<":
+		return ">"
+	case "<=":
+		return ">="
+	case ">":
+		return "<"
+	case ">=":
+		return "<="
+	}
+	return op
 }
 
 // gateOpRight reports whether a comparison, ternary, or logical
@@ -1811,17 +2112,25 @@ func templateOperands(tpl string) []string {
 // string or template literal is prose and never reported (review 5).
 //
 // Silent on:
-//   - gates that PRECEDE the URL construction in source order within
-//     the enclosing function (review 5: a validating regex after the
-//     fetch does not un-send the request): an anchored regex test
-//     (/^[A-Za-z0-9_-]+$/.test(v)), a SAFE_NAME-style constant
-//     assigned a regex literal then .test(v), or an allowlist
-//     membership (X[v] inside an if condition, X.has(v)) — a
-//     server-emitted manifest or Set stops re-targeting exactly like a
-//     name-shape class. A regex gate counts only when the literal is
-//     anchored (^…$) and its body carries no ".", "\s", "\S", "\W", or
-//     negated class "[^" (review 5: /./ accepts "../admin", and a dot
-//     anywhere admits path separators);
+//   - gates that DOMINATE the URL construction (review 6 tightened
+//
+// review 5's source-order rule): the gate sits in the condition
+// of an if whose branch contains the construction, or in an
+// earlier if of a block enclosing it whose failure branch
+// rejects execution via return or throw — only validated values
+// continue to the fetch. A matching check in an unrelated
+// earlier branch constrains nothing, a gate that only sets a flag
+// constrains nothing, and a validating regex after the fetch does
+// not un-send the request. The gate shapes: an anchored regex
+// test (/^[A-Za-z0-9_-]+$/.test(v)), a SAFE_NAME-style constant
+// assigned a regex literal then .test(v), or an allowlist
+// membership (X[v] inside an if condition, X.has(v)) — a
+// server-emitted manifest or Set stops re-targeting exactly like
+// a name-shape class. A regex gate counts only when the literal
+// is anchored (^…$) and built exclusively from name-safe
+// characters and classes — an explicit allowlist, so every
+// backslash escape is out: \x2f, \u002f, \/ and \\ can match a
+// path separator (reviews 5 and 6);
 //   - numeric coercion of the value (Number(v), parseInt(v),
 //     parseFloat(v)): the result is a number or NaN and can never
 //     spell a traversal segment (review 5);
@@ -2094,44 +2403,162 @@ func regexConstNames(code string) map[string]string {
 	return set
 }
 
+// reIfOpen matches an if-condition opener: the '(' of `if (`.
+var reIfOpen = regexp.MustCompile(`\bif\s*\(`)
+
 // attrPathGated reports whether a name-shape or allowlist gate on
-// value v appears in the enclosing function of the site at pos BEFORE
-// pos in source order — the URL is built at pos, and a gate that runs
-// later cannot un-send the request (review 5). For an inline attribute
-// read (not a bare variable) any regex .test( counts: there is no
-// variable to match.
+// value v DOMINATES the URL construction at pos (review 6): the gate
+// sits in the condition of an if whose branch CONTAINS the
+// construction — the check necessarily ran and passed on the path that
+// builds the URL — or in an earlier if of a block enclosing the
+// construction whose failure branch REJECTS execution (return /
+// throw), so only validated values continue. A matching check in an
+// unrelated earlier branch constrains nothing (that branch can be
+// skipped), a gate that only sets a flag constrains nothing, and a
+// gate after pos cannot un-send the request (review 5). For an inline
+// attribute read (not a bare variable) any regex .test( counts: there
+// is no variable to match.
 func attrPathGated(code, v string, regexConsts map[string]string, pos int) bool {
 	start, _ := enclosingFunction(code, pos)
-	body := code[start:pos]
+	body := code[start:]
+	pos0 := pos - start
 	ident := `\w+`
 	if isJSIdent(v) {
 		ident = regexp.QuoteMeta(v)
 	}
-	// Regex-literal gate: /^[A-Za-z0-9_-]+$/.test(v) — anchored and
-	// metacharacter-free only; /./ accepts "../admin".
-	for _, m := range regexp.MustCompile(`(/[^/\n]+/[a-z]*)\s*\.\s*test\s*\(\s*`+ident+`\b`).FindAllStringSubmatch(body, -1) {
-		if regexGateAnchored(m[1]) {
-			return true
+	// One matcher over a condition text: an anchored inline regex test
+	// (/^[A-Za-z0-9_-]+$/.test(v)), a SAFE_NAME-style constant test, an
+	// allowlist membership (manifest[v], seen.has(v)) — the same gate
+	// shapes as before, now judged only where they dominate.
+	reTest := regexp.MustCompile(`(?:(/[^/\n]+/[a-z]*)|(\w+))\s*\.\s*test\s*\(\s*` + ident + `\b`)
+	reAllow := regexp.MustCompile(`\w+\s*\[\s*` + ident + `\s*\]`)
+	reHas := regexp.MustCompile(`\w+\s*\.\s*has\s*\(\s*` + ident + `\b`)
+	gateIn := func(cond string) bool {
+		for _, m := range reTest.FindAllStringSubmatch(cond, -1) {
+			if m[1] != "" {
+				if regexGateAnchored(m[1]) {
+					return true
+				}
+				continue
+			}
+			if lit, ok := regexConsts[m[2]]; ok && regexGateAnchored(lit) {
+				return true
+			}
+		}
+		return reAllow.MatchString(cond) || reHas.MatchString(cond)
+	}
+	for _, loc := range reIfOpen.FindAllStringIndex(body, -1) {
+		if loc[0] >= pos0 {
+			break // every later if is past the construction
+		}
+		open := loc[1] - 1
+		close := matchDelimForward(body, open)
+		if close < 0 || close >= pos0 {
+			continue
+		}
+		if !gateIn(body[open+1 : close]) {
+			continue
+		}
+		b := skipSpace(body, close+1)
+		if b >= len(body) {
+			continue
+		}
+		tEnd := b
+		if body[b] == '{' {
+			if e := matchDelimForward(body, b); e >= 0 {
+				tEnd = e
+			}
+		} else if e := statementEnd(body, b); e < len(body) {
+			tEnd = e
+		}
+		if b <= pos0 && pos0 <= tEnd {
+			return true // the branch that builds the URL ran the gate
+		}
+		if tEnd < pos0 && branchRejects(body[b:tEnd+1]) && ifStillOpenAt(body, tEnd+1, pos0) {
+			return true // the gate's failures left; only validated values continue
 		}
 	}
-	// SAFE_NAME-style constant holding a regex literal.
-	for _, m := range regexp.MustCompile(`(\w+)\s*\.\s*test\s*\(\s*`+ident+`\b`).FindAllStringSubmatch(body, -1) {
-		if lit, ok := regexConsts[m[1]]; ok && regexGateAnchored(lit) {
-			return true
-		}
-	}
-	// Allowlist membership: X[v] inside an if condition, or X.has(v).
-	if regexp.MustCompile(`if\s*\([^)\n]*\w+\s*\[\s*` + ident + `\s*\]`).MatchString(body) {
-		return true
-	}
-	return regexp.MustCompile(`\w+\.has\s*\(\s*` + ident + `\b`).MatchString(body)
+	return false
 }
+
+// branchRejects reports whether an if branch refuses to continue when
+// its condition fails: its (optionally braced) body ends in a return,
+// throw, or continue statement — `if (!RE.test(v)) return;`,
+// `if (!RE.test(v)) { log(); throw new Error(…) }`, and the corpus's
+// own loop spelling `if (!manifest[id]) continue;` all reject.
+func branchRejects(branch string) bool {
+	s := strings.TrimSpace(branch)
+	if strings.HasPrefix(s, "{") {
+		e := matchDelimForward(s, 0)
+		if e < 0 {
+			return false
+		}
+		s = s[1:e]
+	}
+	last := ""
+	for i := len(s) - 1; i >= 0; i-- { // the last statement decides; earlier ones may log
+		if s[i] != ';' {
+			continue
+		}
+		if t := strings.TrimSpace(s[i+1:]); t != "" {
+			last = t
+			break
+		}
+	}
+	if last == "" {
+		last = strings.TrimSpace(s)
+	}
+	return strings.HasPrefix(last, "return") || strings.HasPrefix(last, "throw") ||
+		strings.HasPrefix(last, "continue")
+}
+
+// ifStillOpenAt reports whether the if ending just before from still
+// dominates pos: no '}' closes the if's enclosing block between them.
+// One brace walk over the code view, skipping string and template
+// contents; a depth dip below zero means the if's own block chain
+// closed before the site (the if lives in a branch the site left).
+func ifStillOpenAt(body string, from, pos int) bool {
+	depth := 0
+	for i := from; i < pos; i++ {
+		switch body[i] {
+		case '\'', '"', '`':
+			q := body[i]
+			i++
+			for i < pos && body[i] != q {
+				if body[i] == '\\' {
+					i++
+				}
+				i++
+			}
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth < 0 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// regexSafeClassChars is the explicit allowlist a gate literal's body
+// may draw from: word characters, the hyphen, and the class, group,
+// alternation, and repetition syntax that combines them. Everything
+// else — every backslash escape (\x2f, \u002f, \/ and \\ can match a
+// path separator; \w \s are ambiguous shorthands), the dot, negated
+// classes, and control characters — is out (review 6; review 5 pinned
+// the dot).
+const regexSafeClassChars = "abcdefghijklmnopqrstuvwxyz" +
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "0123456789_-[]()|+*{},"
 
 // regexGateAnchored reports whether a regex literal (with its slashes,
 // optionally flagged) accepts a bounded name shape only: anchored at
-// both ends (^…$) and carrying no ".", "\s", "\S", "\W", or negated
-// class "[^" — each of those admits path separators or arbitrary
-// characters (review 5: /./ accepts "../admin").
+// both ends (^…$) and built exclusively from name-safe characters and
+// classes. An explicit allowlist, so a separator-producing escape
+// disqualifies the gate wherever it sits in the body — review 5's
+// /./ accepts "../admin", review 6's /^[A-Za-z0-9_\x2f-]+$/ accepts
+// "foo/bar" even though no "/" appears in the literal.
 func regexGateAnchored(lit string) bool {
 	if len(lit) < 3 || lit[0] != '/' {
 		return false
@@ -2144,8 +2571,11 @@ func regexGateAnchored(lit string) bool {
 	if !strings.HasPrefix(body, "^") || !strings.HasSuffix(body, "$") {
 		return false
 	}
-	for _, forbidden := range []string{".", `\s`, `\S`, `\W`, "[^"} {
-		if strings.Contains(body, forbidden) {
+	for _, r := range body[1 : len(body)-1] {
+		if r < 0x20 || r == 0x7f {
+			return false // control characters
+		}
+		if !strings.ContainsRune(regexSafeClassChars, r) {
 			return false
 		}
 	}

--- a/core-ui/check/runtimeshapes.go
+++ b/core-ui/check/runtimeshapes.go
@@ -1848,11 +1848,13 @@ var reCmpNumBefore = regexp.MustCompile(`(\d+)\s*(===|==|!==|!=|<=|>=|<|>)\s*$`)
 // statusCompAdmitsOnly2xx reports whether the .status member read at
 // span[start:end] is compared in a way only a 2xx response satisfies:
 // an exact 2xx equality (either polarity — `if (r.status !== 200)
-// throw` leaves exactly 200 on the continuing path), an upper bound
-// below 400, or a >= 200 lower bound conjoined (&&) with such an upper
-// bound later in the same statement. Everything else — truthiness,
-// weak bounds, inequalities against non-2xx literals — still admits a
-// response the mount must not see.
+// throw` leaves exactly 200 on the continuing path), a 2xx-only upper
+// bound (`<` admits at most 300, `<=` at most 299 — a 399 bound admits
+// every redirect exactly like the rejected `< 400`), or a >= 200 lower
+// bound conjoined (&&) with such an upper bound later in the same
+// statement. Everything else — truthiness, weak bounds, inequalities
+// against non-2xx literals — still admits a response the mount must
+// not see.
 func statusCompAdmitsOnly2xx(span string, start, end int) bool {
 	// Comparison to the right: r.status < 300 / === 200 / !== 200 / >= 200.
 	if i := skipSpace(span, end); i < len(span) {
@@ -1866,7 +1868,7 @@ func statusCompAdmitsOnly2xx(span string, start, end int) bool {
 						return true
 					}
 				case op[1] == "<" || op[1] == "<=":
-					if lit <= 399 {
+					if (op[1] == "<" && lit <= 300) || (op[1] == "<=" && lit <= 299) {
 						return true
 					}
 				case op[1] == ">" || op[1] == ">=":
@@ -1883,7 +1885,7 @@ func statusCompAdmitsOnly2xx(span string, start, end int) bool {
 		case "===", "==", "!==", "!=":
 			return lit >= 200 && lit <= 299
 		case "<", "<=":
-			return lit <= 399
+			return (mirror == "<" && lit <= 300) || (mirror == "<=" && lit <= 299)
 		}
 	}
 	return false
@@ -1891,13 +1893,17 @@ func statusCompAdmitsOnly2xx(span string, start, end int) bool {
 
 // reStatusUpperBound matches a .status upper-bound comparison
 // (< 300, <= 299) — the partner a >= 200 lower bound needs to admit
-// only 2xx. Static and run-once, like every gate pattern here.
-var reStatusUpperBound = regexp.MustCompile(`\.\s*status\s*(?:<=|<)\s*(\d+)`)
+// only 2xx. The operator is captured so each spelling can be judged
+// per its own threshold. Static and run-once, like every gate pattern
+// here.
+var reStatusUpperBound = regexp.MustCompile(`\.\s*status\s*(<=|<)\s*(\d+)`)
 
 // lowerBoundConjoined reports whether a >= 200-style lower bound is
-// conjoined (&&) with an upper bound below 400 on the status in the
-// same statement: r.status >= 200 && r.status < 300 admits only 2xx,
-// while the bare lower bound admits every error status.
+// conjoined (&&) with a 2xx-only upper bound (< at most 300, <= at
+// most 299) on the status in the same statement: r.status >= 200 &&
+// r.status < 300 admits only 2xx, while the bare lower bound admits
+// every error status and a < 400 / <= 399 partner admits every
+// redirect.
 func lowerBoundConjoined(span string, from, lit int) bool {
 	if lit < 200 {
 		return false
@@ -1911,7 +1917,11 @@ func lowerBoundConjoined(span string, from, lit int) bool {
 		return false
 	}
 	for _, m := range reStatusUpperBound.FindAllStringSubmatch(rest[and:], -1) {
-		if n, err := strconv.Atoi(m[1]); err == nil && n <= 399 {
+		n, err := strconv.Atoi(m[2])
+		if err != nil {
+			continue
+		}
+		if (m[1] == "<" && n <= 300) || (m[1] == "<=" && n <= 299) {
 			return true
 		}
 	}
@@ -2555,10 +2565,14 @@ const regexSafeClassChars = "abcdefghijklmnopqrstuvwxyz" +
 // regexGateAnchored reports whether a regex literal (with its slashes,
 // optionally flagged) accepts a bounded name shape only: anchored at
 // both ends (^…$) and built exclusively from name-safe characters and
-// classes. An explicit allowlist, so a separator-producing escape
-// disqualifies the gate wherever it sits in the body — review 5's
-// /./ accepts "../admin", review 6's /^[A-Za-z0-9_\x2f-]+$/ accepts
-// "foo/bar" even though no "/" appears in the literal.
+// classes, with flags drawn from i, g, u, y alone. An explicit
+// allowlist, so a separator-producing escape disqualifies the gate
+// wherever it sits in the body — review 5's /./ accepts "../admin",
+// review 6's /^[A-Za-z0-9_\x2f-]+$/ accepts "foo/bar" even though no
+// "/" appears in the literal — and the m flag is rejected with it:
+// multiline makes ^ and $ match at line boundaries, so
+// /^[A-Za-z0-9_-]+$/m accepts "ok\n../admin" (an attribute value can
+// carry the newline) and bounds nothing.
 func regexGateAnchored(lit string) bool {
 	if len(lit) < 3 || lit[0] != '/' {
 		return false
@@ -2566,6 +2580,11 @@ func regexGateAnchored(lit string) bool {
 	end := strings.LastIndexByte(lit, '/')
 	if end <= 0 {
 		return false
+	}
+	for _, r := range lit[end+1:] { // flags: only i, g, u, y keep ^…$ whole-string anchors
+		if !strings.ContainsRune("iguy", r) {
+			return false
+		}
 	}
 	body := lit[1:end]
 	if !strings.HasPrefix(body, "^") || !strings.HasSuffix(body, "$") {
@@ -2583,7 +2602,7 @@ func regexGateAnchored(lit string) bool {
 }
 
 // enclosingFunction returns the [start, end) span of the innermost
-// function containing pos (a '{'-block whose header ends in '=>' or a
+// function containing pos (a '{-block whose header ends in '=>' or a
 // function keyword), or the whole file when pos is at top level.
 func enclosingFunction(code string, pos int) (int, int) {
 	depth := 0

--- a/core-ui/check/runtimeshapes_test.go
+++ b/core-ui/check/runtimeshapes_test.go
@@ -1069,21 +1069,32 @@ func TestLintAttributePathSegments_Review5GatesAndSanitizers(t *testing.T) {
 // function scopes early ─────────────────────────────────────────────
 
 const responseReview6Fixture = `// Review 6: a bare .status truthiness gate passes for 404 and 500,
-// and < 400 admits every client error — only .ok or a comparison that
-// requires a 2xx response is a gate.
+// and < 400 admits every redirect — only .ok or a comparison that
+// requires a 2xx response is a gate. A bound of 399 is the same leak
+// in <= clothing, alone, mirrored, or conjoined with a >= 200 lower
+// bound.
 function mountStatusTruthy(target, src) {
   return fetch(src).then(r => { if (r.status) return r.text(); }).then(html => { target.innerHTML = html; });
 }
 function mountStatusWeakLt400(target, src) {
   return fetch(src).then(r => { if (r.status < 400) return r.text(); }).then(html => { target.innerHTML = html; });
 }
+function mountStatusLe399(target, src) {
+  return fetch(src).then(r => { if (r.status <= 399) return r.text(); }).then(html => { target.innerHTML = html; });
+}
+function mountStatusMirror399(target, src) {
+  return fetch(src).then(r => { if (399 >= r.status) return r.text(); }).then(html => { target.innerHTML = html; });
+}
+function mountStatusWeakRangeLt400(target, src) {
+  return fetch(src).then(r => { if (r.status >= 200 && r.status < 400) return r.text(); }).then(html => { target.innerHTML = html; });
+}
+function mountStatusWeakRangeLe399(target, src) {
+  return fetch(src).then(r => { if (r.status >= 200 && r.status <= 399) return r.text(); }).then(html => { target.innerHTML = html; });
+}
 // Valid gates stay quiet: .ok truthiness (negated or not) and 2xx-only
 // status comparisons.
 function mountOkChecked(target, src) {
   return fetch(src).then(r => { if (r.ok) return r.text(); }).then(html => { target.innerHTML = html; });
-}
-function mountNotOkThrow(target, src) {
-  return fetch(src).then(r => { if (!r.ok) throw new Error('http'); return r.text(); }).then(html => { target.innerHTML = html; });
 }
 function mountStatusEq200(target, src) {
   return fetch(src).then(r => { if (r.status === 200) return r.text(); }).then(html => { target.innerHTML = html; });
@@ -1102,8 +1113,8 @@ func TestLintResponseMountedAfterOK_Review6StatusGates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(res.Violations) != 2 {
-		t.Fatalf("expected exactly 2 findings (status truthiness, < 400), got %d:\n%s",
+	if len(res.Violations) != 6 {
+		t.Fatalf("expected exactly 6 findings (truthiness, < 400, <= 399, mirrored 399 >=, range < 400, range <= 399), got %d:\n%s",
 			len(res.Violations), res.Error())
 	}
 	for _, v := range res.Violations {
@@ -1232,6 +1243,8 @@ func TestLintSelectorInterpolation_Review6NumericIdentifiersMustBeProven(t *test
 
 const regexEscapeReview6Fixture = `// Review 6: \x2f, \u002f, \/ and \\ in a "name-safe" gate match a
 // path separator or an arbitrary character — the gate accepts foo/bar.
+// The m flag is the same leak by other means: ^ and $ go line-bound,
+// so "ok\n../admin" passes the gate.
 function loadHexSlash(el) {
   const tool = el.getAttribute('data-tool');
   if (/^[A-Za-z0-9_\x2f-]+$/.test(tool)) {
@@ -1256,6 +1269,12 @@ function loadBackslash(el) {
     return fetch('/kiln/tool/' + tool);
   }
 }
+function loadMultiline(el) {
+  const tool = el.getAttribute('data-tool');
+  if (/^[A-Za-z0-9_-]+$/m.test(tool)) {
+    return fetch('/kiln/tool/' + tool);
+  }
+}
 `
 
 func TestLintAttributePathSegments_Review6SeparatorMatchingEscapes(t *testing.T) {
@@ -1264,17 +1283,23 @@ func TestLintAttributePathSegments_Review6SeparatorMatchingEscapes(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(res.Violations) != 4 {
-		t.Fatalf("expected exactly 4 findings (\\x2f, \\u002f, \\/, \\\\), got %d:\n%s",
+	if len(res.Violations) != 5 {
+		t.Fatalf("expected exactly 5 findings (\\x2f, \\u002f, \\/, \\\\, m flag), got %d:\n%s",
 			len(res.Violations), res.Error())
 	}
 }
 
 const safeIdentReview6Fixture = `// Review 6: a member assignment is not an identifier assignment, and
 // a function parameter shadows a file-scope safe name inside that
-// function.
+// function. memberOnly's bare id sits in a scope that binds no id and
+// precedes the const, so it fires today; were holder.id = 'fixed'
+// recorded as a file-scope safe event (the guard this pins), it would
+// launder that use instead.
 const holder = {};
 holder.id = 'fixed';
+function memberOnly() {
+  return document.querySelector('[data-member="' + id + '"]');
+}
 function usePlain(id) {
   return document.querySelector('[data-plain="' + id + '"]');
 }
@@ -1299,8 +1324,8 @@ func TestLintSelectorInterpolation_Review6MemberAssignAndParamShadowing(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(res.Violations) != 2 {
-		t.Fatalf("expected exactly 2 findings (member-launded id, shadowed parameter id), got %d:\n%s",
+	if len(res.Violations) != 3 {
+		t.Fatalf("expected exactly 3 findings (unbound id before the const, plain parameter id, shadowed parameter id), got %d:\n%s",
 			len(res.Violations), res.Error())
 	}
 }

--- a/core-ui/check/runtimeshapes_test.go
+++ b/core-ui/check/runtimeshapes_test.go
@@ -1061,3 +1061,275 @@ func TestLintAttributePathSegments_Review5GatesAndSanitizers(t *testing.T) {
 		}
 	}
 }
+
+// ── review 6 findings: status truthiness gates, non-dominating path
+// gates, partial escape operands, unproven numeric identifiers,
+// separator-matching regex escapes, member assignments and parameter
+// shadowing in safe-identifier tracking, regex delimiters closing
+// function scopes early ─────────────────────────────────────────────
+
+const responseReview6Fixture = `// Review 6: a bare .status truthiness gate passes for 404 and 500,
+// and < 400 admits every client error — only .ok or a comparison that
+// requires a 2xx response is a gate.
+function mountStatusTruthy(target, src) {
+  return fetch(src).then(r => { if (r.status) return r.text(); }).then(html => { target.innerHTML = html; });
+}
+function mountStatusWeakLt400(target, src) {
+  return fetch(src).then(r => { if (r.status < 400) return r.text(); }).then(html => { target.innerHTML = html; });
+}
+// Valid gates stay quiet: .ok truthiness (negated or not) and 2xx-only
+// status comparisons.
+function mountOkChecked(target, src) {
+  return fetch(src).then(r => { if (r.ok) return r.text(); }).then(html => { target.innerHTML = html; });
+}
+function mountNotOkThrow(target, src) {
+  return fetch(src).then(r => { if (!r.ok) throw new Error('http'); return r.text(); }).then(html => { target.innerHTML = html; });
+}
+function mountStatusEq200(target, src) {
+  return fetch(src).then(r => { if (r.status === 200) return r.text(); }).then(html => { target.innerHTML = html; });
+}
+function mountStatusLt300(target, src) {
+  return fetch(src).then(r => { if (r.status < 300) return r.text(); }).then(html => { target.innerHTML = html; });
+}
+function mountStatus2xxRange(target, src) {
+  return fetch(src).then(r => { if (r.status >= 200 && r.status < 300) return r.text(); }).then(html => { target.innerHTML = html; });
+}
+`
+
+func TestLintResponseMountedAfterOK_Review6StatusGates(t *testing.T) {
+	dir := writeRuntimeFixture(t, "review6resp.js", responseReview6Fixture)
+	res, err := LintResponseMountedAfterOK(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 2 {
+		t.Fatalf("expected exactly 2 findings (status truthiness, < 400), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+	for _, v := range res.Violations {
+		if !strings.HasPrefix(v.Message, "[response-mounted-unchecked]") {
+			t.Errorf("unexpected message: %s", v.Message)
+		}
+	}
+}
+
+const attrReview6Fixture = `// Review 6: a matching validation in an unrelated earlier branch
+// constrains nothing — the branch can be skipped and the URL still
+// built — and a gate branch that does not reject (return/throw) only
+// sets a flag.
+function loadUnrelatedBranch(el, other) {
+  const tool = el.getAttribute('data-tool');
+  if (other) {
+    if (!/^[A-Za-z0-9_-]+$/.test(tool)) { skipTool(tool); }
+  }
+  return fetch('/kiln/tool/' + tool);
+}
+function skipTool(t) {}
+function loadFlagOnly(el) {
+  const tool = el.getAttribute('data-tool');
+  if (/^[A-Za-z0-9_-]+$/.test(tool)) { flagTool(); }
+  return fetch('/kiln/tool/' + tool);
+}
+function flagTool() {}
+// Dominating gates stay quiet: reject on failure, or enclose the
+// construction in the branch where the gate held.
+function loadRejectReturn(el) {
+  const tool = el.getAttribute('data-tool');
+  if (!/^[A-Za-z0-9_-]+$/.test(tool)) return;
+  return fetch('/kiln/tool/' + tool);
+}
+function loadRejectThrow(el) {
+  const tool = el.getAttribute('data-tool');
+  if (!/^[A-Za-z0-9_-]+$/.test(tool)) throw new Error('bad tool');
+  return fetch('/kiln/tool/' + tool);
+}
+function loadEnclosingBranch(el) {
+  const tool = el.getAttribute('data-tool');
+  if (/^[A-Za-z0-9_-]+$/.test(tool)) {
+    return fetch('/kiln/tool/' + tool);
+  }
+}
+`
+
+func TestLintAttributePathSegments_Review6GateDominance(t *testing.T) {
+	dir := writeRuntimeFixture(t, "review6attr.js", attrReview6Fixture)
+	res, err := LintAttributePathSegments(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 2 {
+		t.Fatalf("expected exactly 2 findings (unrelated branch, flag-only gate), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+}
+
+const selReview6FixtureRaw = `// Review 6: an escape call with a trailing || or ?: operand still
+// carries the raw attribute value whenever the escape result is falsy
+// (the empty string) — the operand must be the WHOLE escape call.
+function escapeOrTrailing(el) {
+  return document.querySelector('[data-or="' + CSS.escape(el.dataset.v) || el.dataset.v + '"]');
+}
+function escapeTernaryTrailing(el) {
+  return document.querySelector('[data-q="' + CSS.escape(el.dataset.q) ? 'x' : el.dataset.q + '"]');
+}
+`
+
+var selReview6Fixture = strings.ReplaceAll(selReview6FixtureRaw, "~", "\x60")
+
+func TestLintSelectorInterpolation_Review6PartialEscapeOperands(t *testing.T) {
+	dir := writeRuntimeFixture(t, "review6sel.js", selReview6Fixture)
+	res, err := LintSelectorInterpolation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 2 {
+		t.Fatalf("expected exactly 2 findings (trailing ||, trailing ?:), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+}
+
+// numericReview6FixtureRaw uses ~ for JS backticks; untailed below.
+const numericReview6FixtureRaw = `// Review 6: an identifier plus a number is numeric arithmetic only
+// when the identifier is PROVEN numeric — from a DOM attribute it is a
+// string, and idx + 1 is string concatenation into an nth-child.
+function rowFromAttr(el) {
+  const idx = el.dataset.rowIndex;
+  return document.querySelector(~ul li:nth-child(${idx + 1})~);
+}
+function rowRevoked(el) {
+  let n = 0;
+  n = el.dataset.rowIndex;
+  return document.querySelector(~ul li:nth-child(${n + 1})~);
+}
+// Proven numeric: a numeric-literal init and a for-loop counter stay
+// quiet.
+function rowFromCounter(list) {
+  const found = [];
+  for (let i = 0; i < 10; i++) {
+    found.push(list.querySelector(~li:nth-child(${i + 1})~));
+  }
+  return found;
+}
+function rowFromInit() {
+  const base = 3;
+  return document.querySelector(~li:nth-child(${base + 1})~);
+}
+`
+
+var numericReview6Fixture = strings.ReplaceAll(numericReview6FixtureRaw, "~", "\x60")
+
+func TestLintSelectorInterpolation_Review6NumericIdentifiersMustBeProven(t *testing.T) {
+	dir := writeRuntimeFixture(t, "review6num.js", numericReview6Fixture)
+	res, err := LintSelectorInterpolation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 2 {
+		t.Fatalf("expected exactly 2 findings (attribute-borne idx, revoked n), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+}
+
+const regexEscapeReview6Fixture = `// Review 6: \x2f, \u002f, \/ and \\ in a "name-safe" gate match a
+// path separator or an arbitrary character — the gate accepts foo/bar.
+function loadHexSlash(el) {
+  const tool = el.getAttribute('data-tool');
+  if (/^[A-Za-z0-9_\x2f-]+$/.test(tool)) {
+    return fetch('/kiln/tool/' + tool);
+  }
+}
+function loadUniSlash(el) {
+  const tool = el.getAttribute('data-tool');
+  if (/^[A-Za-z0-9_\u002f-]+$/.test(tool)) {
+    return fetch('/kiln/tool/' + tool);
+  }
+}
+function loadEscSlash(el) {
+  const tool = el.getAttribute('data-tool');
+  if (/^[A-Za-z0-9_\/]+$/.test(tool)) {
+    return fetch('/kiln/tool/' + tool);
+  }
+}
+function loadBackslash(el) {
+  const tool = el.getAttribute('data-tool');
+  if (/^[A-Za-z0-9\\-]+$/.test(tool)) {
+    return fetch('/kiln/tool/' + tool);
+  }
+}
+`
+
+func TestLintAttributePathSegments_Review6SeparatorMatchingEscapes(t *testing.T) {
+	dir := writeRuntimeFixture(t, "review6re.js", regexEscapeReview6Fixture)
+	res, err := LintAttributePathSegments(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 4 {
+		t.Fatalf("expected exactly 4 findings (\\x2f, \\u002f, \\/, \\\\), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+}
+
+const safeIdentReview6Fixture = `// Review 6: a member assignment is not an identifier assignment, and
+// a function parameter shadows a file-scope safe name inside that
+// function.
+const holder = {};
+holder.id = 'fixed';
+function usePlain(id) {
+  return document.querySelector('[data-plain="' + id + '"]');
+}
+const id = 'fixed';
+function useParam(id) {
+  return document.querySelector('[data-param="' + id + '"]');
+}
+// The file-scope safe name still covers unshadowed uses, and a local
+// literal init still counts.
+function usesGlobal() {
+  return document.querySelector('[data-global="' + id + '"]');
+}
+function localLiteral() {
+  const kind = 'note';
+  return document.querySelector('[data-kind="' + kind + '"]');
+}
+`
+
+func TestLintSelectorInterpolation_Review6MemberAssignAndParamShadowing(t *testing.T) {
+	dir := writeRuntimeFixture(t, "review6safe.js", safeIdentReview6Fixture)
+	res, err := LintSelectorInterpolation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 2 {
+		t.Fatalf("expected exactly 2 findings (member-launded id, shadowed parameter id), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+}
+
+const regexScopeReview6Fixture = `// Review 6: a '}' inside a regex literal must not close the function
+// scope — after /[}]/, a parameter named like a file-scope safe
+// identifier still shadows it.
+const id = 'fixed';
+function afterRegex(id) {
+  const open = /[}]/;
+  return document.querySelector('[data-after="' + id + '"]');
+}
+function plainAfterRegex() {
+  const open = /[}]/;
+  return document.querySelector('[data-plain2="' + id + '"]');
+}
+`
+
+func TestLintSelectorInterpolation_Review6RegexLiteralMustNotCloseScopes(t *testing.T) {
+	dir := writeRuntimeFixture(t, "review6scope.js", regexScopeReview6Fixture)
+	res, err := LintSelectorInterpolation(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Violations) != 1 {
+		t.Fatalf("expected exactly 1 finding (the shadowed parameter after the regex), got %d:\n%s",
+			len(res.Violations), res.Error())
+	}
+	if !strings.Contains(res.Violations[0].Message, `"id"`) {
+		t.Errorf("expected the finding on the shadowed id: %s", res.Error())
+	}
+}

--- a/core/mcp/listgate_security_test.go
+++ b/core/mcp/listgate_security_test.go
@@ -680,6 +680,9 @@ func TestPanickingGatesAreLoggedNotSwallowed(t *testing.T) {
 	if !strings.Contains(logged, "kiln_probe") {
 		t.Errorf("runCallGate: log must carry the tool name: %q", logged)
 	}
+	if !strings.Contains(logged, `operation="call gate"`) {
+		t.Errorf("runCallGate: log must carry the structured operation field: %q", logged)
+	}
 
 	buf.Reset()
 	s := NewServer()
@@ -691,7 +694,7 @@ func TestPanickingGatesAreLoggedNotSwallowed(t *testing.T) {
 	if !strings.Contains(logged, "server gate boom") {
 		t.Errorf("checkServerGate: recovered panic not logged: %q", logged)
 	}
-	if !strings.Contains(logged, "server gate") {
-		t.Errorf("checkServerGate: log must name the operation: %q", logged)
+	if !strings.Contains(logged, `operation="server gate"`) {
+		t.Errorf("checkServerGate: log must carry the structured operation field: %q", logged)
 	}
 }

--- a/core/mcp/listgate_security_test.go
+++ b/core/mcp/listgate_security_test.go
@@ -1,10 +1,12 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -654,5 +656,42 @@ func TestServerGateClosesResourcesSurface(t *testing.T) {
 		if resp.Error == nil {
 			t.Errorf("SECURITY: [authz] %s answered a server-gate-refused caller: %+v", c.method, resp)
 		}
+	}
+}
+
+// Property: a recovered gate panic is not silently swallowed. The
+// fail-closed contract turns the panic into an internal error, but an
+// operator who cannot see the panic cannot tell a gate bug from a
+// refusal storm — runCallGate and checkServerGate log the recovered
+// value (operation, tool name where available) before answering.
+func TestPanickingGatesAreLoggedNotSwallowed(t *testing.T) {
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(old) })
+
+	if err := runCallGate(func(string) error { panic("call gate boom") }, "kiln_probe"); err == nil || err.Error() != "internal tool error" {
+		t.Fatalf("runCallGate: panicking gate must still answer the internal tool error, got %v", err)
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "call gate boom") {
+		t.Errorf("runCallGate: recovered panic not logged: %q", logged)
+	}
+	if !strings.Contains(logged, "kiln_probe") {
+		t.Errorf("runCallGate: log must carry the tool name: %q", logged)
+	}
+
+	buf.Reset()
+	s := NewServer()
+	s.SetGate(func(context.Context) error { panic("server gate boom") })
+	if err := s.checkServerGate(context.Background()); err == nil || err.Error() != "internal tool error" {
+		t.Fatalf("checkServerGate: panicking gate must still answer the internal tool error, got %v", err)
+	}
+	logged = buf.String()
+	if !strings.Contains(logged, "server gate boom") {
+		t.Errorf("checkServerGate: recovered panic not logged: %q", logged)
+	}
+	if !strings.Contains(logged, "server gate") {
+		t.Errorf("checkServerGate: log must name the operation: %q", logged)
 	}
 }

--- a/core/mcp/server.go
+++ b/core/mcp/server.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 	"sync"
@@ -431,10 +432,16 @@ func (s *Server) checkToolGate(ctx context.Context, t Tool) (err error) {
 // runCallGate evaluates the registry-wide call gate with the same net
 // checkToolGate gives the per-tool gate: a panicking gate refuses the
 // call instead of unwinding the transport loop it runs on
-// (recovercallback pins this).
+// (recovercallback pins this). The recovered value is logged before
+// the error is returned — a swallowed panic is indistinguishable from
+// a refusal storm in the logs (review 6).
 func runCallGate(gate func(toolName string) error, name string) (err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
+			slog.Error("panic in MCP call gate recovered",
+				slog.String("operation", "call gate"),
+				slog.String("tool", name),
+				slog.Any("panic", rec))
 			err = errors.New("internal tool error")
 		}
 	}()
@@ -483,7 +490,8 @@ func (s *Server) SetGate(gate func(ctx context.Context) error) {
 // checkServerGate evaluates the server-wide gate, if any, with the
 // same fail-closed net checkToolGate gives the per-tool gate: a
 // panicking gate answers as an error, not an unwound transport
-// (recovercallback pins this).
+// (recovercallback pins this), and the recovered value is logged
+// before that answer (review 6).
 func (s *Server) checkServerGate(ctx context.Context) (err error) {
 	s.mu.RLock()
 	gate := s.serverGate
@@ -493,6 +501,9 @@ func (s *Server) checkServerGate(ctx context.Context) (err error) {
 	}
 	defer func() {
 		if rec := recover(); rec != nil {
+			slog.Error("panic in MCP server gate recovered",
+				slog.String("operation", "server gate"),
+				slog.Any("panic", rec))
 			err = errors.New("internal tool error")
 		}
 	}()

--- a/framework/contracts/analyzers/prefixboundary_test.go
+++ b/framework/contracts/analyzers/prefixboundary_test.go
@@ -460,3 +460,72 @@ func underBeta(assetPath string) bool {
 		t.Errorf("beta's %q is bounded by its own trailing slash; the same package NAME in another directory is a different package and must not cross-resolve (got %d findings)", "/v1/", got)
 	}
 }
+
+// Review 6, build-tag variants: two files of ONE directory declaring
+// the same constant under mutually exclusive build tags. Which value
+// compiles in is a build decision a parse-only pass cannot make, and
+// the merge used to let the later file overwrite the earlier one, so
+// resolveLit answered with an arbitrary variant — the bounded "/assets/"
+// could silence the unbounded "/assets/img" use, or the reverse, by
+// file order. A conflicting name is unresolved and dynamic: BOTH uses
+// report. Two variants carrying the SAME literal still resolve.
+func TestPrefixBoundaryConflictingBuildTagVariantsAreDynamic(t *testing.T) {
+	ds := fixture(t, map[string]string{
+		"tags/asset_unix.go": `//go:build !windows
+
+package tags
+
+import "strings"
+
+const assetBase = "/assets/img"
+
+func underUnix(routePath string) bool {
+	return strings.HasPrefix(routePath, assetBase)
+}
+`,
+		"tags/asset_windows.go": `//go:build windows
+
+package tags
+
+import "strings"
+
+const assetBase = "/assets/"
+
+func underWindows(assetPath string) bool {
+	return strings.HasPrefix(assetPath, assetBase)
+}
+`,
+	})
+	if got := rules(ds)[contracts.RulePrefixSegmentBoundary]; got != 2 {
+		t.Errorf("assetBase carries two different values across mutually exclusive build tags: the name is dynamic and both uses must report (got %d findings)", got)
+	}
+
+	same := fixture(t, map[string]string{
+		"agree/prefix_unix.go": `//go:build !windows
+
+package agree
+
+import "strings"
+
+const assetBase = "/assets/"
+
+func underUnix(assetPath string) bool {
+	return strings.HasPrefix(assetPath, assetBase)
+}
+`,
+		"agree/prefix_windows.go": `//go:build windows
+
+package agree
+
+import "strings"
+
+const assetBase = "/assets/"
+
+func underWindows(assetPath string) bool {
+	return strings.HasPrefix(assetPath, assetBase)
+}
+`,
+	})
+	assertNot(t, same, contracts.RulePrefixSegmentBoundary,
+		`both variants carry the same bounded "/assets/" literal — no conflict, still resolved`)
+}

--- a/framework/contracts/analyzers/routing.go
+++ b/framework/contracts/analyzers/routing.go
@@ -378,21 +378,25 @@ func replaceLiteralFix(p *contracts.Pass, rel string, line int, oldText, newText
 //     terminates the scheme token, so every match has that exact
 //     scheme);
 //   - a prefix identifier that resolves to a package-level CONSTANT
-//     (const prefix = "/__gofastr/runtime/"), in this file or any
-//     sibling file of the same directory (consts.go / scope.go layout;
-//     a same-named package in another directory is a different
-//     package and never resolves), or to a function local that is not
-//     a parameter and whose EVERY assignment in the function is a
-//     string literal (the same
-//     literal): both provably hold that one value at the call. A
-//     parameter conditionally defaulted to a bounded literal stays
-//     dynamic — the caller's value is what runs (review 5: "/api"
-//     claiming /apiary through a defaulted "/api/"), and so does any
-//     local with one non-literal or differently-valued assignment
-//     anywhere in the function. Cross-package constants stay dynamic
-//     (their value is not visible without loading another package's
-//     files), and package-level vars too (a var is assignable from any
-//     function of the package, which a one-file pass cannot see);
+//
+// (const prefix = "/__gofastr/runtime/"), in this file or any
+// sibling file of the same directory (consts.go / scope.go layout;
+// a same-named package in another directory is a different
+// package and never resolves) — unless the directory declares the
+// name twice with DIFFERENT values, the mutually-exclusive
+// build-tag variant layout: which value compiles in is a build
+// decision, so the name stays dynamic (review 6) — or to a
+// function local that is not a parameter and whose EVERY
+// assignment in the function is a string literal (the same
+// literal): both provably hold that one value at the call. A
+// parameter conditionally defaulted to a bounded literal stays
+// dynamic — the caller's value is what runs (review 5: "/api"
+// claiming /apiary through a defaulted "/api/"), and so does any
+// local with one non-literal or differently-valued assignment
+// anywhere in the function. Cross-package constants stay dynamic
+// (their value is not visible without loading another package's
+// files), and package-level vars too (a var is assignable from any
+// function of the package, which a one-file pass cannot see);
 //   - a binary + chain whose RIGHTMOST operand is a string literal (or
 //     resolves to one) ending in "/" (`root+"/"`): the final value
 //     provably stops at a segment boundary. Every other concatenation
@@ -416,6 +420,15 @@ func checkPrefixBoundary(p *contracts.Pass) []contracts.Diagnostic {
 	// separate packages, and one directory's constant must never
 	// resolve (or overwrite) for another's identifiers.
 	pkgLits := map[string]map[string]string{}
+	// conflicted records same-directory names whose declarations
+	// disagree (the build-tag variant layout: two files of one
+	// directory, mutually exclusive //go:build lines, different
+	// values). Which variant compiles in is a build decision a
+	// parse-only pass cannot make, and overwriting by file order let
+	// the bounded variant silence the unbounded one's finding (or the
+	// reverse, by order): the name is unresolved and stays dynamic
+	// (review 6).
+	conflicted := map[string]map[string]bool{}
 	for _, f := range p.AppFiles() {
 		file, ok := p.AST(f.Rel)
 		if !ok {
@@ -425,7 +438,18 @@ func checkPrefixBoundary(p *contracts.Pass) []contracts.Diagnostic {
 		if pkgLits[dir] == nil {
 			pkgLits[dir] = map[string]string{}
 		}
+		if conflicted[dir] == nil {
+			conflicted[dir] = map[string]bool{}
+		}
 		for name, val := range fileScopedLits(file) {
+			if conflicted[dir][name] {
+				continue // a third declaration cannot resurrect the name
+			}
+			if old, ok := pkgLits[dir][name]; ok && old != val {
+				conflicted[dir][name] = true
+				delete(pkgLits[dir], name)
+				continue
+			}
 			pkgLits[dir][name] = val
 		}
 	}

--- a/internal/analyzers/divlimit/divlimit.go
+++ b/internal/analyzers/divlimit/divlimit.go
@@ -169,11 +169,13 @@ func guardedBefore(pass *analysis.Pass, body *ast.BlockStmt, parents map[ast.Nod
 // condProvesNonzero walks a condition's operator tree and reports
 // whether it proves the divisor nonzero: when holds, the condition
 // itself held on the reaching path; when !holds, it failed and the
-// other side of the branch is what runs. For && the held side proves
-// any one operand (A && B held means both held; ¬(A && B) is ¬A ∨ ¬B,
-// so any operand's failure proves it). For || held, WHICH operand is
-// unknown, so every operand must prove it; failed, ¬(A ∨ B) is
-// ¬A ∧ ¬B and any operand's failure still proves it.
+// other side of the branch is what runs. For && held, any one operand
+// suffices (A && B held means both held); failed, ¬(A && B) is ¬A ∨
+// ¬B — which operand failed is unknown, so EVERY operand's failure
+// must prove it (`if limit == 0 && strict { return }` with strict
+// false still divides by zero). For || held, which operand is unknown,
+// so every operand must prove it; failed, ¬(A ∨ B) is ¬A ∧ ¬B — both
+// failed, so any one operand's failure proves it.
 func condProvesNonzero(pass *analysis.Pass, cond ast.Expr, divisor ast.Expr, holds bool) bool {
 	switch x := cond.(type) {
 	case *ast.ParenExpr:
@@ -185,7 +187,10 @@ func condProvesNonzero(pass *analysis.Pass, cond ast.Expr, divisor ast.Expr, hol
 	case *ast.BinaryExpr:
 		switch x.Op {
 		case token.LAND:
-			return condProvesNonzero(pass, x.X, divisor, holds) || condProvesNonzero(pass, x.Y, divisor, holds)
+			if holds {
+				return condProvesNonzero(pass, x.X, divisor, true) || condProvesNonzero(pass, x.Y, divisor, true)
+			}
+			return condProvesNonzero(pass, x.X, divisor, false) && condProvesNonzero(pass, x.Y, divisor, false)
 		case token.LOR:
 			if holds {
 				return condProvesNonzero(pass, x.X, divisor, true) && condProvesNonzero(pass, x.Y, divisor, true)

--- a/internal/analyzers/divlimit/divlimit.go
+++ b/internal/analyzers/divlimit/divlimit.go
@@ -11,13 +11,21 @@
 // OffsetForPage already guarded its own division.
 //
 // Silent postures, deliberately:
-//   - a comparison of the divisor against 0 or 1 that DOMINATES the
-//     division: it sits in the same block before it, in an enclosing
-//     block before the statement holding it, or is the condition of an
-//     enclosing if whose then-branch holds it (the fix posture,
-//     including `limit <= 0 { return }`). A guard inside a nested
-//     conditional body of an earlier statement (a flag-gated check)
-//     executes only when the flag is set and dominates nothing;
+//   - a guard that proves the divisor NONZERO on the reaching path
+//
+// (review 6): a diverging guard — an earlier if whose condition,
+// when false, proves it (`limit == 0`, `limit < 1`, `limit <= 0`)
+// and whose then-branch never completes normally (return, panic,
+// continue, os.Exit), like `limit <= 0 { return }` — or the
+// condition of an enclosing if whose then-branch holds the
+// division, where the condition HELD (`limit != 0`, `limit > 0`,
+// `limit >= 1`). The polarity matters: `if limit == 0 { return
+// total / limit }` divides exactly when the divisor is zero, a
+// branch that merely logs or returns on the safe values leaves
+// the zero values on the continuing path, and a guard inside a
+// nested conditional body of an earlier statement (a flag-gated
+// check) executes only when the flag is set and dominates
+// nothing;
 //   - divisors not named in the limit/perPage/pageSize/size/count/n
 //     family (parameters, or struct fields of that family — a limit
 //     decoded into a request struct is the standard handler spelling):
@@ -118,71 +126,241 @@ func checkFunc(pass *analysis.Pass, fnType *ast.FuncType, body *ast.BlockStmt) {
 	})
 }
 
-// guardedBefore reports whether the divisor was compared against 0 or
-// 1 in a statement or condition that dominates the division: the same
-// block before it, an enclosing block before it, or the condition of
-// an enclosing if whose then-branch holds it. A comparison inside the
-// body of a nested conditional of an earlier statement runs only when
-// that branch is taken and is not a guard.
+// guardedBefore reports whether the divisor is proven nonzero on every
+// path reaching the division (review 6 made the guard branch-aware):
+//
+//   - a diverging guard: an earlier if whose condition, when FALSE,
+//
+// proves the divisor nonzero — `limit == 0`, `limit < 1`,
+// `limit <= 0` — and whose then-branch never completes normally
+// (return, panic, continue, os.Exit): only in-range values
+// continue past it;
+//   - an enclosing condition: an if whose then-branch holds the
+//
+// division and whose condition, held TRUE there, proves the
+// divisor nonzero — `limit != 0`, `limit > 0`, `limit >= 1`.
+//
+// Polarity is the whole point: `if limit == 0 { return total/limit }`
+// reaches the division exactly when the divisor IS zero, a guard whose
+// branch merely logs (or returns on the SAFE values) leaves the zero
+// values on the continuing path, and a comparison in an unrelated
+// earlier branch of the walk (a flag-gated check) executes only when
+// that branch is taken and dominates nothing.
 func guardedBefore(pass *analysis.Pass, body *ast.BlockStmt, parents map[ast.Node]ast.Node, divisor ast.Expr, div *ast.BinaryExpr) bool {
-	if spineComparesDivisor(pass, dominance.Spine(divisor), divisor) {
-		return true
-	}
 	for _, stmts := range dominance.Prefix(div, parents, body) {
 		for _, st := range stmts {
-			if spineComparesDivisor(pass, dominance.Spine(st), divisor) {
+			iff := dominance.IfStmtOf(st)
+			if iff == nil || !dominance.Diverges(iff.Body) {
+				continue
+			}
+			if condProvesNonzero(pass, iff.Cond, divisor, false) {
 				return true
 			}
 		}
 	}
 	for _, cond := range dominance.EnclosingIfConds(div, parents, body) {
-		if spineComparesDivisor(pass, dominance.Spine(cond), divisor) {
+		if condProvesNonzero(pass, cond, divisor, true) {
 			return true
 		}
 	}
 	return false
 }
 
-// spineComparesDivisor reports whether any comparison in nodes matches
-// the divisor expression against a constant 0 or 1.
-func spineComparesDivisor(pass *analysis.Pass, nodes []ast.Node, divisor ast.Expr) bool {
-	for _, n := range nodes {
-		bin, ok := n.(*ast.BinaryExpr)
-		if !ok {
-			continue
+// condProvesNonzero walks a condition's operator tree and reports
+// whether it proves the divisor nonzero: when holds, the condition
+// itself held on the reaching path; when !holds, it failed and the
+// other side of the branch is what runs. For && the held side proves
+// any one operand (A && B held means both held; ¬(A && B) is ¬A ∨ ¬B,
+// so any operand's failure proves it). For || held, WHICH operand is
+// unknown, so every operand must prove it; failed, ¬(A ∨ B) is
+// ¬A ∧ ¬B and any operand's failure still proves it.
+func condProvesNonzero(pass *analysis.Pass, cond ast.Expr, divisor ast.Expr, holds bool) bool {
+	switch x := cond.(type) {
+	case *ast.ParenExpr:
+		return condProvesNonzero(pass, x.X, divisor, holds)
+	case *ast.UnaryExpr:
+		if x.Op == token.NOT {
+			return condProvesNonzero(pass, x.X, divisor, !holds)
 		}
-		switch bin.Op {
-		case token.EQL, token.NEQ, token.LSS, token.LEQ, token.GTR, token.GEQ:
-		default:
-			continue
+	case *ast.BinaryExpr:
+		switch x.Op {
+		case token.LAND:
+			return condProvesNonzero(pass, x.X, divisor, holds) || condProvesNonzero(pass, x.Y, divisor, holds)
+		case token.LOR:
+			if holds {
+				return condProvesNonzero(pass, x.X, divisor, true) && condProvesNonzero(pass, x.Y, divisor, true)
+			}
+			return condProvesNonzero(pass, x.X, divisor, false) || condProvesNonzero(pass, x.Y, divisor, false)
 		}
-		var other ast.Expr
-		switch {
-		case isDivisorExpr(pass, bin.X, divisor):
-			other = bin.Y
-		case isDivisorExpr(pass, bin.Y, divisor):
-			other = bin.X
-		default:
-			continue
-		}
-		if isZeroOrOne(pass, other) {
-			return true
-		}
+		return comparisonProvesNonzero(pass, x, divisor, holds)
 	}
 	return false
 }
 
-// isDivisorExpr reports whether e spells the divisor expression: the
-// same identifier object, or the same printed selector (`q.Limit`).
+// comparisonProvesNonzero reports whether `divisor op constant` with
+// c ∈ {0, 1} proves the divisor nonzero on the given truth value.
+func comparisonProvesNonzero(pass *analysis.Pass, bin *ast.BinaryExpr, divisor ast.Expr, holds bool) bool {
+	if !isComparison(bin.Op) {
+		return false
+	}
+	var other ast.Expr
+	divisorOnLeft := isDivisorExpr(pass, bin.X, divisor)
+	switch {
+	case divisorOnLeft:
+		other = bin.Y
+	case isDivisorExpr(pass, bin.Y, divisor):
+		other = bin.X
+	default:
+		return false
+	}
+	if !isZeroOrOne(pass, other) {
+		return false
+	}
+	c := constValue(pass, other)
+	op := bin.Op
+	if !divisorOnLeft {
+		op = flipComparison(op)
+	}
+	whenTrue, whenFalse := nonzeroSide(op, c)
+	if holds {
+		return whenTrue
+	}
+	return whenFalse
+}
+
+// nonzeroSide reports for `divisor op c` (divisor on the left, c ∈
+// {0, 1}) which truth value of the comparison proves the divisor
+// nonzero: whenTrue for `limit != 0`, `limit > 0`, `limit > 1`,
+// `limit >= 1`, `limit == 1`, `limit < 0`; whenFalse for `limit == 0`,
+// `limit < 1`, `limit <= 0`, `limit <= 1`, `limit != 1`, `limit >= 0`.
+// Every other combination proves neither side (e.g. `limit >= 0` held
+// still contains 0, and its failure proves < 0).
+func nonzeroSide(op token.Token, c int64) (whenTrue, whenFalse bool) {
+	switch op {
+	case token.EQL:
+		return c != 0, c == 0
+	case token.NEQ:
+		return c == 0, c != 0
+	case token.LSS:
+		return c == 0, c == 1 // D < 0 / ¬(D < 1) ⟹ D ≥ 1
+	case token.LEQ:
+		return false, true // ¬(D ≤ c) ⟹ D ≥ 1 for c ∈ {0, 1}
+	case token.GTR:
+		return true, false // D > c ⟹ D ≥ 1; ¬(D > c) ⟹ D ≤ c ∋ 0
+	case token.GEQ:
+		return c == 1, c == 0 // D ≥ 1 / ¬(D ≥ 0) ⟹ D < 0
+	}
+	return false, false
+}
+
+// flipComparison mirrors an operator so the subject can be treated as
+// the left operand.
+func flipComparison(op token.Token) token.Token {
+	switch op {
+	case token.LSS:
+		return token.GTR
+	case token.LEQ:
+		return token.GEQ
+	case token.GTR:
+		return token.LSS
+	case token.GEQ:
+		return token.LEQ
+	}
+	return op
+}
+
+// constValue returns the int64 constant value of e, or ok=false —
+// isZeroOrOne's value, split out for nonzeroSide.
+func constValue(pass *analysis.Pass, e ast.Expr) int64 {
+	tv, ok := pass.TypesInfo.Types[e]
+	if !ok || tv.Value == nil {
+		return -1
+	}
+	i, ok := constant.Int64Val(tv.Value)
+	if !ok {
+		return -1
+	}
+	return i
+}
+
+// isDivisorExpr reports whether e is the divisor expression: the same
+// identifier object, or a selector with the same receiver ROOT BINDING
+// and the same selected field object. Printed-spelling comparison
+// (types.ExprString) let a block-shadowed `q.Limit` match an outer
+// `q.Limit` comparison and suppress the finding (review 6); binding
+// identity cannot.
 func isDivisorExpr(pass *analysis.Pass, e ast.Expr, divisor ast.Expr) bool {
 	switch d := divisor.(type) {
 	case *ast.Ident:
 		return isIdentObj(pass, e, pass.TypesInfo.ObjectOf(d))
 	case *ast.SelectorExpr:
 		ds, ok := e.(*ast.SelectorExpr)
-		return ok && types.ExprString(ds) == types.ExprString(d)
+		if !ok {
+			return false
+		}
+		dObj, dOk := selectorFieldObj(pass, d)
+		eObj, eOk := selectorFieldObj(pass, ds)
+		if !dOk || !eOk || dObj != eObj {
+			return false
+		}
+		dRoot, dHasRoot := selectorRootObj(pass, d)
+		eRoot, eHasRoot := selectorRootObj(pass, ds)
+		if dHasRoot != eHasRoot {
+			return false
+		}
+		if !dHasRoot {
+			// Neither receiver roots in a plain identifier (a call
+			// chain): fall back to the printed receiver, which cannot
+			// shadow.
+			return types.ExprString(ds.X) == types.ExprString(d.X)
+		}
+		return dRoot == eRoot
 	}
 	return false
+}
+
+// isComparison reports whether op is a comparison operator.
+func isComparison(op token.Token) bool {
+	switch op {
+	case token.EQL, token.NEQ, token.LSS, token.LEQ, token.GTR, token.GEQ:
+		return true
+	}
+	return false
+}
+
+// selectorFieldObj resolves the selected field of a struct selector to
+// its *types.Var. Two selectors over the same struct type share the
+// field object, so the receiver binding below is what distinguishes
+// them.
+func selectorFieldObj(pass *analysis.Pass, sel *ast.SelectorExpr) (types.Object, bool) {
+	obj := pass.TypesInfo.ObjectOf(sel.Sel)
+	if obj == nil {
+		return nil, false
+	}
+	return obj, true
+}
+
+// selectorRootObj resolves the receiver's root binding: the object of
+// the identifier the member chain starts from (`q` of q.Limit,
+// `cfg` of cfg.Q.Limit). A shadowing declaration in an inner scope is
+// a different object, so the same printed selector over it is a
+// different value. ok=false when the chain does not root in an
+// identifier.
+func selectorRootObj(pass *analysis.Pass, sel *ast.SelectorExpr) (types.Object, bool) {
+	x := sel.X
+	for {
+		switch v := x.(type) {
+		case *ast.Ident:
+			obj := pass.TypesInfo.ObjectOf(v)
+			return obj, obj != nil
+		case *ast.SelectorExpr:
+			x = v.X
+		case *ast.IndexExpr:
+			x = v.X
+		default:
+			return nil, false
+		}
+	}
 }
 
 // divisorCandidate resolves the divisor to a limit-named function

--- a/internal/analyzers/divlimit/divlimit_test.go
+++ b/internal/analyzers/divlimit/divlimit_test.go
@@ -9,5 +9,5 @@ import (
 )
 
 func TestDivLimit(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), divlimit.Analyzer, "a", "b", "c", "d")
+	analysistest.Run(t, analysistest.TestData(), divlimit.Analyzer, "a", "b", "c", "d", "e")
 }

--- a/internal/analyzers/divlimit/testdata/src/d/d.go
+++ b/internal/analyzers/divlimit/testdata/src/d/d.go
@@ -98,3 +98,24 @@ func keyGuardEmptyRange(total, limit int, xs []int, clamps map[bool]int) int {
 	}
 	return total / limit // want `integer division by limit`
 }
+
+// conjDiverging: the failure of `limit == 0 && strict` can be strict
+// alone — ¬(A && B) is ¬A ∨ ¬B, and which operand failed is unknown —
+// so BOTH operands' failure must prove the divisor nonzero for the
+// diverging guard to count. strict's failure proves nothing, and
+// limit == 0 still reaches the division.
+func conjDiverging(total, limit int, strict bool) int {
+	if limit == 0 && strict {
+		return 0
+	}
+	return total / limit // want `integer division by limit`
+}
+
+// conjHeld: the conjoined enclosing condition held means every operand
+// held, so any one operand proving the divisor nonzero suffices.
+func conjHeld(total, limit int, strict bool) int {
+	if limit > 0 && strict {
+		return total / limit
+	}
+	return 0
+}

--- a/internal/analyzers/divlimit/testdata/src/e/e.go
+++ b/internal/analyzers/divlimit/testdata/src/e/e.go
@@ -1,0 +1,122 @@
+// Package e holds the divlimit spellings review 6 added: the guard
+// must prove the divisor nonzero on the REACHING branch (a comparison
+// selecting the zero values only counts when that branch diverges), a
+// non-diverging guard branch constrains nothing, and selector divisors
+// match by binding identity, not printed spelling.
+package e
+
+import "os"
+
+// unsafeThenBranch divides inside the very branch that selected the
+// zero divisor: the condition held means limit IS zero here.
+func unsafeThenBranch(total, limit int) int {
+	if limit == 0 {
+		return total / limit // want `integer division by limit`
+	}
+	return 0
+}
+
+// safeThenBranch: the condition held on the reaching path proves the
+// divisor nonzero.
+func safeThenBranch(total, limit int) int {
+	if limit != 0 {
+		return total / limit
+	}
+	return 0
+}
+
+// safeLowerBound: limit >= 1 held proves nonzero.
+func safeLowerBound(total, limit int) int {
+	if limit >= 1 {
+		return total / limit
+	}
+	return 0
+}
+
+// nonDivergingGuard logs the zero case and falls through: zero still
+// reaches the division.
+func nonDivergingGuard(total, limit int, log *[]string) int {
+	if limit == 0 {
+		*log = append(*log, "zero limit")
+	}
+	return total / limit // want `integer division by limit`
+}
+
+// wrongPolarityGuard returns on the safe values: only zero (or less)
+// reaches the division.
+func wrongPolarityGuard(total, limit int) int {
+	if limit > 0 {
+		return 0
+	}
+	return total / limit // want `integer division by limit`
+}
+
+// panicGuard, exitGuard, continueGuard: divergence spellings that do
+// prove the continuing path nonzero.
+func panicGuard(total, limit int) int {
+	if limit < 1 {
+		panic("limit must be positive")
+	}
+	return total / limit
+}
+
+func exitGuard(total, limit int) int {
+	if limit == 0 {
+		os.Exit(2)
+	}
+	return total / limit
+}
+
+func continueGuard(rows []int, limit int) int {
+	n := 0
+	for _, r := range rows {
+		if limit == 0 {
+			continue
+		}
+		n += r / limit
+	}
+	return n
+}
+
+// orGuard: on the continuing path err == nil AND limit >= 1, so the
+// disjunct's failure still proves the divisor nonzero.
+func orGuard(rows int, limit int, err error) int {
+	if err != nil || limit < 1 {
+		return 0
+	}
+	return rows / limit
+}
+
+// negatedGuard: !(limit == 0) held means limit != 0.
+func negatedGuard(total, limit int) int {
+	if !(limit == 0) {
+		return total / limit
+	}
+	return 0
+}
+
+type req struct{ Total, Limit int }
+
+// shadowedSelector: the guard compares the parameter q.Limit; the
+// division divides by the block-shadowed q.Limit. Identical printed
+// selectors, two different bindings — printed-form matching suppressed
+// the finding; binding identity must not.
+func shadowedSelector(q req, other req) int {
+	if q.Limit == 0 {
+		return 0
+	}
+	if other.Total > 0 {
+		q := other
+		return q.Total / q.Limit // want `integer division by q.Limit`
+	}
+	return 0
+}
+
+// shadowedSelectorGuarded: guard and division see the SAME binding, so
+// the fix posture holds.
+func shadowedSelectorGuarded(q req) int {
+	if q.Limit == 0 {
+		return 0
+	}
+	return q.Total / q.Limit
+}

--- a/internal/analyzers/internal/dominance/dominance.go
+++ b/internal/analyzers/internal/dominance/dominance.go
@@ -13,7 +13,10 @@
 // holds node always ran by the time node executes, and the cond held.
 package dominance
 
-import "go/ast"
+import (
+	"go/ast"
+	"go/token"
+)
 
 // Parents maps every node in body to its parent node.
 func Parents(body ast.Node) map[ast.Node]ast.Node {
@@ -200,6 +203,73 @@ func Spine(n ast.Node) []ast.Node {
 		expr(n)
 	}
 	return out
+}
+
+// IfStmtOf returns the if statement st carries: st itself when it is
+// an *ast.IfStmt, or the statement a LabeledStmt chain ends in. The
+// divlimit and intwrap branch-aware guards ask for it: only a real if
+// statement has a condition whose failure branch can leave the guard's
+// values behind.
+func IfStmtOf(st ast.Stmt) *ast.IfStmt {
+	switch v := st.(type) {
+	case *ast.IfStmt:
+		return v
+	case *ast.LabeledStmt:
+		return IfStmtOf(v.Stmt)
+	}
+	return nil
+}
+
+// Diverges reports whether every path through st leaves the enclosing
+// statement list without falling through: it ends in a return, a
+// panic, a continue, or an os.Exit call, or is an if/else or block
+// whose arms all diverge. A statement that merely breaks, or a body
+// that can complete normally, does not diverge — the code after the
+// statement stays reachable with the condition's true values, which is
+// exactly what the branch-aware guards refuse to credit (review 6).
+func Diverges(st ast.Stmt) bool {
+	switch v := st.(type) {
+	case *ast.ReturnStmt:
+		return true
+	case *ast.BranchStmt:
+		// continue skips the rest of the loop body on every path; break
+		// is deliberately absent — it leaves the loop and reaches code
+		// after it, goto can jump backward past the use.
+		return v.Tok == token.CONTINUE
+	case *ast.ExprStmt:
+		return exitsCall(v.X)
+	case *ast.BlockStmt:
+		return stmtListDiverges(v)
+	case *ast.LabeledStmt:
+		return Diverges(v.Stmt)
+	case *ast.IfStmt:
+		return v.Else != nil && Diverges(v.Body) && Diverges(v.Else)
+	}
+	return false
+}
+
+// stmtListDiverges reports whether a block never completes normally:
+// every path either diverges in an earlier statement or reaches the
+// last one, so the last statement deciding is sound.
+func stmtListDiverges(b *ast.BlockStmt) bool {
+	return b != nil && len(b.List) > 0 && Diverges(b.List[len(b.List)-1])
+}
+
+// exitsCall reports whether e is a panic(...) or os.Exit(...) call —
+// the expressions through which a guard branch refuses to continue.
+func exitsCall(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name == "panic"
+	case *ast.SelectorExpr:
+		pkg, ok := fn.X.(*ast.Ident)
+		return ok && pkg.Name == "os" && fn.Sel.Name == "Exit"
+	}
+	return false
 }
 
 // containsPath reports whether node sits inside st per the parent map,

--- a/internal/analyzers/intwrap/intwrap.go
+++ b/internal/analyzers/intwrap/intwrap.go
@@ -262,11 +262,13 @@ func dominatingBound(pass *analysis.Pass, node ast.Node, parents map[ast.Node]as
 // condBounds walks a condition's operator tree and reports whether it
 // proves the subject inside the safe range: when holds, the condition
 // itself held on the reaching path; when !holds, it failed and the
-// other side of the branch is what runs. For && the held side proves
-// any one operand (A && B held means both held; ¬(A && B) is ¬A ∨ ¬B,
-// so any operand's failure proves it). For || held, WHICH operand is
-// unknown, so every operand must prove it; failed, ¬(A ∨ B) is
-// ¬A ∧ ¬B and any operand's failure still proves it.
+// other side of the branch is what runs. For && held, any one operand
+// suffices (A && B held means both held); failed, ¬(A && B) is ¬A ∨
+// ¬B — which operand failed is unknown, so EVERY operand's failure
+// must prove it (`if u > math.MaxInt64 && strict { return }` with
+// strict false still converts the out-of-range u). For || held, which
+// operand is unknown, so every operand must prove it; failed, ¬(A ∨ B)
+// is ¬A ∧ ¬B — both failed, so any one operand's failure proves it.
 func condBounds(pass *analysis.Pass, cond ast.Expr, subj subject, family string, holds bool) bool {
 	switch x := cond.(type) {
 	case *ast.ParenExpr:
@@ -278,7 +280,10 @@ func condBounds(pass *analysis.Pass, cond ast.Expr, subj subject, family string,
 	case *ast.BinaryExpr:
 		switch x.Op {
 		case token.LAND:
-			return condBounds(pass, x.X, subj, family, holds) || condBounds(pass, x.Y, subj, family, holds)
+			if holds {
+				return condBounds(pass, x.X, subj, family, true) || condBounds(pass, x.Y, subj, family, true)
+			}
+			return condBounds(pass, x.X, subj, family, false) && condBounds(pass, x.Y, subj, family, false)
 		case token.LOR:
 			if holds {
 				return condBounds(pass, x.X, subj, family, true) && condBounds(pass, x.Y, subj, family, true)

--- a/internal/analyzers/intwrap/intwrap.go
+++ b/internal/analyzers/intwrap/intwrap.go
@@ -15,15 +15,20 @@
 // kiln/expr env.go builtinAbs (fixed in f06f4412), where the saturated
 // fix also errs away from every threshold guard consuming abs().
 //
-// A bound counts only when it DOMINATES the conversion: it must sit in
-// the same block, or an enclosing block, before the statement holding
-// the conversion — inspected only over the parts of that statement
-// that always execute — or be the condition of an enclosing if whose
-// then-branch holds the conversion. A check in a sibling case arm of
-// the same type switch guards nothing — that is exactly how the uint
-// arm shipped without the check its uint64 sibling had — and neither
-// does a check inside a flag-gated nested body of an earlier
-// statement.
+// A bound counts only when it proves the subject inside the safe range
+// on the REACHING path (review 6): a diverging guard — an earlier if
+// whose condition, when false, leaves the subject in range (`u >
+// math.MaxInt64`, `v == math.MinInt64`) and whose then-branch never
+// completes normally (return, panic, continue, os.Exit) — or the
+// condition of an enclosing if whose then-branch holds the node, where
+// the condition HELD and must establish the range (`u <=
+// math.MaxInt64`). A check in a sibling case arm of the same type
+// switch guards nothing — that is exactly how the uint arm shipped
+// without the check its uint64 sibling had — and neither does a check
+// inside a flag-gated nested body of an earlier statement, a branch
+// that merely flags the out-of-range values, or `if u <=
+// math.MaxInt64 { return }`, which leaves exactly the wrapping values
+// on the continuing path.
 //
 // Silent postures, deliberately:
 //   - uint8/uint16 sources: they fit every signed target this rule
@@ -53,6 +58,7 @@ import (
 	"go/constant"
 	"go/token"
 	"go/types"
+	"math"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
@@ -212,84 +218,174 @@ const (
 )
 
 // dominatingBound reports whether node is dominated by a comparison of
-// obj against a bound: the comparison must sit in the same block as the
-// node, or an enclosing block, in a statement before the one holding
-// the node — inspected only over the parts of that statement that
-// always execute — or be the condition of an enclosing if whose
-// then-branch holds the node. Sibling branches (other case arms) and
-// flag-gated nested bodies guard nothing.
+// the subject against a bound (review 6 made the guard branch-aware):
+//
+//   - a diverging guard: an earlier if whose condition, when FALSE,
+//
+// leaves the subject inside the family's safe range —
+// `if u > math.MaxInt64 { return }`, `if v == math.MinInt64 {
+// return }` — and whose then-branch never completes normally
+// (return, panic, continue, os.Exit): only in-range values
+// continue past it;
+//   - an enclosing condition: an if whose then-branch holds the node
+//
+// and whose condition, held TRUE there, establishes the safe
+// range — `if u <= math.MaxInt64 { return int64(u), true }`.
+//
+// Polarity is the whole point: `if u <= math.MaxInt64 { return }`
+// leaves exactly the out-of-range values on the continuing path, a
+// branch that merely flags (or returns on the in-range values) leaves
+// the wrapping values behind, and a comparison inside a nested
+// conditional body of an earlier statement (a flag-gated check) or a
+// sibling case arm guards nothing — that is exactly how the uint arm
+// shipped without the check its uint64 sibling had.
 func dominatingBound(pass *analysis.Pass, node ast.Node, parents map[ast.Node]ast.Node, body *ast.BlockStmt, subj subject, family string) bool {
 	for _, stmts := range dominance.Prefix(node, parents, body) {
 		for _, st := range stmts {
-			if spineBounds(pass, dominance.Spine(st), subj, family, false) {
+			iff := dominance.IfStmtOf(st)
+			if iff == nil || !dominance.Diverges(iff.Body) {
+				continue
+			}
+			if condBounds(pass, iff.Cond, subj, family, false) {
 				return true
 			}
 		}
 	}
 	for _, cond := range dominance.EnclosingIfConds(node, parents, body) {
-		if spineBounds(pass, dominance.Spine(cond), subj, family, true) {
+		if condBounds(pass, cond, subj, family, true) {
 			return true
 		}
 	}
 	return false
 }
 
-// spineBounds reports whether nodes compare obj against the bound
-// family: math.MaxInt/MaxInt32/MaxInt64 or math.MinInt/MinInt64
-// (resolved by import path, not spelling), or an integer literal of
-// bound size. thenBranch selects the comparison direction a condition
-// must have when the node sits in the if's THEN-branch: the condition
-// HELD there, so only operators that establish the safe range dominate
-// — u > math.MaxInt64 in the branch that converts selects exactly the
-// values that wrap. Statement positions (thenBranch false) keep the
-// early-return reading: `if u > math.MaxInt64 { return }` before the
-// node leaves only in-range values behind, whatever the operator.
-func spineBounds(pass *analysis.Pass, nodes []ast.Node, subj subject, family string, thenBranch bool) bool {
-	for _, n := range nodes {
-		bin, ok := n.(*ast.BinaryExpr)
-		if !ok || !isComparison(bin.Op) {
-			continue
+// condBounds walks a condition's operator tree and reports whether it
+// proves the subject inside the safe range: when holds, the condition
+// itself held on the reaching path; when !holds, it failed and the
+// other side of the branch is what runs. For && the held side proves
+// any one operand (A && B held means both held; ¬(A && B) is ¬A ∨ ¬B,
+// so any operand's failure proves it). For || held, WHICH operand is
+// unknown, so every operand must prove it; failed, ¬(A ∨ B) is
+// ¬A ∧ ¬B and any operand's failure still proves it.
+func condBounds(pass *analysis.Pass, cond ast.Expr, subj subject, family string, holds bool) bool {
+	switch x := cond.(type) {
+	case *ast.ParenExpr:
+		return condBounds(pass, x.X, subj, family, holds)
+	case *ast.UnaryExpr:
+		if x.Op == token.NOT {
+			return condBounds(pass, x.X, subj, family, !holds)
 		}
-		var other ast.Expr
-		subjectOnLeft := matchesSubject(pass, bin.X, subj)
-		switch {
-		case subjectOnLeft:
-			other = bin.Y
-		case matchesSubject(pass, bin.Y, subj):
-			other = bin.X
-		default:
-			continue
+	case *ast.BinaryExpr:
+		switch x.Op {
+		case token.LAND:
+			return condBounds(pass, x.X, subj, family, holds) || condBounds(pass, x.Y, subj, family, holds)
+		case token.LOR:
+			if holds {
+				return condBounds(pass, x.X, subj, family, true) && condBounds(pass, x.Y, subj, family, true)
+			}
+			return condBounds(pass, x.X, subj, family, false) || condBounds(pass, x.Y, subj, family, false)
 		}
-		if thenBranch && !establishesSafeRange(bin.Op, subjectOnLeft, family) {
-			continue
-		}
-		if isMathBound(pass, other, family) || isBoundLiteral(pass, other, family) {
-			return true
-		}
+		return comparisonBounds(pass, x, subj, family, holds)
 	}
 	return false
 }
 
-// establishesSafeRange reports whether the comparison, held TRUE in an
-// enclosing if's then-branch, puts the subject inside the safe range
-// for the family: at most the max bound (equality fits exactly), or
-// strictly above the min bound (equality is MinInt, which still wraps
-// under negation).
-func establishesSafeRange(op token.Token, subjectOnLeft bool, family string) bool {
-	if family == boundMax {
-		switch {
-		case subjectOnLeft:
-			return op == token.LSS || op == token.LEQ || op == token.EQL
-		default:
-			return op == token.GTR || op == token.GEQ || op == token.EQL
-		}
+// comparisonBounds reports whether `subj op bound` proves the subject
+// inside the family's safe range on the given truth value. The bound
+// operand is a math constant of the family or a bound-sized literal,
+// exactly as before.
+func comparisonBounds(pass *analysis.Pass, bin *ast.BinaryExpr, subj subject, family string, holds bool) bool {
+	if !isComparison(bin.Op) {
+		return false
 	}
+	var other ast.Expr
+	subjectOnLeft := matchesSubject(pass, bin.X, subj)
 	switch {
 	case subjectOnLeft:
-		return op == token.GTR
+		other = bin.Y
+	case matchesSubject(pass, bin.Y, subj):
+		other = bin.X
 	default:
-		return op == token.LSS
+		return false
 	}
+	if !isMathBound(pass, other, family) && !isBoundLiteral(pass, other, family) {
+		return false
+	}
+	op := bin.Op
+	if !subjectOnLeft {
+		op = flipComparison(op)
+	}
+	whenTrue, whenFalse := boundSide(pass, op, other, family)
+	if holds {
+		return whenTrue
+	}
+	return whenFalse
+}
+
+// boundSide reports for `subj op bound` (subject on the left, op
+// normalized) which truth value of the comparison proves the subject
+// inside the safe range. For boundMax (conversion safety: subj ≤ Max,
+// and every recognized bound is ≤ MaxInt64): holding, the subject is
+// below or at the bound (<, <=, ==); failing, the subject is at most
+// the bound (> , >= fail to ≤/<, != fails to ==). For boundMin
+// (negation safety: subj > Min, a signed subject is always ≥ Min):
+// holding, strictly above the bound (>); failing, above it (<=), or —
+// only when the bound IS the exact minimum — not equal to it (==),
+// since a signed value that is not MinInt64 is above it.
+func boundSide(pass *analysis.Pass, op token.Token, bound ast.Expr, family string) (whenTrue, whenFalse bool) {
+	if family == boundMax {
+		switch op {
+		case token.LSS, token.LEQ, token.EQL:
+			return true, false
+		case token.GTR, token.GEQ, token.NEQ:
+			return false, true
+		}
+		return false, false
+	}
+	switch op {
+	case token.GTR:
+		return true, false
+	case token.LEQ:
+		return false, true
+	case token.EQL:
+		// ¬(v == MinInt64) proves v > MinInt64 only for the exact
+		// minimum: a signed v is always ≥ it. A larger literal bound
+		// (isBoundLiteral accepts any ≤ MinInt32) still admits MinInt64
+		// on the continuing path.
+		return false, isExactMinBound(pass, bound)
+	}
+	return false, false
+}
+
+// isExactMinBound reports whether e is exactly the 64-bit minimum:
+// the math.MinInt/MinInt64 constants (on the 64-bit platforms this
+// repo targets), or that value spelled as a literal.
+func isExactMinBound(pass *analysis.Pass, e ast.Expr) bool {
+	if isMathBound(pass, e, boundMin) {
+		return true
+	}
+	tv, ok := pass.TypesInfo.Types[e]
+	if !ok || tv.Value == nil {
+		return false
+	}
+	i, ok := constant.Int64Val(tv.Value)
+	return ok && i == math.MinInt64
+}
+
+// flipComparison mirrors an operator so the subject can be treated as
+// the left operand.
+func flipComparison(op token.Token) token.Token {
+	switch op {
+	case token.LSS:
+		return token.GTR
+	case token.LEQ:
+		return token.GEQ
+	case token.GTR:
+		return token.LSS
+	case token.GEQ:
+		return token.LEQ
+	}
+	return op
 }
 
 func isMathBound(pass *analysis.Pass, e ast.Expr, family string) bool {

--- a/internal/analyzers/intwrap/intwrap_test.go
+++ b/internal/analyzers/intwrap/intwrap_test.go
@@ -9,5 +9,5 @@ import (
 )
 
 func TestIntWrap(t *testing.T) {
-	analysistest.Run(t, analysistest.TestData(), intwrap.Analyzer, "a", "b", "c", "d")
+	analysistest.Run(t, analysistest.TestData(), intwrap.Analyzer, "a", "b", "c", "d", "e")
 }

--- a/internal/analyzers/intwrap/testdata/src/d/d.go
+++ b/internal/analyzers/intwrap/testdata/src/d/d.go
@@ -107,3 +107,30 @@ func postBoundBreaks(box any, flags map[bool]uint64) int64 {
 	}
 	return int64(u) // want `conversion uint64 → int64 without a dominating bound check`
 }
+
+// conjDiverging: the failure of `u > math.MaxInt64 && strict` can be
+// strict alone — ¬(A && B) is ¬A ∨ ¬B, and which operand failed is
+// unknown — so BOTH operands' failure must bound the subject for the
+// diverging guard to count. strict's failure bounds nothing, and the
+// out-of-range u still reaches the conversion.
+func conjDiverging(box any, strict bool) int64 {
+	if u, ok := box.(uint64); ok {
+		if u > math.MaxInt64 && strict {
+			return 0
+		}
+		return int64(u) // want `conversion uint64 → int64 without a dominating bound check`
+	}
+	return 0
+}
+
+// conjHeld: the conjoined enclosing condition held means every operand
+// held, so any one operand establishing the safe range suffices.
+func conjHeld(box any, strict bool) int64 {
+	if u, ok := box.(uint64); ok {
+		if u <= math.MaxInt64 && strict {
+			return int64(u)
+		}
+		return 0
+	}
+	return 0
+}

--- a/internal/analyzers/intwrap/testdata/src/e/e.go
+++ b/internal/analyzers/intwrap/testdata/src/e/e.go
@@ -1,0 +1,67 @@
+// Package e holds the intwrap spellings review 6 added: a preceding
+// bound check dominates only when its failure branch leaves the
+// subject inside the conversion-safe range — the branch that CONTINUES
+// is the one the conversion sees, and it must actually leave (return /
+// panic), not fall through.
+package e
+
+import "math"
+
+// safeRangeReturn returns on the in-range values: only out-of-range
+// values reach the conversion, exactly the ones that wrap.
+func safeRangeReturn(box any) (int64, bool) {
+	if u, ok := box.(uint64); ok {
+		if u <= math.MaxInt64 {
+			return 0, false
+		}
+		return int64(u), true // want `conversion uint64 → int64 without a dominating bound check`
+	}
+	return 0, false
+}
+
+// unsafeRangeReturn refuses the wrapping values: the continuing path
+// stays in range (the fix posture).
+func unsafeRangeReturn(box any) (int64, bool) {
+	if u, ok := box.(uint64); ok {
+		if u > math.MaxInt64 {
+			return 0, false
+		}
+		return int64(u), true
+	}
+	return 0, false
+}
+
+// nonDivergingBound flags the out-of-range values and falls through:
+// they still reach the conversion.
+func nonDivergingBound(box any, flagged *bool) int64 {
+	if u, ok := box.(uint64); ok {
+		if u > math.MaxInt64 {
+			*flagged = true
+		}
+		return int64(u) // want `conversion uint64 → int64 without a dominating bound check`
+	}
+	return 0
+}
+
+// encloseBound: the condition held on the branch holding the
+// conversion proves the value in range.
+func encloseBound(box any) (int64, bool) {
+	if u, ok := box.(uint64); ok {
+		if u <= math.MaxInt64 {
+			return int64(u), true
+		}
+		return 0, false
+	}
+	return 0, false
+}
+
+// throwBound: a throwing failure branch is a divergence spelling.
+func throwBound(box any) (int64, bool) {
+	if u, ok := box.(uint64); ok {
+		if u > math.MaxInt64 {
+			panic("uint64 overflows int64")
+		}
+		return int64(u), true
+	}
+	return 0, false
+}


### PR DESCRIPTION
Follow-up to #388. The review bot posted a second review on that PR a few minutes after its last push, ten of the eleven findings outside the diff, and the PR merged before they were triaged. All eleven hold on merit and are fixed here, each pinned by a fixture that fails without the change:

- **GOFASTR1006**: constants that conflict within one directory (build-tag variants) become unresolved rather than one overwriting the other.
- **divlimit and intwrap**: selector divisors match by binding identity, not formatted text; a guard counts only when the reaching path is proven safe (an unsafe-range comparison must diverge, a safe-range comparison must enclose the use), so `if limit == 0 { return total / limit }` fires again.
- **Runtime lints**: a truthy `.status` is not a response gate; the attribute gate must dominate the URL construction; the escape call must be the whole selector operand; an identifier plus a number is numeric only when the identifier is proven numeric; regex escapes that can match a separator are rejected; member assignments are not identifier assignments and parameters shadow file-scope safe names; function scopes match on the blanked view so a `}` inside a regex literal cannot close one.
- **MCP gates**: a recovered panic is logged with the operation and tool name before the internal error is returned.

Verification: `go test` on the analyzers, contracts, lint, and MCP packages, the runtime security probes, `make analyze`, and `gofastr verify --no-vet --strict` clean on the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BLjmqxTmrgQgZg2S2wefZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved static-analysis accuracy for runtime shapes, URL construction, numeric conversions, division checks, and prefix boundaries.
  - Reduced false positives and false negatives by accounting for control-flow branches, variable shadowing, build variants, escaping, and response-status validation.
  - Improved recognition of safe guards and rejecting branches in security-related checks.

- **Security**
  - Recovered gate failures are now logged with relevant operation context while continuing to return internal errors.

- **Tests**
  - Expanded coverage for analyzer edge cases, security-gate failures, build variants, escaping, status checks, and control-flow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->