### PR TITLE
fix(static): carry the base path into the exported route graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 ## [Unreleased]
 
 ### Fixed
+- **Client-side navigation works on a static export below a base path.**
+  The export rewrote every href for the base and left the embedded route
+  graph root-relative, and the runtime takes the client-side path only for
+  a link it finds in the graph, so on a GitHub project page every click was
+  a full page load. The graph's paths carry the base too.
 - **A static page no longer loads every component stylesheet twice.** The
   export emitted one `<link>` per component without the `data-fui-style`
   marker the runtime dedupes on, so on load the runtime appended a second
@@ -15,6 +20,7 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
   cascade: a sidebar title stretched to fill its column, a doc layout
   collapsed. The exported links carry the marker and id the runtime would
   have written.
+
 
 ## [0.84.0] - 2026-09-06
 

--- a/framework/static/builder.go
+++ b/framework/static/builder.go
@@ -508,8 +508,22 @@ func (b *Builder) rewriteBaseURLs(page string) string {
 	// <code> to &quot;, so the literal "/__gofastr/ (real double-quote
 	// + path) only occurs in real JSON, never in rendered code text.
 	page = strings.ReplaceAll(page, `"/__gofastr/`, `"`+b.BasePath+`/__gofastr/`)
+	// 3. The route graph. The runtime takes the client-side path only for
+	// a link it finds in the graph, looking the link's pathname up by
+	// route path. Step 1 rewrote every href for the base while the graph
+	// kept root-relative paths, so on a project page no link was ever
+	// recognised and every click was a full page load.
+	page = baseRouteGraph.ReplaceAllStringFunc(page, func(block string) string {
+		m := baseRouteGraph.FindStringSubmatch(block)
+		return m[1] + strings.ReplaceAll(m[2], `"path":"/`, `"path":"`+b.BasePath+`/`) + m[3]
+	})
 	return page
 }
+
+// baseRouteGraph matches the route graph the host embeds in every page,
+// whose "path" values are the keys the runtime's navigation looks links
+// up by.
+var baseRouteGraph = regexp.MustCompile(`(?s)(<script type="application/json" id="gofastr-routes">)(.*?)(</script>)`)
 
 // dumpWidgetAssets writes the widget catalog JSON and each widget's chrome
 // HTML + CSS as query-free static files. Hidden click-to-open widgets

--- a/framework/static/builder_test.go
+++ b/framework/static/builder_test.go
@@ -377,6 +377,42 @@ func TestRenderStaticPageHasNoStaticMarker(t *testing.T) {
 	}
 }
 
+// The runtime's navigation looks a link up in the embedded route graph by
+// its pathname. A base-path export rewrote the hrefs and left the graph
+// root-relative, so nothing matched and every click was a full page load.
+func TestBuildBasePathRewritesRouteGraph(t *testing.T) {
+	a := coreapp.NewApp("SSGTest")
+	a.Register("/", &renderScreen{Body: `<a href="/about">about</a>`}, nil)
+	a.Register("/about", &renderScreen{Body: `<a href="/">home</a>`}, nil)
+	host := uihost.New(a)
+
+	out := t.TempDir()
+	if _, err := (&Builder{Host: host, OutDir: out, BasePath: "/gofastr"}).Build(context.Background()); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(out, "index.html"))
+	if err != nil {
+		t.Fatalf("read index: %v", err)
+	}
+	s := string(data)
+	start := strings.Index(s, `id="gofastr-routes"`)
+	if start < 0 {
+		t.Fatalf("no route graph in the page: %s", s)
+	}
+	graph := s[start:]
+	if end := strings.Index(graph, "</script>"); end >= 0 {
+		graph = graph[:end]
+	}
+	for _, want := range []string{`"path":"/gofastr/about"`, `"path":"/gofastr/"`} {
+		if !strings.Contains(graph, want) {
+			t.Errorf("route graph lacks %s: %s", want, graph)
+		}
+	}
+	if strings.Contains(graph, `"path":"/about"`) {
+		t.Errorf("route graph kept a root-relative path the links no longer use: %s", graph)
+	}
+}
+
 func TestBuildBasePathRewritesURLs(t *testing.T) {
 	// Screen carrying a mix of link/asset URLs to prove the rewrite
 	// prefixes root-absolute internal URLs and leaves others alone.


### PR DESCRIPTION
The runtime takes the client-side path only for a link it finds in the embedded route graph, looking the link's pathname up by route path. A base-path export rewrote every href for the base and left the graph root-relative, so on a GitHub project page (`user.github.io/repo/`) no link was ever recognised and every click was a full page load with the layout rebuilt. Found on the fastr-docs Pages deploy.

`rewriteBaseURLs` now prefixes the graph's `"path"` values as it does the hrefs. Behaviour fix, no exported API change; CHANGELOG entry under Unreleased. The test builds below `/gofastr` and fails without the fix.

Related, not included: after a client-side navigation on a static host the runtime still requests `/__gofastr/widgets?page=…`, which does not exist there; the fetch is non-fatal and the static boot already loaded the full catalog, so it only shows as a 404 in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014v9ptuQG7QVYUTtUH9T4q8
