### PR TITLE
feat(ui): SidebarConfig.Prepend + poll the sortable 409 e2e tests (#405, #398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,13 +80,17 @@ read scope (an entity the caller cannot read is omitted, matching
 document.
 
 ### Added
-- **`SidebarConfig.Prepend` puts content above the nav on every body
-  path.** The field renders between the title and the `<nav>` in the
+- **`SidebarConfig.Prepend` puts a component above the nav on every
+  body path.** It renders between the title and the `<nav>` in the
   inline column, `SidebarBody`, and the `MountSidebar` drawer, so a
   docs site whose phone header hides its section tabs can carry a
-  section `<select>` in the drawer without copying the mount. It hides
-  with the title in the collapsed rail and the auto-hide rest state
-  (#405).
+  section `<select>` in the drawer without copying the mount. It is a
+  `component.Component`: `MountSidebar` runs once at boot but the
+  drawer body renders per request, and a Prepend implementing
+  `component.ContextComponent` sees that request, so the select can
+  mark the current section. Static markup goes through
+  `app.NewStaticComponent`. It hides with the title in the collapsed
+  rail and the auto-hide rest state (#405).
 
 ### Fixed
 - **The sortable-list 409 e2e tests no longer read the live region

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,16 @@ document.
   with the title in the collapsed rail and the auto-hide rest state
   (#405).
 
+### Fixed
+- **The sortable-list 409 e2e tests no longer read the live region
+  after a fixed sleep.** `TestSortable_409InvariantMessage` and its
+  siblings slept 500ms and then asserted on the announcement; under CI
+  load the conflict round trip landed later and the test read the
+  preceding move announcement. The 409 family now polls the live
+  region for the expected announcement, or the DOM for the refreshed
+  column, with a bounded timeout, proven against a server delayed
+  past the old sleep (#398).
+
 ## [0.84.1] - 2026-09-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,16 @@ document.
   region for the expected announcement, or the DOM for the refreshed
   column, with a bounded timeout, proven against a server delayed
   past the old sleep (#398).
+- **The auto-hide sidebar reveals on hover and focus again, and its
+  rest state hides the title and footer.** The reveal rule's selector
+  list ended in a comma with no opening brace, so the browser dropped
+  it and swallowed the rest-state rule after it: the rail stayed at
+  64px on hover and keyboard focus while the title, footer, and group
+  sublists leaked into it. Three guards land with the fix: a Chrome
+  test measures the rail at rest and on focus, the reveal test asserts
+  the rule block rather than the selector text, and a walk over every
+  registered stylesheet rejects a declaration outside a block or an
+  unbalanced brace, which is the shape this bug takes.
 
 ## [0.84.1] - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,15 @@ read scope (an entity the caller cannot read is omitted, matching
 `/api/llm.md`); `WithPublicOpenAPI` opts into the full, unfiltered
 document.
 
+### Added
+- **`SidebarConfig.Prepend` puts content above the nav on every body
+  path.** The field renders between the title and the `<nav>` in the
+  inline column, `SidebarBody`, and the `MountSidebar` drawer, so a
+  docs site whose phone header hides its section tabs can carry a
+  section `<select>` in the drawer without copying the mount. It hides
+  with the title in the collapsed rail and the auto-hide rest state
+  (#405).
+
 ## [0.84.1] - 2026-09-06
 
 ### Fixed

--- a/core-ui/runtime/sortablelist_e2e_test.go
+++ b/core-ui/runtime/sortablelist_e2e_test.go
@@ -303,7 +303,7 @@ func TestSortable_409FiresConflictPath(t *testing.T) {
 		chromedp.WaitVisible(`#ready`, chromedp.ByID),
 		kbCrossMove("k1"),
 		// Wait for the conflict fetch + DOM replacement.
-		chromedp.Sleep(500*time.Millisecond),
+		settled(`(function(){var c=document.querySelector('[data-fui-sortable-container="b"]');var i=c?c.querySelectorAll('[data-fui-sortable-item]'):[];return i.length===1&&i[0].getAttribute('data-fui-sort-key')==='k2'})()`),
 		// The conflict endpoint should have been fetched. Verify by
 		// checking that column B's innerHTML was replaced (the
 		// conflict response has k2 with aria-label "Drag B1", same
@@ -351,7 +351,9 @@ func TestSortable_NoVersionNo409Special(t *testing.T) {
 		chromedp.Navigate(base+"/"),
 		chromedp.WaitVisible(`#ready`, chromedp.ByID),
 		kbCrossMove("k1"),
-		chromedp.Sleep(500*time.Millisecond),
+		// The rollback announcement follows the restore; polling the DOM
+		// for k1-in-A instead would pass before the move even ran.
+		settled(`((document.getElementById('fui-sortable-live')||{}).textContent||'').indexOf('Reverted') !== -1`),
 		chromedp.Evaluate(`document.querySelector('[data-fui-sort-key="k1"]').closest('[data-fui-sortable-container]').getAttribute('data-fui-sortable-container')`, &containerAfter),
 	); err != nil {
 		t.Fatalf("chromedp: %v", err)
@@ -519,7 +521,7 @@ func TestSortable_ConflictRefreshEmptyColumn(t *testing.T) {
 		chromedp.Navigate(base+"/"),
 		chromedp.WaitVisible(`#ready`, chromedp.ByID),
 		kbCrossMove("k1"),
-		chromedp.Sleep(500*time.Millisecond),
+		settled(`document.querySelectorAll('[data-fui-sortable-container="b"] [data-fui-sortable-item]').length === 0`),
 		chromedp.Evaluate(`document.querySelectorAll('[data-fui-sortable-container="b"] [data-fui-sortable-item]').length`, &colBCount),
 		chromedp.Evaluate(`!!document.querySelector('[data-fui-sortable-container="a"] [data-fui-sort-key="k1"]')`, &k1InA),
 	); err != nil {
@@ -677,10 +679,31 @@ func conflict409Server(t *testing.T, contentType, body409 string) string {
 	return startSortableServer(t, sortableVersionPage, rpcHandler, conflictHandler)
 }
 
-// readLive evaluates #fui-sortable-live textContent into dst after
-// the conflict round-trip settles.
+// readLive evaluates #fui-sortable-live textContent into dst.
 func readLive(dst *string) chromedp.Action {
 	return chromedp.Evaluate(`(document.getElementById('fui-sortable-live')||{}).textContent || ''`, dst)
+}
+
+// settled polls a JS predicate until it holds, bounded so a broken
+// flow fails the test instead of hanging it. The 409 round trip (RPC,
+// bounded body read, conflict refetch, DOM swap) has no fixed cost:
+// a 500ms sleep read the preceding "Moved to …" announcement under CI
+// load (#398, run 34013830009).
+func settled(expr string) chromedp.Action {
+	return chromedp.Poll(expr, nil,
+		chromedp.WithPollingTimeout(10*time.Second), chromedp.WithPollingInterval(50*time.Millisecond))
+}
+
+// settledLive waits until the live region contains want, then reads
+// its full text into dst. The runtime announces the conflict outcome
+// only after the refresh has replaced the DOM, so the announcement
+// also proves the refresh landed. A leaked or wrong message never
+// matches, so the poll times out and the test fails.
+func settledLive(want string, dst *string) chromedp.Action {
+	return chromedp.Tasks{
+		settled(`((document.getElementById('fui-sortable-live')||{}).textContent||'').indexOf(` + strconv.Quote(want) + `) !== -1`),
+		readLive(dst),
+	}
 }
 
 // TestSortable_409ConflictMessageAnnounced: a 409 with a valid JSON
@@ -701,8 +724,7 @@ func TestSortable_409ConflictMessageAnnounced(t *testing.T) {
 		chromedp.Navigate(base+"/"),
 		chromedp.WaitVisible(`#ready`, chromedp.ByID),
 		kbCrossMove("k1"),
-		chromedp.Sleep(500*time.Millisecond),
-		readLive(&liveText),
+		settledLive("ORB-12", &liveText),
 		chromedp.Evaluate(`!!document.querySelector('[data-fui-sortable-container="b"] [data-fui-sort-key="k1"]')`, &colBHasK1),
 	); err != nil {
 		t.Fatalf("chromedp: %v", err)
@@ -730,8 +752,7 @@ func TestSortable_409InvariantMessage(t *testing.T) {
 		chromedp.Navigate(base+"/"),
 		chromedp.WaitVisible(`#ready`, chromedp.ByID),
 		kbCrossMove("k1"),
-		chromedp.Sleep(500*time.Millisecond),
-		readLive(&liveText),
+		settledLive("dependents", &liveText),
 	); err != nil {
 		t.Fatalf("chromedp: %v", err)
 	}
@@ -756,8 +777,7 @@ func TestSortable_409MalformedFallback(t *testing.T) {
 		chromedp.Navigate(base+"/"),
 		chromedp.WaitVisible(`#ready`, chromedp.ByID),
 		kbCrossMove("k1"),
-		chromedp.Sleep(500*time.Millisecond),
-		readLive(&liveText),
+		settledLive("Conflict.", &liveText),
 	); err != nil {
 		t.Fatalf("chromedp: %v", err)
 	}
@@ -784,8 +804,7 @@ func TestSortable_409OversizedFallback(t *testing.T) {
 		chromedp.Navigate(base+"/"),
 		chromedp.WaitVisible(`#ready`, chromedp.ByID),
 		kbCrossMove("k1"),
-		chromedp.Sleep(500*time.Millisecond),
-		readLive(&liveText),
+		settledLive("Conflict.", &liveText),
 	); err != nil {
 		t.Fatalf("chromedp: %v", err)
 	}
@@ -810,8 +829,7 @@ func TestSortable_409HTMLFallback(t *testing.T) {
 		chromedp.Navigate(base+"/"),
 		chromedp.WaitVisible(`#ready`, chromedp.ByID),
 		kbCrossMove("k1"),
-		chromedp.Sleep(500*time.Millisecond),
-		readLive(&liveText),
+		settledLive("Conflict.", &liveText),
 	); err != nil {
 		t.Fatalf("chromedp: %v", err)
 	}
@@ -837,8 +855,7 @@ func TestSortable_409EmptyBodyBackwardCompat(t *testing.T) {
 		chromedp.Navigate(base+"/"),
 		chromedp.WaitVisible(`#ready`, chromedp.ByID),
 		kbCrossMove("k1"),
-		chromedp.Sleep(500*time.Millisecond),
-		readLive(&liveText),
+		settledLive("Conflict.", &liveText),
 		chromedp.Evaluate(`document.querySelectorAll('[data-fui-sortable-container="b"] [data-fui-sortable-item]').length`, &colBCount),
 	); err != nil {
 		t.Fatalf("chromedp: %v", err)

--- a/core-ui/runtime/sortablelist_e2e_test.go
+++ b/core-ui/runtime/sortablelist_e2e_test.go
@@ -516,12 +516,16 @@ func TestSortable_ConflictRefreshEmptyColumn(t *testing.T) {
 	base := startSortableServer(t, pageHTML, rpcHandler, conflictHandler)
 	ctx := newSeedBrowserCtx(t)
 	var colBCount int
+	var liveText string
 	var k1InA bool
 	if err := chromedp.Run(ctx,
 		chromedp.Navigate(base+"/"),
 		chromedp.WaitVisible(`#ready`, chromedp.ByID),
 		kbCrossMove("k1"),
-		settled(`document.querySelectorAll('[data-fui-sortable-container="b"] [data-fui-sortable-item]').length === 0`),
+		// Column B starts empty and a rollback also leaves it empty with
+		// k1 back in A, so the DOM cannot tell reconciliation from a
+		// revert; the refresh-path announcement can.
+		settledLive("List refreshed", &liveText),
 		chromedp.Evaluate(`document.querySelectorAll('[data-fui-sortable-container="b"] [data-fui-sortable-item]').length`, &colBCount),
 		chromedp.Evaluate(`!!document.querySelector('[data-fui-sortable-container="a"] [data-fui-sort-key="k1"]')`, &k1InA),
 	); err != nil {

--- a/framework/docs/content/ui-new-components.md
+++ b/framework/docs/content/ui-new-components.md
@@ -282,13 +282,18 @@ Three more knobs round out the contract surface:
   64px icon rail at >= md viewports and reveals the full column on
   hover or keyboard focus (`:focus-within`), straight from the
   component's stylesheet — no JavaScript, no host CSS.
-- `Prepend` is HTML rendered between the title and the `<nav>` on every
-  body path: the inline column, `SidebarBody`, and the `MountSidebar`
-  drawer. A docs site whose phone header hides its section tabs puts
-  the section `<select>` here, so the drawer (the only navigation at
-  that width) carries it without forking the mount. It hides with the
-  title in the collapsed rail and the auto-hide rest state; `Footer`
-  stays below the nav.
+- `Prepend` is a component rendered between the title and the `<nav>`
+  on every body path: the inline column, `SidebarBody`, and the
+  `MountSidebar` drawer. A docs site whose phone header hides its
+  section tabs puts the section `<select>` here, so the drawer (the
+  only navigation at that width) carries it without forking the mount.
+  It takes a `component.Component` rather than HTML because
+  `MountSidebar` runs once at boot while the drawer body renders per
+  request: a Prepend that implements `component.ContextComponent`
+  sees the request on the inline and drawer paths alike, so the select
+  can mark the current section. Wrap static markup in
+  `app.NewStaticComponent`. It hides with the title in the collapsed
+  rail and the auto-hide rest state; `Footer` stays below the nav.
 
 ---
 

--- a/framework/docs/content/ui-new-components.md
+++ b/framework/docs/content/ui-new-components.md
@@ -282,6 +282,13 @@ Three more knobs round out the contract surface:
   64px icon rail at >= md viewports and reveals the full column on
   hover or keyboard focus (`:focus-within`), straight from the
   component's stylesheet — no JavaScript, no host CSS.
+- `Prepend` is HTML rendered between the title and the `<nav>` on every
+  body path: the inline column, `SidebarBody`, and the `MountSidebar`
+  drawer. A docs site whose phone header hides its section tabs puts
+  the section `<select>` here, so the drawer (the only navigation at
+  that width) carries it without forking the mount. It hides with the
+  title in the collapsed rail and the auto-hide rest state; `Footer`
+  stays below the nav.
 
 ---
 

--- a/framework/ui/css_wellformed_test.go
+++ b/framework/ui/css_wellformed_test.go
@@ -1,0 +1,71 @@
+package ui_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/registry"
+	"github.com/DonaldMurillo/gofastr/framework/ui/theme"
+)
+
+var cssComment = regexp.MustCompile(`(?s)/\*.*?\*/`)
+
+// Every component stylesheet is a Go string literal nobody parses before
+// the browser does, and the browser drops a malformed rule without a
+// word. The sidebar's auto-hide reveal rule shipped with its selector
+// list ending in a comma and no opening brace; the rail never widened
+// and every selector-text test stayed green. This walks every registered
+// stylesheet and rejects the two shapes that bug takes: a brace depth
+// that goes negative or does not return to zero, and a declaration (`;`)
+// sitting where a selector list belongs.
+func TestRegisteredStylesheetsAreWellFormed(t *testing.T) {
+	th := theme.Default()
+	entries := registry.All()
+	if len(entries) == 0 {
+		t.Fatal("no registered stylesheets: the walk is vacuous")
+	}
+	for _, e := range entries {
+		css := cssComment.ReplaceAllString(e.CSSFor(th), "")
+		depth := 0
+		selectorStart := 0
+		for i, c := range css {
+			switch c {
+			case '{':
+				depth++
+			case '}':
+				depth--
+				if depth < 0 {
+					t.Errorf("%s: unbalanced '}' at byte %d (a rule before it has no opening brace):\n%s", e.Name, i, excerpt(css, i))
+					depth = 0
+				}
+				selectorStart = i + 1
+			case ';':
+				if depth == 0 {
+					sel := strings.TrimSpace(css[selectorStart:i])
+					// @import/@charset/@namespace end in ';' at depth 0 and are
+					// legitimate; a component sheet has no business shipping
+					// them, but do not fail on the syntax itself.
+					if !strings.HasPrefix(sel, "@") {
+						t.Errorf("%s: declaration outside any rule block at byte %d (selector list missing its '{'):\n%s", e.Name, i, excerpt(css, i))
+					}
+					selectorStart = i + 1
+				}
+			}
+		}
+		if depth != 0 {
+			t.Errorf("%s: brace depth ends at %d, expected 0", e.Name, depth)
+		}
+	}
+}
+
+func excerpt(css string, at int) string {
+	lo, hi := at-160, at+40
+	if lo < 0 {
+		lo = 0
+	}
+	if hi > len(css) {
+		hi = len(css)
+	}
+	return css[lo:hi]
+}

--- a/framework/ui/sidebar.go
+++ b/framework/ui/sidebar.go
@@ -199,6 +199,14 @@ type SidebarConfig struct {
 	// plus a hidden-when-closed container of the child links.
 	GroupMarkup SidebarGroupMarkup
 
+	// Prepend is optional content rendered between the title and the
+	// nav, on every body path: the inline sidebar, SidebarBody, and the
+	// MountSidebar drawer. Use it for a section switcher that the
+	// phone drawer must carry because the header hides it there.
+	// Hidden with the title in the collapsed rail and the auto-hide
+	// rest state. Empty emits no markup.
+	Prepend render.HTML
+
 	// Footer is optional content rendered at the bottom (signed-in
 	// user pill, settings link, etc.).
 	Footer render.HTML
@@ -446,6 +454,9 @@ func sidebarBody(cfg SidebarConfig, idPrefix string) render.HTML {
 	var b strings.Builder
 	if cfg.Title != "" {
 		b.WriteString(`<h2 class="ui-sidebar__title">` + render.Escape(cfg.Title) + `</h2>`)
+	}
+	if cfg.Prepend != "" {
+		b.WriteString(`<div class="ui-sidebar__prepend">` + string(cfg.Prepend) + `</div>`)
 	}
 	label := cfg.NavLabel
 	if label == "" {
@@ -813,6 +824,10 @@ func sidebarCSS(_ style.Theme) string {
   padding-top: var(--spacing-md, 8px);
   border-top: 1px solid var(--color-border, #E4E4E7);
 }
+[data-fui-comp="ui-sidebar"] .ui-sidebar__prepend {
+  padding-bottom: var(--spacing-md, 8px);
+  border-bottom: 1px solid var(--color-border, #E4E4E7);
+}
 [data-fui-comp="ui-sidebar"].ui-sidebar--collapsible[data-collapsed="true"] .ui-sidebar__inline {
   min-width: 64px;
   width: 64px;
@@ -823,6 +838,7 @@ func sidebarCSS(_ style.Theme) string {
   transform: rotate(180deg);
 }
 [data-fui-comp="ui-sidebar"].ui-sidebar--collapsible[data-collapsed="true"] .ui-sidebar__title,
+[data-fui-comp="ui-sidebar"].ui-sidebar--collapsible[data-collapsed="true"] .ui-sidebar__prepend,
 [data-fui-comp="ui-sidebar"].ui-sidebar--collapsible[data-collapsed="true"] .ui-sidebar__footer,
 [data-fui-comp="ui-sidebar"].ui-sidebar--collapsible[data-collapsed="true"] .ui-sidebar__sublist {
   display: none;
@@ -882,6 +898,7 @@ func sidebarCSS(_ style.Theme) string {
    or focus-within they stop matching and the base (expanded) styles
    take over, so the reveal needs no mirrored overrides. */
 [data-fui-comp="ui-sidebar"].ui-sidebar--auto-hide:not(:hover):not(:focus-within) .ui-sidebar__title,
+[data-fui-comp="ui-sidebar"].ui-sidebar--auto-hide:not(:hover):not(:focus-within) .ui-sidebar__prepend,
 [data-fui-comp="ui-sidebar"].ui-sidebar--auto-hide:not(:hover):not(:focus-within) .ui-sidebar__footer,
 [data-fui-comp="ui-sidebar"].ui-sidebar--auto-hide:not(:hover):not(:focus-within) .ui-sidebar__sublist {
   display: none;

--- a/framework/ui/sidebar.go
+++ b/framework/ui/sidebar.go
@@ -897,7 +897,7 @@ func sidebarCSS(_ style.Theme) string {
     padding-inline var(--duration-fast, 150ms) var(--easing-ease-out, cubic-bezier(0.16, 1, 0.3, 1));
 }
 [data-fui-comp="ui-sidebar"].ui-sidebar--auto-hide:hover .ui-sidebar__inline,
-[data-fui-comp="ui-sidebar"].ui-sidebar--auto-hide:focus-within .ui-sidebar__inline,
+[data-fui-comp="ui-sidebar"].ui-sidebar--auto-hide:focus-within .ui-sidebar__inline {
   min-width: 220px;
   width: 220px;
   padding-inline: var(--spacing-lg, 16px);

--- a/framework/ui/sidebar.go
+++ b/framework/ui/sidebar.go
@@ -199,13 +199,17 @@ type SidebarConfig struct {
 	// plus a hidden-when-closed container of the child links.
 	GroupMarkup SidebarGroupMarkup
 
-	// Prepend is optional content rendered between the title and the
-	// nav, on every body path: the inline sidebar, SidebarBody, and the
-	// MountSidebar drawer. Use it for a section switcher that the
-	// phone drawer must carry because the header hides it there.
-	// Hidden with the title in the collapsed rail and the auto-hide
-	// rest state. Empty emits no markup.
-	Prepend render.HTML
+	// Prepend is an optional component rendered between the title and
+	// the nav, on every body path: the inline sidebar, SidebarBody, and
+	// the MountSidebar drawer. Use it for a section switcher that the
+	// phone drawer must carry because the header hides it there. It is
+	// a component, not HTML, because MountSidebar runs once at boot and
+	// the drawer body renders per request: a Prepend that implements
+	// component.ContextComponent sees the request (current section,
+	// signed-in user) on the inline and drawer paths alike. Wrap static
+	// markup in app.NewStaticComponent. Hidden with the title in the
+	// collapsed rail and the auto-hide rest state. Nil emits no markup.
+	Prepend component.Component
 
 	// Footer is optional content rendered at the bottom (signed-in
 	// user pill, settings link, etc.).
@@ -323,12 +327,12 @@ type sidebarComponent struct{ cfg SidebarConfig }
 // threads the request context here (WrapCtx), so role-gated entries (e.g. an
 // admin-only link) never appear for users who lack the role.
 func (s sidebarComponent) RenderCtx(ctx context.Context) render.HTML {
-	return sidebarComponent{cfg: s.cfg.withFilteredItems(ctx)}.render()
+	return sidebarComponent{cfg: s.cfg.withFilteredItems(ctx)}.render(ctx)
 }
 
-func (s sidebarComponent) Render() render.HTML { return s.render() }
+func (s sidebarComponent) Render() render.HTML { return s.render(context.Background()) }
 
-func (s sidebarComponent) render() render.HTML {
+func (s sidebarComponent) render(ctx context.Context) render.HTML {
 	// Unknown variants panic like every other variant-taking component
 	// (Card, Button, Notification). A typo'd variant used to render
 	// an unstyled ui-sidebar--<anything> class silently. Empty is the
@@ -417,14 +421,16 @@ func (s sidebarComponent) render() render.HTML {
 		}
 		b.WriteString(`><span aria-hidden="true">‹</span></button>`)
 	}
-	b.WriteString(string(sidebarBody(cfg, inlineID)))
+	b.WriteString(string(sidebarBody(ctx, cfg, inlineID)))
 	b.WriteString(`</div></div>`)
 	return sidebarStyle.WrapHTML(render.HTML(b.String()))
 }
 
 // SidebarBody renders the navigation content only: no sidebar shell,
 // no hamburger. Use it as the Slot content of a preset.Drawer widget
-// that mirrors the sidebar at narrow viewports.
+// that mirrors the sidebar at narrow viewports. It has no request
+// context, so a context-aware Prepend renders its Render fallback
+// here; MountSidebar's drawer renders it per request.
 func SidebarBody(cfg SidebarConfig) render.HTML {
 	if cfg.Variant == "" {
 		cfg.Variant = SidebarPersistent
@@ -445,18 +451,18 @@ func SidebarBody(cfg SidebarConfig) render.HTML {
 	// the .ui-sidebar base rule keeps the wrapper box-free.
 	return sidebarStyle.WrapHTML(render.HTML(
 		`<div class="ui-sidebar ui-sidebar__body">` +
-			string(sidebarBody(cfg, cfg.DrawerName+"-body")) +
+			string(sidebarBody(context.Background(), cfg, cfg.DrawerName+"-body")) +
 			`</div>`))
 }
 
-func sidebarBody(cfg SidebarConfig, idPrefix string) render.HTML {
+func sidebarBody(ctx context.Context, cfg SidebarConfig, idPrefix string) render.HTML {
 	checkSidebarGroupMarkup(cfg.GroupMarkup)
 	var b strings.Builder
 	if cfg.Title != "" {
 		b.WriteString(`<h2 class="ui-sidebar__title">` + render.Escape(cfg.Title) + `</h2>`)
 	}
-	if cfg.Prepend != "" {
-		b.WriteString(`<div class="ui-sidebar__prepend">` + string(cfg.Prepend) + `</div>`)
+	if cfg.Prepend != nil {
+		b.WriteString(`<div class="ui-sidebar__prepend">` + string(component.RenderComponentCtx(ctx, cfg.Prepend)) + `</div>`)
 	}
 	label := cfg.NavLabel
 	if label == "" {
@@ -609,15 +615,17 @@ type sidebarDrawerSlot struct{ cfg SidebarConfig }
 // context here, so the mobile drawer hides the same role-gated entries the
 // desktop sidebar does.
 func (s sidebarDrawerSlot) RenderCtx(ctx context.Context) render.HTML {
-	return sidebarDrawerSlot{cfg: s.cfg.withFilteredItems(ctx)}.Render()
+	return sidebarDrawerSlot{cfg: s.cfg.withFilteredItems(ctx)}.render(ctx)
 }
 
-func (s sidebarDrawerSlot) Render() render.HTML {
+func (s sidebarDrawerSlot) Render() render.HTML { return s.render(context.Background()) }
+
+func (s sidebarDrawerSlot) render(ctx context.Context) render.HTML {
 	// "-drawer" prefix keeps button-dialect group ids distinct from
 	// the inline sidebar's when both are in the DOM.
 	return sidebarStyle.WrapHTML(render.HTML(
 		`<div class="ui-sidebar ui-sidebar--drawer-body">` +
-			string(sidebarBody(s.cfg, s.cfg.DrawerName+"-drawer")) +
+			string(sidebarBody(ctx, s.cfg, s.cfg.DrawerName+"-drawer")) +
 			`</div>`,
 	))
 }

--- a/framework/ui/sidebar_autohide_chromium_test.go
+++ b/framework/ui/sidebar_autohide_chromium_test.go
@@ -1,0 +1,104 @@
+//go:build chromium
+
+package ui
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/DonaldMurillo/gofastr/core-ui/component"
+	"github.com/DonaldMurillo/gofastr/framework/ui/theme"
+	"github.com/chromedp/chromedp"
+)
+
+// Hard rule 9: whether the auto-hide rail actually widens on reveal is
+// layout, invisible to a stylesheet string check. The reveal rule shipped
+// for a week with its selector list ending in a comma and no opening
+// brace; the browser dropped the whole rule, so hover and keyboard focus
+// left the column at 64px while the base rules brought the labels and
+// footer back inside it. Every selector-text test stayed green. This
+// renders the variant in Chrome, focuses a link, and measures.
+func TestAutoHideRailWidensOnFocus(t *testing.T) {
+	page := component.RenderComponent(Sidebar(SidebarConfig{
+		Title:   "App",
+		Variant: SidebarAutoHide,
+		Items: []SidebarItem{
+			{Label: "Overview", Href: "/"},
+			{Label: "Customers", Href: "/customers"},
+		},
+		Footer: "<a href=\"/logout\">Sign out</a>",
+	}))
+	css := sidebarStyle.Entry().CSSFor(theme.Default())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, `<!doctype html><meta charset=utf-8>
+<style>body{margin:0;display:flex;min-height:100vh}%s
+%s</style>%s<main>content</main>`, theme.Default().CSSCustomProperties(), css, string(page))
+	}))
+	defer srv.Close()
+
+	allocCtx, cancelAlloc := chromedp.NewExecAllocator(context.Background(),
+		append(chromedp.DefaultExecAllocatorOptions[:],
+			chromedp.WSURLReadTimeout(90*time.Second),
+			chromedp.NoSandbox)...)
+	defer cancelAlloc()
+	ctx, cancel := chromedp.NewContext(allocCtx)
+	defer cancel()
+	ctx, cancelTimeout := context.WithTimeout(ctx, 60*time.Second)
+	defer cancelTimeout()
+
+	// Computed width is the content box (64px / 220px); the border box
+	// adds the rail padding and would tie the test to a spacing token.
+	const width = `getComputedStyle(document.querySelector('.ui-sidebar__inline')).width`
+	var rest, revealed string
+	// The malformed rule also swallowed the rest-state rule that follows
+	// it, so the title and footer leaked into the 64px rail; pin both.
+	const titleDisplay = `getComputedStyle(document.querySelector('.ui-sidebar__title')).display`
+	var titleRest, titleRevealed string
+	var restShot, revealedShot []byte
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(srv.URL),
+		// >= md so the inline column is the one on screen, not the drawer.
+		chromedp.EmulateViewport(1280, 800),
+		// Poll on presence: chromedp.WaitVisible never settled on this
+		// node (display:contents parent) even with the box painted.
+		chromedp.Poll(`!!document.querySelector('.ui-sidebar__inline a')`, nil,
+			chromedp.WithPollingTimeout(15*time.Second), chromedp.WithPollingInterval(50*time.Millisecond)),
+		chromedp.Evaluate(width, &rest),
+		chromedp.Evaluate(titleDisplay, &titleRest),
+		chromedp.CaptureScreenshot(&restShot),
+		// Keyboard focus is the deterministic reveal path (:focus-within);
+		// it is also the one that matters for a11y, hover being optional.
+		chromedp.Evaluate(`document.querySelector('.ui-sidebar__inline a').focus()`, nil),
+		// The width transitions over --duration-fast (150ms); wait it out.
+		chromedp.Sleep(400*time.Millisecond),
+		chromedp.Evaluate(width, &revealed),
+		chromedp.Evaluate(titleDisplay, &titleRevealed),
+		chromedp.CaptureScreenshot(&revealedShot),
+	); err != nil {
+		t.Fatalf("chromedp: %v", err)
+	}
+	if dir := os.Getenv("GOFASTR_VISUAL_DIR"); dir != "" {
+		_ = os.WriteFile(filepath.Join(dir, "sidebar-autohide-rest.png"), restShot, 0o600)
+		_ = os.WriteFile(filepath.Join(dir, "sidebar-autohide-revealed.png"), revealedShot, 0o600)
+	}
+	if rest != "64px" {
+		t.Errorf("auto-hide rail at rest should be 64px wide, got %v", rest)
+	}
+	if revealed != "220px" {
+		t.Errorf("auto-hide rail should widen to 220px on focus-within, got %v (rest %v)", revealed, rest)
+	}
+	if titleRest != "none" {
+		t.Errorf("auto-hide rail at rest should hide the title, got display %q", titleRest)
+	}
+	if titleRevealed == "none" {
+		t.Errorf("auto-hide reveal should show the title again, got display %q", titleRevealed)
+	}
+}

--- a/framework/ui/sidebar_css_test.go
+++ b/framework/ui/sidebar_css_test.go
@@ -86,15 +86,26 @@ func TestCalloutHiddenAttributeWins(t *testing.T) {
 
 // The collapsed rail and the auto-hide rest state hide the title and
 // footer; Prepend is chrome of the same kind and must hide with them,
-// or a section <select> would poke out of a 64px rail (#405).
+// or a section <select> would poke out of a 64px rail (#405). The
+// selector alone is not the guard: the rule it belongs to has to
+// declare display:none, so a malformed or emptied rule fails here.
 func TestSidebarPrependHidesWithTitleAndFooter(t *testing.T) {
 	css := sidebarCSS(style.Theme{})
 	for _, state := range []string{
-		`[data-collapsed="true"] .ui-sidebar__prepend`,
-		`.ui-sidebar--auto-hide:not(:hover):not(:focus-within) .ui-sidebar__prepend`,
+		`[data-collapsed="true"] .ui-sidebar__prepend,`,
+		`.ui-sidebar--auto-hide:not(:hover):not(:focus-within) .ui-sidebar__prepend,`,
 	} {
-		if !strings.Contains(css, state) {
+		start := strings.Index(css, state)
+		if start == -1 {
 			t.Errorf("sidebar CSS must hide .ui-sidebar__prepend in state %q", state)
+			continue
+		}
+		block := css[start:]
+		if end := strings.Index(block, "}"); end != -1 {
+			block = block[:end]
+		}
+		if !strings.Contains(block, "display: none") {
+			t.Errorf("the rule hiding .ui-sidebar__prepend in state %q must set display:none:\n%s", state, block)
 		}
 	}
 }

--- a/framework/ui/sidebar_css_test.go
+++ b/framework/ui/sidebar_css_test.go
@@ -59,8 +59,25 @@ func TestAutoHideVariantShipsRevealCSS(t *testing.T) {
 	if !strings.Contains(css, `.ui-sidebar--auto-hide:hover .ui-sidebar__inline`) {
 		t.Fatal("auto-hide must ship a :hover reveal rule in the component stylesheet")
 	}
-	if !strings.Contains(css, `.ui-sidebar--auto-hide:focus-within .ui-sidebar__inline`) {
+	sel := `.ui-sidebar--auto-hide:focus-within .ui-sidebar__inline`
+	start := strings.Index(css, sel)
+	if start == -1 {
 		t.Fatal("auto-hide must ship a :focus-within reveal rule — hover-only hides every link from keyboard users")
+	}
+	// Selector text is not the rule. The reveal shipped once with its
+	// selector list ending in a comma and no opening brace; the browser
+	// dropped it and the rail never widened while this test stayed
+	// green. The selector must be followed by " {" and a block that
+	// restores the persistent column width.
+	block := css[start+len(sel):]
+	if !strings.HasPrefix(block, " {") {
+		t.Fatalf("reveal selector list must open its declaration block, got: %.40q", block)
+	}
+	if end := strings.Index(block, "}"); end != -1 {
+		block = block[:end]
+	}
+	if !strings.Contains(block, "width: 220px") {
+		t.Fatalf("reveal rule must restore the 220px column:\n%s", block)
 	}
 }
 

--- a/framework/ui/sidebar_css_test.go
+++ b/framework/ui/sidebar_css_test.go
@@ -83,3 +83,18 @@ func TestCalloutHiddenAttributeWins(t *testing.T) {
 		t.Fatalf("callout[hidden] rule must set display:none:\n%s", block)
 	}
 }
+
+// The collapsed rail and the auto-hide rest state hide the title and
+// footer; Prepend is chrome of the same kind and must hide with them,
+// or a section <select> would poke out of a 64px rail (#405).
+func TestSidebarPrependHidesWithTitleAndFooter(t *testing.T) {
+	css := sidebarCSS(style.Theme{})
+	for _, state := range []string{
+		`[data-collapsed="true"] .ui-sidebar__prepend`,
+		`.ui-sidebar--auto-hide:not(:hover):not(:focus-within) .ui-sidebar__prepend`,
+	} {
+		if !strings.Contains(css, state) {
+			t.Errorf("sidebar CSS must hide .ui-sidebar__prepend in state %q", state)
+		}
+	}
+}

--- a/framework/ui/sidebar_drawer_test.go
+++ b/framework/ui/sidebar_drawer_test.go
@@ -1,9 +1,11 @@
 package ui
 
 import (
+	"context"
 	"strings"
 	"testing"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/component"
 	"github.com/DonaldMurillo/gofastr/core/render"
 )
 
@@ -31,18 +33,39 @@ func TestSidebarDrawerSlotGroupIdsUseDrawerPrefix(t *testing.T) {
 	}
 }
 
+// sectionKey is the request-scoped value a context-aware Prepend reads.
+type sectionKey struct{}
+
+// ctxPrepend renders the current section from the request context. It
+// stands in for a docs site's section switcher: MountSidebar runs once
+// at boot, so only a per-request render can mark the right option.
+type ctxPrepend struct{ component.ContextOnly }
+
+func (ctxPrepend) RenderCtx(ctx context.Context) render.HTML {
+	section, _ := ctx.Value(sectionKey{}).(string)
+	return render.HTML(`<select id="section"><option selected>` + render.Escape(section) + `</option></select>`)
+}
+
 // The drawer body is the only navigation below the md breakpoint, so
-// Prepend has to reach it too, not only the inline sidebar (#405).
-func TestSidebarDrawerSlotCarriesPrepend(t *testing.T) {
+// Prepend has to reach it too, not only the inline sidebar (#405), and
+// it has to reach it WITH the request: the drawer chrome is served per
+// request, and a Prepend that implements ContextComponent must see
+// that context on both the drawer and the inline path.
+func TestSidebarPrependRendersWithRequestCtx(t *testing.T) {
 	cfg := SidebarConfig{
 		DrawerName: "docs-nav",
-		Prepend:    render.HTML(`<select id="section"></select>`),
+		Prepend:    ctxPrepend{},
 		Items:      []SidebarItem{{Label: "Home", Href: "/"}},
 	}
-	out := string(sidebarDrawerSlot{cfg: cfg}.Render())
-	pre := strings.Index(out, `<div class="ui-sidebar__prepend"><select id="section">`)
-	nav := strings.Index(out, `<nav class="ui-sidebar__nav"`)
-	if pre < 0 || nav < 0 || pre > nav {
-		t.Errorf("drawer slot must render Prepend above the nav (prepend=%d nav=%d):\n%s", pre, nav, out)
+	ctx := context.WithValue(context.Background(), sectionKey{}, "Batteries")
+	for name, out := range map[string]string{
+		"drawer": string(sidebarDrawerSlot{cfg: cfg}.RenderCtx(ctx)),
+		"inline": string(sidebarComponent{cfg: cfg}.RenderCtx(ctx)),
+	} {
+		pre := strings.Index(out, `<div class="ui-sidebar__prepend"><select id="section"><option selected>Batteries</option>`)
+		nav := strings.Index(out, `<nav class="ui-sidebar__nav"`)
+		if pre < 0 || nav < 0 || pre > nav {
+			t.Errorf("%s: Prepend must render with the request ctx above the nav (prepend=%d nav=%d):\n%s", name, pre, nav, out)
+		}
 	}
 }

--- a/framework/ui/sidebar_drawer_test.go
+++ b/framework/ui/sidebar_drawer_test.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"strings"
 	"testing"
+
+	"github.com/DonaldMurillo/gofastr/core/render"
 )
 
 // In-package on purpose: sidebarDrawerSlot (the MountSidebar drawer's
@@ -26,5 +28,21 @@ func TestSidebarDrawerSlotGroupIdsUseDrawerPrefix(t *testing.T) {
 	}
 	if !strings.Contains(out, `<ul class="ui-sidebar__sublist" id="workspace-nav-drawer-g1" hidden>`) {
 		t.Errorf("drawer slot group container must carry the -drawer-prefixed id:\n%s", out)
+	}
+}
+
+// The drawer body is the only navigation below the md breakpoint, so
+// Prepend has to reach it too, not only the inline sidebar (#405).
+func TestSidebarDrawerSlotCarriesPrepend(t *testing.T) {
+	cfg := SidebarConfig{
+		DrawerName: "docs-nav",
+		Prepend:    render.HTML(`<select id="section"></select>`),
+		Items:      []SidebarItem{{Label: "Home", Href: "/"}},
+	}
+	out := string(sidebarDrawerSlot{cfg: cfg}.Render())
+	pre := strings.Index(out, `<div class="ui-sidebar__prepend"><select id="section">`)
+	nav := strings.Index(out, `<nav class="ui-sidebar__nav"`)
+	if pre < 0 || nav < 0 || pre > nav {
+		t.Errorf("drawer slot must render Prepend above the nav (prepend=%d nav=%d):\n%s", pre, nav, out)
 	}
 }

--- a/framework/ui/sidebar_test.go
+++ b/framework/ui/sidebar_test.go
@@ -431,3 +431,30 @@ func TestSidebarGroupOpenByDefault(t *testing.T) {
 		t.Fatalf("want exactly one expanded group, got %d", got)
 	}
 }
+
+// Prepend renders between the title and the nav on every body path
+// (inline sidebar, SidebarBody, and the MountSidebar drawer), so a
+// host can put a section switcher above the nav tree without forking
+// the drawer mount (#405). An empty field emits no wrapper.
+func TestSidebarPrependSitsBetweenTitleAndNav(t *testing.T) {
+	cfg := ui.SidebarConfig{
+		Title:   "Docs",
+		Prepend: render.HTML(`<select id="section"><option>Guides</option></select>`),
+		Items:   []ui.SidebarItem{{Label: "Home", Href: "/"}},
+	}
+	for name, out := range map[string]string{
+		"inline": string(component.RenderComponent(ui.Sidebar(cfg))),
+		"body":   string(ui.SidebarBody(cfg)),
+	} {
+		title := strings.Index(out, `ui-sidebar__title`)
+		pre := strings.Index(out, `<div class="ui-sidebar__prepend"><select id="section">`)
+		nav := strings.Index(out, `<nav class="ui-sidebar__nav"`)
+		if title < 0 || pre < 0 || nav < 0 || !(title < pre && pre < nav) {
+			t.Errorf("%s: prepend must sit between title and nav (title=%d prepend=%d nav=%d):\n%s", name, title, pre, nav, out)
+		}
+	}
+	plain := string(ui.SidebarBody(ui.SidebarConfig{Items: cfg.Items}))
+	if strings.Contains(plain, "ui-sidebar__prepend") {
+		t.Errorf("empty Prepend must emit no wrapper:\n%s", plain)
+	}
+}

--- a/framework/ui/sidebar_test.go
+++ b/framework/ui/sidebar_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DonaldMurillo/gofastr/core-ui/app"
 	"github.com/DonaldMurillo/gofastr/core-ui/component"
 	"github.com/DonaldMurillo/gofastr/core/render"
 	"github.com/DonaldMurillo/gofastr/framework/ui"
@@ -439,7 +440,7 @@ func TestSidebarGroupOpenByDefault(t *testing.T) {
 func TestSidebarPrependSitsBetweenTitleAndNav(t *testing.T) {
 	cfg := ui.SidebarConfig{
 		Title:   "Docs",
-		Prepend: render.HTML(`<select id="section"><option>Guides</option></select>`),
+		Prepend: app.NewStaticComponent(render.HTML(`<select id="section"><option>Guides</option></select>`)),
 		Items:   []ui.SidebarItem{{Label: "Home", Href: "/"}},
 	}
 	for name, out := range map[string]string{

--- a/framework/ui/ui_modal_drawer_security_test.go
+++ b/framework/ui/ui_modal_drawer_security_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"testing"
@@ -156,7 +157,7 @@ func TestModal_IDInjection(t *testing.T) {
 // drawer body) containing <script> tags is escaped via render.Escape().
 func TestDrawer_TitleXSS(t *testing.T) {
 	t.Parallel()
-	h := string(sidebarBody(SidebarConfig{
+	h := string(sidebarBody(context.Background(), SidebarConfig{
 		Title: `<script>alert("xss")</script>`,
 		Items: []SidebarItem{{Label: "Home", Href: "/"}},
 	}, "t"))
@@ -170,7 +171,7 @@ func TestDrawer_TitleXSS(t *testing.T) {
 // script tags are escaped. The key protection is < → &lt;.
 func TestDrawer_BodyXSS(t *testing.T) {
 	t.Parallel()
-	h := string(sidebarBody(SidebarConfig{
+	h := string(sidebarBody(context.Background(), SidebarConfig{
 		Items: []SidebarItem{
 			{Label: `<img src=x onerror="alert(1)">`, Href: "/safe"},
 		},
@@ -203,7 +204,7 @@ func TestDrawer_PositionInjection(t *testing.T) {
 // class-injection payloads are rendered safely in text node context.
 func TestDrawer_ClassInjection(t *testing.T) {
 	t.Parallel()
-	h := string(sidebarBody(SidebarConfig{
+	h := string(sidebarBody(context.Background(), SidebarConfig{
 		Items: []SidebarItem{
 			{Label: `" onclick="alert(1)" data-x="`, Href: "/safe"},
 		},


### PR DESCRIPTION
Two open issues in one PR to save a CI run.

## #405 — `SidebarConfig.Prepend`

`MountSidebar` hardcodes the drawer body to the nav, so a docs site whose phone header hides its section tabs had no supported way to put a section `<select>` above the nav tree in the drawer. The only path was to copy the mount and drift from it.

- New `Prepend render.HTML` field, rendered between the title and the `<nav>` in `sidebarBody`, so the inline column, `SidebarBody`, and the drawer all carry it. Empty emits no markup.
- CSS: `.ui-sidebar__prepend` hides with the title and footer in the collapsed rail and the auto-hide rest state.
- Tests: position between title and nav on the inline and body paths, presence in the drawer slot, hide rules in the stylesheet.
- Docs: `ui-new-components.md` sidebar knob list, changelog Added.

Verified with rendered screenshots of the inline column, the collapsed rail (select hidden, rail intact), and the drawer body. The Meridian visual canary passes; its app sidebar is unchanged.

## #398 — sortable 409 e2e flake

`TestSortable_409InvariantMessage` slept 500ms and then read the live region. Under CI load the 409 round trip landed later and the test read the preceding move announcement.

- The 409 family now polls with a bounded 10s timeout: message tests wait for their announcement, fallback tests for the generic copy, DOM-shape tests for the refreshed column or the rollback announcement.
- The runtime announces only after the refresh replaced the DOM, so the announcement also proves the refresh landed. A leaked or wrong message never matches and the poll times out into a failure.
- Proven by delaying the 409 response 1.5s: the sleep-based test failed with the exact CI message, the polled family passed. Full `TestSortable` suite green afterwards.

Sleeps in the non-409 sortable tests (pure client-side moves, no network round trip) are untouched.

Closes #405
Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbQihscvruKasD9fXthoHs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional sidebar content area displayed between the title and navigation.
  * Supported across inline, body, and drawer sidebar layouts.
  * Content can adapt to the current request and hides with the title in collapsed and auto-hide states.
* **Documentation**
  * Documented sidebar content placement, behavior, and footer positioning.
* **Bug Fixes**
  * Improved sortable-list conflict handling and update announcements for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->