### PR TITLE
chore(release): v0.85.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ stabilises). Breaking changes are clearly marked with **BREAKING**.
 
 ## [Unreleased]
 
+## [0.85.0] - 2026-09-08
+
 ### Security
 - **Round-4 adversarial probes: 54 over twelve property families the
   earlier rounds never opened (authorization at derived surfaces,
@@ -78,7 +80,7 @@ and `/api/docs/openapi.json` now filter entities by the caller's
 read scope (an entity the caller cannot read is omitted, matching
 `/api/llm.md`); `WithPublicOpenAPI` opts into the full, unfiltered
 document.
-+
+
 - **Round-5 adversarial probes: 130 probe files, 158 failing findings
   and 2 data races over the families the earlier rounds never opened
   (log-side scrubbing of panic payloads, stream-seat exhaustion,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ Honest expectations:
 
 ## Supported versions
 
-GoFastr is pre-1.0. Only the **latest minor release** (currently `0.84.x`)
+GoFastr is pre-1.0. Only the **latest minor release** (currently `0.85.x`)
 receives security fixes. Older `0.x` lines are not patched. Upgrade to
 the latest release to stay supported.
 

--- a/cmd/gofastr/upgrades.yml
+++ b/cmd/gofastr/upgrades.yml
@@ -19,7 +19,7 @@
 # The registry is complete through this release: releases ≤ through
 # with no entry below genuinely had no migration-relevant changes.
 # Targets beyond it make the CLI warn that it may be out of date.
-through: v0.84.1
+through: v0.85.0
 
 releases:
   - version: v0.3.0
@@ -1064,3 +1064,51 @@ releases:
       - change: "a static export below a base path carries the base in its embedded route graph, so client-side navigation works on a GitHub project page; exported per-component stylesheet links carry the data-fui-style marker so the runtime does not load them a second time after app.css"
         breaking: false
         guidance: "Re-export. A site that patched either in its own export step can drop the patch; nothing else changes."
+  - version: v0.85.0
+    title: Red-probe rounds 4 and 5, per-language shells, widget lifecycle, CodeBlock options
+    notes:
+      - change: "an MCP tool handler's plain error is answered to the caller as a generic internal tool error (its text is logged server-side); a message meant for the caller is returned as *mcp.RPCError or mcp.ToolResult{IsError: true}"
+        breaking: true
+        detect: 'RegisterTool\(|mcp\.Tool\{'
+        guidance: "Grep your tool handlers for fmt.Errorf/errors.New returned to the caller as user-facing text and switch those to mcp.ToolResult{IsError: true} or *mcp.RPCError; mcp.Gated and the framework's own tools already did."
+      - change: "a duplicate multipart form key is refused for a scalar field and collected into a list for a schema.JSON field, matching the JSON body path"
+        breaking: true
+        detect: 'schema\.JSON|ParseMultipartForm\(|FormFile\('
+        guidance: "A client that sent a scalar field twice and relied on last-wins now gets 400; send it once. A JSON-typed field receives the list."
+      - change: "/openapi.json and /api/docs/openapi.json filter entities by the caller's read scope; WithPublicOpenAPI opts into the full document"
+        breaking: true
+        detect: 'openapi\.json|WithOpenAPI\(|WithPublicOpenAPI\('
+        guidance: "A tooling flow that fetched the spec anonymously to see every entity now sees only what an anonymous caller can read; authenticate the fetch, or call WithPublicOpenAPI on an app whose whole schema is public."
+      - change: "magic-link, password-reset, and email-verification tokens are stored as sha256 digests, so tokens minted before the upgrade stop redeeming"
+        breaking: true
+        detect: 'battery/auth"'
+        guidance: "They are short-lived: wait out the TTL or re-send. Nothing to change in code; a custom token store must store the digest the battery now looks up."
+      - change: "RequireSession, SessionPolicy, and RolePolicy answer 401 to callers authenticated only by an API token"
+        breaking: true
+        detect: 'RequireSession\(|SessionPolicy|RolePolicy'
+        guidance: "A route meant for API tokens uses RequireAuth or RequireAPIScopes; the session-only policies now mean what their names say."
+      - change: "a CRUD create or update whose BelongsTo foreign key names an owner-, tenant-, or read-scoped row the caller cannot read answers 404"
+        breaking: true
+        detect: 'BelongsTo'
+        guidance: "Exemptions are explicit: owner.AllowCrossOwner, the target's CrossOwnerRead permission, tenant.AllowCrossTenant, or WithServerWrites for server-side writes. A client that pointed a record at another user's parent by guessing ids was the bug."
+      - change: "kiln's update_entity requires an approved plan (PlanID); pre-existing journals with ungated update_entity entries fail replay"
+        breaking: true
+        detect: 'update_entity|kiln/'
+        guidance: "Re-record the affected journals through the plan flow; an entry recorded without a plan cannot be replayed."
+      - change: "generated CLIs drop the --token flag; the token resolves from $PREFIX_TOKEN, the stored config, or login --with-token reading stdin"
+        breaking: true
+        detect: '--token'
+        guidance: "Re-generate the CLI and update scripts that passed --token on the command line (visible to every local process via ps) to export the env var or pipe the token into login --with-token."
+      - change: "the harness mcpserver answers malformed JSON-RPC with -32602 invalid params (was -32700 parse error)"
+        breaking: true
+        detect: 'experimental/harness'
+        guidance: "A client that branched on -32700 for a syntactically valid but malformed request now sees -32602; branch on both, or on the message."
+      - change: "Layout.WithKey keys a layout's layer identity independently of its name, App.WithSkipLabel/WithSkipLabelFunc localize the skip link, the outermost rendered layer carries data-fui-lang / data-fui-skip-label, and the runtime copies them onto the document after every swap"
+        breaking: false
+        guidance: "Additive. A multilingual site gives each language's shell the same Name and a per-language WithKey and sets WithLangFunc/WithSkipLabelFunc once; a host that sets nothing renders byte-identically. A downstream runtime that rewrote <html lang> or the skip link itself can drop that code."
+      - change: "the widgets module dispatches fui:widget-open and fui:widget-close on document, and when a host layout places a widget root inside the shell, the root is re-appended to <body> after a shell swap instead of vanishing with the old shell"
+        breaking: false
+        guidance: "Additive. Replace whole-document MutationObservers that waited for widget chrome with a fui:widget-open listener; rebind on open, unbind on close, never assume a root mounts once."
+      - change: "CodeBlockConfig gains HighlightLines, Diff, HighlightWords, and Wrap, and ui.Markdown forwards the fence options title, showLineNumbers, scroll, {1,3-5}/highlight=, diff, words=, and wrap"
+        breaking: false
+        guidance: "Additive; a zero config renders byte-identical markup. A docs site that lifted option-carrying fences out of Markdown to render them itself can delete that parser. Option-carrying fences now also carry the raw info string on the block's data-meta attribute."


### PR DESCRIPTION
Release v0.85.0: red-probe rounds 4 and 5, per-language shells, widget lifecycle events, CodeBlock fence options.

- `CHANGELOG.md`: `[Unreleased]` rolled to `[0.85.0] - 2026-09-08`; a stray `+` line a merge left between the round-4 and round-5 entries is dropped.
- `cmd/gofastr/upgrades.yml`: `through: v0.85.0` and the release entry. Nine breaking notes (MCP plain-error answers, multipart duplicate keys, scoped OpenAPI, sha256 auth tokens, session-only policies vs API tokens, BelongsTo scope check, kiln `update_entity` plans, generated CLIs without `--token`, harness `-32602`), each with a `detect` regex, plus three additive notes.
- `SECURITY.md`: supported line `0.85.x`.

`TestUpgradeRegistryThroughMatchesChangelog`, `TestNewestReleaseBreakingNotesHaveDetectors`, `TestUpgradeRegistryDetectorsCompile`, and the release manifest test pass. After merge: tag the merge commit `v0.85.0` on the green main head; `release.yml` runs `scripts/release-gate.sh` and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Added release notes for version 0.85.0, including nine breaking changes and three new capabilities.

- **Breaking Changes**
  - MCP tools now return plain errors; duplicate multipart keys are rejected.
  - OpenAPI documents respect read permissions, and auth tokens use SHA-256 digests.
  - API-token requests affected by session policies return 401; inaccessible BelongsTo targets return 404.
  - Required plans for kiln updates; generated CLI `--token` removed.
  - Harness JSON-RPC parse errors use an updated error code.

- **New Features**
  - Added layout layer keys, localized skip links, widget lifecycle events, and CodeBlock/Markdown fence options.

- **Documentation**
  - Updated supported versions to 0.85.x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->