### PR TITLE
fix(uihost): mark component stylesheet links so the runtime does not load them twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+### Fixed
+- **A static page no longer loads every component stylesheet twice.** The
+  export emitted one `<link>` per component without the `data-fui-style`
+  marker the runtime dedupes on, so on load the runtime appended a second
+  copy of each after `app.css`, and a host's own overrides lost the
+  cascade: a sidebar title stretched to fill its column, a doc layout
+  collapsed. The exported links carry the marker and id the runtime would
+  have written.
+
 ## [0.84.0] - 2026-09-06
 
 ### Fixed

--- a/core-ui/ARCHITECTURE.md
+++ b/core-ui/ARCHITECTURE.md
@@ -145,7 +145,7 @@ server side and the runtime does the work.
 | `data-fui-action="<name>"` | Marks an element as a server-action trigger. Used together with `data-fui-rpc` to dispatch a named action. |
 | `data-fui-widget="<name>"` | Marks a registered widget instance: the runtime mounts behavior on it after first paint. |
 | `data-fui-backdrop` | Marks an element as a click-to-dismiss overlay backdrop. Pairs with `data-fui-open` to make the floating surface dismissible. |
-| `data-fui-style="<name>"` | Set on the runtime-injected `<link rel="stylesheet">` so duplicates are dedup'd by component name. |
+| `data-fui-style="<name>"` | The dedup key for a component's stylesheet `<link>`. `loadComponentCSS` appends a link only when no `link[data-fui-style="<name>"]` exists, so every per-component link carries it, whether the runtime injected it or the host SSR-emitted it (a single-component page, and every page of a static export, where the bundle is not used). The host's link also carries `id="fui-css-<name>"`, the id the runtime would have given it. An SSR link without the marker is invisible to the dedup and gets loaded a second time, after `app.css`, which reverses the cascade against the host's overrides. |
 | `data-fui-shortcut-click="<chord>"` / `data-fui-shortcut-focus="<chord>"` | Global keyboard shortcut: e.g. `Meta+K` or `/` focuses or clicks the target element. |
 | `data-fui-submit-on-enter` | On a `<form>`, Enter inside any child textarea submits the form. |
 | `data-fui-clear-on-esc` | On an `<input>`/`<textarea>`, Escape clears the value. |
@@ -1265,6 +1265,16 @@ All three converge on `loadComponentCSS(name)`. The function is
 `appendChild`, plus a `_pendingLinks` guard, so promoting a
 component across modes or having two scans race never produces a
 duplicate request.
+
+The existence check is `link[data-fui-style="<name>"]`, so an
+SSR-emitted per-component link must carry the same marker (and the
+`fui-css-<name>` id) as the link the runtime would have written.
+The host emits per-component links on a single-component page and
+on every page of a static export, where the bundle endpoint does
+not exist; without the marker the boot scan appended a second copy
+of each after `app.css` and the host's overrides lost the cascade.
+`core-ui/runtime/static_comp_css_e2e_test.go` pins both halves: a
+marked SSR link is loaded once, an unmarked one twice.
 
 ### The bundle endpoint
 

--- a/core-ui/runtime/static_comp_css_e2e_test.go
+++ b/core-ui/runtime/static_comp_css_e2e_test.go
@@ -1,0 +1,98 @@
+package runtime
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/chromedp/chromedp"
+)
+
+// serveStaticCompCSSPage serves a page in the shape the static export
+// writes: one SSR <link> per component in <head>, the component's marker in
+// the body, and the catalog the runtime resolves names through. marked
+// decides whether the SSR link carries data-fui-style, the attribute
+// loadComponentCSS dedupes on.
+func serveStaticCompCSSPage(t *testing.T, marked bool) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var cssHits atomic.Int32
+	js, err := RuntimeJS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := `<link rel="stylesheet" href="/css/static-probe.css?v=1">`
+	if marked {
+		link = `<link rel="stylesheet" href="/css/static-probe.css?v=1" data-fui-style="static-probe" id="fui-css-static-probe">`
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/__gofastr/runtime.js", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Write([]byte(js))
+	})
+	mux.HandleFunc("/css/static-probe.css", func(w http.ResponseWriter, _ *http.Request) {
+		cssHits.Add(1)
+		w.Header().Set("Content-Type", "text/css")
+		w.Write([]byte(`body{}`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<!doctype html><html><head>`+link+
+			`<script>window.__gofastr_catalog={"static-probe":{stylePath:"/css/static-probe.css",version:"1"}};</script>`+
+			`</head><body>`+
+			`<span data-fui-comp="static-probe">styled</span>`+
+			`<span id="ready">ready</span>`+
+			`<script src="/__gofastr/runtime.js"></script></body></html>`)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &cssHits
+}
+
+func countStaticProbeLinks(t *testing.T, srv *httptest.Server) int {
+	t.Helper()
+	ctx := newSeedBrowserCtx(t)
+	var links int
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL+"/"),
+		chromedp.WaitVisible(`#ready`, chromedp.ByID),
+		// The boot scan runs after the runtime script; a second link would
+		// be appended synchronously by loadComponentCSS, so one more scan
+		// from here settles it either way.
+		chromedp.Evaluate(`window.__gofastr && window.__gofastr.scanAndLoadCSS && window.__gofastr.scanAndLoadCSS(document.body); true`, nil),
+		chromedp.Evaluate(`document.querySelectorAll('link[rel="stylesheet"][href^="/css/static-probe.css"]').length`, &links),
+	); err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+	return links
+}
+
+// TestStaticPage_MarkedSSRLinkIsNotLoadedTwice pins the contract between the
+// host's SSR component links and the runtime's dedup: an SSR <link> that
+// carries data-fui-style="<name>" is the one the runtime would have written,
+// so the boot scan must not append another. The static export writes one
+// such link per component; without the marker every static page loaded each
+// component stylesheet twice, the second copy after app.css, which reversed
+// the cascade against the host's own overrides.
+func TestStaticPage_MarkedSSRLinkIsNotLoadedTwice(t *testing.T) {
+	srv, cssHits := serveStaticCompCSSPage(t, true)
+	if links := countStaticProbeLinks(t, srv); links != 1 {
+		t.Fatalf("a marked SSR link was loaded %d times, want 1: the runtime's data-fui-style dedup did not see it", links)
+	}
+	if hits := cssHits.Load(); hits != 1 {
+		t.Fatalf("the stylesheet was fetched %d times, want 1", hits)
+	}
+}
+
+// TestStaticPage_UnmarkedSSRLinkIsLoadedAgain is the other half of the same
+// contract, and the bug the marker fixes: an SSR link without the marker is
+// invisible to the dedup, so the runtime appends its own. It is what every
+// static page did before the host marked its links, and it is why the host
+// must keep marking them.
+func TestStaticPage_UnmarkedSSRLinkIsLoadedAgain(t *testing.T) {
+	srv, _ := serveStaticCompCSSPage(t, false)
+	if links := countStaticProbeLinks(t, srv); links != 2 {
+		t.Fatalf("an unmarked SSR link was loaded %d times, want 2: the runtime dedupes on data-fui-style, and this page has none", links)
+	}
+}

--- a/framework/uihost/static_render_context_test.go
+++ b/framework/uihost/static_render_context_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/DonaldMurillo/gofastr/core-ui/app"
+	"github.com/DonaldMurillo/gofastr/core-ui/registry"
 	"github.com/DonaldMurillo/gofastr/core/render"
 )
 
@@ -96,5 +97,26 @@ func TestRenderStaticPageKeepsASuppliedRequestAndMatch(t *testing.T) {
 	}
 	if !strings.Contains(page, "match:/docs/:slug slug=other") {
 		t.Fatalf("the supplied route match was replaced: %s", excerpt(page, "match:"))
+	}
+}
+
+// The runtime loads a component's CSS when no link carries its marker, so
+// the links the static export writes must carry it, or every static page
+// loads each component stylesheet twice, the second copy after app.css.
+func TestRenderStaticPageMarksComponentStylesheets(t *testing.T) {
+	registry.IsolateForTest(t)
+	st := registerTestStyle(t, "static")
+	ds := newTestUIHostFor(st)
+
+	page, err := ds.RenderStaticPage(context.Background(), "/")
+	if err != nil {
+		t.Fatalf("RenderStaticPage: %v", err)
+	}
+	want := `href="/__gofastr/comp/` + st.Name() + `.css?v=`
+	if !strings.Contains(page, want) {
+		t.Fatalf("no component stylesheet link in the static page: %s", excerpt(page, "<link"))
+	}
+	if !strings.Contains(page, `data-fui-style="`+st.Name()+`" id="fui-css-`+st.Name()+`"`) {
+		t.Fatalf("the component stylesheet link lacks the runtime's marker: %s", excerpt(page, "/__gofastr/comp/"))
 	}
 }

--- a/framework/uihost/uihost.go
+++ b/framework/uihost/uihost.go
@@ -3472,8 +3472,13 @@ func (ds *UIHost) componentCSSTags(page string, bundle bool) string {
 			if i > 0 {
 				b.WriteByte('\n')
 			}
-			fmt.Fprintf(b, `<link rel="stylesheet" href="/__gofastr/comp/%s.css?v=%s">`,
-				n, e.VersionFor(theme))
+			// The marker the runtime dedupes on (loadComponentCSS checks
+			// link[data-fui-style=name]). Without it, a static page got a
+			// second copy of every component stylesheet appended after
+			// app.css on load, which reversed the cascade against the
+			// host's own overrides.
+			fmt.Fprintf(b, `<link rel="stylesheet" href="/__gofastr/comp/%s.css?v=%s" data-fui-style="%s" id="fui-css-%s">`,
+				n, e.VersionFor(theme), n, n)
 		}
 		return b.String()
 	}


### PR DESCRIPTION
The per-component `<link>` the host emits carried no `data-fui-style` marker, which is exactly what `loadComponentCSS` dedupes on. On every static page the runtime appended a second copy of each component stylesheet after `app.css`, and the host's overrides lost the cascade: on the fastr-docs GitHub Pages deploy the sidebar title stretched to 456px and the doc layout collapsed. The live host was unaffected only because it usually serves the bundle.

The link now carries the marker and id the runtime would have written. Behaviour fix, no exported API change; CHANGELOG entry under Unreleased. The test renders a static page with an isolated registry and fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014v9ptuQG7QVYUTtUH9T4q8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed static exports generating duplicate component stylesheets when pages loaded.
  * Component stylesheet links now use the same markers as runtime-injected styles, preserving host CSS override behavior.

* **Tests**
  * Added coverage verifying exported component stylesheet links include the expected runtime markers and identifiers.

* **Documentation**
  * Documented the static-export stylesheet duplication fix in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->