### PR TITLE
Site: examples page refresh and the gofastr-plugins registry pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
         run: |
           # shellcheck disable=SC2046  # word splitting of go list output is intended
           go test -timeout=20m -p 2 \
-            -skip 'TestBlueprintCLIGeneratesEntireWorkingAppE2E|TestE2E_HotReload_BrowserAutoRefreshes|TestLivereloadSameBuildIDDoesNotReload' \
+            -skip 'TestBlueprintCLIGeneratesEntireWorkingAppE2E|TestE2E_HotReload_BrowserAutoRefreshes|TestLivereloadSameBuildIDDoesNotReload|TestE2E_DevLoop_Examples' \
             $(go list ./... | grep -vE 'gofastr/(examples/site|examples/meridian|kiln/integration|core-ui/runtime|core-ui/widget|evals/ui-quality/internal/evalrunner)$')
 
       - name: Race detector (concurrency packages)
@@ -411,8 +411,11 @@ jobs:
             # Every cmd/gofastr test that drives a real Chrome, the
             # blueprint app E2E plus the two dev livereload browser tests.
             # Kept out of the deterministic step so the websocket connect
-            # isn't starved by parallel package load.
-            run: go test -count=1 -timeout=10m -run 'TestBlueprintCLIGeneratesEntireWorkingAppE2E|TestE2E_HotReload_BrowserAutoRefreshes|TestLivereloadSameBuildIDDoesNotReload' ./cmd/gofastr/
+            # isn't starved by parallel package load. TestE2E_DevLoop_Examples
+            # (builds and boots every example under `gofastr dev`) rides
+            # here too: it needs no Chrome, but its eleven builds would
+            # push the deterministic job past its 20m budget.
+            run: go test -count=1 -timeout=15m -run 'TestBlueprintCLIGeneratesEntireWorkingAppE2E|TestE2E_HotReload_BrowserAutoRefreshes|TestLivereloadSameBuildIDDoesNotReload|TestE2E_DevLoop_Examples' ./cmd/gofastr/
           - suite: core-ui-runtime
             # The runtime hydration suite launches a real Chrome per test
             # binary; under the deterministic job's -p 2 package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,8 +414,9 @@ jobs:
             # isn't starved by parallel package load. TestE2E_DevLoop_Examples
             # (builds and boots every example under `gofastr dev`) rides
             # here too: it needs no Chrome, but its eleven builds would
-            # push the deterministic job past its 20m budget.
-            run: go test -count=1 -timeout=15m -run 'TestBlueprintCLIGeneratesEntireWorkingAppE2E|TestE2E_HotReload_BrowserAutoRefreshes|TestLivereloadSameBuildIDDoesNotReload|TestE2E_DevLoop_Examples' ./cmd/gofastr/
+            # push the deterministic job past its 20m budget. 25m covers its
+            # worst case: eleven examples at the 90s per-example wait.
+            run: go test -count=1 -timeout=25m -run 'TestBlueprintCLIGeneratesEntireWorkingAppE2E|TestE2E_HotReload_BrowserAutoRefreshes|TestLivereloadSameBuildIDDoesNotReload|TestE2E_DevLoop_Examples' ./cmd/gofastr/
           - suite: core-ui-runtime
             # The runtime hydration suite launches a real Chrome per test
             # binary; under the deterministic job's -p 2 package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,14 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   summary-less `<details>` was open. The rule now keys a `<details>`
   root, and a chromedp test pins the computed display of live-rendered
   menus on both paths.
+- **The site's examples page lists every runnable example**: the entity
+  admin (`backoffice`), the process-isolated module
+  (`processmodule-demo`), and the WebMCP remote-assist console were
+  missing, the four blueprint-only examples had no link, and the
+  line-count badges had drifted by up to half (the site badge said
+  6,000 lines for a 9,300-line app). The badges are now pinned by a
+  test that measures the tree, and the home page's example card derives
+  its count from the row list.
 
 ## [0.81.0] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   added now log the panic instead of swallowing it.
 
 ### Added
+- **The site renders the gofastr-plugins registry.** `/plugins` lists
+  every plugin in the vendored `plugins.json` and `/plugins/<name>`
+  shows its manifest, isolation posture, and the `go get` plus
+  `RegisterPlugin` lines to mount it. The copy comes from a
+  gofastr-plugins release asset via `scripts/vendor-plugins-json.sh`,
+  so it carries the release stamp the page shows; a test refuses an
+  unstamped copy, an unknown field, or a sandboxed row granting
+  `allow-same-origin`. Consumed by copy, never by import.
 - **`MenuConfig.LazyPanel` keeps a closed menu's rows out of the
   document tree.** The rows ship inside an inert
   `<template data-fui-menu-lazy>` as the panel's only child, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   added now log the panic instead of swallowing it.
 
 ### Added
+- **`isolation.ListenAddr(projectDir, fallback)`** is the one call a
+  hand-written `main` needs to bind where `gofastr dev`, a PaaS, or
+  worktree isolation says: it reads `$PORT` as a bare port or a
+  host:port, falls back to the given address, and applies the port
+  remap. Every server example binds through it, so `go run .` and
+  `gofastr dev` agree on the address, and the site's examples page and
+  the READMEs now lead with `gofastr dev`. `TestE2E_DevLoop_Examples`
+  boots each example under `gofastr dev` and checks it answers on the
+  banner address.
 - **The site renders the gofastr-plugins registry.** `/plugins` lists
   every plugin in the vendored `plugins.json` and `/plugins/<name>`
   shows its manifest, isolation posture, and the `go get` plus
@@ -47,6 +56,10 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   before.
 
 ### Fixed
+- **Examples answered on the wrong port under `gofastr dev`**: six
+  hardcoded their address and three prefixed `$PORT` with a colon, so
+  the `localhost:<port>` value `gofastr dev` injects became
+  `:localhost:8080`. All bind through `isolation.ListenAddr` now.
 - **Analyzers, contract rules, and runtime lints**: five reviewers
   executed fixtures against the nineteen rules and proved around
   seventy-five gaps; every one is pinned red-then-green. Highlights:

--- a/cmd/gofastr/dev_examples_e2e_test.go
+++ b/cmd/gofastr/dev_examples_e2e_test.go
@@ -1,8 +1,8 @@
 package main
 
 // Boots every server example under `gofastr dev`, the command the site's
-// examples page and the READMEs lead with, and checks each answers on the
-// address the dev banner prints. The examples used to hardcode their port
+// examples page and the READMEs lead with, reads the address the dev
+// banner prints, and checks each answers there. The examples used to hardcode their port
 // or prefix $PORT with a colon, so the banner said one address and the
 // child bound another; isolation.ListenAddr is the fix and this is its
 // gate. The process module is a stdio child, not a server, so it is not
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"testing"
 	"time"
 )
@@ -76,7 +77,11 @@ func TestE2E_DevLoop_Examples(t *testing.T) {
 				_ = dev.Wait()
 				removeDevServerBinary(dev)
 			})
-			url := "http://localhost:" + port + ex.path
+			base := waitForBanner(t, &out, 30*time.Second)
+			if want := "http://localhost:" + port; base != want {
+				t.Fatalf("banner advertises %s, the requested address was %s; dev output:\n%s", base, want, clip(out.String()))
+			}
+			url := base + ex.path
 			status := waitForStatus(t, url, 90*time.Second, &out)
 			if status != ex.wantStatus {
 				t.Fatalf("GET %s under gofastr dev: status %d, want %d; dev output:\n%s", url, status, ex.wantStatus, clip(out.String()))
@@ -84,6 +89,24 @@ func TestE2E_DevLoop_Examples(t *testing.T) {
 		})
 	}
 }
+
+// waitForBanner waits for the dev banner's "Server at http://…" line and
+// returns that address, so the probe hits what the user was told to open
+// rather than the port the test asked for.
+func waitForBanner(t *testing.T, devOut *syncBuffer, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if m := bannerAddr.FindStringSubmatch(devOut.String()); m != nil {
+			return m[1]
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("no \"Server at http://…\" banner within %s; dev output:\n%s", timeout, clip(devOut.String()))
+	return ""
+}
+
+var bannerAddr = regexp.MustCompile(`Server at (http://[^\s]+)`)
 
 // waitForStatus polls url until any HTTP response arrives and returns its
 // status; a connection that never opens fails with the dev output.

--- a/cmd/gofastr/dev_examples_e2e_test.go
+++ b/cmd/gofastr/dev_examples_e2e_test.go
@@ -59,6 +59,9 @@ func TestE2E_DevLoop_Examples(t *testing.T) {
 				// The child resolves isolation from its cwd; a linked worktree
 				// would silently remap the polled port.
 				"GOFASTR_ISOLATION=off",
+				// The generated apps refuse to seed their admin on a fresh
+				// database without this and exit; CI has no .env to supply it.
+				"ADMIN_SEED_PASSWORD=dev-loop-examples-admin-seed-2026", // not-a-secret: test fixture
 			)
 			var out syncBuffer
 			dev.Stdout = &out

--- a/cmd/gofastr/dev_examples_e2e_test.go
+++ b/cmd/gofastr/dev_examples_e2e_test.go
@@ -1,0 +1,103 @@
+package main
+
+// Boots every server example under `gofastr dev`, the command the site's
+// examples page and the READMEs lead with, and checks each answers on the
+// address the dev banner prints. The examples used to hardcode their port
+// or prefix $PORT with a colon, so the banner said one address and the
+// child bound another; isolation.ListenAddr is the fix and this is its
+// gate. The process module is a stdio child, not a server, so it is not
+// here.
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// devExample names one example directory (relative to examples/), the
+// path to probe once the server is up, and the status that proves the
+// example, not a placeholder, answered.
+type devExample struct {
+	dir, path  string
+	wantStatus int
+}
+
+var devExamples = []devExample{
+	{"api-tour", "/posts", http.StatusOK},
+	{"backoffice", "/login", http.StatusOK},
+	{"blog", "/posts", http.StatusOK},
+	{"embed-demo", "/", http.StatusNotFound}, // the app serves embed surfaces only; the customer site is the demo
+	{"semantic-demo", "/semantic/stats", http.StatusUnauthorized},
+	{"spa", "/", http.StatusOK},
+	{"static-site", "/", http.StatusOK},
+	{"webmcp-remote-assist", "/", http.StatusOK},
+	{"meridian", "/", http.StatusOK},
+	{"ecommerce/app", "/", http.StatusOK},
+	{"site", "/examples", http.StatusOK},
+}
+
+func TestE2E_DevLoop_Examples(t *testing.T) {
+	if testing.Short() {
+		t.Skip("dev-loop e2e: builds and serves every example")
+	}
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin := buildGofastrBinary(t)
+	for _, ex := range devExamples {
+		t.Run(ex.dir, func(t *testing.T) {
+			dir := filepath.Join(repoRoot, "examples", ex.dir)
+			port := nextE2EPort(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			dev := exec.CommandContext(ctx, bin, "dev", "-p", port, "--dir", dir, "--no-a11y")
+			dev.Env = append(os.Environ(),
+				// The child resolves isolation from its cwd; a linked worktree
+				// would silently remap the polled port.
+				"GOFASTR_ISOLATION=off",
+			)
+			var out syncBuffer
+			dev.Stdout = &out
+			dev.Stderr = &out
+			configureTestProcessGroup(dev)
+			if err := dev.Start(); err != nil {
+				t.Fatalf("start gofastr dev: %v", err)
+			}
+			t.Cleanup(func() {
+				_ = killTestProcessTree(dev)
+				cancel()
+				_ = dev.Wait()
+				removeDevServerBinary(dev)
+			})
+			url := "http://localhost:" + port + ex.path
+			status := waitForStatus(t, url, 90*time.Second, &out)
+			if status != ex.wantStatus {
+				t.Fatalf("GET %s under gofastr dev: status %d, want %d; dev output:\n%s", url, status, ex.wantStatus, clip(out.String()))
+			}
+		})
+	}
+}
+
+// waitForStatus polls url until any HTTP response arrives and returns its
+// status; a connection that never opens fails with the dev output.
+func waitForStatus(t *testing.T, url string, timeout time.Duration, devOut *syncBuffer) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	last := ""
+	client := &http.Client{Timeout: 5 * time.Second}
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			return resp.StatusCode
+		}
+		last = err.Error()
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("server never answered %s (%s); dev output:\n%s", url, last, clip(devOut.String()))
+	return 0
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,20 @@ Two kinds of example live here.
 
 ## Go examples (runnable)
 
-Self-contained Go programs, run with `go run ./examples/<name>`:
+Self-contained Go programs. Run one under the dev server for
+rebuild-on-save, livereload, and the dev MCP tools your coding agent
+reads:
+
+```bash
+cd examples/<name> && gofastr dev        # or: go run ./examples/<name>
+```
+
+Every server example binds through `isolation.ListenAddr`, so `$PORT`
+(injected by `gofastr dev` and by PaaS runtimes) wins over the example's
+default port. `TestE2E_DevLoop_Examples` in `cmd/gofastr` boots each one
+under `gofastr dev` and checks it answers on the address the banner
+prints. The process module is the exception: it is a stdio child, not a
+server, so `go run` it.
 
 | Example | What it shows |
 |---|---|
@@ -18,7 +31,7 @@ Self-contained Go programs, run with `go run ./examples/<name>`:
 | `embed-demo` | Embeddable surfaces: an app and a customer's site on two origins. |
 | `processmodule-demo` | A process-isolated third-party module speaking the `moduleproto` protocol over stdio. The canonical [process-module](../framework/docs/content/process-modules.md) example and the child the go/no-go gate suite drives end to end. |
 | `webmcp-remote-assist` | Authenticated WebMCP + WebRTC remote support: support-only tool discovery, one typed command behind the manual button and the AI tools, role-filtered realtime state, peer-to-peer camera with server-side signaling only. |
-| `site` | The framework's live component gallery and reference docs site: every UI component rendered one per page, the hosted examples, and the gofastr-plugins registry rendered from a vendored `plugins.json` (`scripts/vendor-plugins-json.sh` refreshes it). Run with `go run ./examples/site` (or `./scripts/dev-watch.sh` for livereload). |
+| `site` | The framework's live component gallery and reference docs site: every UI component rendered one per page, the hosted examples, and the gofastr-plugins registry rendered from a vendored `plugins.json` (`scripts/vendor-plugins-json.sh` refreshes it). Run with `cd examples/site && gofastr dev`. |
 
 ## Blueprint examples (declarative)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ Self-contained Go programs, run with `go run ./examples/<name>`:
 | `embed-demo` | Embeddable surfaces: an app and a customer's site on two origins. |
 | `processmodule-demo` | A process-isolated third-party module speaking the `moduleproto` protocol over stdio. The canonical [process-module](../framework/docs/content/process-modules.md) example and the child the go/no-go gate suite drives end to end. |
 | `webmcp-remote-assist` | Authenticated WebMCP + WebRTC remote support: support-only tool discovery, one typed command behind the manual button and the AI tools, role-filtered realtime state, peer-to-peer camera with server-side signaling only. |
-| `site` | The framework's live component gallery and reference docs site: every UI component rendered one per page, plus the hosted examples. Run with `go run ./examples/site` (or `./scripts/dev-watch.sh` for livereload). |
+| `site` | The framework's live component gallery and reference docs site: every UI component rendered one per page, the hosted examples, and the gofastr-plugins registry rendered from a vendored `plugins.json` (`scripts/vendor-plugins-json.sh` refreshes it). Run with `go run ./examples/site` (or `./scripts/dev-watch.sh` for livereload). |
 
 ## Blueprint examples (declarative)
 

--- a/examples/api-tour/README.md
+++ b/examples/api-tour/README.md
@@ -6,8 +6,8 @@ A graph of users → profiles, users → posts → comments.
 ## Run
 
 ```bash
-go run ./examples/api-tour
-# listening on :8080
+cd examples/api-tour && gofastr dev   # or: go run ./examples/api-tour
+# listening on :8080 (set PORT to change it)
 ```
 
 The first run creates `./api-tour.db` (SQLite) and seeds two users + two

--- a/examples/api-tour/README.md
+++ b/examples/api-tour/README.md
@@ -6,8 +6,9 @@ A graph of users → profiles, users → posts → comments.
 ## Run
 
 ```bash
-cd examples/api-tour && gofastr dev   # or: go run ./examples/api-tour
-# listening on :8080 (set PORT to change it)
+cd examples/api-tour && gofastr dev   # or: go run .
+# :8080 unless PORT is set or a linked worktree remaps it; the startup
+# banner prints the address to open
 ```
 
 The first run creates `./api-tour.db` (SQLite) and seeds two users + two

--- a/examples/api-tour/main.go
+++ b/examples/api-tour/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/core/schema"
 	"github.com/DonaldMurillo/gofastr/core/upload"
 	"github.com/DonaldMurillo/gofastr/framework"
+	"github.com/DonaldMurillo/gofastr/framework/isolation"
 	_ "github.com/DonaldMurillo/gofastr/sqlite/stdlib"
 )
 
@@ -124,8 +125,9 @@ func main() {
 	seedDemoData(db)
 
 	addr := ":8080"
-	if port := os.Getenv("PORT"); port != "" {
-		addr = ":" + port
+	addr, err = isolation.ListenAddr(".", addr)
+	if err != nil {
+		log.Fatal(err)
 	}
 	log.Printf("api-tour listening on %s", addr)
 	if err := app.Start(addr); err != nil {

--- a/examples/backoffice/main.go
+++ b/examples/backoffice/main.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 
 	"github.com/DonaldMurillo/gofastr/battery/admin"
 	appui "github.com/DonaldMurillo/gofastr/core-ui/app"
@@ -31,6 +30,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/framework/ui"
 	"github.com/DonaldMurillo/gofastr/framework/uihost"
 
+	"github.com/DonaldMurillo/gofastr/framework/isolation"
 	_ "github.com/DonaldMurillo/gofastr/sqlite/stdlib"
 )
 
@@ -39,8 +39,9 @@ const sessionCookie = "bo_session"
 func main() {
 	app := setupApp(":memory:")
 	addr := ":8086"
-	if p := os.Getenv("PORT"); p != "" {
-		addr = ":" + p
+	addr, err := isolation.ListenAddr(".", addr)
+	if err != nil {
+		log.Fatal(err)
 	}
 	log.Printf("backoffice on %s; visit /login (any email), then /admin", addr)
 	if err := http.ListenAndServe(addr, app.Router()); err != nil {

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -7,8 +7,8 @@ OpenAPI, and entity MCP tools.
 ## Quick start
 
 ```bash
-# From the repository root:
-go run ./examples/blog
+cd examples/blog && gofastr dev     # rebuild on save + dev MCP tools
+# or, from the repository root: go run ./examples/blog
 ```
 
 The server starts on **http://localhost:8080**.

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -1,13 +1,14 @@
 # GoFastr blog example
 
-A minimal blog application demonstrating JSON entity declarations, CRUD routes,
-soft delete, custom endpoints, generated OpenAPI, and entity MCP tools.
+A minimal blog application: three entities declared in Go, auto-mounted
+CRUD routes, RBAC-gated writes, soft delete, custom endpoints, generated
+OpenAPI, and entity MCP tools.
 
 ## Quick start
 
 ```bash
 # From the repository root:
-go run examples/blog/main.go
+go run ./examples/blog
 ```
 
 The server starts on **http://localhost:8080**.
@@ -16,53 +17,65 @@ The example uses SQLite at `./blog.db` and auto-migrates on startup.
 
 ## Endpoints
 
+The Auth column names the role scope a request needs. A request with no
+matching scope gets 403; there is no anonymous write anywhere.
+
 ### Users
 
-| Method   | Path             | Auth | Description        |
-| -------- | ---------------- | ---- | ------------------ |
-| GET      | `/users`         | No   | List users         |
-| GET      | `/users/{id}`    | No   | Get user by ID     |
-| POST     | `/users`         | Yes  | Create user        |
-| PUT      | `/users/{id}`    | Yes  | Update user        |
-| PATCH    | `/users/{id}`    | Yes  | Sparse-update user |
-| DELETE   | `/users/{id}`    | Yes  | Delete user        |
+Email is PII, so every operation on users is gated, reads included.
+
+| Method   | Path             | Auth          | Description        |
+| -------- | ---------------- | ------------- | ------------------ |
+| GET      | `/users`         | `users:read`  | List users         |
+| GET      | `/users/{id}`    | `users:read`  | Get user by ID     |
+| POST     | `/users`         | `users:write` | Create user        |
+| PUT      | `/users/{id}`    | `users:write` | Update user        |
+| PATCH    | `/users/{id}`    | `users:write` | Sparse-update user |
+| DELETE   | `/users/{id}`    | `users:admin` | Delete user        |
 
 ### Posts
 
-| Method   | Path                  | Auth | Description                  |
-| -------- | --------------------- | ---- | ---------------------------- |
-| GET      | `/posts`              | No   | List posts (paginated)       |
-| GET      | `/posts/{id}`         | No   | Get post by ID               |
-| GET      | `/posts/published`    | No   | List published posts only    |
-| GET      | `/posts/search?q=...` | No   | Search indexed posts         |
-| POST     | `/posts`              | Yes  | Create post                  |
-| PUT      | `/posts/{id}`         | Yes  | Update post                  |
-| PATCH    | `/posts/{id}`         | Yes  | Sparse-update post           |
-| DELETE   | `/posts/{id}`         | Yes  | Soft-delete post             |
+| Method   | Path                  | Auth          | Description                  |
+| -------- | --------------------- | ------------- | ---------------------------- |
+| GET      | `/posts`              | public        | List posts (paginated)       |
+| GET      | `/posts/{id}`         | public        | Get post by ID               |
+| GET      | `/posts/published`    | public        | List published posts only    |
+| GET      | `/posts/search?q=...` | public        | Search indexed posts         |
+| POST     | `/posts`              | `posts:write` | Create post                  |
+| PUT      | `/posts/{id}`         | `posts:write` | Update post                  |
+| PATCH    | `/posts/{id}`         | `posts:write` | Sparse-update post           |
+| DELETE   | `/posts/{id}`         | `posts:admin` | Soft-delete post             |
 
 ### Comments
 
-| Method   | Path                | Auth | Description          |
-| -------- | ------------------- | ---- | -------------------- |
-| GET      | `/comments`         | No   | List comments        |
-| GET      | `/comments/{id}`    | No   | Get comment by ID    |
-| POST     | `/comments`         | Yes  | Create comment       |
-| PUT      | `/comments/{id}`    | Yes  | Update comment       |
-| PATCH    | `/comments/{id}`    | Yes  | Sparse-update comment |
-| DELETE   | `/comments/{id}`    | Yes  | Delete comment       |
+| Method   | Path                | Auth             | Description           |
+| -------- | ------------------- | ---------------- | --------------------- |
+| GET      | `/comments`         | public           | List comments         |
+| GET      | `/comments/{id}`    | public           | Get comment by ID     |
+| POST     | `/comments`         | `comments:write` | Create comment        |
+| PUT      | `/comments/{id}`    | `comments:write` | Update comment        |
+| PATCH    | `/comments/{id}`    | `comments:write` | Sparse-update comment |
+| DELETE   | `/comments/{id}`    | `comments:admin` | Delete comment        |
 
 ### Auth
 
-This example does not enforce auth. Production apps should add auth middleware
-or per-entity access control before exposing write endpoints.
+The scopes come from each entity's `Exposure.Access` block in `main.go`
+and mirror the `access:` block in `gofastr.yml`. The example wires no
+login, so every gated route answers 403 until you add `battery/auth` (or
+any middleware that puts roles on the request context). `blog_test.go`
+pins the fail-closed behaviour, and the comment above `registerEntities`
+explains why the two declarations must agree on exposure.
 
 Create, get, PUT, and PATCH return `{"data": {...}}`; list responses return
 `{"data": [...]}` with pagination metadata.
 
 ```bash
+# Public read:
+curl http://localhost:8080/posts
+# Gated write: 403 until a role with posts:write is on the request
 curl -H "Content-Type: application/json" \
-     -d '{"name":"Ada","email":"ada@example.com"}' \
-     http://localhost:8080/users
+     -d '{"title":"Hello","author_id":"u1"}' \
+     http://localhost:8080/posts
 ```
 
 ### Filtering & pagination
@@ -79,7 +92,8 @@ GET /posts?page=2&limit=10&sort=-created_at&status=published
 | `limit`    | `limit=10`       | Items per page (max 100)        |
 | `sort`     | `sort=-title`    | Sort field (`-` for descending) |
 | `{field}`  | `status=draft`   | Exact-match filter              |
-| `{field}_like` | `title_like=go` | Contains filter             |
+| `{field}_like` | `title_like=go` | Contains filter (wildcards escaped) |
+| `{field}_in` | `status_in=draft,published` | Any-of filter    |
 
 ## Entities & relationships
 

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -11,7 +11,8 @@ cd examples/blog && gofastr dev     # rebuild on save + dev MCP tools
 # or, from the repository root: go run ./examples/blog
 ```
 
-The server starts on **http://localhost:8080**.
+The server binds :8080 unless `PORT` is set or a linked worktree remaps
+it; the startup banner prints the address to open.
 
 The example uses SQLite at `./blog.db` and auto-migrates on startup.
 

--- a/examples/blog/main.go
+++ b/examples/blog/main.go
@@ -6,12 +6,11 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-	"os"
-	"strings"
 
 	"github.com/DonaldMurillo/gofastr/battery/search"
 	"github.com/DonaldMurillo/gofastr/core/schema"
 	"github.com/DonaldMurillo/gofastr/framework"
+	"github.com/DonaldMurillo/gofastr/framework/isolation"
 	_ "github.com/DonaldMurillo/gofastr/sqlite/stdlib"
 )
 
@@ -60,7 +59,11 @@ func main() {
 
 	// --- Start (auto-migrates, auto-routes CRUD, auto-serves OpenAPI + Swagger) ---
 
-	if err := app.Start(listenAddr()); err != nil {
+	addr, err := isolation.ListenAddr(".", ":8080")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := app.Start(addr); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -119,19 +122,6 @@ func registerEntities(app *framework.App) {
 			framework.BelongsTo("author", "users", "author_id"),
 		},
 	})
-}
-
-// listenAddr resolves the bind address, normalizing a bare numeric PORT
-// (e.g. "8088" as injected by most PaaS providers) to ":8088".
-func listenAddr() string {
-	port := os.Getenv("PORT")
-	if port == "" {
-		return ":8080"
-	}
-	if !strings.Contains(port, ":") {
-		return ":" + port
-	}
-	return port
 }
 
 //go:fix inline

--- a/examples/ecommerce/doc.go
+++ b/examples/ecommerce/doc.go
@@ -5,15 +5,15 @@
 //
 //	gofastr generate --from=gofastr.yml
 //
-// The generated app lives under gen/ (gitignored, regenerate with the command
-// above; flagship_test.go regenerates it on every run) and is the proof of the
-// framework's thesis: one blueprint produces a SQL schema,
-// REST CRUD, an OpenAPI spec, a typed MCP tool surface, and a server-rendered
-// UI, none of it hand-written. See flagship_test.go for the end-to-end
-// surface check.
+// The generated app is committed under app/ (output_dir: app in the
+// blueprint) and is the proof of the framework's thesis: one blueprint
+// produces a SQL schema, REST CRUD, an OpenAPI spec, a typed MCP tool
+// surface, and a server-rendered UI, none of it hand-written.
+// flagship_test.go regenerates app/ with --force on every run and
+// blueprint_gate_test.go fails when the committed files differ from what
+// the in-tree generator emits, so app/ can never drift from the CLI.
 //
-// The scaffolded, owned app lives in the app/ subpackage (output_dir: app);
-// run it directly:
+// Run it directly:
 //
 //	go run ./examples/ecommerce/app
 package ecommerce

--- a/examples/embed-demo/main.go
+++ b/examples/embed-demo/main.go
@@ -31,19 +31,23 @@ import (
 	"net/http"
 	"os"
 	"slices"
+	"strings"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/app"
 	"github.com/DonaldMurillo/gofastr/core/handler"
 	"github.com/DonaldMurillo/gofastr/core/render"
 	fembed "github.com/DonaldMurillo/gofastr/framework/embed"
+	"github.com/DonaldMurillo/gofastr/framework/isolation"
 	"github.com/DonaldMurillo/gofastr/framework/ui"
 	"github.com/DonaldMurillo/gofastr/framework/uihost"
 )
 
 const (
-	appAddr      = ":8087"
-	customerAddr = ":8088"
-	appOrigin    = "http://localhost" + appAddr
+	// defaultAppAddr is the app's fallback when $PORT is unset; `gofastr dev`
+	// injects PORT and isolation.ListenAddr honours it. The customer site
+	// keeps a fixed port because its origin is what the allowlist names.
+	defaultAppAddr = ":8087"
+	customerAddr   = ":8088"
 	// The customer's origin, exactly as it must appear in the allowlist.
 	// Exact origins only, http://localhost:8088 does not cover
 	// http://127.0.0.1:8088, and that is the point.
@@ -126,7 +130,26 @@ func (s *demoSource) Allows(_ context.Context, _, origin string) (bool, error) {
 	return false, nil
 }
 
+// appOrigin is the app's origin as the customer page must reference it,
+// derived from the resolved listen address in main.
+var appOrigin string
+
+// localOrigin renders a listen address as an origin: a bare ":8087" is
+// http://localhost:8087, a host:port is used as is.
+func localOrigin(addr string) string {
+	if strings.HasPrefix(addr, ":") {
+		return "http://localhost" + addr
+	}
+	return "http://" + addr
+}
+
 func main() {
+	appAddr, err := isolation.ListenAddr(".", defaultAppAddr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	appOrigin = localOrigin(appAddr)
+
 	secret := os.Getenv("GOFASTR_SECRET")
 	if secret == "" {
 		// Embeds require a real secret, a per-boot key would invalidate every

--- a/examples/semantic-demo/main.go
+++ b/examples/semantic-demo/main.go
@@ -42,9 +42,11 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/DonaldMurillo/gofastr/battery/semantic"
 	"github.com/DonaldMurillo/gofastr/framework"
+	"github.com/DonaldMurillo/gofastr/framework/isolation"
 )
 
 func main() {
@@ -76,10 +78,17 @@ func main() {
 		log.Fatalf("InitPlugins: %v", err)
 	}
 
-	addr := ":8086"
-	fmt.Printf("semantic-demo listening on http://localhost%s\n", addr)
+	addr, err := isolation.ListenAddr(".", ":8086")
+	if err != nil {
+		log.Fatal(err)
+	}
+	base := "http://" + addr
+	if strings.HasPrefix(addr, ":") {
+		base = "http://localhost" + addr
+	}
+	fmt.Printf("semantic-demo listening on %s\n", base)
 	fmt.Printf("auth token: %q (set SEMANTIC_DEMO_TOKEN to change it)\n", token)
-	fmt.Printf("try: curl -H 'Authorization: Bearer %s' 'http://localhost%s/semantic/stats'\n", token, addr)
+	fmt.Printf("try: curl -H 'Authorization: Bearer %s' '%s/semantic/stats'\n", token, base)
 	if err := http.ListenAndServe(addr, app.Router()); err != nil {
 		log.Fatal(err)
 	}

--- a/examples/site/example_loc_gate_test.go
+++ b/examples/site/example_loc_gate_test.go
@@ -43,6 +43,40 @@ func measureExampleLoC(t *testing.T, slug string) int {
 	return total
 }
 
+// locBadgeDrift reports how far a badge is from the measured count as a
+// percentage of the measurement, and whether that is within the 20%
+// tolerance. A zero measurement is never ok: the badge names a directory
+// with no non-test Go.
+func locBadgeDrift(badge, got int) (pct float64, ok bool) {
+	if got == 0 {
+		return 100, false
+	}
+	pct = float64(badge-got) / float64(got) * 100
+	if pct < 0 {
+		pct = -pct
+	}
+	return pct, pct <= 20
+}
+
+func TestLoCBadgeDriftBoundary(t *testing.T) {
+	cases := []struct {
+		badge, got int
+		ok         bool
+	}{
+		{100, 0, false},  // nothing measured
+		{120, 100, true}, // exactly 20% over
+		{80, 100, true},  // exactly 20% under
+		{121, 100, false},
+		{79, 100, false},
+		{100, 100, true},
+	}
+	for _, c := range cases {
+		if _, ok := locBadgeDrift(c.badge, c.got); ok != c.ok {
+			t.Errorf("locBadgeDrift(%d, %d) ok = %v, want %v", c.badge, c.got, ok, c.ok)
+		}
+	}
+}
+
 func TestExampleLoCBadgesMatchTree(t *testing.T) {
 	page := body(t, "/examples")
 	for slug, badge := range exampleLoC {
@@ -51,12 +85,8 @@ func TestExampleLoCBadgesMatchTree(t *testing.T) {
 			t.Errorf("%s: no non-test Go under examples/%s", slug, slug)
 			continue
 		}
-		diff := float64(badge-got) / float64(got)
-		if diff < 0 {
-			diff = -diff
-		}
-		if diff > 0.20 {
-			t.Errorf("%s: badge says ~%d LoC, tree has %d (%.0f%% off) — update exampleLoC", slug, badge, got, diff*100)
+		if pct, ok := locBadgeDrift(badge, got); !ok {
+			t.Errorf("%s: badge says ~%d LoC, tree has %d (%.0f%% off) — update exampleLoC", slug, badge, got, pct)
 		}
 		if !strings.Contains(page, `id="`+slug+`"`) {
 			t.Errorf("%s: has a LoC badge but no row on /examples", slug)

--- a/examples/site/example_loc_gate_test.go
+++ b/examples/site/example_loc_gate_test.go
@@ -1,0 +1,73 @@
+package main
+
+// Gate for the "~N LoC" badges on /examples. Each badge is a constant in
+// exampleLoC; this test measures the non-test Go lines under
+// examples/<slug> and fails when a badge is more than 20% off, so the
+// badges get re-measured instead of remembered. It also pins that every
+// badge slug has a row and that the blueprint-only list stays linked.
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func measureExampleLoC(t *testing.T, slug string) int {
+	t.Helper()
+	dir := filepath.Join("..", slug)
+	total := 0
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		sc := bufio.NewScanner(f)
+		sc.Buffer(make([]byte, 1<<20), 1<<20)
+		for sc.Scan() {
+			total++
+		}
+		return sc.Err()
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return total
+}
+
+func TestExampleLoCBadgesMatchTree(t *testing.T) {
+	page := body(t, "/examples")
+	for slug, badge := range exampleLoC {
+		got := measureExampleLoC(t, slug)
+		if got == 0 {
+			t.Errorf("%s: no non-test Go under examples/%s", slug, slug)
+			continue
+		}
+		diff := float64(badge-got) / float64(got)
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > 0.20 {
+			t.Errorf("%s: badge says ~%d LoC, tree has %d (%.0f%% off) — update exampleLoC", slug, badge, got, diff*100)
+		}
+		if !strings.Contains(page, `id="`+slug+`"`) {
+			t.Errorf("%s: has a LoC badge but no row on /examples", slug)
+		}
+	}
+	for _, slug := range []string{"lms", "portfolio", "project-manager", "real-estate"} {
+		if !strings.Contains(page, "tree/main/examples/"+slug) {
+			t.Errorf("/examples blueprint list is missing a source link for %q", slug)
+		}
+		if _, err := os.Stat(filepath.Join("..", slug, "gofastr.yml")); err != nil {
+			t.Errorf("examples/%s/gofastr.yml: %v", slug, err)
+		}
+	}
+}

--- a/examples/site/layout.go
+++ b/examples/site/layout.go
@@ -150,6 +150,7 @@ func (h *HeaderComponent) Render() render.HTML {
 			{Label: "Interactivity", Href: "/interactivity", MatchPrefix: true},
 			{Label: "Generator", Href: "/generator", MatchPrefix: true},
 			{Label: "Examples", Href: "/examples", MatchPrefix: true},
+			{Label: "Plugins", Href: "/plugins", MatchPrefix: true},
 		},
 		MobileExtraLinks: []ui.SiteHeaderLink{
 			{Label: "Home", Href: "/"},
@@ -190,6 +191,7 @@ func (f *FooterComponent) Render() render.HTML {
 			}},
 			{Title: "Use", Links: []ui.SiteFooterLink{
 				{Label: "Examples", Href: "/examples"},
+				{Label: "Plugins", Href: "/plugins"},
 				{Label: "Kiln (experimental)", Href: "/kiln"},
 				{Label: "CLI", Href: "https://pkg.go.dev/github.com/DonaldMurillo/gofastr/cmd/gofastr", External: true},
 			}},

--- a/examples/site/main.go
+++ b/examples/site/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/framework/docs"
 	"github.com/DonaldMurillo/gofastr/framework/gallery"
 	fwimage "github.com/DonaldMurillo/gofastr/framework/image"
+	"github.com/DonaldMurillo/gofastr/framework/isolation"
 	"github.com/DonaldMurillo/gofastr/framework/ui"
 	"github.com/DonaldMurillo/gofastr/framework/uihost"
 )
@@ -71,10 +72,12 @@ func main() {
 		return
 	}
 
-	// Port from $PORT (dev-watch sets it); default 8083 for plain `go run .`.
-	addr := ":8083"
-	if p := os.Getenv("PORT"); p != "" {
-		addr = ":" + p
+	// $PORT wins (gofastr dev, dev-watch, and PaaS runtimes inject it, as a
+	// bare port or host:port); default 8083 for plain `go run .`.
+	addr, err := isolation.ListenAddr(".", ":8083")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "listen address: %v\n", err)
+		os.Exit(1)
 	}
 	fmt.Println("━─────────────────────────────────────────────")
 	fmt.Println("  GoFastr product site (v2)")

--- a/examples/site/main.go
+++ b/examples/site/main.go
@@ -747,7 +747,8 @@ var paletteCatalog = []paletteRoute{
 	{"Get started", "/get-started"},
 	{"Docs index", "/docs/"},
 	{"Entity declarations: modeling the domain", "/docs/entity-declarations"},
-	{"Examples: six reference apps", "/examples"},
+	{"Examples: the reference apps", "/examples"},
+	{"Plugins: the gofastr-plugins registry", "/plugins"},
 	{"Workspace: master-detail pane-host example", "/examples/workspace"},
 	{"Live dashboard: SSE + signals reference", "/examples/live-dashboard?presence=live-dashboard-demo"},
 	{"Live presence: viewer roster demo", "/examples/presence?presence=presence-demo"},
@@ -839,6 +840,11 @@ func registerScreens(site *app.App) {
 	// dashboard fed by SSE island push. The ticker that advances the
 	// demo state is wired in setupServer; see screen_livedash.go.
 	site.Register("/examples/live-dashboard", &LiveDashboardScreen{}, nil)
+	// The gofastr-plugins registry: one index plus one page per row of the
+	// vendored plugins.json (see screen_plugins.go). PluginScreen 404s an
+	// unknown name (Load) and enumerates every row via StaticPaths.
+	site.Register("/plugins", &PluginsScreen{}, nil)
+	site.Register("/plugins/:name", &PluginScreen{}, nil)
 	site.Register("/kiln", &KilnScreen{}, nil)
 	site.Register("/philosophy", &PhilosophyScreen{}, nil)
 	// /reader: a reader-ready article, the simple way. This is a normal

--- a/examples/site/plugins/plugins.json
+++ b/examples/site/plugins/plugins.json
@@ -1,0 +1,357 @@
+{
+  "registryVersion": "1",
+  "$comment": "Curated registry index for gofastr-plugins. This is a CONVENTION, not a service: a JSON manifest + the docs/plugin-platform.md page. There is no runtime discovery server. Apps import a plugin package directly via its modulePath and mount it with framework.RegisterPlugin. Each row mirrors the plugin's own identity/route constants and its pluginhost.Manifest (see <pkg>/plugin.go). Update a plugin's row in the same change that bumps its Version or capabilities. This file is consumed by COPY, not import: a host fetches it from a release asset and vendors it, so nothing imports a Go API for it. In THIS repo it is parsed by internal/registry (test-only, not importable by consumers) -- keep it valid JSON, and add new keys to the Go structs in internal/registry/registry.go at the same time (the parser rejects unknown fields).",
+  "description": "Officially-maintained heavy-JavaScript plugins for the GoFastr framework. Most run isolated in an opaque-origin sandboxed iframe and talk to the host only over a versioned postMessage capability bridge (isolation \"sandbox-iframe-opaque\"). A plugin that must reach the host DOM (the guided-tour plugin) instead runs as a vouched-for trusted host-page script (isolation \"trusted-host-page\", trusted:true) — never sandboxed and never same-origin-in-a-frame. See docs/plugin-platform.md for the platform contract.",
+  "framework": {
+    "name": "gofastr",
+    "modulePath": "github.com/DonaldMurillo/gofastr",
+    "note": "gofastr uses calendar-ish semver (YYYY-MM-DD releases until the API stabilises). These plugins are built and tested against the published gofastr pinned in go.mod; frameworkCompat is a best-effort floor, not a tested matrix. The gofastr-plugins ROOT module is versioned by this repo's own vX.Y.Z tags; there is no separately-versioned registry submodule."
+  },
+  "plugins": [
+    {
+      "name": "richtext",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/richtext",
+      "version": "0.1.0-phase0",
+      "description": "Full Rich Text block editor built on ProseMirror. Block-JSON canonical, markdown export + a pure-Go SSR read view (richtext/ssr). The first heavy-JS plugin and the forcing function that proved the third-party isolation contract.",
+      "isolation": "sandbox-iframe-opaque",
+      "sandbox": [
+        "allow-scripts"
+      ],
+      "capabilities": [
+        "document:read",
+        "document:write",
+        "upload:images",
+        "theme:read"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/richtext",
+      "entry": "/__gofastr/plugin/richtext/editor.html",
+      "schema": "richtext-v1",
+      "minHeight": "240px",
+      "docs": "docs/richtext-editor.md"
+    },
+    {
+      "name": "mermaid",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/mermaid",
+      "version": "0.1.0-phase0",
+      "description": "Isolated Mermaid diagram editor/renderer. The second heavy-JS plugin — the completeness canary proving the extracted pluginhost platform generalizes beyond the editor. Canonical doc is {source:\"...\"}; no upload path.",
+      "isolation": "sandbox-iframe-opaque",
+      "sandbox": [
+        "allow-scripts"
+      ],
+      "capabilities": [
+        "document:read",
+        "document:write",
+        "theme:read"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/mermaid",
+      "entry": "/__gofastr/plugin/mermaid/diagram.html",
+      "schema": "mermaid-v1",
+      "minHeight": "320px",
+      "docs": "docs/mermaid.md"
+    },
+    {
+      "name": "monaco",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/monaco",
+      "version": "0.1.0-phase0",
+      "description": "Configurable Monaco (VS Code) code editor. The third sandboxed heavy-JS plugin. Canonical doc is {code, language}; syntax highlighting runs worker-free on the main thread (opaque-origin safe), with an opt-in real-worker path. Supports a diff-editor mode and per-instance language/theme/read-only/minimap/word-wrap config.",
+      "isolation": "sandbox-iframe-opaque",
+      "sandbox": [
+        "allow-scripts"
+      ],
+      "capabilities": [
+        "document:read",
+        "document:write",
+        "theme:read"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/monaco",
+      "entry": "/__gofastr/plugin/monaco/editor.html",
+      "schema": "monaco-v1",
+      "minHeight": "320px",
+      "docs": "docs/monaco.md"
+    },
+    {
+      "name": "pdf",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/pdf",
+      "version": "0.1.0",
+      "description": "PDF viewer / editor / redactor built on pdf.js (render) + pdf-lib (write). The fourth sandboxed heavy-JS plugin. pdf.js runs WORKER-FREE on the main thread and the frame fetches nothing: under the framed CSP's connect-src 'none' the document bytes arrive over the postMessage bridge, which means the frame holding a confidential PDF structurally cannot exfiltrate it. Canonical doc is an annotation OVERLAY ({src, annotations[], formFields{}, redactions[], pageOps[]}) in PDF user space, never the file bytes. Host-selected mode (view/annotate/redact) is enforced on both sides. Redaction rasterizes affected pages and rebuilds a fresh document, then verifies the output before releasing it; download and print are host capabilities because the CSP sandbox token forbids them in-frame.",
+      "isolation": "sandbox-iframe-opaque",
+      "sandbox": [
+        "allow-scripts"
+      ],
+      "capabilities": [
+        "document:read",
+        "document:write",
+        "theme:read"
+      ],
+      "optionalCapabilities": [
+        "pdf:export"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/pdf",
+      "entry": "/__gofastr/plugin/pdf/viewer.html",
+      "schema": "pdf-v1",
+      "minHeight": "480px",
+      "docs": "docs/pdf.md"
+    },
+    {
+      "name": "datagrid",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/datagrid",
+      "version": "0.1.0",
+      "description": "Data grid over AG Grid Community's infinite row model — the fifth sandboxed heavy-JS plugin, and the first whose traffic is pages rather than one document. The framed CSP's connect-src 'none' means the frame can never fetch its own rows: every page crosses the postMessage bridge as a correlated requestRows/rowsResult event pair (the richtext requestUpload pattern), and sorting, filtering and paging all run in the host's Go rows source behind POST /rows. Canonical doc is VIEW STATE ONLY ({columns[], sort, filter, pageSize}, schema datagrid-v1) — rows are never part of it. Cell editing (requestCellWrite → POST /cell) and view-state saves gate on optional data:write; host-side CSV export (requestExport → POST /export, the download starts in the host page) gates on optional data:export — each granted exactly when the host wires the matching handler option, like pdf:export.",
+      "isolation": "sandbox-iframe-opaque",
+      "sandbox": [
+        "allow-scripts"
+      ],
+      "capabilities": [
+        "data:read",
+        "theme:read"
+      ],
+      "optionalCapabilities": [
+        "data:write",
+        "data:export"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/datagrid",
+      "entry": "/__gofastr/plugin/datagrid/grid.html",
+      "schema": "datagrid-v1",
+      "minHeight": "480px",
+      "docs": "docs/datagrid.md"
+    },
+    {
+      "name": "tour",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/tour",
+      "version": "0.1.0",
+      "description": "Guided product-tour (\"app cues\") plugin: spotlights host-page elements with stepped tooltip bubbles, progress, and don't-show-again persistence. The FIRST trusted host-page plugin — it runs in the host page with full DOM access (it must, to highlight real elements), so it is NOT sandboxed. Runtime is a same-origin script + stylesheet; tours are registered server-side and completion is persisted client-side and via a seen endpoint.",
+      "isolation": "trusted-host-page",
+      "trusted": true,
+      "capabilities": [
+        "tour:read",
+        "tour:write"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/tour",
+      "docs": "docs/tour.md"
+    },
+    {
+      "name": "map",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/geomap",
+      "version": "0.3.0",
+      "description": "Interactive vector map (MapLibre GL + OpenFreeMap). A TRUSTED host-page plugin (like tour) — it runs in the host page with fetch/worker access so it can render OpenFreeMap vector tiles (free for commercial use, no API key). Canonical doc is {lat,lng,zoom,markers[]}; click-to-add draggable pins whose popup is a live label editor with per-pin delete, a style switcher (layers), geolocate + scale controls, optional marker clustering, an optional place-search box backed by the plugin's own same-origin geocode proxy, and a fly-to side panel. The host page CSP MUST allow connect-src/img-src https://tiles.openfreemap.org and worker-src blob: (see docs/geomap.md); search needs no extra CSP host because it is proxied through the plugin's own origin. Place search is opt-in (geomap.WithSearch): enabling it registers /__gofastr/plugin/map/geocode and adds the optionalCapability geocode:search.",
+      "isolation": "trusted-host-page",
+      "trusted": true,
+      "capabilities": [
+        "document:read",
+        "document:write",
+        "theme:read"
+      ],
+      "optionalCapabilities": [
+        "geocode:search"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/map",
+      "schema": "map-v1",
+      "minHeight": "360px",
+      "docs": "docs/geomap.md"
+    },
+    {
+      "name": "chart",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/chart",
+      "version": "0.1.0",
+      "description": "One chart spec, two agreeing renderers: a pure-Go SSR SVG (chart/ssr — the page works with JavaScript off) and a sandboxed Observable Plot frame that hydrates it into an interactive chart. The Go tick algorithm is a line-for-line port of d3-array's ticks, so server and client axis labels agree exactly; an e2e agreement test compares both SVGs on awkward ranges. Canonical doc is {type, series[], axes, options} (chart-v1) covering line/bar/area/scatter with axes, legend and title; the data lives in the doc, capped at 10,000 total points across at most 12 series.",
+      "isolation": "sandbox-iframe-opaque",
+      "sandbox": [
+        "allow-scripts"
+      ],
+      "capabilities": [
+        "document:read",
+        "document:write",
+        "theme:read"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/chart",
+      "entry": "/__gofastr/plugin/chart/chart.html",
+      "schema": "chart-v1",
+      "minHeight": "360px",
+      "docs": "docs/chart.md"
+    },
+    {
+      "name": "logstream",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/logstream",
+      "version": "0.1.0",
+      "description": "Live log tail in an opaque-origin sandboxed iframe (xterm.js). The only plugin whose traffic is not turn-based: the host PUSHES NDJSON lines from GET /stream and delivers unsolicited streamBatch events over the postMessage bridge; the frame renders one batch per ~16ms tick and acks with streamAck carrying the last rendered sequence number. Backpressure is explicit — a 4-batch ack window and a bounded host buffer that drops from the OLDEST end when the producer outruns the frame, with the dropped count riding the next batch and rendering as a visible 'N lines dropped' marker. Scrollback is bounded at 10,000 lines. Read-only: stream:read + theme:read only, no PTY, no shell, no command input, no writes.",
+      "isolation": "sandbox-iframe-opaque",
+      "sandbox": [
+        "allow-scripts"
+      ],
+      "capabilities": [
+        "stream:read",
+        "theme:read"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/logstream",
+      "entry": "/__gofastr/plugin/logstream/term.html",
+      "schema": "logstream-v1",
+      "minHeight": "560px",
+      "docs": "docs/logstream.md"
+    },
+    {
+      "name": "imageedit",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/imageedit",
+      "version": "0.1.0",
+      "description": "Crop / annotate / redact image editor, and the proof that the pdf plugin's bytes-over-the-bridge design generalizes: the frame has connect-src 'none' and receives the image as an ArrayBuffer over postMessage, the canonical doc is an OPERATION LIST (imageedit-v1: src, crop, rotate, annotations[], redactions[] in image coordinates — never pixels), and every export is re-rendered by Go from that list using only the standard library. EXIF is stripped by full re-encode, 16 MiB / 24 MP / 8192px caps are enforced at the header stage before decode, and redactions are verified against the produced bytes — a region must be gone, not painted over, or the export fails closed.",
+      "isolation": "sandbox-iframe-opaque",
+      "sandbox": [
+        "allow-scripts"
+      ],
+      "capabilities": [
+        "document:read",
+        "document:write",
+        "theme:read"
+      ],
+      "optionalCapabilities": [
+        "upload:images"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/imageedit",
+      "entry": "/__gofastr/plugin/imageedit/editor.html",
+      "schema": "imageedit-v1",
+      "minHeight": "520px",
+      "docs": "docs/imageedit.md"
+    },
+    {
+      "name": "formbuilder",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/formbuilder",
+      "version": "0.1.0",
+      "description": "Form-schema authoring tool — the first plugin whose output the framework itself consumes and enforces. A drag-to-reorder field list plus a property panel in an opaque-origin sandboxed iframe (no vendor library) edits a canonical doc that is DATA ONLY: {version, fields[]} per formbuilder-v1, never markup — Go validates every save and refuses bad schemas with specific 400 codes (unknown type, duplicate/empty/invalid name, malformed rule, unknown version, markup). The demo closes the loop: a second route renders the SAVED schema as a real working form through GoFastr's own ui.Form and re-validates every rule server-side on POST, with zero client trust in the path.",
+      "isolation": "sandbox-iframe-opaque",
+      "sandbox": [
+        "allow-scripts"
+      ],
+      "capabilities": [
+        "document:read",
+        "document:write",
+        "theme:read"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/formbuilder",
+      "entry": "/__gofastr/plugin/formbuilder/builder.html",
+      "schema": "formbuilder-v1",
+      "minHeight": "560px",
+      "docs": "docs/formbuilder.md"
+    },
+    {
+      "name": "calendar",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/calendar",
+      "version": "0.1.0",
+      "description": "Month/week/day calendar written from scratch — no FullCalendar, no upstream JS library at all (~24 KB bundle, 0 npm dependencies). The parts everyone gets wrong run in Go: RRULE expansion (DAILY/WEEKLY/MONTHLY with COUNT/UNTIL/BYDAY, wall-clock anchored, everything else rejected loudly), timezone resolution with an explicit gap/fold policy (spring-forward times carried past the gap, ambiguous hours resolved to the first occurrence — table-tested against America/New_York and Lord Howe's 30-minute step), and conflict detection over resolved instants. The frame renders server-resolved occurrences only and sends move INTENTS — a wall-clock delta — which the host re-resolves: a drag onto a DST boundary can come back with a different wall-clock delta than was dragged, and the demo's live readout shows requested vs wall vs elapsed.",
+      "isolation": "sandbox-iframe-opaque",
+      "sandbox": [
+        "allow-scripts"
+      ],
+      "capabilities": [
+        "document:read",
+        "document:write",
+        "theme:read"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/calendar",
+      "entry": "/__gofastr/plugin/calendar/app.html",
+      "schema": "calendar-v1",
+      "minHeight": "620px",
+      "docs": "docs/calendar.md"
+    },
+    {
+      "name": "whiteboard",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/whiteboard",
+      "version": "0.1.0",
+      "description": "Collaborative whiteboard, and the proof that collaboration does not need a socket in the cage. The frame (Yjs CRDT + a small canvas controller, ~28 KB gzip) runs under connect-src 'none': strokes are order-insensitive binary update blobs that cross the postMessage bridge as ArrayBuffers, and the HOST relays them between browsers — SSE fan-out, replay-on-join, and presence cursors carrying an opaque pid and a colour, never a name, because identity is the host's to decide and the frame is untrusted. The optional sync:room capability is granted exactly when the host wires a room hub; the routes fail closed without one, and a reconnect publishes the frame's full CRDT state so offline edits on both sides converge instead of last-writer-winning.",
+      "isolation": "sandbox-iframe-opaque",
+      "sandbox": [
+        "allow-scripts"
+      ],
+      "capabilities": [
+        "theme:read"
+      ],
+      "optionalCapabilities": [
+        "sync:room"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/whiteboard",
+      "entry": "/__gofastr/plugin/whiteboard/board.html",
+      "schema": "whiteboard-v1",
+      "minHeight": "480px",
+      "docs": "docs/whiteboard.md"
+    },
+    {
+      "name": "scanner",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/scanner",
+      "version": "0.1.0",
+      "description": "Barcode and QR scanning where the camera is UNREACHABLE from the plugin: an opaque-origin frame is refused getUserMedia outright (SecurityError: Invalid security origin, and an allow=\"camera\" attribute does not change it — measured), so the HOST page owns the MediaStream and pushes grayscale luminance frames over the postMessage bridge, one in flight at a time, released by the frame's frameDone ack. The frame decodes and returns text plus format; pixels never come back and the cage still has connect-src 'none'. Two decoders: the platform's BarcodeDetector where the engine has one, and a bundled pure-JS zxing (no wasm) for Safari, Firefox and Chromium on Linux. Native is preferred for correctness, not speed — zxing's JS port fails to read some valid QR codes its own encoder produces. No document store, no upload path, no save route: a decoded string goes to the host page and nowhere else.",
+      "isolation": "sandbox-iframe-opaque",
+      "sandbox": [
+        "allow-scripts"
+      ],
+      "capabilities": [
+        "scan:decode",
+        "theme:read"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/scanner",
+      "entry": "/__gofastr/plugin/scanner/scan.html",
+      "schema": "scanner-v1",
+      "minHeight": "460px",
+      "docs": "docs/scanner.md"
+    },
+    {
+      "name": "genui",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/genui",
+      "version": "0.1.0",
+      "description": "Generative UI: a model composes a view out of a FIXED registry of React components, naming component ids and typed props — never markup, never CSS, never code. The bounded registry IS the containment story: eight components, each declaring a closed set of props, so there is no style, className or dangerouslySetInnerHTML for generated output to travel through. Compositions are validated twice on purpose — in Go before they are stored and served, and again in the frame before they are rendered, because \"the host already checked it\" is the assumption that turns one bug into a rendered payload. The model runs HOST-side in Go: the frame receives a finished tree over the postMessage bridge, holds no credentials, and keeps connect-src 'none', so a composer that could call a model could never also send it the document. Generated controls may only fire actions the host explicitly allow-listed. Async by design: a placeholder, then the finished view; no tokens streamed into the DOM.",
+      "isolation": "sandbox-iframe-opaque",
+      "sandbox": [
+        "allow-scripts"
+      ],
+      "capabilities": [
+        "genui:compose",
+        "theme:read"
+      ],
+      "frameworkCompat": ">=0.28.0",
+      "routePrefix": "/__gofastr/plugin/genui",
+      "entry": "/__gofastr/plugin/genui/genui.html",
+      "schema": "genui-v1",
+      "minHeight": "360px",
+      "docs": "docs/genui.md"
+    },
+    {
+      "name": "sqlnotebook",
+      "modulePath": "github.com/DonaldMurillo/gofastr-plugins/sqlnotebook",
+      "version": "0.1.0",
+      "description": "A SQL notebook running a real SQLite engine (sql.js, WebAssembly) inside the opaque-origin frame. Query a database in the browser that has no way to reach the network: connect-src 'none' means the frame cannot even fetch its own engine, so the host hands the .wasm across the bridge as bytes. This is the only plugin here that opts into the 'wasm-unsafe-eval' tier, and the tier grants exactly that: eval() and new Function() stay refused, storage and cookies stay unreachable, the origin stays opaque.",
+      "isolation": "sandbox-iframe-opaque",
+      "sandbox": [
+        "allow-scripts"
+      ],
+      "capabilities": [
+        "theme:read"
+      ],
+      "csp": [
+        "'wasm-unsafe-eval'"
+      ],
+      "frameworkCompat": ">=0.74.0",
+      "routePrefix": "/__gofastr/plugin/sqlnotebook",
+      "entry": "/__gofastr/plugin/sqlnotebook/frame.html",
+      "schema": "sqlnotebook.v1",
+      "minHeight": "360px",
+      "docs": "docs/sqlnotebook.md"
+    }
+  ],
+  "release": {
+    "tag": "v0.5.0",
+    "commit": "e2f5e043c5f3c5e5e709a4a2c00d9b33ee45959f",
+    "published": "2026-09-01T21:30:14Z",
+    "source": "https://github.com/DonaldMurillo/gofastr-plugins"
+  }
+}

--- a/examples/site/screen_home.go
+++ b/examples/site/screen_home.go
@@ -475,7 +475,7 @@ func exploreSection() render.HTML {
 			render.Text("Scaffold a Go app from a declaration when you want a head start. It writes plain Go you own and edit."),
 		),
 		card("/examples", "examples/", "The example apps",
-			render.Text("Runnable reference apps include a blog, a SaaS console, an API tour, semantic search, and this site. Each starts with one command."),
+			render.Text(fmt.Sprintf("%d runnable reference apps: a blog, a SaaS console, a storefront, an API tour, an entity admin, a process-isolated module, a WebMCP support console, and this site. Each starts with one command.", len(exRowItems()))),
 		),
 	)
 

--- a/examples/site/screen_home.go
+++ b/examples/site/screen_home.go
@@ -475,7 +475,7 @@ func exploreSection() render.HTML {
 			render.Text("Scaffold a Go app from a declaration when you want a head start. It writes plain Go you own and edit."),
 		),
 		card("/examples", "examples/", "The example apps",
-			render.Text(fmt.Sprintf("%d runnable reference apps: a blog, a SaaS console, a storefront, an API tour, an entity admin, a process-isolated module, a WebMCP support console, and this site. Each starts with one command.", len(exRowItems()))),
+			render.Text(fmt.Sprintf("%d runnable reference apps, including a blog, a SaaS console, a storefront, an API tour, an entity admin, a process-isolated module, a WebMCP support console, and this site. Each starts with one command.", len(exRowItems()))),
 		),
 	)
 

--- a/examples/site/screen_plugins.go
+++ b/examples/site/screen_plugins.go
@@ -19,6 +19,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path"
 	"strings"
 	"sync"
@@ -94,10 +95,66 @@ func parsePluginRegistry(data []byte) (*pluginRegistry, error) {
 	if reg.Release == nil || reg.Release.Tag == "" {
 		return nil, fmt.Errorf("plugins.json: no release stamp; vendor a published copy with scripts/vendor-plugins-json.sh")
 	}
-	if len(reg.Plugins) == 0 {
-		return nil, fmt.Errorf("plugins.json: no plugins")
+	if _, err := dec.Token(); err != io.EOF {
+		return nil, fmt.Errorf("plugins.json: trailing data after the registry object")
+	}
+	if err := validatePluginRegistry(&reg); err != nil {
+		return nil, err
 	}
 	return &reg, nil
+}
+
+// validatePluginRegistry enforces what the decoder cannot: every row is
+// complete, names are unique, the isolation value is one the pages know
+// how to present, and the trusted/sandbox pairing matches that value. An
+// unknown isolation would otherwise render as a sandboxed iframe, the
+// safer-looking posture, which is the wrong way for a mistake to fail.
+func validatePluginRegistry(reg *pluginRegistry) error {
+	if len(reg.Plugins) == 0 {
+		return fmt.Errorf("plugins.json: no plugins")
+	}
+	if reg.Release.Commit == "" || reg.Release.Published == "" || !strings.HasPrefix(reg.Release.Source, "https://") {
+		return fmt.Errorf("plugins.json: release stamp incomplete: %+v", *reg.Release)
+	}
+	seen := make(map[string]bool, len(reg.Plugins))
+	root := ""
+	for _, p := range reg.Plugins {
+		if seen[p.Name] {
+			return fmt.Errorf("plugins.json: duplicate row %q", p.Name)
+		}
+		seen[p.Name] = true
+		for k, v := range map[string]string{"name": p.Name, "modulePath": p.ModulePath, "version": p.Version, "description": p.Description, "frameworkCompat": p.FrameworkCompat, "routePrefix": p.RoutePrefix} {
+			if v == "" {
+				return fmt.Errorf("plugins.json: row %q has an empty %s", p.Name, k)
+			}
+		}
+		if root == "" {
+			root = pluginRootModule(p.ModulePath)
+		} else if got := pluginRootModule(p.ModulePath); got != root {
+			return fmt.Errorf("plugins.json: row %q lives in module %q, the rest in %q", p.Name, got, root)
+		}
+		switch p.Isolation {
+		case "sandbox-iframe-opaque":
+			if p.Trusted {
+				return fmt.Errorf("plugins.json: sandboxed row %q is marked trusted", p.Name)
+			}
+			for _, tok := range p.Sandbox {
+				if tok == "allow-same-origin" {
+					return fmt.Errorf("plugins.json: row %q grants allow-same-origin, which collapses the opaque origin", p.Name)
+				}
+			}
+		case "trusted-host-page":
+			if !p.Trusted {
+				return fmt.Errorf("plugins.json: trusted-host-page row %q lacks trusted:true", p.Name)
+			}
+			if len(p.Sandbox) != 0 {
+				return fmt.Errorf("plugins.json: trusted row %q declares sandbox tokens %v", p.Name, p.Sandbox)
+			}
+		default:
+			return fmt.Errorf("plugins.json: row %q has unknown isolation %q", p.Name, p.Isolation)
+		}
+	}
+	return nil
 }
 
 var (

--- a/examples/site/screen_plugins.go
+++ b/examples/site/screen_plugins.go
@@ -1,0 +1,352 @@
+// =============================================================================
+// /plugins and /plugins/<name>: the gofastr-plugins registry, rendered.
+//
+// The sibling repo publishes plugins.json with every release. It is
+// consumed by COPY, never by import: importing a Go API for it would make
+// gofastr depend on a repo that depends on gofastr. So a vendored copy
+// lives at plugins/plugins.json, refreshed by scripts/vendor-plugins-json.sh
+// from a release asset, and these screens render one index plus one page
+// per plugin from it. The release stamp on the copy (tag, commit,
+// published) is shown on the page so a stale copy is visibly stale.
+// screen_plugins_test.go gates the copy's shape.
+// =============================================================================
+
+package main
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/core-ui/html"
+	"github.com/DonaldMurillo/gofastr/core/render"
+	"github.com/DonaldMurillo/gofastr/framework/ui"
+)
+
+//go:embed plugins/plugins.json
+var pluginRegistryJSON []byte
+
+// pluginRegistry mirrors the published plugins.json shape (registryVersion
+// "1"). Parsing rejects unknown fields on purpose: a key the registry adds
+// must reach these structs, and the page, in the same change as the refresh.
+type pluginRegistry struct {
+	RegistryVersion string          `json:"registryVersion"`
+	Comment         string          `json:"$comment,omitempty"`
+	Description     string          `json:"description"`
+	Framework       pluginFramework `json:"framework"`
+	Plugins         []pluginEntry   `json:"plugins"`
+	// Release is stamped by the gofastr-plugins release workflow. The file in
+	// that repo's git has none, so its presence proves the copy came from a
+	// release rather than a hand copy.
+	Release *pluginRelease `json:"release,omitempty"`
+}
+
+type pluginFramework struct {
+	Name       string `json:"name"`
+	ModulePath string `json:"modulePath"`
+	Note       string `json:"note,omitempty"`
+}
+
+type pluginRelease struct {
+	Tag       string `json:"tag"`
+	Commit    string `json:"commit"`
+	Published string `json:"published"`
+	Source    string `json:"source"`
+}
+
+type pluginEntry struct {
+	Name                 string   `json:"name"`
+	ModulePath           string   `json:"modulePath"`
+	Version              string   `json:"version"`
+	Description          string   `json:"description"`
+	Isolation            string   `json:"isolation"`
+	Trusted              bool     `json:"trusted,omitempty"`
+	Sandbox              []string `json:"sandbox,omitempty"`
+	Capabilities         []string `json:"capabilities"`
+	OptionalCapabilities []string `json:"optionalCapabilities,omitempty"`
+	CSP                  []string `json:"csp,omitempty"`
+	FrameworkCompat      string   `json:"frameworkCompat"`
+	RoutePrefix          string   `json:"routePrefix"`
+	Entry                string   `json:"entry"`
+	Schema               string   `json:"schema"`
+	MinHeight            string   `json:"minHeight"`
+	Docs                 string   `json:"docs"`
+}
+
+// parsePluginRegistry decodes a registry copy strictly. Exposed for the
+// gate test; the screens use the embedded copy through pluginReg.
+func parsePluginRegistry(data []byte) (*pluginRegistry, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var reg pluginRegistry
+	if err := dec.Decode(&reg); err != nil {
+		return nil, fmt.Errorf("plugins.json: %w", err)
+	}
+	if reg.RegistryVersion != "1" {
+		return nil, fmt.Errorf("plugins.json: registryVersion %q, this site renders version 1", reg.RegistryVersion)
+	}
+	if reg.Release == nil || reg.Release.Tag == "" {
+		return nil, fmt.Errorf("plugins.json: no release stamp; vendor a published copy with scripts/vendor-plugins-json.sh")
+	}
+	if len(reg.Plugins) == 0 {
+		return nil, fmt.Errorf("plugins.json: no plugins")
+	}
+	return &reg, nil
+}
+
+var (
+	pluginRegOnce sync.Once
+	pluginRegVal  *pluginRegistry
+	pluginRegErr  error
+)
+
+// pluginReg returns the embedded registry, parsed once. A copy that fails
+// the parse is a build-time mistake the gate test reports first; at
+// runtime the screens fall back to an empty index instead of panicking.
+func pluginReg() (*pluginRegistry, error) {
+	pluginRegOnce.Do(func() { pluginRegVal, pluginRegErr = parsePluginRegistry(pluginRegistryJSON) })
+	return pluginRegVal, pluginRegErr
+}
+
+func pluginByName(name string) (pluginEntry, bool) {
+	reg, err := pluginReg()
+	if err != nil {
+		return pluginEntry{}, false
+	}
+	for _, p := range reg.Plugins {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return pluginEntry{}, false
+}
+
+// pluginRootModule is the go-gettable module a plugin package lives in,
+// the first three path segments of its module path.
+func pluginRootModule(modulePath string) string {
+	parts := strings.SplitN(modulePath, "/", 4)
+	if len(parts) < 3 {
+		return modulePath
+	}
+	return strings.Join(parts[:3], "/")
+}
+
+// pluginDocsURL points at the plugin's doc in the sibling repo at the
+// vendored release's tag, so the link matches the version described.
+func pluginDocsURL(reg *pluginRegistry, p pluginEntry) string {
+	if p.Docs == "" || reg.Release == nil {
+		return ""
+	}
+	return strings.TrimSuffix(reg.Release.Source, "/") + "/blob/" + reg.Release.Tag + "/" + p.Docs
+}
+
+func pluginIsolationPill(p pluginEntry) render.HTML {
+	if p.Isolation == "trusted-host-page" {
+		return ui.StatusPill(ui.StatusPillConfig{Label: "trusted host page", Dot: true})
+	}
+	return ui.StatusPill(ui.StatusPillConfig{Label: "sandboxed iframe", Tone: ui.StatusPillAccent, Dot: true})
+}
+
+// pluginSummary is the card-length description: the registry's descriptions
+// run from one sentence to a paragraph, so the index shows the first
+// sentence and the plugin's own page carries the whole text.
+func pluginSummary(desc string) string {
+	const cap = 180
+	if i := strings.Index(desc, ". "); i > 0 && i+1 <= cap {
+		return desc[:i+1]
+	}
+	if len(desc) <= cap {
+		return desc
+	}
+	cut := strings.LastIndex(desc[:cap], " ")
+	if cut <= 0 {
+		cut = cap
+	}
+	return desc[:cut] + "…"
+}
+
+func pluginPills(p pluginEntry) render.HTML {
+	return ui.Cluster(ui.ClusterConfig{Gap: ui.GapSM},
+		ui.StatusPill(ui.StatusPillConfig{Label: "v" + p.Version}),
+		pluginIsolationPill(p),
+	)
+}
+
+// =============================================================================
+// /plugins
+// =============================================================================
+
+type PluginsScreen struct{}
+
+func (s *PluginsScreen) ScreenTitle() string { return "Plugins" }
+func (s *PluginsScreen) ScreenDescription() string {
+	reg, err := pluginReg()
+	if err != nil {
+		return "Officially maintained heavy-JavaScript plugins for GoFastr."
+	}
+	return fmt.Sprintf("%d officially maintained heavy-JavaScript plugins for GoFastr, from the gofastr-plugins registry at %s. Each is one go get away and runs isolated from the host by default.", len(reg.Plugins), reg.Release.Tag)
+}
+func (s *PluginsScreen) ScreenType() app.ScreenType { return app.ScreenPage }
+
+func (s *PluginsScreen) Render() render.HTML {
+	reg, err := pluginReg()
+	if err != nil {
+		return container(ui.Callout(ui.CalloutConfig{Title: "Registry unavailable", Variant: ui.StatusWarning},
+			render.Text("The vendored plugins.json did not parse: "+err.Error())))
+	}
+	cards := make([]render.HTML, 0, len(reg.Plugins))
+	for _, p := range reg.Plugins {
+		cards = append(cards, ui.Card(ui.CardConfig{
+			Heading:      p.Name,
+			HeadingLevel: 2,
+			Description:  pluginSummary(p.Description),
+			Href:         "/plugins/" + p.Name,
+			Footer:       pluginPills(p),
+		}))
+	}
+	return container(
+		ui.PageHeader(ui.PageHeaderConfig{
+			Eyebrow:  "gofastr-plugins · " + reg.Release.Tag,
+			Title:    fmt.Sprintf("%d plugins, each one go get away", len(reg.Plugins)),
+			Subtitle: "The heavy-JavaScript features that would break the core's runtime budget live in a sibling repo. Most run in an opaque-origin sandboxed iframe and reach the host only over a versioned postMessage bridge; the few that must touch the host page say so.",
+		}),
+		ui.Grid(ui.GridConfig{Min: "20rem", Gap: ui.GapLG}, cards...),
+		ui.Section(ui.SectionConfig{
+			ID:      "registry",
+			Heading: "Where this list comes from",
+			Description: fmt.Sprintf("This page is rendered from plugins.json as published with gofastr-plugins %s on %s. The registry is a convention, not a service: there is no discovery at runtime, an app imports the package it wants and mounts it with app.RegisterPlugin. The site vendors the file by copy and refreshes it with scripts/vendor-plugins-json.sh.",
+				reg.Release.Tag, strings.SplitN(reg.Release.Published, "T", 2)[0]),
+		},
+			ui.CodeBlock(ui.CodeBlockConfig{
+				Language: "bash",
+				Code:     "curl -fsSL -O " + strings.TrimSuffix(reg.Release.Source, "/") + "/releases/download/" + reg.Release.Tag + "/plugins.json",
+			}),
+			html.Paragraph(html.TextConfig{},
+				render.Text("The isolation model, the capability grammar, and the trusted-mount opt-out are in "),
+				html.Link(html.LinkConfig{Href: "/docs/plugin-platform", Text: "the plugin platform doc"}),
+				render.Text(". The registry file itself is on "),
+				html.LinkHTML(html.LinkHTMLConfig{Href: reg.Release.Source, ExtraAttrs: html.Attrs{"rel": "external"}, Content: render.Text("GitHub")}),
+				render.Text("."),
+			),
+		),
+	)
+}
+
+// =============================================================================
+// /plugins/<name>
+// =============================================================================
+
+type PluginScreen struct{ name string }
+
+func (s *PluginScreen) SetParams(p map[string]string) { s.name = p["name"] }
+func (s *PluginScreen) ScreenType() app.ScreenType    { return app.ScreenPage }
+
+func (s *PluginScreen) ScreenTitle() string {
+	if p, ok := pluginByName(s.name); ok {
+		return p.Name + " plugin"
+	}
+	return "Plugin"
+}
+
+func (s *PluginScreen) ScreenDescription() string {
+	if p, ok := pluginByName(s.name); ok {
+		return p.Description
+	}
+	return "A gofastr-plugins entry."
+}
+
+// Load rejects unknown names so the site serves its 404 instead of an
+// empty plugin page.
+func (s *PluginScreen) Load(ctx context.Context) error {
+	if _, ok := pluginByName(s.name); !ok {
+		return fmt.Errorf("plugins: no registry entry for %q", s.name)
+	}
+	return nil
+}
+
+// StaticPaths enumerates every plugin so the static export, sitemap, and
+// strict coverage gate produce one page per registry row.
+func (s *PluginScreen) StaticPaths(ctx context.Context) []map[string]string {
+	reg, err := pluginReg()
+	if err != nil {
+		return nil
+	}
+	out := make([]map[string]string, 0, len(reg.Plugins))
+	for _, p := range reg.Plugins {
+		out = append(out, map[string]string{"name": p.Name})
+	}
+	return out
+}
+
+func (s *PluginScreen) Render() render.HTML {
+	reg, err := pluginReg()
+	p, ok := pluginByName(s.name)
+	if err != nil || !ok {
+		return container(ui.EmptyState(ui.EmptyStateConfig{
+			Title:        "No such plugin",
+			Description:  "That name is not in the vendored registry.",
+			HeadingLevel: 1,
+		}), html.Link(html.LinkConfig{Href: "/plugins", Text: "Back to the plugin list"}))
+	}
+	pkg := path.Base(p.ModulePath)
+	mount := fmt.Sprintf("go get %s@%s\n\nimport %q\n\napp.RegisterPlugin(%s.New())", pluginRootModule(p.ModulePath), reg.Release.Tag, p.ModulePath, pkg)
+
+	list := func(v []string) render.HTML {
+		if len(v) == 0 {
+			return html.Span(html.TextConfig{}, render.Text("none"))
+		}
+		return render.Text(strings.Join(v, ", "))
+	}
+	items := []ui.DetailItem{
+		{Label: "Module path", Value: html.LinkHTML(html.LinkHTMLConfig{
+			Href: "https://pkg.go.dev/" + p.ModulePath, ExtraAttrs: html.Attrs{"rel": "external"},
+			Content: render.Text(p.ModulePath)})},
+		{Label: "Plugin version", Value: render.Text(p.Version)},
+		{Label: "Framework compat", Value: render.Text(p.FrameworkCompat)},
+		{Label: "Isolation", Value: render.Text(p.Isolation)},
+		{Label: "Sandbox tokens", Value: list(p.Sandbox)},
+		{Label: "Capabilities", Value: list(p.Capabilities)},
+		{Label: "Optional capabilities", Value: list(p.OptionalCapabilities)},
+		{Label: "CSP additions", Value: list(p.CSP)},
+		{Label: "Route prefix", Value: codeText(p.RoutePrefix)},
+		{Label: "Entry", Value: codeText(p.Entry)},
+		{Label: "Schema", Value: render.Text(p.Schema)},
+		{Label: "Min height", Value: render.Text(p.MinHeight)},
+	}
+	if u := pluginDocsURL(reg, p); u != "" {
+		items = append(items, ui.DetailItem{Label: "Docs", Value: html.LinkHTML(html.LinkHTMLConfig{
+			Href: u, ExtraAttrs: html.Attrs{"rel": "external"}, Content: render.Text(p.Docs)})})
+	}
+
+	var posture render.HTML
+	if p.Isolation == "trusted-host-page" {
+		posture = ui.Callout(ui.CalloutConfig{Title: "Runs in the host page", Variant: ui.StatusWarning},
+			render.Text("This plugin is not sandboxed. It has full DOM access because its job needs it, and the app owner who compiles it in vouches for it. Its capability names still gate its server endpoints."))
+	} else {
+		posture = ui.Callout(ui.CalloutConfig{Title: "Runs in an opaque-origin iframe", Variant: ui.StatusInfo},
+			render.Text("The frame never gets allow-same-origin, so it cannot reach host cookies, the database, or the host DOM. It talks to the host only over the versioned postMessage bridge, limited to the capabilities listed below."))
+	}
+
+	return container(
+		ui.PageHeader(ui.PageHeaderConfig{
+			Eyebrow:  "gofastr-plugins · " + reg.Release.Tag,
+			Title:    p.Name,
+			Subtitle: p.Description,
+			Actions:  pluginPills(p),
+		}),
+		ui.Section(ui.SectionConfig{ID: "install", Heading: "Install and mount"},
+			ui.CodeBlock(ui.CodeBlockConfig{Language: "go", Code: mount, ShowCopy: true}),
+		),
+		ui.Section(ui.SectionConfig{ID: "posture", Heading: "Isolation"}, posture),
+		ui.Section(ui.SectionConfig{ID: "manifest", Heading: "Manifest"},
+			ui.DetailList(ui.DetailListConfig{Items: items}),
+		),
+		html.Paragraph(html.TextConfig{}, html.Link(html.LinkConfig{Href: "/plugins", Text: "All plugins"})),
+	)
+}

--- a/examples/site/screen_plugins_test.go
+++ b/examples/site/screen_plugins_test.go
@@ -16,68 +16,90 @@ func TestPluginRegistryVendoredCopy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if reg.Release.Commit == "" || reg.Release.Published == "" || reg.Release.Source == "" {
-		t.Errorf("release stamp incomplete: %+v", *reg.Release)
-	}
-	if !strings.HasPrefix(reg.Release.Source, "https://github.com/") {
-		t.Errorf("release source %q is not a GitHub URL", reg.Release.Source)
-	}
-	seen := map[string]bool{}
-	root := ""
-	for _, p := range reg.Plugins {
-		if seen[p.Name] {
-			t.Errorf("%s: duplicate row", p.Name)
-		}
-		seen[p.Name] = true
-		for k, v := range map[string]string{"modulePath": p.ModulePath, "version": p.Version, "description": p.Description, "isolation": p.Isolation, "frameworkCompat": p.FrameworkCompat, "routePrefix": p.RoutePrefix} {
-			if v == "" {
-				t.Errorf("%s: empty %s", p.Name, k)
-			}
-		}
-		if root == "" {
-			root = pluginRootModule(p.ModulePath)
-		} else if got := pluginRootModule(p.ModulePath); got != root {
-			t.Errorf("%s: root module %q, want %q", p.Name, got, root)
-		}
-		switch p.Isolation {
-		case "sandbox-iframe-opaque":
-			if p.Trusted {
-				t.Errorf("%s: sandboxed row marked trusted", p.Name)
-			}
-			for _, tok := range p.Sandbox {
-				if tok == "allow-same-origin" {
-					t.Errorf("%s: sandbox grants allow-same-origin, which collapses the opaque origin", p.Name)
-				}
-			}
-		case "trusted-host-page":
-			if !p.Trusted {
-				t.Errorf("%s: trusted-host-page row without trusted:true", p.Name)
-			}
-			if len(p.Sandbox) != 0 {
-				t.Errorf("%s: trusted row declares sandbox tokens %v", p.Name, p.Sandbox)
-			}
-		default:
-			t.Errorf("%s: unknown isolation %q", p.Name, p.Isolation)
-		}
+	if len(reg.Plugins) < 2 {
+		t.Fatalf("vendored registry has %d plugins; the mutation cases below need at least two", len(reg.Plugins))
 	}
 }
 
-func TestPluginRegistryRejectsUnstampedOrUnknown(t *testing.T) {
+// mutateRegistry decodes the vendored copy loosely, lets the case edit it,
+// and re-encodes it, so every guard in parsePluginRegistry is exercised
+// against a copy that is valid except for the one thing the case breaks.
+func mutateRegistry(t *testing.T, edit func(raw map[string]any, rows []map[string]any)) []byte {
+	t.Helper()
 	var raw map[string]any
 	if err := json.Unmarshal(pluginRegistryJSON, &raw); err != nil {
 		t.Fatal(err)
 	}
-	delete(raw, "release")
-	unstamped, _ := json.Marshal(raw)
-	if _, err := parsePluginRegistry(unstamped); err == nil {
-		t.Error("a copy with no release stamp parsed; a hand copy from git would pass as published")
+	rowsAny := raw["plugins"].([]any)
+	rows := make([]map[string]any, len(rowsAny))
+	for i, r := range rowsAny {
+		rows[i] = r.(map[string]any)
 	}
-	raw["release"] = map[string]string{"tag": "v0.0.0", "commit": "x", "published": "now", "source": "https://github.com/x/y"}
-	raw["newKey"] = true
-	unknown, _ := json.Marshal(raw)
-	if _, err := parsePluginRegistry(unknown); err == nil {
-		t.Error("a copy with an unknown top-level key parsed; a new registry field would be silently dropped")
+	edit(raw, rows)
+	out, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
 	}
+	return out
+}
+
+func TestPluginRegistryGuardsEachFail(t *testing.T) {
+	sandboxed := func(rows []map[string]any) map[string]any {
+		for _, r := range rows {
+			if r["isolation"] == "sandbox-iframe-opaque" {
+				return r
+			}
+		}
+		t.Fatal("no sandboxed row in the vendored copy")
+		return nil
+	}
+	trusted := func(rows []map[string]any) map[string]any {
+		for _, r := range rows {
+			if r["isolation"] == "trusted-host-page" {
+				return r
+			}
+		}
+		t.Fatal("no trusted row in the vendored copy")
+		return nil
+	}
+	cases := map[string]func(raw map[string]any, rows []map[string]any){
+		"no release stamp":             func(raw map[string]any, _ []map[string]any) { delete(raw, "release") },
+		"release stamp without commit": func(raw map[string]any, _ []map[string]any) { delete(raw["release"].(map[string]any), "commit") },
+		"unknown top-level key":        func(raw map[string]any, _ []map[string]any) { raw["newKey"] = true },
+		"unknown row key":              func(_ map[string]any, rows []map[string]any) { rows[0]["newKey"] = true },
+		"registry version 2":           func(raw map[string]any, _ []map[string]any) { raw["registryVersion"] = "2" },
+		"no plugins":                   func(raw map[string]any, _ []map[string]any) { raw["plugins"] = []any{} },
+		"duplicate name":               func(_ map[string]any, rows []map[string]any) { rows[1]["name"] = rows[0]["name"] },
+		"empty version":                func(_ map[string]any, rows []map[string]any) { rows[0]["version"] = "" },
+		"unknown isolation":            func(_ map[string]any, rows []map[string]any) { rows[0]["isolation"] = "same-origin-frame" },
+		"sandboxed row marked trusted": func(_ map[string]any, rows []map[string]any) { sandboxed(rows)["trusted"] = true },
+		"sandboxed row allows same-origin": func(_ map[string]any, rows []map[string]any) {
+			r := sandboxed(rows)
+			r["sandbox"] = append(toAnySlice(r["sandbox"]), "allow-same-origin")
+		},
+		"trusted row without trusted:true": func(_ map[string]any, rows []map[string]any) { delete(trusted(rows), "trusted") },
+		"trusted row with sandbox tokens":  func(_ map[string]any, rows []map[string]any) { trusted(rows)["sandbox"] = []any{"allow-scripts"} },
+		"row in a different module":        func(_ map[string]any, rows []map[string]any) { rows[1]["modulePath"] = "github.com/someone/else/x" },
+	}
+	for name, edit := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parsePluginRegistry(mutateRegistry(t, edit)); err == nil {
+				t.Errorf("parsed a copy with %s; that guard is not guarding", name)
+			}
+		})
+	}
+	t.Run("trailing data", func(t *testing.T) {
+		if _, err := parsePluginRegistry(append(append([]byte{}, pluginRegistryJSON...), []byte(" {}")...)); err == nil {
+			t.Error("parsed a copy followed by a second JSON value")
+		}
+	})
+}
+
+func toAnySlice(v any) []any {
+	if v == nil {
+		return nil
+	}
+	return v.([]any)
 }
 
 func TestPluginsIndexListsEveryPlugin(t *testing.T) {

--- a/examples/site/screen_plugins_test.go
+++ b/examples/site/screen_plugins_test.go
@@ -1,0 +1,139 @@
+package main
+
+// Gates for the vendored gofastr-plugins registry and the pages rendered
+// from it. The copy is consumed by copy, not import, so nothing else
+// notices when it goes stale or malformed; these tests do.
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestPluginRegistryVendoredCopy(t *testing.T) {
+	reg, err := parsePluginRegistry(pluginRegistryJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reg.Release.Commit == "" || reg.Release.Published == "" || reg.Release.Source == "" {
+		t.Errorf("release stamp incomplete: %+v", *reg.Release)
+	}
+	if !strings.HasPrefix(reg.Release.Source, "https://github.com/") {
+		t.Errorf("release source %q is not a GitHub URL", reg.Release.Source)
+	}
+	seen := map[string]bool{}
+	root := ""
+	for _, p := range reg.Plugins {
+		if seen[p.Name] {
+			t.Errorf("%s: duplicate row", p.Name)
+		}
+		seen[p.Name] = true
+		for k, v := range map[string]string{"modulePath": p.ModulePath, "version": p.Version, "description": p.Description, "isolation": p.Isolation, "frameworkCompat": p.FrameworkCompat, "routePrefix": p.RoutePrefix} {
+			if v == "" {
+				t.Errorf("%s: empty %s", p.Name, k)
+			}
+		}
+		if root == "" {
+			root = pluginRootModule(p.ModulePath)
+		} else if got := pluginRootModule(p.ModulePath); got != root {
+			t.Errorf("%s: root module %q, want %q", p.Name, got, root)
+		}
+		switch p.Isolation {
+		case "sandbox-iframe-opaque":
+			if p.Trusted {
+				t.Errorf("%s: sandboxed row marked trusted", p.Name)
+			}
+			for _, tok := range p.Sandbox {
+				if tok == "allow-same-origin" {
+					t.Errorf("%s: sandbox grants allow-same-origin, which collapses the opaque origin", p.Name)
+				}
+			}
+		case "trusted-host-page":
+			if !p.Trusted {
+				t.Errorf("%s: trusted-host-page row without trusted:true", p.Name)
+			}
+			if len(p.Sandbox) != 0 {
+				t.Errorf("%s: trusted row declares sandbox tokens %v", p.Name, p.Sandbox)
+			}
+		default:
+			t.Errorf("%s: unknown isolation %q", p.Name, p.Isolation)
+		}
+	}
+}
+
+func TestPluginRegistryRejectsUnstampedOrUnknown(t *testing.T) {
+	var raw map[string]any
+	if err := json.Unmarshal(pluginRegistryJSON, &raw); err != nil {
+		t.Fatal(err)
+	}
+	delete(raw, "release")
+	unstamped, _ := json.Marshal(raw)
+	if _, err := parsePluginRegistry(unstamped); err == nil {
+		t.Error("a copy with no release stamp parsed; a hand copy from git would pass as published")
+	}
+	raw["release"] = map[string]string{"tag": "v0.0.0", "commit": "x", "published": "now", "source": "https://github.com/x/y"}
+	raw["newKey"] = true
+	unknown, _ := json.Marshal(raw)
+	if _, err := parsePluginRegistry(unknown); err == nil {
+		t.Error("a copy with an unknown top-level key parsed; a new registry field would be silently dropped")
+	}
+}
+
+func TestPluginsIndexListsEveryPlugin(t *testing.T) {
+	reg, err := pluginReg()
+	if err != nil {
+		t.Fatal(err)
+	}
+	page := body(t, "/plugins")
+	if !strings.Contains(page, reg.Release.Tag) {
+		t.Errorf("/plugins does not show the vendored release tag %s", reg.Release.Tag)
+	}
+	for _, p := range reg.Plugins {
+		if !strings.Contains(page, `href="/plugins/`+p.Name+`"`) {
+			t.Errorf("/plugins has no link to /plugins/%s", p.Name)
+		}
+	}
+	if !strings.Contains(page, `href="/docs/plugin-platform"`) {
+		t.Error("/plugins does not link the plugin platform doc")
+	}
+}
+
+func TestPluginPagesShowMountSnippet(t *testing.T) {
+	reg, err := pluginReg()
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths := (&PluginScreen{}).StaticPaths(t.Context())
+	if len(paths) != len(reg.Plugins) {
+		t.Errorf("StaticPaths = %d, want one per plugin (%d)", len(paths), len(reg.Plugins))
+	}
+	for _, p := range reg.Plugins {
+		page := body(t, "/plugins/"+p.Name)
+		for _, want := range []string{p.ModulePath, "RegisterPlugin(", "go get " + pluginRootModule(p.ModulePath) + "@" + reg.Release.Tag, "pkg.go.dev/" + p.ModulePath} {
+			if !strings.Contains(page, want) {
+				t.Errorf("/plugins/%s missing %q", p.Name, want)
+			}
+		}
+		if p.Docs != "" && !strings.Contains(page, "/blob/"+reg.Release.Tag+"/"+p.Docs) {
+			t.Errorf("/plugins/%s docs link is not pinned to %s", p.Name, reg.Release.Tag)
+		}
+	}
+	if rec := serve(t, http.MethodGet, "/plugins/not-a-plugin"); rec.Code != http.StatusNotFound {
+		t.Errorf("/plugins/not-a-plugin: got %d, want 404", rec.Code)
+	}
+}
+
+func TestPluginSummaryCutsAtFirstSentence(t *testing.T) {
+	cases := map[string]string{
+		"One sentence.": "One sentence.",
+		"First sentence. Second sentence that goes on.": "First sentence.",
+		strings.Repeat("word ", 50) + "end":             strings.TrimSpace(strings.Repeat("word ", 36)) + "…",
+		"A v0.1.0 thing (see docs/x.md) with no period": "A v0.1.0 thing (see docs/x.md) with no period",
+	}
+	for in, want := range cases {
+		if got := pluginSummary(in); got != want {
+			t.Errorf("pluginSummary(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/examples/site/screen_plugins_test.go
+++ b/examples/site/screen_plugins_test.go
@@ -80,6 +80,16 @@ func TestPluginRegistryGuardsEachFail(t *testing.T) {
 		"trusted row without trusted:true": func(_ map[string]any, rows []map[string]any) { delete(trusted(rows), "trusted") },
 		"trusted row with sandbox tokens":  func(_ map[string]any, rows []map[string]any) { trusted(rows)["sandbox"] = []any{"allow-scripts"} },
 		"row in a different module":        func(_ map[string]any, rows []map[string]any) { rows[1]["modulePath"] = "github.com/someone/else/x" },
+		"release stamp without tag":        func(raw map[string]any, _ []map[string]any) { raw["release"].(map[string]any)["tag"] = "" },
+		"release stamp without published":  func(raw map[string]any, _ []map[string]any) { delete(raw["release"].(map[string]any), "published") },
+		"release source over http": func(raw map[string]any, _ []map[string]any) {
+			raw["release"].(map[string]any)["source"] = "http://github.com/x/y"
+		},
+		"empty name":            func(_ map[string]any, rows []map[string]any) { rows[0]["name"] = "" },
+		"empty modulePath":      func(_ map[string]any, rows []map[string]any) { rows[0]["modulePath"] = "" },
+		"empty description":     func(_ map[string]any, rows []map[string]any) { rows[0]["description"] = "" },
+		"empty frameworkCompat": func(_ map[string]any, rows []map[string]any) { rows[0]["frameworkCompat"] = "" },
+		"empty routePrefix":     func(_ map[string]any, rows []map[string]any) { rows[0]["routePrefix"] = "" },
 	}
 	for name, edit := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/examples/site/screens_pages.go
+++ b/examples/site/screens_pages.go
@@ -393,7 +393,7 @@ func exHero() render.HTML {
 				render.Text(fmt.Sprintf("%d reference apps. Each runs in one command.", len(exRowItems()))),
 			),
 			html.Paragraph(html.TextConfig{Class: "lede"},
-				render.Text("Clone the one that looks like your problem; swap the entity declarations. Each app's full source is under examples/ in the repo. Copy what you need."),
+				render.Text("Clone the one that looks like your problem; swap the entity declarations. Each app's full source is under examples/ in the repo. Run it with gofastr dev for rebuild-on-save, livereload, and the dev MCP tools; plain go run . works too."),
 			),
 		),
 	)
@@ -432,7 +432,7 @@ func exRowItems() []render.HTML {
 		exRow("01", "examples/meridian", "Meridian: SaaS console", "flagship", "seeded + hand-evolved",
 			"A billing & revenue console (customers, subscriptions, invoices, MRR + charts) plus its marketing site, auth, RBAC, and an admin back-office, seeded from one gofastr.yml and hand-evolved since, with writable screens (add/edit/delete).",
 			[]string{"One blueprint seeded marketing + app + auth + admin", "Server-rendered DataTable / charts / forms, island RPCs", "Writable CRUD + RBAC, with a generated end-to-end test suite"},
-			"cd examples/meridian && go run .",
+			"cd examples/meridian && gofastr dev",
 			// The exact, full blueprint that generates the app, embedded at
 			// build time, shown verbatim in a scrolling block. Drift-guarded by
 			// TestEmbeddedBlueprintsMatchSource.
@@ -440,7 +440,7 @@ func exRowItems() []render.HTML {
 		exRow("02", "examples/ecommerce", "ShopFront: storefront", "blueprint pipeline", "100% generated",
 			"A complete storefront from one gofastr.yml: five related entities (categories, products, orders, order_items, reviews), a themed eight-screen UI, custom endpoints, and seed data. Nothing under app/ is hand-written.",
 			[]string{"Second blueprint pipeline beside Meridian", "Owner-scoped orders and reviews", "Exercised by its own end-to-end test"},
-			"cd examples/ecommerce && go run ./app",
+			"cd examples/ecommerce && gofastr dev --dir app",
 			codeBlock("examples/ecommerce/gofastr.yml", []render.HTML{
 				ln(com("# 5 entities, 8 screens, auth, seeds: one YAML")),
 				ln(render.Text("$ gofastr generate   "), com("// emits ./app: plain Go")),
@@ -449,7 +449,7 @@ func exRowItems() []render.HTML {
 		exRow("03", "examples/blog", "Go-declared blog", "smallest", locBadge("blog", ""),
 			"Users, posts, comments. Three entities. Start here: it's the end-to-end story in one file.",
 			[]string{"Three entities declared in Go", "Auto-CRUD + Swagger UI + MCP", "SQLite by default; swap for Postgres in main.go"},
-			"cd examples/blog && go run .",
+			"cd examples/blog && gofastr dev",
 			codeBlock("examples/blog/main.go", []render.HTML{
 				ln(render.Text("app."), fn_("Entity"), pn("("), str_(`"users"`), pn(","), render.Text(" …"), pn(")")),
 				ln(render.Text("app."), fn_("Entity"), pn("("), str_(`"posts"`), pn(","), render.Text(" …"), pn(")")),
@@ -459,7 +459,7 @@ func exRowItems() []render.HTML {
 		exRow("04", "examples/site", "This site (UI showcase)", "largest", locBadge("site", ""),
 			"Every core-ui pattern + framework/ui component, one page each, plus the docs, SEO, multi-step wizard, and print-battery demos. The site you're reading right now.",
 			[]string{"Every core-ui pattern + framework/ui component", "Docs, philosophy, examples, Kiln pages", "SEO interfaces, sitemap/robots, wizard, print"},
-			"cd examples/site && go run .",
+			"cd examples/site && gofastr dev",
 			codeBlock("examples/site/main.go", []render.HTML{
 				ln(render.Text("host "), pn(":="), render.Text(" uihost."), fn_("New"), pn("("), render.Text("site"), pn(", …)")),
 				ln(render.Text("app "), pn(":="), render.Text(" framework."), fn_("NewUIHostApp"), pn("("), render.Text("host"), pn(")")),
@@ -468,7 +468,7 @@ func exRowItems() []render.HTML {
 		exRow("05", "examples/api-tour", "API tour", "annotated source", locBadge("api-tour", ""),
 			"Every v2 API feature in one annotated main.go, with the curl commands to exercise each one in the file header.",
 			[]string{"Cursor + offset pagination", "Eager loading (?include=…)", "Batch endpoints, SSE entity events, uploads"},
-			"cd examples/api-tour && go run .",
+			"cd examples/api-tour && gofastr dev",
 			codeBlock("examples/api-tour/main.go", []render.HTML{
 				ln(render.Text("app."), fn_("Entity"), pn("("), str_(`"posts"`), pn(","), render.Text(" …"), pn(")")),
 				ln(com("// cursor + offset paging, ?include=, batch, SSE")),
@@ -477,7 +477,7 @@ func exRowItems() []render.HTML {
 		exRow("06", "examples/semantic-demo", "Local semantic search", "no API key", locBadge("semantic-demo", ""),
 			"A markdown corpus indexed locally via battery/semantic. No external API key; works offline.",
 			[]string{"Brute-force cosine, hybrid keyword fusion", "Snapshot + WAL persistence", "Poll-watch for file changes"},
-			"cd examples/semantic-demo && go run .",
+			"cd examples/semantic-demo && gofastr dev",
 			codeBlock("examples/semantic-demo/main.go", []render.HTML{
 				ln(render.Text("idx, _ "), pn(":="), render.Text(" semantic."), fn_("Open"), pn("("), render.Text("semantic."), ty("Options"), pn("{…})")),
 				ln(render.Text("idx."), fn_("Add"), pn("("), render.Text("ctx, docs…"), pn(")"), render.Text("   "), com("// local vectors")),
@@ -486,7 +486,7 @@ func exRowItems() []render.HTML {
 		exRow("07", "examples/spa", "Vue + GoFastr API", "BYO client", locBadge("spa", " server"),
 			"For teams who already have a client app. Shows the framework is happy to just be your typed API.",
 			[]string{"Same auto-CRUD entities", "Vue 3 + Vue Router from a CDN, no npm, no build step", "No SSR: the Go app serves JSON and the static files"},
-			"cd examples/spa && go run .",
+			"cd examples/spa && gofastr dev",
 			codeBlock("examples/spa/main.go", []render.HTML{
 				ln(render.Text("app."), fn_("Entity"), pn("("), str_(`"articles"`), pn(","), render.Text(" …"), pn(")")),
 				ln(com("// JSON API under /api: your Vue app is the client")),
@@ -495,7 +495,7 @@ func exRowItems() []render.HTML {
 		exRow("08", "examples/embed-demo", "Embeddable surfaces", "cross-origin", locBadge("embed-demo", ""),
 			"Two servers on different ports: a GoFastr app, and a customer's website that pastes one script tag and gets a live, themed, authenticated panel from it.",
 			[]string{"Single-use handshake nonce, exact origin allowlist", "Frame runtime with no SPA navigation", "Customer brand token applied to the app's own components"},
-			"cd examples/embed-demo && go run .",
+			"cd examples/embed-demo && gofastr dev",
 			codeBlock("examples/embed-demo/main.go", []render.HTML{
 				ln(render.Text("embeds, _ "), pn(":="), render.Text(" embed."), fn_("New"), pn("("), render.Text("embed."), ty("Config"), pn("{…})")),
 				ln(render.Text("nonce, _ "), pn(":="), render.Text(" embeds."), fn_("MintNonce"), pn("("), str_(`"reports"`), render.Text(", user.ID, origin, "), render.Text("nil"), pn(")")),
@@ -504,7 +504,7 @@ func exRowItems() []render.HTML {
 		exRow("09", "examples/static-site", "Static file server", "no screens", locBadge("static-site", ""),
 			"A plain file server on the framework router: static.Mount serves the pages/ directory, with HTML and CSS straight from disk, no screens, no runtime JS.",
 			[]string{"static.Mount with SPA mode off: only real files serve", "index.html answers /", "API routes can mount beside it on the same router"},
-			"cd examples/static-site && go run .",
+			"cd examples/static-site && gofastr dev",
 			codeBlock("examples/static-site/main.go", []render.HTML{
 				ln(render.Text("static."), fn_("Mount"), pn("("), render.Text("app."), fn_("Router"), pn("(), static."), ty("Config"), pn("{")),
 				ln(render.Text("  FS: os."), fn_("DirFS"), pn("("), render.Text("pagesDir"), pn("),")),
@@ -514,7 +514,7 @@ func exRowItems() []render.HTML {
 		exRow("10", "examples/backoffice", "Entity admin", "battery/admin", locBadge("backoffice", ""),
 			"Three entities and one admin.New call: the whole back-office (list, create, edit, delete) is generated with defaults, behind a demo login. No bespoke JavaScript anywhere in the app.",
 			[]string{"admin.New with AllEntities: true generates every screen", "DataTable island paginates without a reload", "Delete is a data-fui-confirm button; forms are server-rendered"},
-			"cd examples/backoffice && go run .",
+			"cd examples/backoffice && gofastr dev",
 			codeBlock("examples/backoffice/main.go", []render.HTML{
 				ln(render.Text("app."), fn_("Entity"), pn("("), str_(`"products"`), pn(","), render.Text(" …"), pn(")")),
 				ln(render.Text("app."), fn_("RegisterBattery"), pn("("), render.Text("admin."), fn_("New"), pn("("), render.Text("admin."), ty("Config"), pn("{")),
@@ -534,7 +534,7 @@ func exRowItems() []render.HTML {
 		exRow("12", "examples/webmcp-remote-assist", "WebMCP remote assist", "WebMCP + WebRTC", locBadge("webmcp-remote-assist", ""),
 			"One binary, one origin, two roles: a support console whose in-browser agent guides an operator through a camera session. Support-only WebMCP tool discovery, one typed command behind the button and the tools, and peer-to-peer video with server-side signaling only.",
 			[]string{"Tools scoped to /support and authorization-wrapped", "Role cookies authorize; the WebMCP header only attributes", "Sequenced realtime state over the ws runtime module"},
-			"cd examples/webmcp-remote-assist && go run .",
+			"cd examples/webmcp-remote-assist && gofastr dev",
 			codeBlock("examples/webmcp-remote-assist/main.go", []render.HTML{
 				ln(render.Text("tools "), pn(":="), render.Text(" webmcp."), fn_("New"), pn("("), render.Text("webmcp."), fn_("WithInstructions"), pn("(…))")),
 				ln(render.Text("group."), fn_("Handle"), pn("("), render.Text("rt, sendInstruction, handler,")),

--- a/examples/site/screens_pages.go
+++ b/examples/site/screens_pages.go
@@ -547,8 +547,9 @@ func exRowItems() []render.HTML {
 // exBlueprints is row 13: the declarative examples that are blueprints
 // only, no Go until `gofastr generate` runs. It shares exRowShell with
 // the runnable rows but stays out of exRowItems, whose length is the
-// "runs in one command" count. Each point is one whole-item link, so the
-// link is the block rather than a color-only span inside prose.
+// "runs in one command" count. The source links sit in their own blocks
+// below the points, never inline in prose, so axe's link-in-text-block
+// rule has nothing to flag.
 func exBlueprints() render.HTML {
 	items := []struct{ slug, domain string }{
 		{"lms", "courses, lessons, enrollments"},
@@ -556,13 +557,15 @@ func exBlueprints() render.HTML {
 		{"project-manager", "projects, tasks, teams"},
 		{"real-estate", "listings, agents, inquiries"},
 	}
-	lis := make([]render.HTML, 0, len(items))
+	points := make([]render.HTML, 0, len(items))
+	links := make([]render.HTML, 0, len(items))
 	for _, it := range items {
-		lis = append(lis, html.ListItem(html.ListItemConfig{},
+		points = append(points, html.ListItem(html.ListItemConfig{}, render.Text(it.slug+": "+it.domain)))
+		links = append(links, html.Div(html.DivConfig{Class: "ex-row__src"},
 			html.LinkHTML(html.LinkHTMLConfig{
 				Href:       "https://github.com/DonaldMurillo/gofastr/tree/main/examples/" + it.slug,
 				ExtraAttrs: html.Attrs{"rel": "external"},
-				Content:    render.Text("examples/" + it.slug + ": " + it.domain),
+				Content:    render.Text("examples/" + it.slug + " ↗"),
 			}),
 		))
 	}
@@ -572,8 +575,9 @@ func exBlueprints() render.HTML {
 		Path:    "examples/…",
 		Title:   "Four more blueprints",
 		Desc:    "Each is one gofastr.yml with no Go beside it. Generate in the directory to get a runnable app you own; every one is validated by the CLI's blueprint test suite.",
-		Points:  lis,
+		Points:  points,
 		Command: "cd examples/lms && gofastr generate --from=gofastr.yml",
+		Extra:   ui.Cluster(ui.ClusterConfig{Gap: ui.GapMD}, links...),
 	})
 	right := html.Div(html.DivConfig{Class: "ex-row__right"},
 		codeBlock("examples/lms/gofastr.yml", []render.HTML{
@@ -594,7 +598,8 @@ func exRows() render.HTML {
 type exRowBodyConfig struct {
 	Tag, LoC, Path, Title, Desc, Command string
 	Points                               []render.HTML
-	Source                               string // "View source" href; empty hides the link
+	Source                               string      // "View source" href; empty hides the link
+	Extra                                render.HTML // optional trailing block (the blueprint row's source links)
 }
 
 // exRowBody renders the left column: meta pills, title, description,
@@ -615,6 +620,9 @@ func exRowBody(c exRowBodyConfig) render.HTML {
 			html.Span(html.TextConfig{Class: "p"}, render.Text("$")),
 			render.Text(c.Command),
 		),
+	}
+	if c.Extra != "" {
+		parts = append(parts, c.Extra)
 	}
 	if c.Source != "" {
 		parts = append(parts, html.Div(html.DivConfig{Class: "ex-row__src"},

--- a/examples/site/screens_pages.go
+++ b/examples/site/screens_pages.go
@@ -545,9 +545,10 @@ func exRowItems() []render.HTML {
 }
 
 // exBlueprints is row 13: the declarative examples that are blueprints
-// only, no Go until `gofastr generate` runs. It sits on the same row grid
-// as the runnable apps but stays out of exRowItems, whose length is the
-// "runs in one command" count.
+// only, no Go until `gofastr generate` runs. It shares exRowShell with
+// the runnable rows but stays out of exRowItems, whose length is the
+// "runs in one command" count. Each point is one whole-item link, so the
+// link is the block rather than a color-only span inside prose.
 func exBlueprints() render.HTML {
 	items := []struct{ slug, domain string }{
 		{"lms", "courses, lessons, enrollments"},
@@ -561,29 +562,19 @@ func exBlueprints() render.HTML {
 			html.LinkHTML(html.LinkHTMLConfig{
 				Href:       "https://github.com/DonaldMurillo/gofastr/tree/main/examples/" + it.slug,
 				ExtraAttrs: html.Attrs{"rel": "external"},
-				Content:    render.Text("examples/" + it.slug),
+				Content:    render.Text("examples/" + it.slug + ": " + it.domain),
 			}),
-			render.Text(": "+it.domain),
 		))
 	}
-	body := html.Div(html.DivConfig{Class: "ex-row__body"},
-		html.Div(html.DivConfig{Class: "ex-row__meta"},
-			tagAccent("gofastr.yml only"),
-			html.Span(html.TextConfig{Class: "lc"}, render.Text("0 LoC until you generate")),
-		),
-		html.Heading(html.HeadingConfig{Level: 2, Class: "ex-row__title"},
-			render.Text("examples/… — "),
-			html.Span(html.TextConfig{Class: "amber"}, render.Text("Four more blueprints")),
-		),
-		html.Paragraph(html.TextConfig{Class: "ex-row__desc"},
-			render.Text("Each is one gofastr.yml with no Go beside it. Generate in the directory to get a runnable app you own; every one is validated by the CLI's blueprint test suite."),
-		),
-		html.UnorderedList(html.ListConfig{Class: "ex-row__points"}, lis...),
-		html.Div(html.DivConfig{Class: "ex-row__cli"},
-			html.Span(html.TextConfig{Class: "p"}, render.Text("$")),
-			render.Text("cd examples/lms && gofastr generate --from=gofastr.yml"),
-		),
-	)
+	body := exRowBody(exRowBodyConfig{
+		Tag:     "gofastr.yml only",
+		LoC:     "0 LoC until you generate",
+		Path:    "examples/…",
+		Title:   "Four more blueprints",
+		Desc:    "Each is one gofastr.yml with no Go beside it. Generate in the directory to get a runnable app you own; every one is validated by the CLI's blueprint test suite.",
+		Points:  lis,
+		Command: "cd examples/lms && gofastr generate --from=gofastr.yml",
+	})
 	right := html.Div(html.DivConfig{Class: "ex-row__right"},
 		codeBlock("examples/lms/gofastr.yml", []render.HTML{
 			ln(com("# entities, screens, nav, endpoints, seed: one YAML")),
@@ -591,26 +582,69 @@ func exBlueprints() render.HTML {
 			ln(render.Text("$ go run .")),
 		}),
 	)
-	grid := html.Div(html.DivConfig{Class: "ex-row__grid"},
-		html.Span(html.TextConfig{Class: "ex-row__num"}, render.Text("13")),
-		body,
-		right,
-	)
-	return html.Section(html.SectionConfig{ID: "blueprints", Class: "ex-row", Label: "Blueprint examples"}, grid)
+	return exRowShell("13", "blueprints", "Blueprint examples", body, right)
 }
 
 func exRows() render.HTML {
 	return container(render.Join(exRowItems()...), exBlueprints())
 }
 
-// exRow renders one example. code is the pre-built code sample (a snippet for
-// most rows; the full embedded blueprint for Meridian); path names the
-// directory for the "View source" link.
+// exRowBodyConfig is the left column of one example row. Points are
+// pre-built <li>s so a row can decide whether a point is text or a link.
+type exRowBodyConfig struct {
+	Tag, LoC, Path, Title, Desc, Command string
+	Points                               []render.HTML
+	Source                               string // "View source" href; empty hides the link
+}
+
+// exRowBody renders the left column: meta pills, title, description,
+// points, the run command, and the optional source link.
+func exRowBody(c exRowBodyConfig) render.HTML {
+	parts := []render.HTML{
+		html.Div(html.DivConfig{Class: "ex-row__meta"},
+			tagAccent(c.Tag),
+			html.Span(html.TextConfig{Class: "lc"}, render.Text(c.LoC)),
+		),
+		html.Heading(html.HeadingConfig{Level: 2, Class: "ex-row__title"},
+			render.Text(c.Path+" — "),
+			html.Span(html.TextConfig{Class: "amber"}, render.Text(c.Title)),
+		),
+		html.Paragraph(html.TextConfig{Class: "ex-row__desc"}, render.Text(c.Desc)),
+		html.UnorderedList(html.ListConfig{Class: "ex-row__points"}, c.Points...),
+		html.Div(html.DivConfig{Class: "ex-row__cli"},
+			html.Span(html.TextConfig{Class: "p"}, render.Text("$")),
+			render.Text(c.Command),
+		),
+	}
+	if c.Source != "" {
+		parts = append(parts, html.Div(html.DivConfig{Class: "ex-row__src"},
+			html.LinkHTML(html.LinkHTMLConfig{
+				Href:       c.Source,
+				ExtraAttrs: html.Attrs{"rel": "external"},
+				Content:    render.Text("View source ↗"),
+			}),
+		))
+	}
+	return html.Div(html.DivConfig{Class: "ex-row__body"}, parts...)
+}
+
+// exRowShell is the row grid every example row sits on: the number, the
+// body column, and the right column (code sample + placeholder shot).
+func exRowShell(num, id, label string, body, right render.HTML) render.HTML {
+	grid := html.Div(html.DivConfig{Class: "ex-row__grid"},
+		html.Span(html.TextConfig{Class: "ex-row__num"}, render.Text(num)),
+		body,
+		right,
+	)
+	return html.Section(html.SectionConfig{ID: id, Class: "ex-row", Label: label}, grid)
+}
+
+// exRow renders one runnable example. code is the pre-built code sample (a
+// snippet for most rows; the full embedded blueprint for Meridian); path
+// names the directory for the "View source" link.
 func exRow(num, path, title, tag, loc, desc string, points []string, cmd string, code render.HTML) render.HTML {
 	slug := strings.TrimPrefix(path, "examples/")
-	srcURL := "https://github.com/DonaldMurillo/gofastr/tree/main/" + path
-
-	pointLis := []render.HTML{}
+	pointLis := make([]render.HTML, 0, len(points))
 	for _, p := range points {
 		pointLis = append(pointLis, html.ListItem(html.ListItemConfig{}, render.Text(p)))
 	}
@@ -625,37 +659,14 @@ func exRow(num, path, title, tag, loc, desc string, points []string, cmd string,
 		),
 		html.Div(html.DivConfig{Class: "bar"}),
 	)
-	miniCode := code
-	body := html.Div(html.DivConfig{Class: "ex-row__body"},
-		html.Div(html.DivConfig{Class: "ex-row__meta"},
-			tagAccent(tag),
-			html.Span(html.TextConfig{Class: "lc"}, render.Text(loc)),
-		),
-		html.Heading(html.HeadingConfig{Level: 2, Class: "ex-row__title"},
-			render.Text(path+" — "),
-			html.Span(html.TextConfig{Class: "amber"}, render.Text(title)),
-		),
-		html.Paragraph(html.TextConfig{Class: "ex-row__desc"}, render.Text(desc)),
-		html.UnorderedList(html.ListConfig{Class: "ex-row__points"}, pointLis...),
-		html.Div(html.DivConfig{Class: "ex-row__cli"},
-			html.Span(html.TextConfig{Class: "p"}, render.Text("$")),
-			render.Text(cmd),
-		),
-		html.Div(html.DivConfig{Class: "ex-row__src"},
-			html.LinkHTML(html.LinkHTMLConfig{
-				Href:       srcURL,
-				ExtraAttrs: html.Attrs{"rel": "external"},
-				Content:    render.Text("View source ↗"),
-			}),
-		),
-	)
-	right := html.Div(html.DivConfig{Class: "ex-row__right"}, miniCode, shot)
-	grid := html.Div(html.DivConfig{Class: "ex-row__grid"},
-		html.Span(html.TextConfig{Class: "ex-row__num"}, render.Text(num)),
-		body,
-		right,
-	)
-	return html.Section(html.SectionConfig{ID: slug, Class: "ex-row", Label: path}, grid)
+	body := exRowBody(exRowBodyConfig{
+		Tag: tag, LoC: loc, Path: path, Title: title, Desc: desc,
+		Points:  pointLis,
+		Command: cmd,
+		Source:  "https://github.com/DonaldMurillo/gofastr/tree/main/" + path,
+	})
+	right := html.Div(html.DivConfig{Class: "ex-row__right"}, code, shot)
+	return exRowShell(num, slug, path, body, right)
 }
 
 // =============================================================================

--- a/examples/site/screens_pages.go
+++ b/examples/site/screens_pages.go
@@ -399,6 +399,30 @@ func exHero() render.HTML {
 	)
 }
 
+// exampleLoC is the non-test Go line count each row's badge cites, keyed
+// by the example directory and rounded to two significant figures.
+// TestExampleLoCBadgesMatchTree measures examples/<slug> and fails when a
+// badge is more than 20% off, so the numbers are re-measured instead of
+// remembered.
+var exampleLoC = map[string]int{
+	"blog":                 190,
+	"site":                 9300,
+	"api-tour":             160,
+	"semantic-demo":        120,
+	"spa":                  110,
+	"embed-demo":           310,
+	"static-site":          60,
+	"backoffice":           310,
+	"processmodule-demo":   330,
+	"webmcp-remote-assist": 1600,
+}
+
+// locBadge renders the "~N LoC" badge for one example row; suffix adds a
+// qualifier such as " server" for apps whose client lives elsewhere.
+func locBadge(slug, suffix string) string {
+	return fmt.Sprintf("~%d LoC%s", exampleLoC[slug], suffix)
+}
+
 // exRowItems builds every example row. Copy that cites an app count
 // (the hero pill, the H1, the get-started card, the meta description)
 // derives it from len() of this slice, so the number can't drift from
@@ -422,7 +446,7 @@ func exRowItems() []render.HTML {
 				ln(render.Text("$ gofastr generate   "), com("// emits ./app: plain Go")),
 				ln(render.Text("$ go run ./app")),
 			})),
-		exRow("03", "examples/blog", "Go-declared blog", "smallest", "~120 LoC",
+		exRow("03", "examples/blog", "Go-declared blog", "smallest", locBadge("blog", ""),
 			"Users, posts, comments. Three entities. Start here: it's the end-to-end story in one file.",
 			[]string{"Three entities declared in Go", "Auto-CRUD + Swagger UI + MCP", "SQLite by default; swap for Postgres in main.go"},
 			"cd examples/blog && go run .",
@@ -432,7 +456,7 @@ func exRowItems() []render.HTML {
 				ln(render.Text("app."), fn_("Entity"), pn("("), str_(`"comments"`), pn(","), render.Text(" …"), pn(")")),
 				ln(render.Text("app."), fn_("Start"), pn("("), str_(`":8080"`), pn(")")),
 			})),
-		exRow("04", "examples/site", "This site (UI showcase)", "largest", "~6000 LoC",
+		exRow("04", "examples/site", "This site (UI showcase)", "largest", locBadge("site", ""),
 			"Every core-ui pattern + framework/ui component, one page each, plus the docs, SEO, multi-step wizard, and print-battery demos. The site you're reading right now.",
 			[]string{"Every core-ui pattern + framework/ui component", "Docs, philosophy, examples, Kiln pages", "SEO interfaces, sitemap/robots, wizard, print"},
 			"cd examples/site && go run .",
@@ -441,7 +465,7 @@ func exRowItems() []render.HTML {
 				ln(render.Text("app "), pn(":="), render.Text(" framework."), fn_("NewUIHostApp"), pn("("), render.Text("host"), pn(")")),
 				ln(render.Text("app."), fn_("Start"), pn("("), str_(`":8083"`), pn(")")),
 			})),
-		exRow("05", "examples/api-tour", "API tour", "annotated source", "~180 LoC",
+		exRow("05", "examples/api-tour", "API tour", "annotated source", locBadge("api-tour", ""),
 			"Every v2 API feature in one annotated main.go, with the curl commands to exercise each one in the file header.",
 			[]string{"Cursor + offset pagination", "Eager loading (?include=…)", "Batch endpoints, SSE entity events, uploads"},
 			"cd examples/api-tour && go run .",
@@ -450,7 +474,7 @@ func exRowItems() []render.HTML {
 				ln(com("// cursor + offset paging, ?include=, batch, SSE")),
 				ln(render.Text("app."), fn_("Start"), pn("("), str_(`":8080"`), pn(")")),
 			})),
-		exRow("06", "examples/semantic-demo", "Local semantic search", "no API key", "~180 LoC",
+		exRow("06", "examples/semantic-demo", "Local semantic search", "no API key", locBadge("semantic-demo", ""),
 			"A markdown corpus indexed locally via battery/semantic. No external API key; works offline.",
 			[]string{"Brute-force cosine, hybrid keyword fusion", "Snapshot + WAL persistence", "Poll-watch for file changes"},
 			"cd examples/semantic-demo && go run .",
@@ -459,16 +483,16 @@ func exRowItems() []render.HTML {
 				ln(render.Text("idx."), fn_("Add"), pn("("), render.Text("ctx, docs…"), pn(")"), render.Text("   "), com("// local vectors")),
 				ln(render.Text("hits, _ "), pn(":="), render.Text(" idx."), fn_("Query"), pn("("), render.Text("ctx, semantic."), ty("Query"), pn("{"), render.Text("Text: "), str_(`"hooks"`), pn(", "), render.Text("Limit: 5"), pn("})")),
 			})),
-		exRow("07", "examples/spa", "Vue + GoFastr API", "BYO client", "~140 LoC server",
+		exRow("07", "examples/spa", "Vue + GoFastr API", "BYO client", locBadge("spa", " server"),
 			"For teams who already have a client app. Shows the framework is happy to just be your typed API.",
 			[]string{"Same auto-CRUD entities", "Vue 3 + Vue Router from a CDN, no npm, no build step", "No SSR: the Go app serves JSON and the static files"},
 			"cd examples/spa && go run .",
 			codeBlock("examples/spa/main.go", []render.HTML{
-				ln(render.Text("app."), fn_("Entity"), pn("("), str_(`"posts"`), pn(","), render.Text(" …"), pn(")")),
-				ln(com("// JSON API only: your Vue app is the client")),
-				ln(render.Text("app."), fn_("Start"), pn("("), str_(`":8080"`), pn(")")),
+				ln(render.Text("app."), fn_("Entity"), pn("("), str_(`"articles"`), pn(","), render.Text(" …"), pn(")")),
+				ln(com("// JSON API under /api: your Vue app is the client")),
+				ln(render.Text("app."), fn_("Start"), pn("("), str_(`":3090"`), pn(")")),
 			})),
-		exRow("08", "examples/embed-demo", "Embeddable surfaces", "cross-origin", "~180 LoC",
+		exRow("08", "examples/embed-demo", "Embeddable surfaces", "cross-origin", locBadge("embed-demo", ""),
 			"Two servers on different ports: a GoFastr app, and a customer's website that pastes one script tag and gets a live, themed, authenticated panel from it.",
 			[]string{"Single-use handshake nonce, exact origin allowlist", "Frame runtime with no SPA navigation", "Customer brand token applied to the app's own components"},
 			"cd examples/embed-demo && go run .",
@@ -477,7 +501,7 @@ func exRowItems() []render.HTML {
 				ln(render.Text("nonce, _ "), pn(":="), render.Text(" embeds."), fn_("MintNonce"), pn("("), str_(`"reports"`), render.Text(", user.ID, origin, "), render.Text("nil"), pn(")")),
 				ln(com("// the customer pastes: <script src=\".../__gofastr/embed.js\" data-token=…>")),
 			})),
-		exRow("09", "examples/static-site", "Static file server", "no screens", "~60 LoC",
+		exRow("09", "examples/static-site", "Static file server", "no screens", locBadge("static-site", ""),
 			"A plain file server on the framework router: static.Mount serves the pages/ directory, with HTML and CSS straight from disk, no screens, no runtime JS.",
 			[]string{"static.Mount with SPA mode off: only real files serve", "index.html answers /", "API routes can mount beside it on the same router"},
 			"cd examples/static-site && go run .",
@@ -487,11 +511,96 @@ func exRowItems() []render.HTML {
 				ln(pn("})")),
 				ln(render.Text("app."), fn_("Start"), pn("("), str_(`":3070"`), pn(")")),
 			})),
+		exRow("10", "examples/backoffice", "Entity admin", "battery/admin", locBadge("backoffice", ""),
+			"Three entities and one admin.New call: the whole back-office (list, create, edit, delete) is generated with defaults, behind a demo login. No bespoke JavaScript anywhere in the app.",
+			[]string{"admin.New with AllEntities: true generates every screen", "DataTable island paginates without a reload", "Delete is a data-fui-confirm button; forms are server-rendered"},
+			"cd examples/backoffice && go run .",
+			codeBlock("examples/backoffice/main.go", []render.HTML{
+				ln(render.Text("app."), fn_("Entity"), pn("("), str_(`"products"`), pn(","), render.Text(" …"), pn(")")),
+				ln(render.Text("app."), fn_("RegisterBattery"), pn("("), render.Text("admin."), fn_("New"), pn("("), render.Text("admin."), ty("Config"), pn("{")),
+				ln(render.Text("  Title: "), str_(`"Backoffice"`), pn(", "), render.Text("AllEntities: true"), pn(",")),
+				ln(pn("}))")),
+			})),
+		exRow("11", "examples/processmodule-demo", "Process-isolated module", "moduleproto", locBadge("processmodule-demo", ""),
+			"A third-party module as its own process: it speaks moduleproto over stdio, serves three routes and one tool to the host, and answers a reverse entity query. The child the process-module gate suite drives end to end.",
+			[]string{"Depends only on the moduleproto package + the standard library", "Handshake, ready, health, http, drain, tool.list, tool.call", "Reverse host.entity.query proves the broker path"},
+			"go run ./examples/processmodule-demo",
+			codeBlock("examples/processmodule-demo/main.go", []render.HTML{
+				ln(render.Text("codec, _ "), pn(":="), render.Text(" moduleproto."), fn_("NewCodec"), pn("("), render.Text("os.Stdin, os.Stdout, …"), pn(")")),
+				ln(render.Text("peer "), pn(":="), render.Text(" moduleproto."), fn_("NewPeer"), pn("("), render.Text("codec, moduleproto.RoleChild"), pn(")")),
+				ln(render.Text("peer."), fn_("Handle"), pn("("), render.Text("moduleproto.MethodHTTP, serveRoute"), pn(")")),
+				ln(render.Text("peer."), fn_("Start"), pn("(); "), pn("<-"), render.Text("peer."), fn_("Done"), pn("()")),
+			})),
+		exRow("12", "examples/webmcp-remote-assist", "WebMCP remote assist", "WebMCP + WebRTC", locBadge("webmcp-remote-assist", ""),
+			"One binary, one origin, two roles: a support console whose in-browser agent guides an operator through a camera session. Support-only WebMCP tool discovery, one typed command behind the button and the tools, and peer-to-peer video with server-side signaling only.",
+			[]string{"Tools scoped to /support and authorization-wrapped", "Role cookies authorize; the WebMCP header only attributes", "Sequenced realtime state over the ws runtime module"},
+			"cd examples/webmcp-remote-assist && go run .",
+			codeBlock("examples/webmcp-remote-assist/main.go", []render.HTML{
+				ln(render.Text("tools "), pn(":="), render.Text(" webmcp."), fn_("New"), pn("("), render.Text("webmcp."), fn_("WithInstructions"), pn("(…))")),
+				ln(render.Text("group."), fn_("Handle"), pn("("), render.Text("rt, sendInstruction, handler,")),
+				ln(render.Text("  webmcp."), fn_("WithHTTPMiddleware"), pn("("), render.Text("requireSupport"), pn("))")),
+				ln(render.Text("webmcp."), fn_("WithDocumentScope"), pn("("), render.Text("supportScope"), pn(")")),
+			})),
 	}
 }
 
+// exBlueprints is row 13: the declarative examples that are blueprints
+// only, no Go until `gofastr generate` runs. It sits on the same row grid
+// as the runnable apps but stays out of exRowItems, whose length is the
+// "runs in one command" count.
+func exBlueprints() render.HTML {
+	items := []struct{ slug, domain string }{
+		{"lms", "courses, lessons, enrollments"},
+		{"portfolio", "projects and case studies"},
+		{"project-manager", "projects, tasks, teams"},
+		{"real-estate", "listings, agents, inquiries"},
+	}
+	lis := make([]render.HTML, 0, len(items))
+	for _, it := range items {
+		lis = append(lis, html.ListItem(html.ListItemConfig{},
+			html.LinkHTML(html.LinkHTMLConfig{
+				Href:       "https://github.com/DonaldMurillo/gofastr/tree/main/examples/" + it.slug,
+				ExtraAttrs: html.Attrs{"rel": "external"},
+				Content:    render.Text("examples/" + it.slug),
+			}),
+			render.Text(": "+it.domain),
+		))
+	}
+	body := html.Div(html.DivConfig{Class: "ex-row__body"},
+		html.Div(html.DivConfig{Class: "ex-row__meta"},
+			tagAccent("gofastr.yml only"),
+			html.Span(html.TextConfig{Class: "lc"}, render.Text("0 LoC until you generate")),
+		),
+		html.Heading(html.HeadingConfig{Level: 2, Class: "ex-row__title"},
+			render.Text("examples/… — "),
+			html.Span(html.TextConfig{Class: "amber"}, render.Text("Four more blueprints")),
+		),
+		html.Paragraph(html.TextConfig{Class: "ex-row__desc"},
+			render.Text("Each is one gofastr.yml with no Go beside it. Generate in the directory to get a runnable app you own; every one is validated by the CLI's blueprint test suite."),
+		),
+		html.UnorderedList(html.ListConfig{Class: "ex-row__points"}, lis...),
+		html.Div(html.DivConfig{Class: "ex-row__cli"},
+			html.Span(html.TextConfig{Class: "p"}, render.Text("$")),
+			render.Text("cd examples/lms && gofastr generate --from=gofastr.yml"),
+		),
+	)
+	right := html.Div(html.DivConfig{Class: "ex-row__right"},
+		codeBlock("examples/lms/gofastr.yml", []render.HTML{
+			ln(com("# entities, screens, nav, endpoints, seed: one YAML")),
+			ln(render.Text("$ gofastr generate --from=gofastr.yml")),
+			ln(render.Text("$ go run .")),
+		}),
+	)
+	grid := html.Div(html.DivConfig{Class: "ex-row__grid"},
+		html.Span(html.TextConfig{Class: "ex-row__num"}, render.Text("13")),
+		body,
+		right,
+	)
+	return html.Section(html.SectionConfig{ID: "blueprints", Class: "ex-row", Label: "Blueprint examples"}, grid)
+}
+
 func exRows() render.HTML {
-	return container(render.Join(exRowItems()...))
+	return container(render.Join(exRowItems()...), exBlueprints())
 }
 
 // exRow renders one example. code is the pre-built code sample (a snippet for

--- a/examples/site/site_test.go
+++ b/examples/site/site_test.go
@@ -193,7 +193,7 @@ func TestPageTitlesSingleSuffix(t *testing.T) {
 
 func TestExamplesHaveSourceLinksAndAnchors(t *testing.T) {
 	html := body(t, "/examples")
-	slugs := []string{"meridian", "ecommerce", "blog", "site", "api-tour", "semantic-demo", "spa", "embed-demo", "static-site"}
+	slugs := []string{"meridian", "ecommerce", "blog", "site", "api-tour", "semantic-demo", "spa", "embed-demo", "static-site", "backoffice", "processmodule-demo", "webmcp-remote-assist"}
 	for _, slug := range slugs {
 		if !strings.Contains(html, `id="`+slug+`"`) {
 			t.Errorf("/examples missing anchor id=%q", slug)

--- a/examples/spa/README.md
+++ b/examples/spa/README.md
@@ -30,8 +30,8 @@ Entity CRUD routes are mounted under `/api/` so they don't conflict with Vue Rou
 
 ```bash
 cd examples/spa
-go run .
-# Open http://localhost:3090
+gofastr dev          # or: go run .
+# Open http://localhost:3090 (or the address the banner prints)
 ```
 
 ## Tech

--- a/examples/spa/README.md
+++ b/examples/spa/README.md
@@ -30,7 +30,7 @@ Entity CRUD routes are mounted under `/api/` so they don't conflict with Vue Rou
 
 ```bash
 cd examples/spa
-go run main.go
+go run .
 # Open http://localhost:3090
 ```
 

--- a/examples/spa/main.go
+++ b/examples/spa/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/core/schema"
 	"github.com/DonaldMurillo/gofastr/core/static"
 	"github.com/DonaldMurillo/gofastr/framework"
+	"github.com/DonaldMurillo/gofastr/framework/isolation"
 	_ "github.com/DonaldMurillo/gofastr/sqlite/stdlib"
 )
 
@@ -81,9 +82,12 @@ func main() {
 
 	// --- Start ---
 
-	log.Println("SPA example starting on :3090")
-	log.Println("Open http://localhost:3090 in your browser")
-	if err := app.Start(":3090"); err != nil {
+	addr, err := isolation.ListenAddr(".", ":3090")
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("SPA example starting on %s", addr)
+	if err := app.Start(addr); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/static-site/README.md
+++ b/examples/static-site/README.md
@@ -25,7 +25,7 @@ examples/static-site/
 
 ```bash
 cd examples/static-site
-go run main.go
+go run .
 # Open http://localhost:3070
 ```
 

--- a/examples/static-site/README.md
+++ b/examples/static-site/README.md
@@ -25,8 +25,8 @@ examples/static-site/
 
 ```bash
 cd examples/static-site
-go run .
-# Open http://localhost:3070
+gofastr dev          # or: go run .
+# Open http://localhost:3070 (or the address the banner prints)
 ```
 
 ## Adding pages

--- a/examples/static-site/main.go
+++ b/examples/static-site/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/DonaldMurillo/gofastr/core/static"
 	"github.com/DonaldMurillo/gofastr/framework"
+	"github.com/DonaldMurillo/gofastr/framework/isolation"
 )
 
 func main() {
@@ -28,10 +29,13 @@ func main() {
 		// index.html is served automatically for "/".
 	})
 
-	log.Println("Static site example starting on :3070")
+	addr, err := isolation.ListenAddr(".", ":3070")
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Static site example starting on %s", addr)
 	log.Println("Serving files from:", pagesDir)
-	log.Println("Open http://localhost:3070 in your browser")
-	if err := app.Start(":3070"); err != nil {
+	if err := app.Start(addr); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/webmcp-remote-assist/README.md
+++ b/examples/webmcp-remote-assist/README.md
@@ -18,7 +18,7 @@ together:
 ## Run it
 
 ```bash
-go run ./examples/webmcp-remote-assist
+cd examples/webmcp-remote-assist && gofastr dev   # or: go run .
 ```
 
 Open <http://localhost:8090> (the framework's dev isolation may remap

--- a/examples/webmcp-remote-assist/main.go
+++ b/examples/webmcp-remote-assist/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/DonaldMurillo/gofastr/core/router"
 	"github.com/DonaldMurillo/gofastr/framework"
 	"github.com/DonaldMurillo/gofastr/framework/experimental/webmcp"
+	"github.com/DonaldMurillo/gofastr/framework/isolation"
 	"github.com/DonaldMurillo/gofastr/framework/ui"
 	"github.com/DonaldMurillo/gofastr/framework/ui/theme"
 	"github.com/DonaldMurillo/gofastr/framework/uihost"
@@ -53,14 +54,20 @@ var appJS []byte
 // their own via buildApp and reset it per server.
 var assist *assistApp
 
-const listenAddr = ":8090"
+// defaultAddr is the fallback when $PORT is unset; `gofastr dev` and PaaS
+// runtimes inject PORT and isolation.ListenAddr honours it.
+const defaultAddr = ":8090"
 
 func main() {
 	fwApp := buildApp()
 	if os.Getenv("ASSIST_SUPPORT_KEY") == "" {
 		log.Printf("support sign-in key (set ASSIST_SUPPORT_KEY to choose one): %s", assist.supportKey)
 	}
-	log.Printf("webmcp-remote-assist listening on http://localhost%s", listenAddr)
+	listenAddr, err := isolation.ListenAddr(".", defaultAddr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("webmcp-remote-assist listening on %s", localURL(listenAddr))
 	if err := fwApp.Start(listenAddr); err != nil && err != http.ErrServerClosed {
 		log.Fatal(err)
 	}
@@ -469,4 +476,13 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
+}
+
+// localURL renders a listen address as the URL to open: a bare ":8090"
+// becomes http://localhost:8090, a host:port is used as is.
+func localURL(addr string) string {
+	if strings.HasPrefix(addr, ":") {
+		return "http://localhost" + addr
+	}
+	return "http://" + addr
 }

--- a/framework/docs/content/isolation.md
+++ b/framework/docs/content/isolation.md
@@ -79,6 +79,24 @@ if err != nil {
 db, err := sql.Open(driver, dsn)
 ```
 
+For the listen address, `isolation.ListenAddr` is the whole recipe: it
+reads `$PORT` (a bare `8088` from a PaaS or a `localhost:8088` from
+`gofastr dev`), falls back to the address you pass when it is unset, and
+applies the port remap. Every example app binds this way, so `go run .`
+and `gofastr dev` agree on where the server is:
+
+<!-- gofastr:compile
+import "github.com/DonaldMurillo/gofastr/framework/isolation"
+import "log"
+stmt: _ = addr
+-->
+```go
+addr, err := isolation.ListenAddr(".", ":8080")
+if err != nil {
+    log.Fatal(err)
+}
+```
+
 Hand-written apps still get automatic port isolation through `App.Start`.
 Database isolation is automatic when the app either runs through `gofastr dev`
 and reads env, or opens the database through `Runtime.Database`.

--- a/framework/docs/content/plugin-platform.md
+++ b/framework/docs/content/plugin-platform.md
@@ -462,6 +462,15 @@ and mounts it with `app.RegisterPlugin(...)`; the registry file is the
 human/tooling index, updated in the same change as a plugin's version
 or capability set.
 
+The docs site (`examples/site`) is the first consumer. It vendors the
+copy published with each gofastr-plugins release, which carries a
+`release` stamp the file in git does not, and renders `/plugins` plus
+one page per row from it. `scripts/vendor-plugins-json.sh [vX.Y.Z]`
+refreshes the copy; the site's `TestPluginRegistryVendoredCopy` refuses
+an unstamped copy, an unknown field, or a sandboxed row that grants
+`allow-same-origin`. Nothing imports a Go API for the file: that would
+make gofastr depend on a repo that depends on gofastr.
+
 ## Common mistakes
 
 - **Adding `allow-same-origin` to "fix" a frame that can't load its

--- a/framework/isolation/isolation.go
+++ b/framework/isolation/isolation.go
@@ -183,6 +183,25 @@ func (r *Runtime) Addr(addr string) (string, error) {
 	return joinAddr(host, next, shape), nil
 }
 
+// ListenAddr is the one call a hand-written main needs to bind where
+// `gofastr dev`, a PaaS, or worktree isolation says: it resolves isolation
+// for projectDir, reads $PORT (a bare port "8088" or a host:port
+// "localhost:8088", both of which `gofastr dev` and PaaS runtimes inject),
+// falls back to fallback when $PORT is empty, and returns the address
+// with isolation's port remap applied. Pass the result to App.Start or
+// http.ListenAndServe.
+func ListenAddr(projectDir, fallback string) (string, error) {
+	rt, err := Resolve(projectDir)
+	if err != nil {
+		return "", err
+	}
+	addr := os.Getenv("PORT")
+	if addr == "" {
+		addr = fallback
+	}
+	return rt.Addr(addr)
+}
+
 // Env returns env with configured local resources isolated.
 func (r *Runtime) Env(env []string) []string {
 	if !r.Active() {

--- a/framework/isolation/listenaddr_test.go
+++ b/framework/isolation/listenaddr_test.go
@@ -1,0 +1,23 @@
+package isolation
+
+import "testing"
+
+func TestListenAddrHonoursPortShapes(t *testing.T) {
+	t.Setenv("GOFASTR_ISOLATION", "off")
+	cases := []struct{ port, fallback, want string }{
+		{"", ":3090", ":3090"},                        // unset: fallback as given
+		{"8088", ":3090", ":8088"},                    // PaaS bare port
+		{"localhost:8123", ":3090", "localhost:8123"}, // gofastr dev host:port
+		{"", "localhost:8080", "localhost:8080"},
+	}
+	for _, c := range cases {
+		t.Setenv("PORT", c.port)
+		got, err := ListenAddr(".", c.fallback)
+		if err != nil {
+			t.Fatalf("PORT=%q: %v", c.port, err)
+		}
+		if got != c.want {
+			t.Errorf("PORT=%q fallback=%q: got %q, want %q", c.port, c.fallback, got, c.want)
+		}
+	}
+}

--- a/framework/isolation/listenaddr_test.go
+++ b/framework/isolation/listenaddr_test.go
@@ -1,6 +1,10 @@
 package isolation
 
-import "testing"
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestListenAddrHonoursPortShapes(t *testing.T) {
 	t.Setenv("GOFASTR_ISOLATION", "off")
@@ -19,5 +23,38 @@ func TestListenAddrHonoursPortShapes(t *testing.T) {
 		if got != c.want {
 			t.Errorf("PORT=%q fallback=%q: got %q, want %q", c.port, c.fallback, got, c.want)
 		}
+	}
+}
+
+func TestListenAddrRemapsInALinkedWorktree(t *testing.T) {
+	t.Setenv("GOFASTR_ISOLATION", "")
+	t.Setenv("GOFASTR_ISOLATION_REWRITE", "")
+	t.Setenv("PORT", "")
+	dir := t.TempDir()
+	// A .git FILE pointing at a worktrees/ gitdir is what marks a linked
+	// worktree, the default trigger for isolation.
+	writeFile(t, filepath.Join(dir, ".git"), "gitdir: "+filepath.Join(t.TempDir(), ".git", "worktrees", "feature")+"\n")
+	got, err := ListenAddr(dir, ":8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == ":8080" {
+		t.Fatal("linked worktree left :8080 unremapped; ListenAddr is not applying Runtime.Addr")
+	}
+	if _, port, _, err := splitAddr(got); err != nil || port <= 0 {
+		t.Fatalf("remapped address %q is not a valid listen address: %v", got, err)
+	}
+}
+
+func TestListenAddrReturnsResolveErrors(t *testing.T) {
+	t.Setenv("GOFASTR_ISOLATION", "on")
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "gofastr.isolation.yml"), "isolation:\n  mode: bogus\n")
+	_, err := ListenAddr(dir, ":8080")
+	if err == nil {
+		t.Fatal("a config with an unsupported mode resolved; the Resolve error is being swallowed")
+	}
+	if !strings.Contains(err.Error(), "mode") {
+		t.Fatalf("error is not the unsupported-mode refusal: %v", err)
 	}
 }

--- a/scripts/vendor-plugins-json.sh
+++ b/scripts/vendor-plugins-json.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Vendors the gofastr-plugins registry index into the docs site.
+#
+# The site consumes plugins.json by COPY, not by import (a Go import would
+# make gofastr depend on a repo that depends on gofastr). This fetches the
+# published copy from a gofastr-plugins release, which carries a `release`
+# stamp (tag, commit, published, source) the file in that repo's git does
+# not, so the vendored copy says where it came from. The site's
+# TestPluginRegistryVendoredCopy fails on a copy without the stamp.
+#
+# Usage:
+#   scripts/vendor-plugins-json.sh            # latest release
+#   scripts/vendor-plugins-json.sh v0.5.0     # a pinned release
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="$ROOT/examples/site/plugins/plugins.json"
+REPO="https://github.com/DonaldMurillo/gofastr-plugins"
+TAG="${1:-latest}"
+
+if [ "$TAG" = "latest" ]; then
+  URL="$REPO/releases/latest/download/plugins.json"
+else
+  URL="$REPO/releases/download/$TAG/plugins.json"
+fi
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+curl -fsSL "$URL" -o "$TMP"
+if ! grep -q '"release"' "$TMP"; then
+  echo "vendor-plugins-json: $URL carries no release stamp; refusing to vendor an unstamped copy" >&2
+  exit 1
+fi
+mv "$TMP" "$OUT"
+trap - EXIT
+echo "vendored $URL -> ${OUT#"$ROOT"/}"
+echo "now run: go test ./examples/site -run 'TestPlugin'"


### PR DESCRIPTION
## Examples page and READMEs

Every drift gate passed at HEAD, so what had gone stale was copy.

- `/examples` listed 9 of the 12 runnable examples. Rows added for `backoffice`, `processmodule-demo`, and `webmcp-remote-assist`, plus a row linking the four blueprint-only examples.
- The line-count badges had drifted by up to half (the site badge said 6,000 lines for a 9,300-line app). They now come from one table that `TestExampleLoCBadgesMatchTree` measures against the tree, and the home card derives its count from the row list. The gate was proven red on a wrong value before being trusted.
- The spa snippet showed a fabricated entity and port; fixed to the real ones.
- The blog README described JSON declarations and said the example enforces no auth. The code gates every write and every users read on a role scope. Tables now show the real scopes.
- The ecommerce doc comment still pointed at a gitignored `gen/`; the app is committed under `app/` and parity-gated.

## gofastr-plugins registry

The sibling repo publishes `plugins.json` with each release and its README names this site as the first consumer. This adds that consumer.

- `examples/site/plugins/plugins.json` is the copy from the v0.5.0 release asset, carrying the `release` stamp the file in git does not. `scripts/vendor-plugins-json.sh [vX.Y.Z]` refreshes it.
- `/plugins` renders one card per row; `/plugins/<name>` shows the manifest, the isolation posture, and the `go get` plus `RegisterPlugin` lines. Every plugin exports `New(opts ...Option)`, so the snippet is real.
- `TestPluginRegistryVendoredCopy` refuses an unstamped copy, an unknown field, a sandboxed row granting `allow-same-origin`, and a trusted row declaring sandbox tokens. Consumed by copy, never by import, so gofastr never depends on the repo that depends on it.
- Static export produces a page per plugin; screenshots checked in light, dark, and at 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BLjmqxTmrgQgZg2S2wefZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Plugins section with a registry index and individual plugin detail pages.
  - Expanded the examples catalog with additional runnable and blueprint-only examples.
  - Examples now support consistent address selection through `gofastr dev` and `$PORT`.

- **Bug Fixes**
  - Fixed example servers that failed to bind correctly when using host-and-port values.

- **Documentation**
  - Updated plugin platform documentation and example guides with setup, authentication, filtering, and run instructions.
  - Added guidance for refreshing plugin registry data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->