### PR TITLE
fix(uihost): render a static page with the request and route match a live one gets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Fixed
+- **A static export renders layout chrome for the page being exported.**
+  `uihost.RenderStaticPage` rendered with neither a request nor a route
+  match in the context, so a layout component that reads the path, such as
+  a sidebar for the section being read or a header whose language follows
+  the page, rendered for no page at all: every exported page carried the
+  chrome of the site root, and a translated page shipped with the original's
+  sidebar. The static render now carries a request for the path and the
+  route match, exactly as `handlePage` installs them for a live request.
+
 ## [0.83.0] - 2026-09-06
 
 ### Security

--- a/framework/uihost/static_render_context_test.go
+++ b/framework/uihost/static_render_context_test.go
@@ -1,0 +1,70 @@
+package uihost
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/core/render"
+)
+
+// pathAwareChrome is a layout component that renders for the page being
+// served, the way a docs sidebar or a header whose language follows the page
+// does: it reads the path from the request and the route match.
+type pathAwareChrome struct{}
+
+func (pathAwareChrome) Render() render.HTML { return render.Text("chrome for nothing") }
+
+func (pathAwareChrome) RenderCtx(ctx context.Context) render.HTML {
+	path := "none"
+	if r := app.RequestFromContext(ctx); r != nil && r.URL != nil {
+		path = r.URL.Path
+	}
+	match := "none"
+	if m, ok := app.MatchFromContext(ctx); ok {
+		match = m.ScreenID() + " slug=" + m.Param("slug")
+	}
+	return render.Text("request:" + path + " match:" + match)
+}
+
+// slugScreen is a screen on a dynamic route; the router requires one to
+// accept its params.
+type slugScreen struct{ slug string }
+
+func (s *slugScreen) SetParams(params map[string]string) { s.slug = params["slug"] }
+func (s *slugScreen) Render() render.HTML                { return render.Text("doc " + s.slug) }
+
+// A static export must render layout chrome with the same context a live
+// request gets. It rendered with neither a request nor a route match, so a
+// sidebar for the section being read, or a header whose language follows
+// the page, rendered for no page at all: every exported page carried the
+// chrome of the site root.
+func TestRenderStaticPageCarriesTheRequestAndMatch(t *testing.T) {
+	application := app.NewApp("StaticContext")
+	application.SetDefaultLayout(app.NewLayout("main").WithHeader(pathAwareChrome{}))
+	application.RegisterScreen(app.NewScreen("/docs/{slug}", &slugScreen{}).WithTitle("Doc"), nil)
+
+	page, err := New(application).RenderStaticPage(context.Background(), "/docs/guide")
+	if err != nil {
+		t.Fatalf("RenderStaticPage: %v", err)
+	}
+	if !strings.Contains(page, "request:/docs/guide") {
+		t.Fatalf("static chrome rendered without the request path: %s", excerpt(page, "request:"))
+	}
+	if !strings.Contains(page, "match:/docs/:slug slug=guide") {
+		t.Fatalf("static chrome rendered without the route match: %s", excerpt(page, "match:"))
+	}
+}
+
+func excerpt(page, marker string) string {
+	i := strings.Index(page, marker)
+	if i < 0 {
+		return "(marker absent)"
+	}
+	end := i + 80
+	if end > len(page) {
+		end = len(page)
+	}
+	return page[i:end]
+}

--- a/framework/uihost/static_render_context_test.go
+++ b/framework/uihost/static_render_context_test.go
@@ -2,6 +2,7 @@ package uihost
 
 import (
 	"context"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -67,4 +68,33 @@ func excerpt(page, marker string) string {
 		end = len(page)
 	}
 	return page[i:end]
+}
+
+// A caller that already supplies a request and a route match keeps them: the
+// static render only fills in what is missing. Without these guards a host
+// rendering a page under another page's request, as a preview does, would
+// have its context replaced.
+func TestRenderStaticPageKeepsASuppliedRequestAndMatch(t *testing.T) {
+	application := app.NewApp("StaticContextSupplied")
+	application.SetDefaultLayout(app.NewLayout("main").WithHeader(pathAwareChrome{}))
+	application.RegisterScreen(app.NewScreen("/docs/{slug}", &slugScreen{}).WithTitle("Doc"), nil)
+
+	req := httptest.NewRequest("GET", "/somewhere/else", nil)
+	ctx := app.WithRequest(context.Background(), req)
+	supplied, ok := application.Router.MatchFor("/docs/other")
+	if !ok {
+		t.Fatal("no match for /docs/other")
+	}
+	ctx = app.WithMatch(ctx, supplied)
+
+	page, err := New(application).RenderStaticPage(ctx, "/docs/guide")
+	if err != nil {
+		t.Fatalf("RenderStaticPage: %v", err)
+	}
+	if !strings.Contains(page, "request:/somewhere/else") {
+		t.Fatalf("the supplied request was replaced: %s", excerpt(page, "request:"))
+	}
+	if !strings.Contains(page, "match:/docs/:slug slug=other") {
+		t.Fatalf("the supplied route match was replaced: %s", excerpt(page, "match:"))
+	}
 }

--- a/framework/uihost/uihost.go
+++ b/framework/uihost/uihost.go
@@ -3325,6 +3325,23 @@ func (e *PolicyBlockedError) Error() string {
 // graph, but skips the SSE meta tag because there is no live session.
 // The result is safe to write to disk and serve from any static host.
 func (ds *UIHost) RenderStaticPage(ctx context.Context, path string) (string, error) {
+	// The chrome renders with the same context a live request gets. A
+	// layout component that reads the path from the request, such as a
+	// sidebar for the section being read or a header whose language follows
+	// the page, rendered for no page at all in an export, so every exported
+	// page carried the chrome of the site root. An SSG build passes no
+	// request, so one is made for the path, and the route match is
+	// installed the way handlePage does it.
+	if app.RequestFromContext(ctx) == nil {
+		if req, err := http.NewRequestWithContext(ctx, http.MethodGet, path, nil); err == nil {
+			ctx = app.WithRequest(ctx, req)
+		}
+	}
+	if _, ok := app.MatchFromContext(ctx); !ok {
+		if m, ok := ds.App.Router.MatchFor(path); ok {
+			ctx = app.WithMatch(ctx, m)
+		}
+	}
 	// Install the value bag so producer-seeded slice values are captured
 	// during the static render (matches the live handlePage path).
 	ctx = store.WithValues(ctx)


### PR DESCRIPTION
`uihost.RenderStaticPage` rendered with neither a request nor a route match in the context. A layout component that reads the path from the request (a sidebar for the section being read, a header whose language follows the page) rendered for no page at all, so every exported page carried the chrome of the site root. Found exporting fastr-docs: every Spanish page shipped with the English sidebar.

The static render now carries a request for the path and the route match, installed exactly as `handlePage` installs them for a live request. Behaviour fix, no exported API change; CHANGELOG entry under Unreleased.

The new test renders a dynamic route through a path-aware header and fails without the fix with `request:none match:none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014v9ptuQG7QVYUTtUH9T4q8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Static page exports now preserve the requested path and matched route.
  * Path-aware layouts, language-specific headers, and other route-dependent page elements now render correctly instead of using the site root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->