### PR TITLE
chore(release): v0.84.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.84.1] - 2026-09-06
+
 ### Fixed
 - **Client-side navigation works on a static export below a base path.**
   The export rewrote every href for the base and left the embedded route

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.84.0
+through: v0.84.1
 
 releases:
   - version: v0.3.0
@@ -1058,3 +1058,9 @@ releases:
       - change: "uihost.RenderStaticPage carries a request for the path and the route match, as a live request does, so layout components that read the path render for the page being exported"
         breaking: false
         guidance: "A static export whose sidebar or header follows the page now writes the right chrome on every page; an export whose chrome ignored the path is byte-identical. Nothing to change."
+  - version: v0.84.1
+    title: Static exports work below a base path and load each stylesheet once
+    notes:
+      - change: "a static export below a base path carries the base in its embedded route graph, so client-side navigation works on a GitHub project page; exported per-component stylesheet links carry the data-fui-style marker so the runtime does not load them a second time after app.css"
+        breaking: false
+        guidance: "Re-export. A site that patched either in its own export step can drop the patch; nothing else changes."


### PR DESCRIPTION
Release commit for v0.84.1: CHANGELOG header and the `upgrades.yml` block (one additive note); SECURITY.md already names 0.84.x. The code shipped in #401 and #403: a static export below a base path navigates client-side, and loads each component stylesheet once.

After merge: tag the merge commit `v0.84.1` and push the tag; the release gate publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014v9ptuQG7QVYUTtUH9T4q8
